### PR TITLE
feat(api): agent management endpoints + Redis activity tracker

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/presence/AgentActivityFlusher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/presence/AgentActivityFlusher.kt
@@ -1,0 +1,21 @@
+package dev.gvart.genesara.api.internal.mcp.presence
+
+import dev.gvart.genesara.player.AgentLastActiveStore
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+internal class AgentActivityFlusher(
+    private val source: ActivitySnapshotSource,
+    private val tracker: AgentActivityTracker,
+    private val store: AgentLastActiveStore,
+) {
+
+    @Scheduled(fixedDelayString = "\${application.presence.flush-interval}")
+    fun flush() {
+        val snapshot = source.snapshot()
+        if (snapshot.isEmpty()) return
+        store.saveLastActive(snapshot)
+        snapshot.keys.forEach(tracker::forget)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/presence/AgentActivityRegistry.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/presence/AgentActivityRegistry.kt
@@ -1,29 +1,27 @@
 package dev.gvart.genesara.api.internal.mcp.presence
 
 import dev.gvart.genesara.player.AgentId
-import org.springframework.stereotype.Component
 import java.time.Clock
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 
-/**
- * Tracks per-agent activity for presence/auto-unspawn. An agent is "active" while it has called
- * any MCP tool within the configured presence window. The presence reaper drives auto-unspawn
- * off this signal.
- */
-@Component
-internal class AgentActivityRegistry(private val clock: Clock) {
+internal class AgentActivityRegistry(private val clock: Clock) : AgentActivityTracker {
 
     private val lastSeen = ConcurrentHashMap<AgentId, Instant>()
 
-    fun touch(agent: AgentId) {
+    override fun touch(agent: AgentId) {
         lastSeen[agent] = clock.instant()
     }
 
-    fun staleAgents(olderThan: Instant): List<AgentId> =
+    override fun staleAgents(olderThan: Instant): List<AgentId> =
         lastSeen.entries.filter { it.value.isBefore(olderThan) }.map { it.key }
 
-    fun forget(agent: AgentId) {
+    override fun lastActiveAt(agent: AgentId): Instant? = lastSeen[agent]
+
+    override fun lastActiveBatch(ids: Collection<AgentId>): Map<AgentId, Instant> =
+        ids.mapNotNull { id -> lastSeen[id]?.let { id to it } }.toMap()
+
+    override fun forget(agent: AgentId) {
         lastSeen.remove(agent)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/presence/AgentActivityTracker.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/presence/AgentActivityTracker.kt
@@ -1,0 +1,16 @@
+package dev.gvart.genesara.api.internal.mcp.presence
+
+import dev.gvart.genesara.player.AgentId
+import java.time.Instant
+
+internal interface AgentActivityTracker {
+    fun touch(agent: AgentId)
+    fun staleAgents(olderThan: Instant): List<AgentId>
+    fun lastActiveAt(agent: AgentId): Instant?
+    fun lastActiveBatch(ids: Collection<AgentId>): Map<AgentId, Instant>
+    fun forget(agent: AgentId)
+}
+
+internal fun interface ActivitySnapshotSource {
+    fun snapshot(): Map<AgentId, Instant>
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/presence/PresenceProperties.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/presence/PresenceProperties.kt
@@ -7,4 +7,5 @@ import java.time.Duration
 internal data class PresenceProperties(
     val timeout: Duration = Duration.ofMinutes(30),
     val reaperInterval: Duration = Duration.ofMinutes(1),
+    val flushInterval: Duration = Duration.ofSeconds(60),
 )

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/presence/PresenceReaper.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/presence/PresenceReaper.kt
@@ -9,13 +9,9 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import java.time.Clock
 
-/**
- * Submits an UnspawnAgent command for any agent whose last tool activity falls outside the
- * configured presence window. Runs at `application.presence.reaper-interval`.
- */
 @Component
 internal class PresenceReaper(
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
     private val gateway: WorldCommandGateway,
     private val engine: TickClock,
     private val query: WorldQueryGateway,

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/presence/RedisAgentActivityTracker.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/presence/RedisAgentActivityTracker.kt
@@ -1,0 +1,73 @@
+package dev.gvart.genesara.api.internal.mcp.presence
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentLastActiveStore
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.Instant
+import java.util.UUID
+
+@Component
+internal class RedisAgentActivityTracker(
+    private val redis: StringRedisTemplate,
+    private val store: AgentLastActiveStore,
+    private val clock: Clock,
+) : AgentActivityTracker, ActivitySnapshotSource {
+
+    override fun touch(agent: AgentId) {
+        redis.opsForHash<String, String>().put(KEY, agent.id.toString(), clock.instant().toEpochMilli().toString())
+    }
+
+    override fun staleAgents(olderThan: Instant): List<AgentId> {
+        val all = redis.opsForHash<String, String>().entries(KEY)
+        if (all.isEmpty()) return emptyList()
+        val cutoff = olderThan.toEpochMilli()
+        return all.entries
+            .mapNotNull { (id, millis) ->
+                val ts = millis.toLongOrNull() ?: return@mapNotNull null
+                if (ts < cutoff) parseAgentId(id) else null
+            }
+    }
+
+    override fun lastActiveAt(agent: AgentId): Instant? {
+        val redisValue = redis.opsForHash<String, String>().get(KEY, agent.id.toString())
+        if (redisValue != null) return Instant.ofEpochMilli(redisValue.toLong())
+        return store.findLastActive(agent)
+    }
+
+    override fun lastActiveBatch(ids: Collection<AgentId>): Map<AgentId, Instant> {
+        if (ids.isEmpty()) return emptyMap()
+        val keys = ids.map { it.id.toString() }
+        val redisValues = redis.opsForHash<String, String>().multiGet(KEY, keys)
+        val fromRedis = ids.zip(redisValues)
+            .mapNotNull { (id, raw) -> raw?.toLongOrNull()?.let { id to Instant.ofEpochMilli(it) } }
+            .toMap()
+        val missing = ids.filter { it !in fromRedis.keys }
+        if (missing.isEmpty()) return fromRedis
+        return fromRedis + store.findLastActiveBatch(missing)
+    }
+
+    override fun forget(agent: AgentId) {
+        redis.opsForHash<String, String>().delete(KEY, agent.id.toString())
+    }
+
+    override fun snapshot(): Map<AgentId, Instant> {
+        val all = redis.opsForHash<String, String>().entries(KEY)
+        if (all.isEmpty()) return emptyMap()
+        return all.entries.mapNotNull { (id, millis) ->
+            val ts = millis.toLongOrNull() ?: return@mapNotNull null
+            parseAgentId(id)?.let { it to Instant.ofEpochMilli(ts) }
+        }.toMap()
+    }
+
+    private fun parseAgentId(raw: String): AgentId? = try {
+        AgentId(UUID.fromString(raw))
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+
+    private companion object {
+        const val KEY = "agents:last_active"
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/presence/ToolActivityBinding.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/presence/ToolActivityBinding.kt
@@ -4,14 +4,7 @@ import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.mcp.McpToolUtils
 
-/**
- * Marks the calling agent as recently active. Called at the top of every MCP tool method
- * so the presence reaper can distinguish "in the world" from "idle past timeout".
- *
- * The [toolContext] argument is also a hint that the call came in via MCP (rather than a REST
- * mirror); we don't currently use the exchange but reading it here documents the intent.
- */
-internal fun touchActivity(toolContext: ToolContext, activity: AgentActivityRegistry) {
+internal fun touchActivity(toolContext: ToolContext, activity: AgentActivityTracker) {
     McpToolUtils.getMcpExchange(toolContext)
     activity.touch(AgentContextHolder.current())
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/consume/ConsumeTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/consume/ConsumeTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.consume
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.world.ItemId
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component
 internal class ConsumeTool(
     private val world: WorldCommandGateway,
     private val engine: TickClock,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/drink/DrinkTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/drink/DrinkTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.drink
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.world.WorldCommandGateway
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component
 internal class DrinkTool(
     private val world: WorldCommandGateway,
     private val engine: TickClock,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.equipment
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.world.EquipRejection
 import dev.gvart.genesara.world.EquipResult
@@ -15,7 +15,7 @@ import java.util.UUID
 @Component
 internal class EquipItemTool(
     private val equipment: EquipmentService,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/GetEquipmentTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/GetEquipmentTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.equipment
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.world.EquipmentInstance
 import dev.gvart.genesara.world.EquipmentInstanceStore
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component
 @Component
 internal class GetEquipmentTool(
     private val store: EquipmentInstanceStore,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.equipment
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.world.EquipSlot
 import dev.gvart.genesara.world.EquipmentService
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component
 @Component
 internal class UnequipSlotTool(
     private val equipment: EquipmentService,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/gather/GatherTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/gather/GatherTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.gather
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.world.ItemId
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component
 internal class GatherTool(
     private val world: WorldCommandGateway,
     private val engine: TickClock,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getmap/GetMapTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getmap/GetMapTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.getmap
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.world.AgentMapMemoryGateway
 import org.springframework.ai.chat.model.ToolContext
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component
 @Component
 internal class GetMapTool(
     private val mapMemory: AgentMapMemoryGateway,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.getstatus
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentRegistry
@@ -15,7 +15,7 @@ internal class GetStatusTool(
     private val agents: AgentRegistry,
     private val world: WorldQueryGateway,
     private val engine: TickClock,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.inspect
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.Agent
@@ -24,7 +24,7 @@ internal class InspectTool(
     private val agents: AgentRegistry,
     private val classes: ClassPropertiesLookup,
     private val items: ItemLookup,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
     private val tick: TickClock,
 ) {
 

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inventory/GetInventoryTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inventory/GetInventoryTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.inventory
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.ItemLookup
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component
 internal class GetInventoryTool(
     private val world: WorldQueryGateway,
     private val items: ItemLookup,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.lookaround
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentId
@@ -23,7 +23,7 @@ internal class LookAroundTool(
     private val world: WorldQueryGateway,
     private val agents: AgentRegistry,
     private val classes: ClassPropertiesLookup,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
     private val tick: TickClock,
     private val mapMemory: AgentMapMemoryGateway,
 ) {

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/mine/MineTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/mine/MineTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.mine
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.world.ItemId
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component
 internal class MineTool(
     private val world: WorldCommandGateway,
     private val engine: TickClock,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/move/MoveTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/move/MoveTool.kt
@@ -1,6 +1,6 @@
 package dev.gvart.genesara.api.internal.mcp.tools.move
 
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component
 internal class MoveTool(
     private val world: WorldCommandGateway,
     private val engine: TickClock,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
     @Tool(name = "move", description = "Move agent to the given adjacent node")
     fun invoke(req: MoveRequest, toolContext: ToolContext): MoveResponse {

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/respawn/RespawnTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/respawn/RespawnTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.respawn
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.world.WorldCommandGateway
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component
 internal class RespawnTool(
     private val world: WorldCommandGateway,
     private val engine: TickClock,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/safenode/SetSafeNodeTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/safenode/SetSafeNodeTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.safenode
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.world.WorldCommandGateway
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component
 internal class SetSafeNodeTool(
     private val world: WorldCommandGateway,
     private val engine: TickClock,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/skills/EquipSkillTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/skills/EquipSkillTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.skills
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.SkillId
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component
 internal class EquipSkillTool(
     private val skills: AgentSkillsRegistry,
     private val catalog: SkillLookup,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/skills/GetSkillsTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/skills/GetSkillsTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.skills
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.SkillLookup
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component
 internal class GetSkillsTool(
     private val skills: AgentSkillsRegistry,
     private val catalog: SkillLookup,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/spawn/SpawnTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/spawn/SpawnTool.kt
@@ -1,7 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.spawn
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentRegistry
@@ -18,7 +18,7 @@ internal class SpawnTool(
     private val query: WorldQueryGateway,
     private val agents: AgentRegistry,
     private val engine: TickClock,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/unspawn/UnspawnTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/unspawn/UnspawnTool.kt
@@ -1,6 +1,6 @@
 package dev.gvart.genesara.api.internal.mcp.tools.unspawn
 
-import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component
 internal class UnspawnTool(
     private val world: WorldCommandGateway,
     private val engine: TickClock,
-    private val activity: AgentActivityRegistry,
+    private val activity: AgentActivityTracker,
 ) {
 
     @Tool(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/AgentManagementController.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/AgentManagementController.kt
@@ -1,0 +1,64 @@
+package dev.gvart.genesara.api.internal.rest
+
+import dev.gvart.genesara.account.Player
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.world.WorldAgentPurger
+import dev.gvart.genesara.world.WorldQueryGateway
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/agents")
+internal class AgentManagementController(
+    private val agents: AgentRegistry,
+    private val world: WorldQueryGateway,
+    private val activity: AgentActivityTracker,
+    private val purger: WorldAgentPurger,
+) {
+
+    @GetMapping
+    fun list(@AuthenticationPrincipal player: Player): List<AgentSummary> {
+        val owned = agents.listForOwner(player.id)
+        if (owned.isEmpty()) return emptyList()
+        val lastActive = activity.lastActiveBatch(owned.map { it.id })
+        return owned.map { agent ->
+            projectAgentSummary(
+                agent = agent,
+                body = world.bodyOf(agent.id),
+                location = world.locationOf(agent.id),
+                activeNode = world.activePositionOf(agent.id),
+                lastActiveAt = lastActive[agent.id],
+            )
+        }
+    }
+
+    @DeleteMapping("/{agentId}")
+    fun delete(
+        @AuthenticationPrincipal player: Player,
+        @PathVariable agentId: UUID,
+    ): ResponseEntity<Void> {
+        val target = agents.find(AgentId(agentId))
+        if (target == null || target.owner != player.id) {
+            throw ResponseStatusException(HttpStatus.NOT_FOUND, "Agent not found")
+        }
+        // Order matters: drop the agents row first so any concurrent tick reducer that drains a
+        // queued command for this agent sees no character state and short-circuits. Purger second
+        // cleans world-side rows (no FK back to agents); activity.forget last clears the Redis hot
+        // entry. A failure between steps leaves orphan world rows or a stale Redis entry — both
+        // tolerable; the sweep eventually wins.
+        agents.delete(target.id)
+        purger.purge(target.id)
+        activity.forget(target.id)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/AgentSummaryProjection.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/AgentSummaryProjection.kt
@@ -1,0 +1,62 @@
+package dev.gvart.genesara.api.internal.rest
+
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.world.BodyView
+import dev.gvart.genesara.world.NodeId
+import java.time.Instant
+import java.util.UUID
+
+internal data class AgentSummary(
+    val agentId: UUID,
+    val name: String,
+    val classId: String?,
+    val race: String,
+    val level: Int,
+    val xpCurrent: Int,
+    val xpToNext: Int,
+    val gauges: Gauges?,
+    val locationNodeId: Long?,
+    val spawned: Boolean,
+    val lastActiveAt: Instant?,
+) {
+
+    data class Gauges(
+        val hp: Pool,
+        val stamina: Pool,
+        val mana: Pool,
+        val hunger: Pool,
+        val thirst: Pool,
+        val sleep: Pool,
+    )
+
+    data class Pool(val current: Int, val max: Int)
+}
+
+internal fun projectAgentSummary(
+    agent: Agent,
+    body: BodyView?,
+    location: NodeId?,
+    activeNode: NodeId?,
+    lastActiveAt: Instant?,
+): AgentSummary = AgentSummary(
+    agentId = agent.id.id,
+    name = agent.name,
+    classId = agent.classId?.name,
+    race = agent.race.value,
+    level = agent.level,
+    xpCurrent = agent.xpCurrent,
+    xpToNext = agent.xpToNext,
+    gauges = body?.let {
+        AgentSummary.Gauges(
+            hp = AgentSummary.Pool(it.hp, it.maxHp),
+            stamina = AgentSummary.Pool(it.stamina, it.maxStamina),
+            mana = AgentSummary.Pool(it.mana, it.maxMana),
+            hunger = AgentSummary.Pool(it.hunger, it.maxHunger),
+            thirst = AgentSummary.Pool(it.thirst, it.maxThirst),
+            sleep = AgentSummary.Pool(it.sleep, it.maxSleep),
+        )
+    },
+    locationNodeId = location?.value,
+    spawned = activeNode != null,
+    lastActiveAt = lastActiveAt,
+)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/PlayerSelfController.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/PlayerSelfController.kt
@@ -1,0 +1,26 @@
+package dev.gvart.genesara.api.internal.rest
+
+import dev.gvart.genesara.account.Player
+import dev.gvart.genesara.account.PlayerApiTokenStore
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/me")
+internal class PlayerSelfController(
+    private val tokens: PlayerApiTokenStore,
+) {
+
+    data class ApiTokenResponse(val apiToken: String)
+
+    @GetMapping("/api-token")
+    fun getApiToken(@AuthenticationPrincipal player: Player): ApiTokenResponse =
+        ApiTokenResponse(player.apiToken)
+
+    @PostMapping("/api-token/rotate")
+    fun rotate(@AuthenticationPrincipal player: Player): ApiTokenResponse =
+        ApiTokenResponse(tokens.rotate(player.id))
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/presence/AgentActivityFlusherTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/presence/AgentActivityFlusherTest.kt
@@ -1,0 +1,63 @@
+package dev.gvart.genesara.api.internal.mcp.presence
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentLastActiveStore
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AgentActivityFlusherTest {
+
+    private val now = Instant.parse("2026-05-02T12:00:00Z")
+    private val agentA = AgentId(UUID.randomUUID())
+    private val agentB = AgentId(UUID.randomUUID())
+
+    @Test
+    fun `flush copies snapshot to store and drains the tracker for those keys`() {
+        val store = RecordingStore()
+        val tracker = TrackingTracker()
+        val source = ActivitySnapshotSource { mapOf(agentA to now, agentB to now.minusSeconds(30)) }
+        val flusher = AgentActivityFlusher(source, tracker, store)
+
+        flusher.flush()
+
+        assertEquals(1, store.calls.size)
+        assertEquals(now, store.calls.single()[agentA])
+        assertEquals(now.minusSeconds(30), store.calls.single()[agentB])
+        assertEquals(setOf(agentA, agentB), tracker.forgotten.toSet())
+    }
+
+    @Test
+    fun `flush is a no-op when the snapshot is empty`() {
+        val store = RecordingStore()
+        val tracker = TrackingTracker()
+        val flusher = AgentActivityFlusher(ActivitySnapshotSource { emptyMap() }, tracker, store)
+
+        flusher.flush()
+
+        assertTrue(store.calls.isEmpty())
+        assertTrue(tracker.forgotten.isEmpty())
+    }
+
+    private class RecordingStore : AgentLastActiveStore {
+        val calls = mutableListOf<Map<AgentId, Instant>>()
+        override fun findLastActive(agentId: AgentId): Instant? = null
+        override fun findLastActiveBatch(ids: Collection<AgentId>): Map<AgentId, Instant> = emptyMap()
+        override fun saveLastActive(updates: Map<AgentId, Instant>) {
+            calls += updates
+        }
+    }
+
+    private class TrackingTracker : AgentActivityTracker {
+        val forgotten = mutableListOf<AgentId>()
+        override fun touch(agent: AgentId) {}
+        override fun staleAgents(olderThan: Instant): List<AgentId> = emptyList()
+        override fun lastActiveAt(agent: AgentId): Instant? = null
+        override fun lastActiveBatch(ids: Collection<AgentId>): Map<AgentId, Instant> = emptyMap()
+        override fun forget(agent: AgentId) {
+            forgotten += agent
+        }
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/presence/RedisAgentActivityTrackerIntegrationTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/presence/RedisAgentActivityTrackerIntegrationTest.kt
@@ -1,0 +1,132 @@
+package dev.gvart.genesara.api.internal.mcp.presence
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentLastActiveStore
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@Testcontainers
+class RedisAgentActivityTrackerIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val redis: GenericContainer<*> =
+            GenericContainer(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379)
+    }
+
+    private lateinit var template: StringRedisTemplate
+    private lateinit var connectionFactory: LettuceConnectionFactory
+
+    private val now = Instant.parse("2026-05-02T12:00:00Z")
+    private val clock = Clock.fixed(now, ZoneOffset.UTC)
+
+    private val agentA = AgentId(UUID.randomUUID())
+    private val agentB = AgentId(UUID.randomUUID())
+    private val agentC = AgentId(UUID.randomUUID())
+
+    private val coldStore = StubLastActiveStore(
+        mapOf(agentC to now.minusSeconds(3600)),
+    )
+
+    private lateinit var tracker: RedisAgentActivityTracker
+
+    @BeforeEach
+    fun setUp() {
+        connectionFactory = LettuceConnectionFactory(redis.host, redis.firstMappedPort).apply {
+            afterPropertiesSet()
+        }
+        template = StringRedisTemplate(connectionFactory)
+        template.connectionFactory!!.connection.serverCommands().flushDb()
+        tracker = RedisAgentActivityTracker(template, coldStore, clock)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        connectionFactory.destroy()
+    }
+
+    @Test
+    fun `touch then lastActiveAt round-trips through Redis`() {
+        tracker.touch(agentA)
+
+        assertEquals(now, tracker.lastActiveAt(agentA))
+    }
+
+    @Test
+    fun `lastActiveAt falls back to the cold store when Redis has no entry`() {
+        val coldTime = now.minusSeconds(3600)
+
+        assertEquals(coldTime, tracker.lastActiveAt(agentC))
+        assertNull(tracker.lastActiveAt(agentB))
+    }
+
+    @Test
+    fun `lastActiveBatch combines hot Redis entries with cold-store fallbacks`() {
+        tracker.touch(agentA)
+
+        val result = tracker.lastActiveBatch(listOf(agentA, agentB, agentC))
+
+        assertEquals(now, result[agentA])
+        assertEquals(null, result[agentB])
+        assertEquals(now.minusSeconds(3600), result[agentC])
+    }
+
+    @Test
+    fun `staleAgents returns only entries older than the cutoff`() {
+        val staleClockTracker = RedisAgentActivityTracker(
+            template,
+            coldStore,
+            Clock.fixed(now.minusSeconds(120), ZoneOffset.UTC),
+        )
+        staleClockTracker.touch(agentA)
+        tracker.touch(agentB)
+
+        val cutoff = now.minusSeconds(60)
+        val stale = tracker.staleAgents(cutoff)
+
+        assertEquals(listOf(agentA), stale)
+    }
+
+    @Test
+    fun `forget removes the entry from Redis but does not touch the cold store`() {
+        tracker.touch(agentA)
+        tracker.forget(agentA)
+
+        assertNull(tracker.lastActiveAt(agentA))
+    }
+
+    @Test
+    fun `snapshot returns every Redis entry mapped back to AgentId and Instant`() {
+        tracker.touch(agentA)
+        tracker.touch(agentB)
+
+        val snap = tracker.snapshot()
+
+        assertTrue(agentA in snap)
+        assertTrue(agentB in snap)
+        assertEquals(now, snap[agentA])
+        assertEquals(now, snap[agentB])
+    }
+
+    private class StubLastActiveStore(private val rows: Map<AgentId, Instant>) : AgentLastActiveStore {
+        override fun findLastActive(agentId: AgentId): Instant? = rows[agentId]
+        override fun findLastActiveBatch(ids: Collection<AgentId>): Map<AgentId, Instant> =
+            rows.filterKeys { it in ids }
+        override fun saveLastActive(updates: Map<AgentId, Instant>) = error("not used")
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/AgentManagementControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/AgentManagementControllerTest.kt
@@ -1,0 +1,207 @@
+package dev.gvart.genesara.api.internal.rest
+
+import dev.gvart.genesara.account.Player
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.world.BodyView
+import dev.gvart.genesara.world.InventoryView
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NodeResources
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.WorldAgentPurger
+import dev.gvart.genesara.world.WorldQueryGateway
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AgentManagementControllerTest {
+
+    private val player = Player(
+        id = PlayerId(UUID.randomUUID()),
+        username = "alice",
+        apiToken = "plr_token",
+    )
+    private val activeAgent = Agent(id = AgentId(UUID.randomUUID()), owner = player.id, name = "Spawned", level = 3)
+    private val idleAgent = Agent(id = AgentId(UUID.randomUUID()), owner = player.id, name = "Despawned", level = 1)
+
+    private val body = BodyView(
+        hp = 50, maxHp = 100,
+        stamina = 50, maxStamina = 100,
+        mana = 0, maxMana = 0,
+        hunger = 100, maxHunger = 100,
+        thirst = 100, maxThirst = 100,
+        sleep = 100, maxSleep = 100,
+    )
+
+    @Test
+    fun `list returns one summary per owned agent with live body for spawned and last-location for despawned`() {
+        val registry = StubRegistry(player.id, listOf(activeAgent, idleAgent))
+        val world = StubWorld(
+            bodies = mapOf(activeAgent.id to body),
+            locations = mapOf(activeAgent.id to NodeId(11L), idleAgent.id to NodeId(7L)),
+            activePositions = mapOf(activeAgent.id to NodeId(11L)),
+        )
+        val activity = StubActivity(mapOf(activeAgent.id to Instant.parse("2026-05-02T12:00:00Z")))
+        val controller = AgentManagementController(registry, world, activity, NoopPurger)
+
+        val out = controller.list(player)
+
+        assertEquals(2, out.size)
+        val active = assertNotNull(out.firstOrNull { it.agentId == activeAgent.id.id })
+        val idle = assertNotNull(out.firstOrNull { it.agentId == idleAgent.id.id })
+        assertNotNull(active.gauges)
+        assertEquals(11L, active.locationNodeId)
+        assertTrue(active.spawned)
+        assertNotNull(active.lastActiveAt)
+
+        assertNull(idle.gauges)
+        assertEquals(7L, idle.locationNodeId)
+        assertFalse(idle.spawned)
+        assertNull(idle.lastActiveAt)
+    }
+
+    @Test
+    fun `list returns empty when the player owns no agents and skips the activity batch call`() {
+        val registry = StubRegistry(player.id, emptyList())
+        val activity = SpyActivity()
+        val controller = AgentManagementController(registry, StubWorld(), activity, NoopPurger)
+
+        val out = controller.list(player)
+
+        assertTrue(out.isEmpty())
+        assertEquals(0, activity.batchCalls)
+    }
+
+    @Test
+    fun `delete purges world rows, forgets activity, deletes the agent row`() {
+        val registry = TrackingRegistry(player.id, mutableMapOf(activeAgent.id to activeAgent))
+        val purger = RecordingPurger()
+        val activity = TrackingActivity()
+        val controller = AgentManagementController(registry, StubWorld(), activity, purger)
+
+        val response = controller.delete(player, activeAgent.id.id)
+
+        assertEquals(HttpStatus.NO_CONTENT, response.statusCode)
+        assertEquals(listOf(activeAgent.id), purger.purged)
+        assertEquals(listOf(activeAgent.id), activity.forgotten)
+        assertEquals(listOf(activeAgent.id), registry.deleted)
+    }
+
+    @Test
+    fun `delete returns 404 when the agent does not exist`() {
+        val registry = TrackingRegistry(player.id, mutableMapOf())
+        val controller = AgentManagementController(registry, StubWorld(), TrackingActivity(), RecordingPurger())
+
+        val ex = assertThrows<ResponseStatusException> { controller.delete(player, UUID.randomUUID()) }
+
+        assertEquals(HttpStatus.NOT_FOUND, ex.statusCode)
+    }
+
+    @Test
+    fun `delete returns 404 when the agent belongs to another player so existence is not leaked`() {
+        val foreign = Agent(id = AgentId(UUID.randomUUID()), owner = PlayerId(UUID.randomUUID()), name = "Theirs")
+        val registry = TrackingRegistry(player.id, mutableMapOf(foreign.id to foreign))
+        val purger = RecordingPurger()
+        val controller = AgentManagementController(registry, StubWorld(), TrackingActivity(), purger)
+
+        val ex = assertThrows<ResponseStatusException> { controller.delete(player, foreign.id.id) }
+
+        assertEquals(HttpStatus.NOT_FOUND, ex.statusCode)
+        assertTrue(purger.purged.isEmpty())
+    }
+
+    private class StubRegistry(
+        private val owner: PlayerId,
+        private val agents: List<Agent>,
+    ) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = agents.firstOrNull { it.id == id }
+        override fun listForOwner(o: PlayerId): List<Agent> = if (o == owner) agents else emptyList()
+    }
+
+    private class TrackingRegistry(
+        private val owner: PlayerId,
+        private val rows: MutableMap<AgentId, Agent>,
+    ) : AgentRegistry {
+        val deleted = mutableListOf<AgentId>()
+        override fun find(id: AgentId): Agent? = rows[id]
+        override fun listForOwner(o: PlayerId): List<Agent> = rows.values.filter { it.owner == o }
+        override fun delete(agentId: AgentId): Boolean {
+            deleted += agentId
+            return rows.remove(agentId) != null
+        }
+    }
+
+    private class StubWorld(
+        private val bodies: Map<AgentId, BodyView> = emptyMap(),
+        private val locations: Map<AgentId, NodeId> = emptyMap(),
+        private val activePositions: Map<AgentId, NodeId> = emptyMap(),
+    ) : WorldQueryGateway {
+        override fun locationOf(agent: AgentId): NodeId? = locations[agent]
+        override fun activePositionOf(agent: AgentId): NodeId? = activePositions[agent]
+        override fun bodyOf(agent: AgentId): BodyView? = bodies[agent]
+        override fun node(id: NodeId): Node? = null
+        override fun region(id: RegionId): Region? = null
+        override fun nodesWithin(origin: NodeId, radius: Int): Set<NodeId> = emptySet()
+        override fun randomSpawnableNode(): NodeId? = null
+        override fun starterNodeFor(race: RaceId): NodeId? = null
+        override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
+        override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
+    }
+
+    private class StubActivity(private val rows: Map<AgentId, Instant>) : AgentActivityTracker {
+        override fun touch(agent: AgentId) {}
+        override fun staleAgents(olderThan: Instant): List<AgentId> = emptyList()
+        override fun lastActiveAt(agent: AgentId): Instant? = rows[agent]
+        override fun lastActiveBatch(ids: Collection<AgentId>): Map<AgentId, Instant> =
+            rows.filterKeys { it in ids }
+        override fun forget(agent: AgentId) {}
+    }
+
+    private class SpyActivity : AgentActivityTracker {
+        var batchCalls = 0
+        override fun touch(agent: AgentId) {}
+        override fun staleAgents(olderThan: Instant): List<AgentId> = emptyList()
+        override fun lastActiveAt(agent: AgentId): Instant? = null
+        override fun lastActiveBatch(ids: Collection<AgentId>): Map<AgentId, Instant> {
+            batchCalls++
+            return emptyMap()
+        }
+        override fun forget(agent: AgentId) {}
+    }
+
+    private class TrackingActivity : AgentActivityTracker {
+        val forgotten = mutableListOf<AgentId>()
+        override fun touch(agent: AgentId) {}
+        override fun staleAgents(olderThan: Instant): List<AgentId> = emptyList()
+        override fun lastActiveAt(agent: AgentId): Instant? = null
+        override fun lastActiveBatch(ids: Collection<AgentId>): Map<AgentId, Instant> = emptyMap()
+        override fun forget(agent: AgentId) {
+            forgotten += agent
+        }
+    }
+
+    private object NoopPurger : WorldAgentPurger {
+        override fun purge(agent: AgentId) {}
+    }
+
+    private class RecordingPurger : WorldAgentPurger {
+        val purged = mutableListOf<AgentId>()
+        override fun purge(agent: AgentId) {
+            purged += agent
+        }
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/AgentSummaryProjectionTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/AgentSummaryProjectionTest.kt
@@ -1,0 +1,110 @@
+package dev.gvart.genesara.api.internal.rest
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.world.BodyView
+import dev.gvart.genesara.world.NodeId
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AgentSummaryProjectionTest {
+
+    private val agent = Agent(
+        id = AgentId(UUID.randomUUID()),
+        owner = PlayerId(UUID.randomUUID()),
+        name = "Komar",
+        classId = AgentClass.SCOUT,
+        race = RaceId("human_steppe"),
+        level = 4,
+        xpCurrent = 30,
+        xpToNext = 400,
+    )
+
+    private val body = BodyView(
+        hp = 80, maxHp = 100,
+        stamina = 60, maxStamina = 100,
+        mana = 0, maxMana = 0,
+        hunger = 50, maxHunger = 100,
+        thirst = 50, maxThirst = 100,
+        sleep = 50, maxSleep = 100,
+    )
+
+    @Test
+    fun `spawned agent populates gauges, location, and spawned flag`() {
+        val node = NodeId(42L)
+
+        val summary = projectAgentSummary(
+            agent = agent,
+            body = body,
+            location = node,
+            activeNode = node,
+            lastActiveAt = Instant.parse("2026-05-02T12:00:00Z"),
+        )
+
+        assertEquals(agent.id.id, summary.agentId)
+        assertEquals("Komar", summary.name)
+        assertEquals("SCOUT", summary.classId)
+        assertEquals(4, summary.level)
+        val gauges = assertNotNull(summary.gauges)
+        assertEquals(80, gauges.hp.current)
+        assertEquals(100, gauges.hp.max)
+        assertEquals(42L, summary.locationNodeId)
+        assertTrue(summary.spawned)
+    }
+
+    @Test
+    fun `despawned agent shows last-known location with spawned=false`() {
+        val node = NodeId(7L)
+
+        val summary = projectAgentSummary(
+            agent = agent,
+            body = body,
+            location = node,
+            activeNode = null,
+            lastActiveAt = null,
+        )
+
+        assertEquals(7L, summary.locationNodeId)
+        assertFalse(summary.spawned)
+        assertNull(summary.lastActiveAt)
+    }
+
+    @Test
+    fun `agent that has never spawned has null gauges, null location, spawned=false`() {
+        val summary = projectAgentSummary(
+            agent = agent,
+            body = null,
+            location = null,
+            activeNode = null,
+            lastActiveAt = null,
+        )
+
+        assertNull(summary.gauges)
+        assertNull(summary.locationNodeId)
+        assertFalse(summary.spawned)
+    }
+
+    @Test
+    fun `classId null when the agent has not been assigned a class`() {
+        val unclassed = agent.copy(classId = null)
+
+        val summary = projectAgentSummary(
+            agent = unclassed,
+            body = null,
+            location = null,
+            activeNode = null,
+            lastActiveAt = null,
+        )
+
+        assertNull(summary.classId)
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/PlayerSelfControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/PlayerSelfControllerTest.kt
@@ -1,0 +1,43 @@
+package dev.gvart.genesara.api.internal.rest
+
+import dev.gvart.genesara.account.Player
+import dev.gvart.genesara.account.PlayerApiTokenStore
+import dev.gvart.genesara.account.PlayerId
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class PlayerSelfControllerTest {
+
+    private val player = Player(
+        id = PlayerId(UUID.randomUUID()),
+        username = "alice",
+        apiToken = "plr_old",
+    )
+
+    @Test
+    fun `getApiToken returns the principal's current token`() {
+        val controller = PlayerSelfController(NoopTokenStore)
+
+        val response = controller.getApiToken(player)
+
+        assertEquals("plr_old", response.apiToken)
+    }
+
+    @Test
+    fun `rotate delegates to the store and returns the freshly minted token`() {
+        val controller = PlayerSelfController(StubTokenStore("plr_new"))
+
+        val response = controller.rotate(player)
+
+        assertEquals("plr_new", response.apiToken)
+    }
+
+    private object NoopTokenStore : PlayerApiTokenStore {
+        override fun rotate(playerId: PlayerId): String = error("not used")
+    }
+
+    private class StubTokenStore(private val next: String) : PlayerApiTokenStore {
+        override fun rotate(playerId: PlayerId): String = next
+    }
+}

--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -43,6 +43,7 @@ application:
   presence:
     timeout: PT30M
     reaper-interval: PT1M
+    flush-interval: PT60S
   events:
     backlog-cap: 500
     ttl: PT1H

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentLastActiveStore.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentLastActiveStore.kt
@@ -1,0 +1,9 @@
+package dev.gvart.genesara.player
+
+import java.time.Instant
+
+interface AgentLastActiveStore {
+    fun findLastActive(agentId: AgentId): Instant?
+    fun findLastActiveBatch(ids: Collection<AgentId>): Map<AgentId, Instant>
+    fun saveLastActive(updates: Map<AgentId, Instant>)
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
@@ -6,6 +6,9 @@ interface AgentRegistry {
     fun find(id: AgentId): Agent?
     fun listForOwner(owner: PlayerId): List<Agent>
 
+    /** Hard-deletes the agent row. CASCADE clears player-side rows (profile, skills). Returns true if a row was removed. */
+    fun delete(agentId: AgentId): Boolean = throw NotImplementedError("delete not implemented for this AgentRegistry")
+
     /**
      * Apply the canonical death penalty atomically.
      *

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
@@ -5,6 +5,7 @@ import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentLastActiveStore
 import dev.gvart.genesara.player.AgentProfile
 import dev.gvart.genesara.player.AgentProfileRepository
 import dev.gvart.genesara.player.AgentRegistrar
@@ -21,6 +22,8 @@ import org.jooq.DSLContext
 import org.jooq.TableField
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.ZoneOffset
 import java.util.UUID
 
 @Component
@@ -28,7 +31,7 @@ internal class JooqAgentRegistry(
     private val dsl: DSLContext,
     private val profiles: AgentProfileRepository,
     private val raceAssigner: RaceAssigner,
-) : AgentRegistry, AgentRegistrar {
+) : AgentRegistry, AgentRegistrar, AgentLastActiveStore {
 
     override fun find(id: AgentId): Agent? =
         dsl.selectFrom(AGENTS)
@@ -41,6 +44,39 @@ internal class JooqAgentRegistry(
             .where(AGENTS.OWNER_ID.eq(owner.id))
             .orderBy(AGENTS.CREATED_AT.asc())
             .fetch { it.toAgent() }
+
+    @Transactional
+    override fun delete(agentId: AgentId): Boolean =
+        dsl.deleteFrom(AGENTS).where(AGENTS.ID.eq(agentId.id)).execute() > 0
+
+    override fun findLastActive(agentId: AgentId): Instant? =
+        dsl.select(AGENTS.LAST_ACTIVE_AT)
+            .from(AGENTS)
+            .where(AGENTS.ID.eq(agentId.id))
+            .fetchOne()
+            ?.get(AGENTS.LAST_ACTIVE_AT)
+            ?.toInstant()
+
+    override fun findLastActiveBatch(ids: Collection<AgentId>): Map<AgentId, Instant> {
+        if (ids.isEmpty()) return emptyMap()
+        return dsl.select(AGENTS.ID, AGENTS.LAST_ACTIVE_AT)
+            .from(AGENTS)
+            .where(AGENTS.ID.`in`(ids.map { it.id }))
+            .and(AGENTS.LAST_ACTIVE_AT.isNotNull)
+            .fetch()
+            .associate { AgentId(it[AGENTS.ID]!!) to it[AGENTS.LAST_ACTIVE_AT]!!.toInstant() }
+    }
+
+    @Transactional
+    override fun saveLastActive(updates: Map<AgentId, Instant>) {
+        if (updates.isEmpty()) return
+        val batch = updates.map { (id, instant) ->
+            dsl.update(AGENTS)
+                .set(AGENTS.LAST_ACTIVE_AT, instant.atOffset(ZoneOffset.UTC))
+                .where(AGENTS.ID.eq(id.id))
+        }
+        dsl.batch(batch).execute()
+    }
 
     @Transactional
     override fun register(owner: PlayerId, name: String): Agent {

--- a/player/src/main/resources/db/migration/player/V204__agents_last_active.sql
+++ b/player/src/main/resources/db/migration/player/V204__agents_last_active.sql
@@ -1,0 +1,2 @@
+ALTER TABLE agents
+    ADD COLUMN last_active_at TIMESTAMPTZ;

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryLastActiveIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryLastActiveIntegrationTest.kt
@@ -1,0 +1,161 @@
+package dev.gvart.genesara.player.internal.store
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AgentProfile
+import dev.gvart.genesara.player.AgentProfileRepository
+import dev.gvart.genesara.player.AttributeMods
+import dev.gvart.genesara.player.Race
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.player.RaceLookup
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENTS
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENT_PROFILES
+import dev.gvart.genesara.player.internal.race.RaceAssigner
+import dev.gvart.genesara.player.internal.race.RaceDefinitionProperties
+import dev.gvart.genesara.player.internal.race.RandomSource
+import dev.gvart.genesara.player.internal.testsupport.PlayerFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@Testcontainers
+class JooqAgentRegistryLastActiveIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("last_active_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = PlayerFlyway.pooledDataSource(postgres)
+            PlayerFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private val owner = PlayerId(UUID.randomUUID())
+
+    @BeforeEach
+    fun resetTables() {
+        dsl.truncate(AGENT_PROFILES).cascade().execute()
+        dsl.truncate(AGENTS).cascade().execute()
+    }
+
+    @Test
+    fun `findLastActive returns null for an agent that has never been touched`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Newcomer")
+
+        assertNull(registry.findLastActive(agent.id))
+    }
+
+    @Test
+    fun `saveLastActive then findLastActive round-trips an Instant rounded to microseconds`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Active")
+        val ts = Instant.parse("2026-05-02T12:34:56.123456Z")
+
+        registry.saveLastActive(mapOf(agent.id to ts))
+
+        assertEquals(ts, registry.findLastActive(agent.id))
+    }
+
+    @Test
+    fun `saveLastActive overwrites the prior value`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Updated")
+        val older = Instant.parse("2026-05-02T10:00:00Z")
+        val newer = Instant.parse("2026-05-02T11:00:00Z")
+
+        registry.saveLastActive(mapOf(agent.id to older))
+        registry.saveLastActive(mapOf(agent.id to newer))
+
+        assertEquals(newer, registry.findLastActive(agent.id))
+    }
+
+    @Test
+    fun `findLastActiveBatch only returns agents with a non-null last_active_at`() {
+        val registry = registry()
+        val active = registry.register(owner, "Touched")
+        val never = registry.register(owner, "Quiet")
+        val ts = Instant.parse("2026-05-02T12:00:00Z")
+        registry.saveLastActive(mapOf(active.id to ts))
+
+        val batch = registry.findLastActiveBatch(listOf(active.id, never.id))
+
+        assertEquals(mapOf(active.id to ts), batch)
+    }
+
+    @Test
+    fun `saveLastActive on an empty map is a no-op`() {
+        val registry = registry()
+
+        registry.saveLastActive(emptyMap())
+    }
+
+    @Test
+    fun `findLastActiveBatch on an empty input is an empty result with no DB call`() {
+        val registry = registry()
+
+        assertEquals(emptyMap(), registry.findLastActiveBatch(emptyList()))
+    }
+
+    private fun registry(): JooqAgentRegistry {
+        val race = Race(
+            id = RaceId("test_race"),
+            displayName = "Test",
+            weight = 1,
+            attributeMods = AttributeMods.NONE,
+            description = "",
+        )
+        val lookup = SingleRaceLookup(race)
+        val props = RaceDefinitionProperties(defaultId = race.id.value)
+        val assigner = RaceAssigner(lookup, props, FixedRandom)
+        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner)
+    }
+
+    private class SingleRaceLookup(private val race: Race) : RaceLookup {
+        override fun byId(id: RaceId): Race? = if (id == race.id) race else null
+        override fun all(): List<Race> = listOf(race)
+    }
+
+    private object FixedRandom : RandomSource {
+        override fun nextInt(boundExclusive: Int): Int = 0
+    }
+
+    private class JooqProfileRepository(private val dsl: DSLContext) : AgentProfileRepository {
+        override fun save(profile: AgentProfile) {
+            dsl.insertInto(AGENT_PROFILES)
+                .set(AGENT_PROFILES.AGENT_ID, profile.id.id)
+                .set(AGENT_PROFILES.MAX_HP, profile.maxHp)
+                .set(AGENT_PROFILES.MAX_STAMINA, profile.maxStamina)
+                .set(AGENT_PROFILES.MAX_MANA, profile.maxMana)
+                .execute()
+        }
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldAgentPurger.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldAgentPurger.kt
@@ -1,0 +1,12 @@
+package dev.gvart.genesara.world
+
+import dev.gvart.genesara.player.AgentId
+
+/**
+ * Synchronously removes every world-side row keyed by [AgentId]. Called by the player-management
+ * REST surface when an agent is being permanently deleted. World tables intentionally lack an FK
+ * back to `agents` (cross-module), so deletion needs an explicit purge rather than a CASCADE.
+ */
+interface WorldAgentPurger {
+    fun purge(agent: AgentId)
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/worldstate/JooqWorldAgentPurger.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/worldstate/JooqWorldAgentPurger.kt
@@ -1,0 +1,29 @@
+package dev.gvart.genesara.world.internal.worldstate
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.WorldAgentPurger
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_BODIES
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_EQUIPMENT_INSTANCES
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_INVENTORY
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_NODE_MEMORY
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_POSITIONS
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_SAFE_NODES
+import org.jooq.DSLContext
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+internal class JooqWorldAgentPurger(
+    private val dsl: DSLContext,
+) : WorldAgentPurger {
+
+    @Transactional
+    override fun purge(agent: AgentId) {
+        dsl.deleteFrom(AGENT_EQUIPMENT_INSTANCES).where(AGENT_EQUIPMENT_INSTANCES.AGENT_ID.eq(agent.id)).execute()
+        dsl.deleteFrom(AGENT_INVENTORY).where(AGENT_INVENTORY.AGENT_ID.eq(agent.id)).execute()
+        dsl.deleteFrom(AGENT_NODE_MEMORY).where(AGENT_NODE_MEMORY.AGENT_ID.eq(agent.id)).execute()
+        dsl.deleteFrom(AGENT_SAFE_NODES).where(AGENT_SAFE_NODES.AGENT_ID.eq(agent.id)).execute()
+        dsl.deleteFrom(AGENT_BODIES).where(AGENT_BODIES.AGENT_ID.eq(agent.id)).execute()
+        dsl.deleteFrom(AGENT_POSITIONS).where(AGENT_POSITIONS.AGENT_ID.eq(agent.id)).execute()
+    }
+}


### PR DESCRIPTION
## Summary

Builds on #44 (player JWT) to deliver the rest of the agent-management surface:

- `GET /api/agents` lists every agent the JWT-authenticated player owns, with live gauges, location, spawned flag, and last-active timestamp.
- `DELETE /api/agents/{id}` removes an agent (404 on missing/foreign — no existence oracle).
- `GET/POST /api/me/api-token` retrieve / rotate the player's MCP credential.
- Activity tracking moves from in-memory to **Redis** with periodic flush to `agents.last_active_at`, surviving restarts and (later) multi-instance deploys.

## Why

Player JWT shipped without a way to enumerate or delete the agents a player has registered. Without `lastActiveAt` survival, the dashboard can't show "last seen 3 minutes ago" after a deploy. Both gaps blocked the dashboard work.

## What's in this PR

### Endpoints
- `AgentManagementController` (`/api/agents`):
  - `GET` — `AgentSummary` per owned agent (id, name, classId, race, level, xpCurrent/xpToNext, gauges, locationNodeId, spawned, lastActiveAt).
  - `DELETE /{agentId}` — orders matters: drop player-side row first (CASCADE clears profile + skills), then purge world-side rows, then forget the Redis hot entry. Concurrent tick reducers see no character state and short-circuit.
- `PlayerSelfController` (`/api/me`):
  - `GET /api-token` — reveal the current token.
  - `POST /api-token/rotate` — mint a fresh token via `PlayerApiTokenStore.rotate`.

### Activity tracker (Redis + DB)
- New `AgentActivityTracker` interface (`touch / staleAgents / lastActiveAt / lastActiveBatch / forget`).
- New `RedisAgentActivityTracker @Component` — hash `agents:last_active`, field=UUID, value=epoch-millis. Falls back to `agents.last_active_at` on cache miss.
- New `AgentActivityFlusher @Scheduled @Component` — drain semantics: snapshot Redis, batch-`UPDATE` DB, then `HDEL` the persisted keys. Bounds Redis hash growth.
- Existing in-memory `AgentActivityRegistry` keeps its shape for tests; loses `@Component` (Redis tracker takes the prod binding).
- All 17+ MCP tools retyped to depend on the interface.

### Persistence
- `player/V204__agents_last_active.sql` adds nullable `agents.last_active_at TIMESTAMPTZ`.
- `AgentLastActiveStore` interface in `:player`; implemented on `JooqAgentRegistry` with `findLastActive`, `findLastActiveBatch`, `saveLastActive` (jOOQ batch update).
- `AgentRegistry.delete` + `JooqAgentRegistry.delete`.

### World cleanup
- `WorldAgentPurger` interface; `JooqWorldAgentPurger @Component` deletes from every agent-keyed world table (`agent_positions`, `agent_bodies`, `agent_inventory`, `agent_node_memory`, `agent_equipment_instances`, `agent_safe_nodes`). Cross-module FKs are intentionally absent so the purger is the explicit cleanup path.

## Tests

`./gradlew test` green across all modules. Added in this PR (25 tests):
- `RedisAgentActivityTrackerIntegrationTest` (6) — Testcontainers Redis: touch / lastActiveAt / hot+cold batch / staleAgents / forget / snapshot
- `AgentActivityFlusherTest` (2) — drain semantics + empty-snapshot no-op
- `JooqAgentRegistryLastActiveIntegrationTest` (6) — Testcontainers Postgres: round-trip + overwrite + batch + empty input
- `AgentSummaryProjectionTest` (4) — spawned / despawned / never-spawned / classless
- `AgentManagementControllerTest` (5) — list + delete happy path + 404 on missing + 404 on foreign
- `PlayerSelfControllerTest` (2) — get + rotate

Pre-existing `AgentActivityRegistryTest` (4 tests) still passes — the in-memory implementation now satisfies the new interface.

## Test plan

- [ ] `./gradlew test` green in CI (Testcontainers Redis + Postgres needed)
- [ ] `GET /api/agents` with JWT returns summaries (gauges populated for spawned, null for never-spawned)
- [ ] `DELETE /api/agents/{ownAgent}` → 204; row gone from `agents`, world tables, Redis hash
- [ ] `DELETE /api/agents/{foreignAgent}` → 404 (existence not leaked)
- [ ] `GET /api/me/api-token` returns the principal's current token; `POST /api/me/api-token/rotate` invalidates the old (MCP filter rejects the previous, accepts the new)
- [ ] After tool calls, `HGET agents:last_active <agentId>` shows recent epoch; after one flush interval the value lands in `agents.last_active_at` and the Redis entry is gone

## Deferred / follow-up

Surfaced by `code-quality-reviewer`:
- Cross-module DELETE atomicity is best-effort (player row first; world orphans tolerated). Consider a tick-aligned `WorldCommand.PurgeAgent` if the orphan window becomes a real issue.
- DELETE may race with the tick reducer for in-flight commands targeting the agent. Mitigation today: agents row gone first → reducer reads no character state → short-circuit. Quiescence guarantee can land later.
- Consider a single multi-row UPSERT for `saveLastActive` once the agent population grows.
- N5–S6 + N9 nits from the prior slice's review (token hashing at rest, JWT clock skew, `iss` claim, MCP filter caching) remain open.