### PR TITLE
feat(world): very-high survival buff tier on stamina regen

### DIFF
--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -44,6 +44,12 @@ internal interface BalanceLookup {
      */
     fun gaugeLowThreshold(gauge: Gauge): Int
 
+    /** At-or-above this value the gauge is "very high" — earning the buff tier. */
+    fun gaugeBuffThreshold(gauge: Gauge): Int = 0
+
+    /** Stamina regen multiplier when both hunger and thirst meet [gaugeBuffThreshold]. */
+    fun staminaRegenBuffMultiplier(): Double = 1.0
+
     /**
      * HP damage per tick when any survival gauge has hit zero. Single value applied
      * once per tick (not per starving gauge) — agents starve out, but linearly.
@@ -137,6 +143,10 @@ internal class WorldDefinitionBalanceLookup(
 
     override fun gaugeLowThreshold(gauge: Gauge): Int = GAUGE_LOW_THRESHOLD
 
+    override fun gaugeBuffThreshold(gauge: Gauge): Int = GAUGE_BUFF_THRESHOLD
+
+    override fun staminaRegenBuffMultiplier(): Double = STAMINA_REGEN_BUFF_MULTIPLIER
+
     override fun starvationDamagePerTick(): Int = STARVATION_DAMAGE_PER_TICK
 
     override fun isWaterSource(terrain: Terrain): Boolean =
@@ -162,6 +172,8 @@ internal class WorldDefinitionBalanceLookup(
         const val BASE_GATHER_YIELD = 1
         const val GAUGE_DRAIN_PER_TICK = 1
         const val GAUGE_LOW_THRESHOLD = 25
+        const val GAUGE_BUFF_THRESHOLD = 75
+        const val STAMINA_REGEN_BUFF_MULTIPLIER = 1.5
         const val STARVATION_DAMAGE_PER_TICK = 1
         const val DRINK_STAMINA_COST = 1
         const val DRINK_THIRST_REFILL = 25

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/body/AgentBody.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/body/AgentBody.kt
@@ -54,6 +54,10 @@ internal data class AgentBody(
     fun isVitalsLow(lowThreshold: (Gauge) -> Int): Boolean =
         Gauge.entries.any { gauge -> valueOf(gauge) <= lowThreshold(gauge) }
 
+    /** Hunger AND thirst at-or-above the buff threshold. Sleep excluded — its high-end is offline regen, not a stamina buff. */
+    fun isVitalsHigh(buffThreshold: (Gauge) -> Int): Boolean =
+        hunger >= buffThreshold(Gauge.HUNGER) && thirst >= buffThreshold(Gauge.THIRST)
+
     /** True if any survival gauge has hit zero — body is starving and takes damage. */
     fun isStarving(): Boolean = hunger == 0 || thirst == 0 || sleep == 0
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/passive/Passives.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/passive/Passives.kt
@@ -6,15 +6,17 @@ import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.worldstate.WorldState
+import kotlin.math.roundToInt
 
 internal fun interface Passive {
     fun deltasFor(state: WorldState, balance: BalanceLookup): Map<AgentId, BodyDelta>
 }
 
 /**
- * Stamina regen gated on survival vitals: an agent whose hunger / thirst / sleep is at
- * or below its per-gauge low threshold doesn't recover. HP / Mana regen will read the
- * same per-gauge gate when those passives ship.
+ * Stamina regen gated on survival vitals: any gauge at-or-below its low threshold
+ * suppresses regen entirely; both hunger and thirst at-or-above the buff threshold
+ * multiply it. The low-gate runs first so halt and buff stay mutually exclusive. HP /
+ * Mana regen will read the same gates when those passives ship.
  */
 internal val staminaRegenPassive = Passive { state, balance ->
     state.bodies.mapNotNull { (id, body) ->
@@ -23,7 +25,12 @@ internal val staminaRegenPassive = Passive { state, balance ->
         val node = state.nodes[nodeId] ?: return@mapNotNull null
         val region = state.regions[node.regionId] ?: return@mapNotNull null
         val climate = region.climate ?: return@mapNotNull null
-        val regen = balance.staminaRegenPerTick(climate)
+        val baseRegen = balance.staminaRegenPerTick(climate)
+        val regen = if (body.isVitalsHigh(balance::gaugeBuffThreshold)) {
+            (baseRegen * balance.staminaRegenBuffMultiplier()).roundToInt()
+        } else {
+            baseRegen
+        }
         if (regen == 0) null else id to BodyDelta(stamina = regen)
     }.toMap()
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/passive/SurvivalPassivesTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/passive/SurvivalPassivesTest.kt
@@ -59,6 +59,8 @@ class SurvivalPassivesTest {
         regen: Int = 1,
         drain: Int = 1,
         threshold: Int = 25,
+        buffThreshold: Int = 75,
+        buffMultiplier: Double = 1.0,
         starvationDamage: Int = 2,
         sleepRegen: Int = 0,
     ) = object : BalanceLookup {
@@ -69,6 +71,8 @@ class SurvivalPassivesTest {
         override fun gatherYield(item: ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: Gauge): Int = drain
         override fun gaugeLowThreshold(gauge: Gauge): Int = threshold
+        override fun gaugeBuffThreshold(gauge: Gauge): Int = buffThreshold
+        override fun staminaRegenBuffMultiplier(): Double = buffMultiplier
         override fun starvationDamagePerTick(): Int = starvationDamage
         override fun isWaterSource(terrain: Terrain): Boolean = false
         override fun drinkStaminaCost(): Int = 1
@@ -119,5 +123,72 @@ class SurvivalPassivesTest {
         val nextBody = next.bodies[agent]!!
         assertEquals(31, nextBody.stamina)  // regen applied
         assertEquals(79, nextBody.hunger)   // drain applied
+    }
+
+    @Test
+    fun `stamina regen is multiplied when hunger and thirst are at or above the buff threshold`() {
+        val wellFed = body(stamina = 30, hunger = 80, thirst = 80, sleep = 50)
+        val (next, _) = applyPassives(
+            stateWith(wellFed),
+            balance(regen = 2, buffThreshold = 75, buffMultiplier = 1.5),
+            tick = 1,
+        )
+
+        assertEquals(33, next.bodies[agent]!!.stamina)
+    }
+
+    @Test
+    fun `stamina regen is unbuffed when only one of hunger or thirst meets the buff threshold`() {
+        val partial = body(stamina = 30, hunger = 80, thirst = 74, sleep = 80)
+        val (next, _) = applyPassives(
+            stateWith(partial),
+            balance(regen = 2, buffThreshold = 75, buffMultiplier = 1.5),
+            tick = 1,
+        )
+
+        assertEquals(32, next.bodies[agent]!!.stamina)
+    }
+
+    @Test
+    fun `buff fires at exactly the buff threshold and not one below`() {
+        val atThreshold = body(stamina = 30, hunger = 75, thirst = 75, sleep = 80)
+        val (atNext, _) = applyPassives(
+            stateWith(atThreshold),
+            balance(regen = 2, buffThreshold = 75, buffMultiplier = 1.5),
+            tick = 1,
+        )
+        assertEquals(33, atNext.bodies[agent]!!.stamina)
+
+        val belowOnOne = body(stamina = 30, hunger = 75, thirst = 74, sleep = 80)
+        val (belowNext, _) = applyPassives(
+            stateWith(belowOnOne),
+            balance(regen = 2, buffThreshold = 75, buffMultiplier = 1.5),
+            tick = 1,
+        )
+        assertEquals(32, belowNext.bodies[agent]!!.stamina)
+    }
+
+    @Test
+    fun `low-gate halt wins over buff when sleep is low while hunger and thirst are buffed`() {
+        val tired = body(stamina = 30, hunger = 80, thirst = 80, sleep = 20)
+        val (next, _) = applyPassives(
+            stateWith(tired),
+            balance(regen = 2, buffThreshold = 75, buffMultiplier = 1.5),
+            tick = 1,
+        )
+
+        assertEquals(30, next.bodies[agent]!!.stamina)
+    }
+
+    @Test
+    fun `buffed regen rounds half-away-from-zero`() {
+        val wellFed = body(stamina = 30, hunger = 80, thirst = 80, sleep = 80)
+        val (next, _) = applyPassives(
+            stateWith(wellFed),
+            balance(regen = 3, buffThreshold = 75, buffMultiplier = 1.5),
+            tick = 1,
+        )
+
+        assertEquals(35, next.bodies[agent]!!.stamina)
     }
 }


### PR DESCRIPTION
## Summary

Closes the spec §6 gap by adding the very-high buff tier on hunger / thirst. When both gauges sit at-or-above the per-gauge buff threshold, stamina regen is multiplied. The existing low-halt gate runs first so halt and buff stay mutually exclusive. Sleep is excluded from the buff predicate — spec §6 reserves sleep's high-end for offline regen, not a stamina buff.

- `BalanceLookup.gaugeBuffThreshold(gauge)` and `staminaRegenBuffMultiplier()` (interface defaults `0` and `1.0` keep all sibling stubs intact).
- `WorldDefinitionBalanceLookup`: `GAUGE_BUFF_THRESHOLD = 75`, `STAMINA_REGEN_BUFF_MULTIPLIER = 1.5`.
- `AgentBody.isVitalsHigh(buffThreshold)` — hunger AND thirst above threshold.
- `staminaRegenPassive`: `roundToInt(baseRegen * multiplier)` when buffed.

## Test plan

- [x] `./gradlew :world:test --tests "*SurvivalPassivesTest*"` — 9/9 (4 existing + 5 new: buff fires, partial gauge, exact threshold boundary, low-gate priority over buff, rounding policy).
- [x] `./gradlew :world:test` — 297 tests, all green.
- [x] `./gradlew test` — full project, all green.

Closes #4