### PR TITLE
feat(world): Strength-driven carry-weight cap on gather + mine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,26 @@ Every implementation slice follows this loop until green. Do not skip steps even
 
 ---
 
+## Code style: self-explanatory code
+
+Default to **zero comments**. The code, the function and parameter names, and the test names should carry the meaning on their own. Before committing, re-read every comment in the diff and delete it unless it falls into one of the allowed buckets below.
+
+**Allowed:**
+- `TODO(<tag>): ...` markers tracking deferred work, with a short note on the gap.
+- One-line KDoc on **public-API surfaces** (interface methods, sealed-class members) — match the brevity of existing entries in `BalanceLookup` and `WorldRejection`.
+- A short **WHY** when an invariant or constraint is genuinely non-obvious from the code (an ordering requirement that protects a side-effect, a clamp guarding against integer overflow, etc.).
+
+**Not allowed:**
+- "This block does X then Y" running commentary.
+- Test-setup comments restating the math the reader can compute from the literals (`5 × 100 g = 500 g`).
+- Block-level KDocs on private helpers, test stubs, or test fixtures.
+- Labels on assertions like `// Side-effect check:` or `// Boundary case:` — the test name conveys it.
+- KDocs that re-state the function name.
+
+If removing the comment wouldn't confuse a future reader, delete it.
+
+---
+
 ## Tech Stack
 
 | Layer          | Technology                              |

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
@@ -96,4 +96,17 @@ sealed interface WorldRejection {
      * Distinct from [UnknownNode] which means a specific node id is gone.
      */
     data class NoSpawnableNode(val agent: AgentId) : WorldRejection
+
+    /**
+     * Adding the requested items would push the agent's total carried weight
+     * past the Strength-driven cap. [requested] is the would-be total grams
+     * (existing stowed + equipped + the new add); [capacity] is
+     * `Strength × carryGramsPerStrengthPoint`. Both surfaced so an agent can
+     * see the gap without round-tripping through inventory + catalog.
+     */
+    data class OverEncumbered(
+        val agent: AgentId,
+        val requested: Int,
+        val capacity: Int,
+    ) : WorldRejection
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
@@ -97,13 +97,6 @@ sealed interface WorldRejection {
      */
     data class NoSpawnableNode(val agent: AgentId) : WorldRejection
 
-    /**
-     * Adding the requested items would push the agent's total carried weight
-     * past the Strength-driven cap. [requested] is the would-be total grams
-     * (existing stowed + equipped + the new add); [capacity] is
-     * `Strength × carryGramsPerStrengthPoint`. Both surfaced so an agent can
-     * see the gap without round-tripping through inventory + catalog.
-     */
     data class OverEncumbered(
         val agent: AgentId,
         val requested: Int,

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -2,8 +2,10 @@ package dev.gvart.genesara.world.internal
 
 import arrow.core.Either
 import dev.gvart.genesara.player.AgentProfileLookup
+import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
@@ -31,6 +33,8 @@ internal fun reduce(
     items: ItemLookup,
     resources: NodeResourceStore,
     skills: AgentSkillsRegistry,
+    agents: AgentRegistry,
+    equipment: EquipmentInstanceStore,
     safeNodes: AgentSafeNodeGateway,
     safeNodeResolver: SafeNodeResolver,
     publisher: ApplicationEventPublisher,
@@ -39,8 +43,10 @@ internal fun reduce(
     is WorldCommand.SpawnAgent -> reduceSpawn(state, command, profiles, tick)
     is WorldCommand.MoveAgent -> reduceMove(state, command, balance, tick)
     is WorldCommand.UnspawnAgent -> reduceUnspawn(state, command, tick)
-    is WorldCommand.GatherResource -> reduceGather(state, command, balance, items, resources, skills, publisher, tick)
-    is WorldCommand.MineResource -> reduceMine(state, command, balance, items, resources, skills, publisher, tick)
+    is WorldCommand.GatherResource ->
+        reduceGather(state, command, balance, items, resources, skills, agents, equipment, publisher, tick)
+    is WorldCommand.MineResource ->
+        reduceMine(state, command, balance, items, resources, skills, agents, equipment, publisher, tick)
     is WorldCommand.ConsumeItem -> reduceConsume(state, command, items, tick)
     is WorldCommand.Drink -> reduceDrink(state, command, balance, tick)
     is WorldCommand.SetSafeNode -> reduceSetSafeNode(state, command, safeNodes, tick)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -90,12 +90,7 @@ internal interface BalanceLookup {
      */
     fun xpLossOnDeath(): Int = 0
 
-    /**
-     * Grams of carry capacity granted per point of Strength. Multiplied by the
-     * agent's [dev.gvart.genesara.player.AgentAttributes.strength] to derive
-     * the total weight an agent can hold (stowed + equipped). Tuning constant —
-     * adjust here, not at call sites.
-     */
+    /** Grams of carry capacity granted per point of Strength. */
     fun carryGramsPerStrengthPoint(): Int = 0
 }
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -89,6 +89,14 @@ internal interface BalanceLookup {
      * supplies the real value.
      */
     fun xpLossOnDeath(): Int = 0
+
+    /**
+     * Grams of carry capacity granted per point of Strength. Multiplied by the
+     * agent's [dev.gvart.genesara.player.AgentAttributes.strength] to derive
+     * the total weight an agent can hold (stowed + equipped). Tuning constant —
+     * adjust here, not at call sites.
+     */
+    fun carryGramsPerStrengthPoint(): Int = 0
 }
 
 @Component
@@ -150,6 +158,8 @@ internal class WorldDefinitionBalanceLookup(
 
     override fun xpLossOnDeath(): Int = XP_LOSS_ON_DEATH
 
+    override fun carryGramsPerStrengthPoint(): Int = CARRY_GRAMS_PER_STRENGTH_POINT
+
     private companion object {
         const val BASE_MOVE_COST = 1
         const val BASE_REGEN_PER_TICK = 1.0
@@ -162,5 +172,6 @@ internal class WorldDefinitionBalanceLookup(
         const val DRINK_THIRST_REFILL = 25
         const val SLEEP_REGEN_PER_OFFLINE_TICK = 2
         const val XP_LOSS_ON_DEATH = 25
+        const val CARRY_GRAMS_PER_STRENGTH_POINT = 5_000
     }
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/gather/GatherReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/gather/GatherReducer.kt
@@ -7,8 +7,10 @@ import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.NodeId
@@ -16,6 +18,9 @@ import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.inventory.enforceCarryCap
+import dev.gvart.genesara.world.internal.inventory.equippedGrams
+import dev.gvart.genesara.world.internal.inventory.totalGrams
 import dev.gvart.genesara.world.internal.resources.NodeResourceCell
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.worldstate.WorldState
@@ -37,8 +42,8 @@ import java.util.UUID
  * items with no `gathering-skill` at all. The mining verb owns MINING-skill items;
  * the symmetric check lives in [reduceMine][dev.gvart.genesara.world.internal.mine.reduceMine].
  *
- * Out of scope: carry-weight cap, `Item.maxStack` cap, multi-event return for the
- * gather that takes a cell to zero (see TODOs).
+ * Out of scope: `Item.maxStack` cap, multi-event return for the gather that takes a
+ * cell to zero (see TODOs).
  */
 internal fun reduceGather(
     state: WorldState,
@@ -47,6 +52,8 @@ internal fun reduceGather(
     items: ItemLookup,
     resources: NodeResourceStore,
     skills: AgentSkillsRegistry,
+    agents: AgentRegistry,
+    equipment: EquipmentInstanceStore,
     publisher: ApplicationEventPublisher,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
@@ -70,10 +77,23 @@ internal fun reduceGather(
     }
 
     val quantity = balance.gatherYield(command.item).coerceAtMost(cell.quantity)
+
+    // Carry-cap gate runs before the cell decrement and the inventory write so a
+    // rejected gather leaves no side-effect (the resource cell stays full, no XP
+    // accrues). All add-paths into inventory must call enforceCarryCap; future
+    // consume-pickup / craft-output / equip reducers mirror this block. The agent
+    // is already known to be in the world (positions[command.agent] above), so a
+    // missing registry row is invariant violation, not a rejectable user error.
+    val agentRecord = agents.find(command.agent)
+        ?: error("Invariant violated: agent ${command.agent} has a position but no registry row")
+    val currentGrams = state.inventoryOf(command.agent).totalGrams(items) +
+        equippedGrams(equipment.equippedFor(command.agent), items)
+    val additionalGrams = quantity * itemDef.weightPerUnit
+    enforceCarryCap(command.agent, agentRecord.attributes.strength, currentGrams, additionalGrams, balance)
+
     resources.decrement(nodeId, command.item, quantity, tick)
     accrueXpOrRecommend(command.agent, command.commandId, itemDef.gatheringSkill, quantity, tick, skills, publisher)
 
-    // TODO(carry-weight): reject when total weight would exceed Strength × multiplier.
     // TODO(max-stack): reject (StackFull) when adding `quantity` would exceed maxStack.
     // TODO(events): emit WorldEvent.NodeResourceDepleted alongside ResourceGathered when
     //               this gather takes the cell to zero — needs multi-event reducer return.

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/gather/GatherReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/gather/GatherReducer.kt
@@ -78,12 +78,6 @@ internal fun reduceGather(
 
     val quantity = balance.gatherYield(command.item).coerceAtMost(cell.quantity)
 
-    // Carry-cap gate runs before the cell decrement and the inventory write so a
-    // rejected gather leaves no side-effect (the resource cell stays full, no XP
-    // accrues). All add-paths into inventory must call enforceCarryCap; future
-    // consume-pickup / craft-output / equip reducers mirror this block. The agent
-    // is already known to be in the world (positions[command.agent] above), so a
-    // missing registry row is invariant violation, not a rejectable user error.
     val agentRecord = agents.find(command.agent)
         ?: error("Invariant violated: agent ${command.agent} has a position but no registry row")
     val currentGrams = state.inventoryOf(command.agent).totalGrams(items) +

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/inventory/CarryCap.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/inventory/CarryCap.kt
@@ -1,0 +1,41 @@
+package dev.gvart.genesara.world.internal.inventory
+
+import arrow.core.raise.Raise
+import arrow.core.raise.ensure
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+
+internal fun AgentInventory.totalGrams(items: ItemLookup): Int =
+    stacks.entries.sumOf { (id, qty) -> (items.byId(id)?.weightPerUnit ?: 0) * qty }
+
+// TODO(carry-weight): equippedGrams only sees slotted instances. Spec §8 says stowed +
+// equipped count; once equip / craft / loot slices land, walk listByAgent(...) and add
+// the unequipped tail. Today no flow produces unequipped rows, so the gap isn't reachable.
+internal fun equippedGrams(equipped: Map<EquipSlot, EquipmentInstance>, items: ItemLookup): Int =
+    equipped.values.sumOf { items.byId(it.itemId)?.weightPerUnit ?: 0 }
+
+internal fun Raise<WorldRejection>.enforceCarryCap(
+    agent: AgentId,
+    strength: Int,
+    currentGrams: Int,
+    additionalGrams: Int,
+    balance: BalanceLookup,
+) {
+    // All math widened to Long so a permissive test stub or a misconfigured catalog
+    // (heavy item × big yield) can't silently wrap to a negative Int and bypass the cap;
+    // the rejection's Int fields clamp at Int.MAX_VALUE so the agent gets a meaningful
+    // gap report even in the over-Int case.
+    val capacityLong = strength.toLong() * balance.carryGramsPerStrengthPoint().toLong()
+    val requestedLong = currentGrams.toLong() + additionalGrams.toLong()
+    ensure(requestedLong <= capacityLong) {
+        WorldRejection.OverEncumbered(
+            agent = agent,
+            requested = requestedLong.coerceIn(0L, Int.MAX_VALUE.toLong()).toInt(),
+            capacity = capacityLong.coerceIn(0L, Int.MAX_VALUE.toLong()).toInt(),
+        )
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/inventory/CarryCap.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/inventory/CarryCap.kt
@@ -12,9 +12,7 @@ import dev.gvart.genesara.world.internal.balance.BalanceLookup
 internal fun AgentInventory.totalGrams(items: ItemLookup): Int =
     stacks.entries.sumOf { (id, qty) -> (items.byId(id)?.weightPerUnit ?: 0) * qty }
 
-// TODO(carry-weight): equippedGrams only sees slotted instances. Spec §8 says stowed +
-// equipped count; once equip / craft / loot slices land, walk listByAgent(...) and add
-// the unequipped tail. Today no flow produces unequipped rows, so the gap isn't reachable.
+// TODO(carry-weight): also count unequipped EquipmentInstance rows once a flow produces them.
 internal fun equippedGrams(equipped: Map<EquipSlot, EquipmentInstance>, items: ItemLookup): Int =
     equipped.values.sumOf { items.byId(it.itemId)?.weightPerUnit ?: 0 }
 
@@ -25,10 +23,6 @@ internal fun Raise<WorldRejection>.enforceCarryCap(
     additionalGrams: Int,
     balance: BalanceLookup,
 ) {
-    // All math widened to Long so a permissive test stub or a misconfigured catalog
-    // (heavy item × big yield) can't silently wrap to a negative Int and bypass the cap;
-    // the rejection's Int fields clamp at Int.MAX_VALUE so the agent gets a meaningful
-    // gap report even in the over-Int case.
     val capacityLong = strength.toLong() * balance.carryGramsPerStrengthPoint().toLong()
     val requestedLong = currentGrams.toLong() + additionalGrams.toLong()
     ensure(requestedLong <= capacityLong) {

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/mine/MineReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/mine/MineReducer.kt
@@ -7,8 +7,10 @@ import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.NodeId
@@ -16,6 +18,9 @@ import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.inventory.enforceCarryCap
+import dev.gvart.genesara.world.internal.inventory.equippedGrams
+import dev.gvart.genesara.world.internal.inventory.totalGrams
 import dev.gvart.genesara.world.internal.resources.NodeResourceCell
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.worldstate.WorldState
@@ -41,6 +46,8 @@ internal fun reduceMine(
     items: ItemLookup,
     resources: NodeResourceStore,
     skills: AgentSkillsRegistry,
+    agents: AgentRegistry,
+    equipment: EquipmentInstanceStore,
     publisher: ApplicationEventPublisher,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
@@ -63,6 +70,17 @@ internal fun reduceMine(
     }
 
     val quantity = balance.gatherYield(command.item).coerceAtMost(cell.quantity)
+
+    // Carry-cap gate runs before decrement + XP so a rejected mine leaves no
+    // side-effect. Mirrors reduceGather; both add-paths must call enforceCarryCap.
+    // Missing registry row → invariant violation (the agent is already positioned).
+    val agentRecord = agents.find(command.agent)
+        ?: error("Invariant violated: agent ${command.agent} has a position but no registry row")
+    val currentGrams = state.inventoryOf(command.agent).totalGrams(items) +
+        equippedGrams(equipment.equippedFor(command.agent), items)
+    val additionalGrams = quantity * itemDef.weightPerUnit
+    enforceCarryCap(command.agent, agentRecord.attributes.strength, currentGrams, additionalGrams, balance)
+
     resources.decrement(nodeId, command.item, quantity, tick)
     accrueMiningXp(command.agent, command.commandId, SkillId(skillIdString), quantity, tick, skills, publisher)
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/mine/MineReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/mine/MineReducer.kt
@@ -71,9 +71,6 @@ internal fun reduceMine(
 
     val quantity = balance.gatherYield(command.item).coerceAtMost(cell.quantity)
 
-    // Carry-cap gate runs before decrement + XP so a rejected mine leaves no
-    // side-effect. Mirrors reduceGather; both add-paths must call enforceCarryCap.
-    // Missing registry row → invariant violation (the agent is already positioned).
     val agentRecord = agents.find(command.agent)
         ?: error("Invariant violated: agent ${command.agent} has a position but no registry row")
     val currentGrams = state.inventoryOf(command.agent).totalGrams(items) +

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -5,6 +5,7 @@ import dev.gvart.genesara.player.AgentProfileLookup
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
@@ -31,6 +32,7 @@ internal class WorldTickHandler(
     private val resources: NodeResourceStore,
     private val skills: AgentSkillsRegistry,
     private val agents: AgentRegistry,
+    private val equipment: EquipmentInstanceStore,
     private val safeNodes: AgentSafeNodeGateway,
     private val safeNodeResolver: SafeNodeResolver,
 ) {
@@ -57,7 +59,10 @@ internal class WorldTickHandler(
 
         val commands = queue.drainFor(tick.number)
         val (next, commandEvents) = commands.fold(afterDeaths to emptyList<WorldEvent>()) { (state, acc), command ->
-            reduce(state, command, balance, profiles, items, resources, skills, safeNodes, safeNodeResolver, publisher, tick.number).fold(
+            reduce(
+                state, command, balance, profiles, items, resources, skills, agents, equipment,
+                safeNodes, safeNodeResolver, publisher, tick.number,
+            ).fold(
                 ifLeft = { rejection ->
                     log.info("Rejected {} at tick {}: {}", command, tick.number, rejection)
                     state to acc

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/gather/GatherReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/gather/GatherReducerTest.kt
@@ -1,7 +1,11 @@
 package dev.gvart.genesara.world.internal.gather
 
+import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillState
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.AgentSkillsSnapshot
@@ -9,6 +13,9 @@ import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillSlotError
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.Item
 import dev.gvart.genesara.world.ItemCategory
 import dev.gvart.genesara.world.ItemId
@@ -17,6 +24,7 @@ import dev.gvart.genesara.world.Node
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.NodeResources
 import dev.gvart.genesara.world.NodeResourceView
+import dev.gvart.genesara.world.Rarity
 import dev.gvart.genesara.world.Region
 import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.ResourceSpawnRule
@@ -86,6 +94,16 @@ class GatherReducerTest {
         ),
     )
 
+    /**
+     * Default test fixtures for the carry-cap path. Strength-100 (effectively
+     * uncapped at the default 5 kg/pt = 500 kg) and an empty equipment store
+     * mean tests that don't care about carry-weight pass without setup. Tests
+     * that exercise the cap construct their own [StubAgentRegistry] /
+     * [StubEquipmentStore] with tighter values.
+     */
+    private val agents: AgentRegistry = StubAgentRegistry(strength = 100)
+    private val equipment: EquipmentInstanceStore = StubEquipmentStore()
+
     @Test
     fun `happy path adds yield to inventory, spends stamina, emits ResourceGathered`() {
         val state = stateWith()
@@ -94,7 +112,9 @@ class GatherReducerTest {
         val skills = StubSkillsRegistry()
         val publisher = RecordingPublisher()
 
-        val result = reduceGather(state, command, balance, items, store, skills, publisher, tick = 7)
+        val result = reduceGather(
+            state, command, balance, items, store, skills, agents, equipment, publisher, tick = 7,
+        )
 
         val (next, event) = assertNotNull(result.getOrNull())
         assertEquals(1, next.inventoryOf(agent).quantityOf(wood))
@@ -117,7 +137,7 @@ class GatherReducerTest {
 
         val result = reduceGather(
             state, WorldCommand.GatherResource(agent, wood), balance, items,
-            StubResourceStore(), skills, publisher, tick = 1,
+            StubResourceStore(), skills, agents, equipment, publisher, tick = 1,
         )
 
         assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
@@ -131,7 +151,7 @@ class GatherReducerTest {
 
         val result = reduceGather(
             state, WorldCommand.GatherResource(agent, unknown), balance, emptyCatalog,
-            StubResourceStore(), StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            StubResourceStore(), StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         assertEquals(WorldRejection.UnknownItem(unknown), result.leftOrNull())
@@ -146,7 +166,7 @@ class GatherReducerTest {
 
         val result = reduceGather(
             state, WorldCommand.GatherResource(agent, berry), balance, items,
-            store, StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         assertEquals(
@@ -164,7 +184,7 @@ class GatherReducerTest {
             // Pre-seed the cell so cell-not-null isn't what's catching this; the
             // verb gate must fire first.
             StubResourceStore(initial = mapOf(stone to 50)),
-            StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         assertEquals(
@@ -180,7 +200,7 @@ class GatherReducerTest {
 
         val result = reduceGather(
             state, WorldCommand.GatherResource(agent, wood), balance, items,
-            store, StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         assertEquals(
@@ -196,7 +216,7 @@ class GatherReducerTest {
 
         val result = reduceGather(
             state, WorldCommand.GatherResource(agent, wood), balance, items,
-            store, StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         assertEquals(
@@ -212,7 +232,7 @@ class GatherReducerTest {
 
         val result = reduceGather(
             state, WorldCommand.GatherResource(agent, wood), balance, items,
-            store, StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -232,7 +252,7 @@ class GatherReducerTest {
 
         val result = reduceGather(
             state, WorldCommand.GatherResource(agent, wood), highYield, items,
-            store, StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         val (next, event) = assertNotNull(result.getOrNull())
@@ -240,6 +260,115 @@ class GatherReducerTest {
         assertEquals(0, store.quantity(wood))
         val gathered = assertIs<WorldEvent.ResourceGathered>(event)
         assertEquals(1, gathered.quantity)
+    }
+
+    // ─────────────────────── Carry-weight cap ───────────────────────
+
+    @Test
+    fun `rejects when adding the gathered yield would exceed the carry cap`() {
+        // 100 g/pt × Strength 1 = 100 g cap. Pre-load 5 wood (5 × 100 g = 500 g already
+        // over the cap, but the gate only fires on add-paths; we trigger it by gathering
+        // one more unit and assert the rejection's requested/capacity reflect the gap).
+        val state = stateWith().copy(
+            inventories = mapOf(
+                agent to dev.gvart.genesara.world.internal.inventory.AgentInventory.EMPTY.add(wood, 5),
+            ),
+        )
+        val tightBalance = balance(
+            spawns = mapOf(Terrain.FOREST to listOf(rule(wood, 1.0, 50..200))),
+            staminaCost = 5,
+            carryGramsPerStrengthPoint = 100, // 1 STR × 100 g = 100 g cap; existing 500 g already over
+        )
+        val skinnyAgents = StubAgentRegistry(strength = 1)
+        val store = StubResourceStore(initial = mapOf(wood to 50))
+
+        val result = reduceGather(
+            state, WorldCommand.GatherResource(agent, wood), tightBalance, items, store,
+            StubSkillsRegistry(), skinnyAgents, equipment, RecordingPublisher(), tick = 1,
+        )
+
+        // 5 existing × 100 g + 1 new × 100 g = 600 g requested vs 100 g cap.
+        assertEquals(
+            WorldRejection.OverEncumbered(agent, requested = 600, capacity = 100),
+            result.leftOrNull(),
+        )
+        // Side-effect check: a rejected gather must not decrement the cell.
+        assertEquals(50, store.quantity(wood))
+    }
+
+    @Test
+    fun `accepts the gather that lands exactly at the carry cap`() {
+        // Strength 1 × 100 g/pt = 100 g cap. Inventory empty, item is 100 g/unit.
+        // Adding 1 unit takes us to exactly 100 g — equal, not over.
+        val tightBalance = balance(
+            spawns = mapOf(Terrain.FOREST to listOf(rule(wood, 1.0, 50..200))),
+            staminaCost = 5,
+            carryGramsPerStrengthPoint = 100,
+        )
+        val skinnyAgents = StubAgentRegistry(strength = 1)
+        val store = StubResourceStore(initial = mapOf(wood to 50))
+
+        val result = reduceGather(
+            state = stateWith(),
+            WorldCommand.GatherResource(agent, wood), tightBalance, items, store,
+            StubSkillsRegistry(), skinnyAgents, equipment, RecordingPublisher(), tick = 1,
+        )
+
+        val (next, _) = assertNotNull(result.getOrNull())
+        assertEquals(1, next.inventoryOf(agent).quantityOf(wood))
+    }
+
+    @Test
+    fun `equipped items count toward the carry cap`() {
+        // Empty inventory but a 200 g equipped item; cap = 1 × 100 = 100 g.
+        // Adding any wood should be rejected because the equipped item alone
+        // already exceeds the cap.
+        val tightBalance = balance(
+            spawns = mapOf(Terrain.FOREST to listOf(rule(wood, 1.0, 50..200))),
+            staminaCost = 5,
+            carryGramsPerStrengthPoint = 100,
+        )
+        val skinnyAgents = StubAgentRegistry(strength = 1)
+        val heavyHelmet = EquipmentInstance(
+            instanceId = UUID.randomUUID(),
+            agentId = agent,
+            itemId = ItemId("HEAVY_HELMET"),
+            rarity = Rarity.COMMON,
+            durabilityCurrent = 100,
+            durabilityMax = 100,
+            creatorAgentId = null,
+            createdAtTick = 0L,
+            equippedInSlot = EquipSlot.HELMET,
+        )
+        val itemsWithHelmet = StubItemLookup(
+            mapOf(
+                wood to itemFor(wood, gatheringSkill = "LUMBERJACKING"),
+                stone to itemFor(stone, gatheringSkill = "MINING"),
+                berry to itemFor(berry, gatheringSkill = "FORAGING"),
+                ItemId("HEAVY_HELMET") to Item(
+                    id = ItemId("HEAVY_HELMET"),
+                    displayName = "Heavy Helmet",
+                    description = "",
+                    category = ItemCategory.RESOURCE,
+                    weightPerUnit = 200,
+                    maxStack = 1,
+                ),
+            ),
+        )
+        val helmetEquipped = StubEquipmentStore(equipped = mapOf(EquipSlot.HELMET to heavyHelmet))
+        val store = StubResourceStore(initial = mapOf(wood to 50))
+
+        val result = reduceGather(
+            state = stateWith(),
+            WorldCommand.GatherResource(agent, wood), tightBalance, itemsWithHelmet, store,
+            StubSkillsRegistry(), skinnyAgents, helmetEquipped, RecordingPublisher(), tick = 1,
+        )
+
+        // 200 g equipped + 100 g new = 300 g requested vs 100 g cap.
+        assertEquals(
+            WorldRejection.OverEncumbered(agent, requested = 300, capacity = 100),
+            result.leftOrNull(),
+        )
     }
 
     // ─────────────────────── Skill XP / recommendation paths ───────────────────────
@@ -253,7 +382,7 @@ class GatherReducerTest {
 
         reduceGather(
             state, WorldCommand.GatherResource(agent, wood), balance, items,
-            store, skills, publisher, tick = 7,
+            store, skills, agents, equipment, publisher, tick = 7,
         )
 
         assertEquals(1, skills.xpAddCalls.size)
@@ -279,7 +408,7 @@ class GatherReducerTest {
 
         reduceGather(
             state, WorldCommand.GatherResource(agent, wood), balance, items,
-            store, skills, publisher, tick = 7,
+            store, skills, agents, equipment, publisher, tick = 7,
         )
 
         val milestoneEvents = publisher.events.filterIsInstance<WorldEvent.SkillMilestoneReached>()
@@ -303,7 +432,7 @@ class GatherReducerTest {
 
         reduceGather(
             state, WorldCommand.GatherResource(agent, wood), balance, items,
-            store, skills, publisher, tick = 7,
+            store, skills, agents, equipment, publisher, tick = 7,
         )
 
         val recs = publisher.events.filterIsInstance<WorldEvent.SkillRecommended>()
@@ -322,7 +451,7 @@ class GatherReducerTest {
 
         reduceGather(
             state, WorldCommand.GatherResource(agent, wood), balance, items,
-            store, skills, publisher, tick = 7,
+            store, skills, agents, equipment, publisher, tick = 7,
         )
 
         assertTrue(publisher.events.none { it is WorldEvent.SkillRecommended })
@@ -340,7 +469,7 @@ class GatherReducerTest {
 
         reduceGather(
             state, WorldCommand.GatherResource(agent, wood), balance, skillFreeItems,
-            store, skills, publisher, tick = 7,
+            store, skills, agents, equipment, publisher, tick = 7,
         )
 
         assertEquals(0, skills.xpAddCalls.size)
@@ -358,6 +487,7 @@ class GatherReducerTest {
         spawns: Map<Terrain, List<ResourceSpawnRule>>,
         staminaCost: Int,
         yield: Int = 1,
+        carryGramsPerStrengthPoint: Int = 5_000,
     ) = object : BalanceLookup {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
         override fun staminaRegenPerTick(climate: Climate) = 0
@@ -372,6 +502,7 @@ class GatherReducerTest {
         override fun drinkThirstRefill(): Int = 25
         override fun sleepRegenPerOfflineTick(): Int = 0
         override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun carryGramsPerStrengthPoint(): Int = carryGramsPerStrengthPoint
     }
 
     private fun itemFor(id: ItemId, gatheringSkill: String? = null) = Item(
@@ -496,5 +627,36 @@ class GatherReducerTest {
         override fun publishEvent(event: Any) {
             events += event
         }
+    }
+
+    private inner class StubAgentRegistry(private val strength: Int) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = if (id == agent) {
+            Agent(
+                id = id,
+                owner = PlayerId(UUID.randomUUID()),
+                name = "test",
+                apiToken = "tok",
+                attributes = AgentAttributes(strength = strength),
+            )
+        } else {
+            null
+        }
+
+        override fun findByToken(token: String): Agent? = error("not used in this test")
+        override fun listForOwner(owner: PlayerId): List<Agent> = error("not used in this test")
+    }
+
+    private class StubEquipmentStore(
+        private val equipped: Map<EquipSlot, EquipmentInstance> = emptyMap(),
+    ) : EquipmentInstanceStore {
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> = equipped
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = error("not used")
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? =
+            error("not used")
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = error("not used")
+        override fun delete(instanceId: UUID): Boolean = error("not used")
     }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/gather/GatherReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/gather/GatherReducerTest.kt
@@ -94,13 +94,6 @@ class GatherReducerTest {
         ),
     )
 
-    /**
-     * Default test fixtures for the carry-cap path. Strength-100 (effectively
-     * uncapped at the default 5 kg/pt = 500 kg) and an empty equipment store
-     * mean tests that don't care about carry-weight pass without setup. Tests
-     * that exercise the cap construct their own [StubAgentRegistry] /
-     * [StubEquipmentStore] with tighter values.
-     */
     private val agents: AgentRegistry = StubAgentRegistry(strength = 100)
     private val equipment: EquipmentInstanceStore = StubEquipmentStore()
 
@@ -266,9 +259,6 @@ class GatherReducerTest {
 
     @Test
     fun `rejects when adding the gathered yield would exceed the carry cap`() {
-        // 100 g/pt × Strength 1 = 100 g cap. Pre-load 5 wood (5 × 100 g = 500 g already
-        // over the cap, but the gate only fires on add-paths; we trigger it by gathering
-        // one more unit and assert the rejection's requested/capacity reflect the gap).
         val state = stateWith().copy(
             inventories = mapOf(
                 agent to dev.gvart.genesara.world.internal.inventory.AgentInventory.EMPTY.add(wood, 5),
@@ -277,7 +267,7 @@ class GatherReducerTest {
         val tightBalance = balance(
             spawns = mapOf(Terrain.FOREST to listOf(rule(wood, 1.0, 50..200))),
             staminaCost = 5,
-            carryGramsPerStrengthPoint = 100, // 1 STR × 100 g = 100 g cap; existing 500 g already over
+            carryGramsPerStrengthPoint = 100,
         )
         val skinnyAgents = StubAgentRegistry(strength = 1)
         val store = StubResourceStore(initial = mapOf(wood to 50))
@@ -287,19 +277,15 @@ class GatherReducerTest {
             StubSkillsRegistry(), skinnyAgents, equipment, RecordingPublisher(), tick = 1,
         )
 
-        // 5 existing × 100 g + 1 new × 100 g = 600 g requested vs 100 g cap.
         assertEquals(
             WorldRejection.OverEncumbered(agent, requested = 600, capacity = 100),
             result.leftOrNull(),
         )
-        // Side-effect check: a rejected gather must not decrement the cell.
         assertEquals(50, store.quantity(wood))
     }
 
     @Test
     fun `accepts the gather that lands exactly at the carry cap`() {
-        // Strength 1 × 100 g/pt = 100 g cap. Inventory empty, item is 100 g/unit.
-        // Adding 1 unit takes us to exactly 100 g — equal, not over.
         val tightBalance = balance(
             spawns = mapOf(Terrain.FOREST to listOf(rule(wood, 1.0, 50..200))),
             staminaCost = 5,
@@ -320,9 +306,6 @@ class GatherReducerTest {
 
     @Test
     fun `equipped items count toward the carry cap`() {
-        // Empty inventory but a 200 g equipped item; cap = 1 × 100 = 100 g.
-        // Adding any wood should be rejected because the equipped item alone
-        // already exceeds the cap.
         val tightBalance = balance(
             spawns = mapOf(Terrain.FOREST to listOf(rule(wood, 1.0, 50..200))),
             staminaCost = 5,
@@ -364,7 +347,6 @@ class GatherReducerTest {
             StubSkillsRegistry(), skinnyAgents, helmetEquipped, RecordingPublisher(), tick = 1,
         )
 
-        // 200 g equipped + 100 g new = 300 g requested vs 100 g cap.
         assertEquals(
             WorldRejection.OverEncumbered(agent, requested = 300, capacity = 100),
             result.leftOrNull(),

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/inventory/CarryCapTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/inventory/CarryCapTest.kt
@@ -39,7 +39,6 @@ class CarryCapTest {
     @Test
     fun `totalGrams sums multi-stack inventory by catalog weight`() {
         val inventory = AgentInventory.EMPTY.add(wood, 3).add(stone, 2)
-        // 3 * 800 + 2 * 1500 = 2400 + 3000
         assertEquals(5400, inventory.totalGrams(items))
     }
 
@@ -50,15 +49,14 @@ class CarryCapTest {
 
     @Test
     fun `totalGrams contributes zero for items missing from the catalog`() {
-        // Stale stack pointing at a removed catalog entry — tolerate, don't crash.
         val inventory = AgentInventory.EMPTY.add(wood, 1).add(phantom, 99)
         assertEquals(800, inventory.totalGrams(items))
     }
 
     @Test
     fun `equippedGrams sums each equipped instance via the catalog`() {
-        val helmet = instance(itemId = wood)   // 800 g
-        val chest = instance(itemId = stone)   // 1500 g
+        val helmet = instance(itemId = wood)
+        val chest = instance(itemId = stone)
         val equipped = mapOf(EquipSlot.HELMET to helmet, EquipSlot.CHEST to chest)
         assertEquals(2300, equippedGrams(equipped, items))
     }
@@ -70,12 +68,11 @@ class CarryCapTest {
 
     @Test
     fun `enforceCarryCap accepts when total lands exactly at the cap`() {
-        // Strength 5 * 1000 g/pt = 5000 g cap. Existing 4000 + add 1000 = 5000.
         val balance = balanceWithCarry(1000)
         val result: Either<WorldRejection, Unit> = either {
             enforceCarryCap(agent, strength = 5, currentGrams = 4000, additionalGrams = 1000, balance)
         }
-        assertNull(result.leftOrNull(), "expected helper to accept at the cap")
+        assertNull(result.leftOrNull())
     }
 
     @Test
@@ -92,7 +89,6 @@ class CarryCapTest {
 
     @Test
     fun `enforceCarryCap rejects when strength is zero`() {
-        // Strength 0 * any = 0 cap; any add is over.
         val balance = balanceWithCarry(5000)
         val result: Either<WorldRejection, Unit> = either {
             enforceCarryCap(agent, strength = 0, currentGrams = 0, additionalGrams = 1, balance)
@@ -105,8 +101,6 @@ class CarryCapTest {
 
     @Test
     fun `enforceCarryCap accepts strength zero with a zero-gram add`() {
-        // Cap = 0; requested = 0 → equal, not over. Boundary case for callers that
-        // might invoke the gate with no payload (e.g. a future no-op pickup).
         val balance = balanceWithCarry(5000)
         val result: Either<WorldRejection, Unit> = either {
             enforceCarryCap(agent, strength = 0, currentGrams = 0, additionalGrams = 0, balance)
@@ -116,8 +110,6 @@ class CarryCapTest {
 
     @Test
     fun `enforceCarryCap rejects when Int multiplication would overflow current+add`() {
-        // Heavy item × big yield: current = 1.5 GB, add = 1.5 GB. Naive Int math
-        // wraps; Long widening should catch this and reject with a clamped Int payload.
         val balance = balanceWithCarry(1000)
         val result: Either<WorldRejection, Unit> = either {
             enforceCarryCap(
@@ -128,7 +120,6 @@ class CarryCapTest {
                 balance,
             )
         }
-        // capacity = 5 × 1000 = 5000; requested clamps to Int.MAX_VALUE.
         assertEquals(
             WorldRejection.OverEncumbered(agent, requested = Int.MAX_VALUE, capacity = 5000),
             result.leftOrNull(),
@@ -137,17 +128,12 @@ class CarryCapTest {
 
     @Test
     fun `enforceCarryCap clamps the cap to Int MAX_VALUE under permissive multipliers`() {
-        // strength 100 × Int.MAX_VALUE overflows in Long → clamped to Int.MAX_VALUE
-        // for the rejection's capacity field. With current 0 and add 1 we still fit
-        // way below — assert this passes (no rejection).
         val balance = balanceWithCarry(Int.MAX_VALUE)
         val result: Either<WorldRejection, Unit> = either {
             enforceCarryCap(agent, strength = 100, currentGrams = 0, additionalGrams = 1, balance)
         }
         assertNull(result.leftOrNull())
     }
-
-    // ──────────────────────────── Test fixtures ────────────────────────────
 
     private fun itemFor(id: ItemId, weight: Int) = Item(
         id = id,

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/inventory/CarryCapTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/inventory/CarryCapTest.kt
@@ -1,0 +1,194 @@
+package dev.gvart.genesara.world.internal.inventory
+
+import arrow.core.Either
+import arrow.core.raise.either
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.Gauge
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.Rarity
+import dev.gvart.genesara.world.ResourceSpawnRule
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CarryCapTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val wood = ItemId("WOOD")
+    private val stone = ItemId("STONE")
+    private val phantom = ItemId("PHANTOM")
+
+    private val items = StubItemLookup(
+        mapOf(
+            wood to itemFor(wood, weight = 800),
+            stone to itemFor(stone, weight = 1500),
+        ),
+    )
+
+    @Test
+    fun `totalGrams sums multi-stack inventory by catalog weight`() {
+        val inventory = AgentInventory.EMPTY.add(wood, 3).add(stone, 2)
+        // 3 * 800 + 2 * 1500 = 2400 + 3000
+        assertEquals(5400, inventory.totalGrams(items))
+    }
+
+    @Test
+    fun `totalGrams returns zero for empty inventory`() {
+        assertEquals(0, AgentInventory.EMPTY.totalGrams(items))
+    }
+
+    @Test
+    fun `totalGrams contributes zero for items missing from the catalog`() {
+        // Stale stack pointing at a removed catalog entry — tolerate, don't crash.
+        val inventory = AgentInventory.EMPTY.add(wood, 1).add(phantom, 99)
+        assertEquals(800, inventory.totalGrams(items))
+    }
+
+    @Test
+    fun `equippedGrams sums each equipped instance via the catalog`() {
+        val helmet = instance(itemId = wood)   // 800 g
+        val chest = instance(itemId = stone)   // 1500 g
+        val equipped = mapOf(EquipSlot.HELMET to helmet, EquipSlot.CHEST to chest)
+        assertEquals(2300, equippedGrams(equipped, items))
+    }
+
+    @Test
+    fun `equippedGrams returns zero for empty map`() {
+        assertEquals(0, equippedGrams(emptyMap(), items))
+    }
+
+    @Test
+    fun `enforceCarryCap accepts when total lands exactly at the cap`() {
+        // Strength 5 * 1000 g/pt = 5000 g cap. Existing 4000 + add 1000 = 5000.
+        val balance = balanceWithCarry(1000)
+        val result: Either<WorldRejection, Unit> = either {
+            enforceCarryCap(agent, strength = 5, currentGrams = 4000, additionalGrams = 1000, balance)
+        }
+        assertNull(result.leftOrNull(), "expected helper to accept at the cap")
+    }
+
+    @Test
+    fun `enforceCarryCap rejects one gram over with OverEncumbered`() {
+        val balance = balanceWithCarry(1000)
+        val result: Either<WorldRejection, Unit> = either {
+            enforceCarryCap(agent, strength = 5, currentGrams = 4000, additionalGrams = 1001, balance)
+        }
+        assertEquals(
+            WorldRejection.OverEncumbered(agent, requested = 5001, capacity = 5000),
+            result.leftOrNull(),
+        )
+    }
+
+    @Test
+    fun `enforceCarryCap rejects when strength is zero`() {
+        // Strength 0 * any = 0 cap; any add is over.
+        val balance = balanceWithCarry(5000)
+        val result: Either<WorldRejection, Unit> = either {
+            enforceCarryCap(agent, strength = 0, currentGrams = 0, additionalGrams = 1, balance)
+        }
+        assertEquals(
+            WorldRejection.OverEncumbered(agent, requested = 1, capacity = 0),
+            result.leftOrNull(),
+        )
+    }
+
+    @Test
+    fun `enforceCarryCap accepts strength zero with a zero-gram add`() {
+        // Cap = 0; requested = 0 → equal, not over. Boundary case for callers that
+        // might invoke the gate with no payload (e.g. a future no-op pickup).
+        val balance = balanceWithCarry(5000)
+        val result: Either<WorldRejection, Unit> = either {
+            enforceCarryCap(agent, strength = 0, currentGrams = 0, additionalGrams = 0, balance)
+        }
+        assertNull(result.leftOrNull())
+    }
+
+    @Test
+    fun `enforceCarryCap rejects when Int multiplication would overflow current+add`() {
+        // Heavy item × big yield: current = 1.5 GB, add = 1.5 GB. Naive Int math
+        // wraps; Long widening should catch this and reject with a clamped Int payload.
+        val balance = balanceWithCarry(1000)
+        val result: Either<WorldRejection, Unit> = either {
+            enforceCarryCap(
+                agent,
+                strength = 5,
+                currentGrams = 1_500_000_000,
+                additionalGrams = 1_500_000_000,
+                balance,
+            )
+        }
+        // capacity = 5 × 1000 = 5000; requested clamps to Int.MAX_VALUE.
+        assertEquals(
+            WorldRejection.OverEncumbered(agent, requested = Int.MAX_VALUE, capacity = 5000),
+            result.leftOrNull(),
+        )
+    }
+
+    @Test
+    fun `enforceCarryCap clamps the cap to Int MAX_VALUE under permissive multipliers`() {
+        // strength 100 × Int.MAX_VALUE overflows in Long → clamped to Int.MAX_VALUE
+        // for the rejection's capacity field. With current 0 and add 1 we still fit
+        // way below — assert this passes (no rejection).
+        val balance = balanceWithCarry(Int.MAX_VALUE)
+        val result: Either<WorldRejection, Unit> = either {
+            enforceCarryCap(agent, strength = 100, currentGrams = 0, additionalGrams = 1, balance)
+        }
+        assertNull(result.leftOrNull())
+    }
+
+    // ──────────────────────────── Test fixtures ────────────────────────────
+
+    private fun itemFor(id: ItemId, weight: Int) = Item(
+        id = id,
+        displayName = id.value,
+        description = "",
+        category = ItemCategory.RESOURCE,
+        weightPerUnit = weight,
+        maxStack = 100,
+    )
+
+    private fun instance(itemId: ItemId) = EquipmentInstance(
+        instanceId = UUID.randomUUID(),
+        agentId = agent,
+        itemId = itemId,
+        rarity = Rarity.COMMON,
+        durabilityCurrent = 100,
+        durabilityMax = 100,
+        creatorAgentId = null,
+        createdAtTick = 0L,
+        equippedInSlot = EquipSlot.HELMET,
+    )
+
+    private class StubItemLookup(private val byId: Map<ItemId, Item>) : ItemLookup {
+        override fun byId(id: ItemId): Item? = byId[id]
+        override fun all(): List<Item> = byId.values.toList()
+    }
+
+    private fun balanceWithCarry(gramsPerStrengthPoint: Int) = object : BalanceLookup {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
+        override fun staminaRegenPerTick(climate: Climate) = 0
+        override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
+        override fun gatherStaminaCost(item: ItemId): Int = 1
+        override fun gatherYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun carryGramsPerStrengthPoint(): Int = gramsPerStrengthPoint
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/mine/MineReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/mine/MineReducerTest.kt
@@ -1,7 +1,11 @@
 package dev.gvart.genesara.world.internal.mine
 
+import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillState
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.AgentSkillsSnapshot
@@ -9,6 +13,9 @@ import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillSlotError
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.Item
 import dev.gvart.genesara.world.ItemCategory
 import dev.gvart.genesara.world.ItemId
@@ -17,6 +24,7 @@ import dev.gvart.genesara.world.Node
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.NodeResources
 import dev.gvart.genesara.world.NodeResourceView
+import dev.gvart.genesara.world.Rarity
 import dev.gvart.genesara.world.Region
 import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.ResourceSpawnRule
@@ -85,6 +93,9 @@ class MineReducerTest {
         ),
     )
 
+    private val agents: AgentRegistry = StubAgentRegistry(strength = 100)
+    private val equipment: EquipmentInstanceStore = StubEquipmentStore()
+
     @Test
     fun `happy path on a non-renewable adds yield, spends stamina, emits ResourceGathered`() {
         val state = stateWith()
@@ -93,7 +104,9 @@ class MineReducerTest {
         val skills = StubSkillsRegistry()
         val publisher = RecordingPublisher()
 
-        val result = reduceMine(state, command, balance, items, store, skills, publisher, tick = 7)
+        val result = reduceMine(
+            state, command, balance, items, store, skills, agents, equipment, publisher, tick = 7,
+        )
 
         val (next, event) = assertNotNull(result.getOrNull())
         assertEquals(1, next.inventoryOf(agent).quantityOf(stone))
@@ -116,7 +129,7 @@ class MineReducerTest {
 
         val result = reduceMine(
             state, command, balance, items, store,
-            StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -129,7 +142,7 @@ class MineReducerTest {
 
         val result = reduceMine(
             state, WorldCommand.MineResource(agent, stone), balance, items,
-            StubResourceStore(), StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            StubResourceStore(), StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
@@ -143,7 +156,7 @@ class MineReducerTest {
 
         val result = reduceMine(
             state, WorldCommand.MineResource(agent, unknown), balance, emptyCatalog,
-            StubResourceStore(), StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            StubResourceStore(), StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         assertEquals(WorldRejection.UnknownItem(unknown), result.leftOrNull())
@@ -156,7 +169,7 @@ class MineReducerTest {
         val result = reduceMine(
             state, WorldCommand.MineResource(agent, wood), balance, items,
             StubResourceStore(initial = mapOf(wood to 50)),
-            StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         assertEquals(
@@ -173,7 +186,7 @@ class MineReducerTest {
 
         val result = reduceMine(
             state, WorldCommand.MineResource(agent, odd), balance, catalog,
-            StubResourceStore(), StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            StubResourceStore(), StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         assertEquals(
@@ -190,7 +203,7 @@ class MineReducerTest {
 
         val result = reduceMine(
             state, WorldCommand.MineResource(agent, stone), balance, items,
-            store, StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         assertEquals(
@@ -206,7 +219,7 @@ class MineReducerTest {
 
         val result = reduceMine(
             state, WorldCommand.MineResource(agent, stone), balance, items,
-            store, StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         assertEquals(
@@ -222,7 +235,7 @@ class MineReducerTest {
 
         val result = reduceMine(
             state, WorldCommand.MineResource(agent, stone), balance, items,
-            store, StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         assertEquals(
@@ -238,7 +251,7 @@ class MineReducerTest {
 
         val result = reduceMine(
             state, WorldCommand.MineResource(agent, stone), balance, items,
-            store, StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -258,7 +271,7 @@ class MineReducerTest {
 
         val result = reduceMine(
             state, WorldCommand.MineResource(agent, stone), highYield, items,
-            store, StubSkillsRegistry(), RecordingPublisher(), tick = 1,
+            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
         )
 
         val (next, event) = assertNotNull(result.getOrNull())
@@ -266,6 +279,106 @@ class MineReducerTest {
         assertEquals(0, store.quantity(stone))
         val gathered = assertIs<WorldEvent.ResourceGathered>(event)
         assertEquals(1, gathered.quantity)
+    }
+
+    // ─────────────────────── Carry-weight cap ───────────────────────
+
+    @Test
+    fun `rejects when adding the mined yield would exceed the carry cap`() {
+        // Strength 1 × 100 g/pt = 100 g cap. Pre-load inventory with 5 stone (5 × 100 g).
+        val state = stateWith().copy(
+            inventories = mapOf(
+                agent to dev.gvart.genesara.world.internal.inventory.AgentInventory.EMPTY.add(stone, 5),
+            ),
+        )
+        val tightBalance = balance(
+            spawns = mapOf(Terrain.MOUNTAIN to listOf(rule(stone, 1.0, 50..200))),
+            staminaCost = 5,
+            carryGramsPerStrengthPoint = 100,
+        )
+        val skinnyAgents = StubAgentRegistry(strength = 1)
+        val store = StubResourceStore(initial = mapOf(stone to 50))
+
+        val result = reduceMine(
+            state, WorldCommand.MineResource(agent, stone), tightBalance, items, store,
+            StubSkillsRegistry(), skinnyAgents, equipment, RecordingPublisher(), tick = 1,
+        )
+
+        assertEquals(
+            WorldRejection.OverEncumbered(agent, requested = 600, capacity = 100),
+            result.leftOrNull(),
+        )
+        // Side-effect check: the rejected mine must not decrement the cell.
+        assertEquals(50, store.quantity(stone))
+    }
+
+    @Test
+    fun `accepts the mine that lands exactly at the carry cap`() {
+        val tightBalance = balance(
+            spawns = mapOf(Terrain.MOUNTAIN to listOf(rule(stone, 1.0, 50..200))),
+            staminaCost = 5,
+            carryGramsPerStrengthPoint = 100,
+        )
+        val skinnyAgents = StubAgentRegistry(strength = 1)
+        val store = StubResourceStore(initial = mapOf(stone to 50))
+
+        val result = reduceMine(
+            state = stateWith(),
+            WorldCommand.MineResource(agent, stone), tightBalance, items, store,
+            StubSkillsRegistry(), skinnyAgents, equipment, RecordingPublisher(), tick = 1,
+        )
+
+        val (next, _) = assertNotNull(result.getOrNull())
+        assertEquals(1, next.inventoryOf(agent).quantityOf(stone))
+    }
+
+    @Test
+    fun `equipped items count toward the mine carry cap`() {
+        val tightBalance = balance(
+            spawns = mapOf(Terrain.MOUNTAIN to listOf(rule(stone, 1.0, 50..200))),
+            staminaCost = 5,
+            carryGramsPerStrengthPoint = 100,
+        )
+        val skinnyAgents = StubAgentRegistry(strength = 1)
+        val heavyHelmet = EquipmentInstance(
+            instanceId = UUID.randomUUID(),
+            agentId = agent,
+            itemId = ItemId("HEAVY_HELMET"),
+            rarity = Rarity.COMMON,
+            durabilityCurrent = 100,
+            durabilityMax = 100,
+            creatorAgentId = null,
+            createdAtTick = 0L,
+            equippedInSlot = EquipSlot.HELMET,
+        )
+        val itemsWithHelmet = StubItemLookup(
+            mapOf(
+                stone to itemFor(stone, gatheringSkill = "MINING", regenerating = false),
+                clay to itemFor(clay, gatheringSkill = "MINING", regenerating = true),
+                wood to itemFor(wood, gatheringSkill = "LUMBERJACKING", regenerating = true),
+                ItemId("HEAVY_HELMET") to Item(
+                    id = ItemId("HEAVY_HELMET"),
+                    displayName = "Heavy Helmet",
+                    description = "",
+                    category = ItemCategory.RESOURCE,
+                    weightPerUnit = 200,
+                    maxStack = 1,
+                ),
+            ),
+        )
+        val helmetEquipped = StubEquipmentStore(equipped = mapOf(EquipSlot.HELMET to heavyHelmet))
+        val store = StubResourceStore(initial = mapOf(stone to 50))
+
+        val result = reduceMine(
+            state = stateWith(),
+            WorldCommand.MineResource(agent, stone), tightBalance, itemsWithHelmet, store,
+            StubSkillsRegistry(), skinnyAgents, helmetEquipped, RecordingPublisher(), tick = 1,
+        )
+
+        assertEquals(
+            WorldRejection.OverEncumbered(agent, requested = 300, capacity = 100),
+            result.leftOrNull(),
+        )
     }
 
     // ─────────────────────── Skill XP / recommendation paths ───────────────────────
@@ -279,7 +392,7 @@ class MineReducerTest {
 
         reduceMine(
             state, WorldCommand.MineResource(agent, stone), balance, items,
-            store, skills, publisher, tick = 7,
+            store, skills, agents, equipment, publisher, tick = 7,
         )
 
         assertEquals(1, skills.xpAddCalls.size)
@@ -302,7 +415,7 @@ class MineReducerTest {
 
         reduceMine(
             state, WorldCommand.MineResource(agent, stone), balance, items,
-            store, skills, publisher, tick = 7,
+            store, skills, agents, equipment, publisher, tick = 7,
         )
 
         val milestoneEvents = publisher.events.filterIsInstance<WorldEvent.SkillMilestoneReached>()
@@ -325,7 +438,7 @@ class MineReducerTest {
 
         reduceMine(
             state, WorldCommand.MineResource(agent, stone), balance, items,
-            store, skills, publisher, tick = 7,
+            store, skills, agents, equipment, publisher, tick = 7,
         )
 
         val recs = publisher.events.filterIsInstance<WorldEvent.SkillRecommended>()
@@ -344,7 +457,7 @@ class MineReducerTest {
 
         reduceMine(
             state, WorldCommand.MineResource(agent, stone), balance, items,
-            store, skills, publisher, tick = 7,
+            store, skills, agents, equipment, publisher, tick = 7,
         )
 
         assertTrue(publisher.events.none { it is WorldEvent.SkillRecommended })
@@ -360,6 +473,7 @@ class MineReducerTest {
         spawns: Map<Terrain, List<ResourceSpawnRule>>,
         staminaCost: Int,
         yield: Int = 1,
+        carryGramsPerStrengthPoint: Int = 5_000,
     ) = object : BalanceLookup {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
         override fun staminaRegenPerTick(climate: Climate) = 0
@@ -374,6 +488,7 @@ class MineReducerTest {
         override fun drinkThirstRefill(): Int = 25
         override fun sleepRegenPerOfflineTick(): Int = 0
         override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun carryGramsPerStrengthPoint(): Int = carryGramsPerStrengthPoint
     }
 
     private fun itemFor(
@@ -486,5 +601,36 @@ class MineReducerTest {
         override fun publishEvent(event: Any) {
             events += event
         }
+    }
+
+    private inner class StubAgentRegistry(private val strength: Int) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = if (id == agent) {
+            Agent(
+                id = id,
+                owner = PlayerId(UUID.randomUUID()),
+                name = "test",
+                apiToken = "tok",
+                attributes = AgentAttributes(strength = strength),
+            )
+        } else {
+            null
+        }
+
+        override fun findByToken(token: String): Agent? = error("not used in this test")
+        override fun listForOwner(owner: PlayerId): List<Agent> = error("not used in this test")
+    }
+
+    private class StubEquipmentStore(
+        private val equipped: Map<EquipSlot, EquipmentInstance> = emptyMap(),
+    ) : EquipmentInstanceStore {
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> = equipped
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = error("not used")
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? =
+            error("not used")
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = error("not used")
+        override fun delete(instanceId: UUID): Boolean = error("not used")
     }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/mine/MineReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/mine/MineReducerTest.kt
@@ -285,7 +285,6 @@ class MineReducerTest {
 
     @Test
     fun `rejects when adding the mined yield would exceed the carry cap`() {
-        // Strength 1 × 100 g/pt = 100 g cap. Pre-load inventory with 5 stone (5 × 100 g).
         val state = stateWith().copy(
             inventories = mapOf(
                 agent to dev.gvart.genesara.world.internal.inventory.AgentInventory.EMPTY.add(stone, 5),
@@ -308,7 +307,6 @@ class MineReducerTest {
             WorldRejection.OverEncumbered(agent, requested = 600, capacity = 100),
             result.leftOrNull(),
         )
-        // Side-effect check: the rejected mine must not decrement the cell.
         assertEquals(50, store.quantity(stone))
     }
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -88,7 +88,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 7)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopSafeNodeGateway, NoopSafeNodeResolver)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver)
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -109,7 +109,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, ghostId), appliesAtTick = 1)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopSafeNodeGateway, NoopSafeNodeResolver)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver)
 
         handler.onTick(Tick(1, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -140,7 +140,7 @@ class WorldTickHandlerTest {
             override fun sleepRegenPerOfflineTick(): Int = 0
             override fun isTraversable(terrain: Terrain): Boolean = true
         }
-        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopSafeNodeGateway, NoopSafeNodeResolver)
+        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver)
 
         handler.onTick(Tick(2, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -156,7 +156,7 @@ class WorldTickHandlerTest {
         val queue = CommandQueue()
         val publisher = RecordingPublisher()
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 99)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopSafeNodeGateway, NoopSafeNodeResolver)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver)
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -227,6 +227,32 @@ class WorldTickHandlerTest {
         override fun listForOwner(owner: dev.gvart.genesara.account.PlayerId): List<dev.gvart.genesara.player.Agent> = emptyList()
         // Inherits the default-throwing applyDeathPenalty; tests that need it
         // would substitute their own.
+    }
+
+    /**
+     * Equipment-store stand-in for tick tests that don't exercise gather/mine. Reducers
+     * outside the inventory-add path never call into this; the gather / mine paths in
+     * this test would only land via NoopResourceStore returning availability=null first,
+     * which makes the cell-not-found rejection fire before equipment lookup.
+     */
+    private object NoopEquipmentStore : dev.gvart.genesara.world.EquipmentInstanceStore {
+        override fun equippedFor(agentId: AgentId): Map<dev.gvart.genesara.world.EquipSlot, dev.gvart.genesara.world.EquipmentInstance> =
+            emptyMap()
+        override fun insert(instance: dev.gvart.genesara.world.EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): dev.gvart.genesara.world.EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<dev.gvart.genesara.world.EquipmentInstance> = error("not used")
+        override fun assignToSlot(
+            instanceId: UUID,
+            agentId: AgentId,
+            slot: dev.gvart.genesara.world.EquipSlot,
+        ): dev.gvart.genesara.world.EquipmentInstance? = error("not used")
+        override fun clearSlot(
+            agentId: AgentId,
+            slot: dev.gvart.genesara.world.EquipSlot,
+        ): dev.gvart.genesara.world.EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): dev.gvart.genesara.world.EquipmentInstance? =
+            error("not used")
+        override fun delete(instanceId: UUID): Boolean = error("not used")
     }
 
     private object NoopSafeNodeGateway : dev.gvart.genesara.world.AgentSafeNodeGateway {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -229,12 +229,6 @@ class WorldTickHandlerTest {
         // would substitute their own.
     }
 
-    /**
-     * Equipment-store stand-in for tick tests that don't exercise gather/mine. Reducers
-     * outside the inventory-add path never call into this; the gather / mine paths in
-     * this test would only land via NoopResourceStore returning availability=null first,
-     * which makes the cell-not-found rejection fire before equipment lookup.
-     */
     private object NoopEquipmentStore : dev.gvart.genesara.world.EquipmentInstanceStore {
         override fun equippedFor(agentId: AgentId): Map<dev.gvart.genesara.world.EquipSlot, dev.gvart.genesara.world.EquipmentInstance> =
             emptyMap()


### PR DESCRIPTION
Closes #3 (the **Strength-driven carry-weight cap** sub-item; the stackable inventory bullet was already shipped).

## Summary

- New `WorldRejection.OverEncumbered(agent, requested, capacity)` so a rejected gather/mine surfaces both the would-be total and the cap — agent can see the gap without round-tripping inventory + catalog.
- New `BalanceLookup.carryGramsPerStrengthPoint()` constant; production value **5 kg per Strength point** (`floor(strength × 5_000)` per spec §8). Tunable via `WorldDefinitionBalanceLookup`.
- New helper module `world/.../internal/inventory/CarryCap.kt` (`totalGrams`, `equippedGrams`, `enforceCarryCap`). Long-widened math + `Int.MAX_VALUE`-clamped rejection payload so a permissive stub or misconfigured catalog can't silently overflow Int and bypass the cap.
- Wired into `reduceGather` and `reduceMine`. Ordering: cap check fires **before** `resources.decrement` and skill XP — a rejected action leaves zero side-effect (asserted in tests).
- `AgentRegistry` + `EquipmentInstanceStore` threaded through the `WorldReducer` dispatcher and `WorldTickHandler` so future call sites (consume-pickup, craft-output, equip) can reuse the same helper without further plumbing.

## Behaviour

- 1 STR, 5 kg cap by default. With WOOD = 800 g a starter agent can carry ~6 woods before the gate fires — tight enough to drive Strength investment, not crippling.
- Equipped items count toward the cap (per spec §8). Stowed and equipped weighted equally (out-of-scope per the issue).
- Pre-emptive rejection on every add path keeps agents below the cap at all times, so the spec's "stamina drops to zero over the cap" branch is unreachable in v1.

## Out of scope (per issue)

- `Item.maxStack` enforcement — separate TODO already in `GatherReducer`.
- Equipped-vs-stowed weight differential — assume equal in v1.
- Future `consume-pickup` / `craft-output` / `equip` reducer call sites — helper is reusable; those slices wire it when they land.

## Known follow-up

- `CarryCap.kt` carries a `TODO(carry-weight)` for unequipped `EquipmentInstance` rows (`equippedInSlot = null`). Not reachable today (no flow produces unequipped instances), but the equip / craft / loot slices will need to count that tail.

## Test plan

- [x] `./gradlew :world:test` — **295 passing** (was 293), 0 failures.
- [x] Full project compile (`./gradlew compileKotlin compileTestKotlin`) — green across all modules.
- [x] 9 new helper unit tests in `CarryCapTest`: empty / multi-stack / missing-catalog tolerance; exact-cap acceptance; one-gram-over rejection; strength-zero edges; Int-overflow guard; permissive-multiplier clamp.
- [x] 3 new reducer tests on each of `GatherReducerTest` + `MineReducerTest`: over-cap rejection (with cell-stays-full assertion); exactly-at-cap acceptance; equipped-weight-counts.
- [ ] Manual smoke via MCP — deferred to integration after PR review (no DB-touching code paths in this slice).

## Reviewer-applied fixes

A pre-merge review pass surfaced two real issues that landed in the diff:

1. **Int overflow in `enforceCarryCap`'s `currentGrams + additionalGrams`** — widened both sides to Long, clamped rejection payload at `Int.MAX_VALUE`. Covered by a new test.
2. **`UnknownAgent` rejection in the reducers was unreachable but inconsistent** — switched to an `error(...)` invariant violation, matching the existing `bodyOf` pattern in the same reducer (the agent is already positioned, so a missing registry row is corruption, not user error).