### PR TITLE
feat: Phase 1 Tier-1 Buildings (#9)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpResourceSubscriptionCustomizer.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpResourceSubscriptionCustomizer.kt
@@ -17,5 +17,6 @@ internal class McpResourceSubscriptionCustomizer : McpSyncServerCustomizer {
                 .resources(true, false)
                 .build(),
         )
+        serverBuilder.immediateExecution(true)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
@@ -3,6 +3,8 @@ package dev.gvart.genesara.api.internal.mcp
 import dev.gvart.genesara.api.internal.mcp.events.EventLogProperties
 import dev.gvart.genesara.api.internal.mcp.presence.PresenceProperties
 import dev.gvart.genesara.api.internal.mcp.tools.build.BuildTool
+import dev.gvart.genesara.api.internal.mcp.tools.chest.DepositToChestTool
+import dev.gvart.genesara.api.internal.mcp.tools.chest.WithdrawFromChestTool
 import dev.gvart.genesara.api.internal.mcp.tools.consume.ConsumeTool
 import dev.gvart.genesara.api.internal.mcp.tools.drink.DrinkTool
 import dev.gvart.genesara.api.internal.mcp.tools.equipment.EquipItemTool
@@ -54,13 +56,15 @@ internal class McpServerConfiguration {
         setSafeNode: SetSafeNodeTool,
         respawn: RespawnTool,
         build: BuildTool,
+        depositToChest: DepositToChestTool,
+        withdrawFromChest: WithdrawFromChestTool,
     ): ToolCallbackProvider =
         MethodToolCallbackProvider.builder()
             .toolObjects(
                 spawn, move, lookAround, unspawn, getStatus, gather, mine, getInventory,
                 consume, drink, getSkills, equipSkill, inspect, getMap,
                 equipItem, unequipSlot, getEquipment,
-                setSafeNode, respawn, build,
+                setSafeNode, respawn, build, depositToChest, withdrawFromChest,
             )
             .build()
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp
 
 import dev.gvart.genesara.api.internal.mcp.events.EventLogProperties
 import dev.gvart.genesara.api.internal.mcp.presence.PresenceProperties
+import dev.gvart.genesara.api.internal.mcp.tools.build.BuildTool
 import dev.gvart.genesara.api.internal.mcp.tools.consume.ConsumeTool
 import dev.gvart.genesara.api.internal.mcp.tools.drink.DrinkTool
 import dev.gvart.genesara.api.internal.mcp.tools.equipment.EquipItemTool
@@ -52,13 +53,14 @@ internal class McpServerConfiguration {
         getEquipment: GetEquipmentTool,
         setSafeNode: SetSafeNodeTool,
         respawn: RespawnTool,
+        build: BuildTool,
     ): ToolCallbackProvider =
         MethodToolCallbackProvider.builder()
             .toolObjects(
                 spawn, move, lookAround, unspawn, getStatus, gather, mine, getInventory,
                 consume, drink, getSkills, equipSkill, inspect, getMap,
                 equipItem, unequipSlot, getEquipment,
-                setSafeNode, respawn,
+                setSafeNode, respawn, build,
             )
             .build()
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventResourceConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventResourceConfiguration.kt
@@ -21,5 +21,15 @@ internal class AgentEventResourceConfiguration {
                 ),
                 handler::read,
             ),
+            SyncResourceTemplateSpecification(
+                ResourceTemplate(
+                    "agent://{agentId}/events?after={after}",
+                    "agent-events-after",
+                    "Per-agent event log resumed after a known sequence number.",
+                    "application/json",
+                    null,
+                ),
+                handler::read,
+            ),
         )
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/projection/VitalBand.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/projection/VitalBand.kt
@@ -1,0 +1,18 @@
+package dev.gvart.genesara.api.internal.mcp.projection
+
+/**
+ * Coarse vitals projection used by every read tool that surfaces an agent's HP / Stamina /
+ * Mana or a building's HP. Keeps the band ladder identical across `inspect` (agent vitals)
+ * and `look_around` (building HP) so a future tuning of the thresholds doesn't have to
+ * track multiple call sites.
+ *
+ * [zeroLabel] differs by domain: agent body uses "dead", building HP uses "destroyed",
+ * future status-effect surfaces may want their own term — the math is the only shared part.
+ */
+internal fun vitalBand(current: Int, max: Int, zeroLabel: String = "dead"): String = when {
+    max <= 0 -> "unknown"
+    current <= 0 -> zeroLabel
+    current * 10 < max * 3 -> "low"
+    current * 10 < max * 7 -> "mid"
+    else -> "high"
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildTool.kt
@@ -1,0 +1,44 @@
+package dev.gvart.genesara.api.internal.mcp.tools.build
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.stereotype.Component
+
+@Component
+internal class BuildTool(
+    private val world: WorldCommandGateway,
+    private val engine: TickClock,
+    private val activity: AgentActivityTracker,
+) {
+
+    @Tool(
+        name = "build",
+        description = "Spend one work step on a building type id at the agent's current node. " +
+            "First call lays the foundation; subsequent calls advance the same in-progress build until it completes. " +
+            "Queues a BuildStructure command; the resulting BuildingPlaced/Progressed/Completed event " +
+            "arrives on the agent's event stream once the tick lands. Costs per-step stamina + materials.",
+    )
+    fun invoke(req: BuildRequest, toolContext: ToolContext): BuildResponse {
+        touchActivity(toolContext, activity, "build")
+        val type = parseType(req.type)
+            ?: return BuildResponse.error(
+                req.type,
+                "Unknown building type: '${req.type}'. Valid types: ${BuildingType.entries.joinToString { it.name }}",
+            )
+        val agent = AgentContextHolder.current()
+        val command = WorldCommand.BuildStructure(agent = agent, type = type)
+        val nextTick = engine.currentTick() + 1
+        world.submit(command, appliesAtTick = nextTick)
+        return BuildResponse.queued(command.commandId, nextTick, type.name)
+    }
+
+    private fun parseType(raw: String): BuildingType? =
+        runCatching { BuildingType.valueOf(raw.trim().uppercase()) }.getOrNull()
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildTool.kt
@@ -4,7 +4,6 @@ import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
-import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.WorldCommandGateway
 import dev.gvart.genesara.world.commands.WorldCommand
 import org.springframework.ai.chat.model.ToolContext
@@ -20,25 +19,17 @@ internal class BuildTool(
 
     @Tool(
         name = "build",
-        description = "Spend one work step on a building type id at the agent's current node. " +
+        description = "Spend one work step on a building type at the agent's current node. " +
             "First call lays the foundation; subsequent calls advance the same in-progress build until it completes. " +
             "Queues a BuildStructure command; the resulting BuildingPlaced/Progressed/Completed event " +
             "arrives on the agent's event stream once the tick lands. Costs per-step stamina + materials.",
     )
     fun invoke(req: BuildRequest, toolContext: ToolContext): BuildResponse {
         touchActivity(toolContext, activity, "build")
-        val type = parseType(req.type)
-            ?: return BuildResponse.error(
-                req.type,
-                "Unknown building type: '${req.type}'. Valid types: ${BuildingType.entries.joinToString { it.name }}",
-            )
         val agent = AgentContextHolder.current()
-        val command = WorldCommand.BuildStructure(agent = agent, type = type)
+        val command = WorldCommand.BuildStructure(agent = agent, type = req.type)
         val nextTick = engine.currentTick() + 1
         world.submit(command, appliesAtTick = nextTick)
-        return BuildResponse.queued(command.commandId, nextTick, type.name)
+        return BuildResponse(commandId = command.commandId, appliesAtTick = nextTick, type = req.type)
     }
-
-    private fun parseType(raw: String): BuildingType? =
-        runCatching { BuildingType.valueOf(raw.trim().uppercase()) }.getOrNull()
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildToolIo.kt
@@ -2,10 +2,11 @@ package dev.gvart.genesara.api.internal.mcp.tools.build
 
 import com.fasterxml.jackson.annotation.JsonClassDescription
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import dev.gvart.genesara.world.BuildingType
 import java.util.UUID
 
 @JsonClassDescription(
-    "Spend one work step on a building type id at the agent's current node. The first call lays the " +
+    "Spend one work step on a building type at the agent's current node. The first call lays the " +
         "foundation (creates an UNDER_CONSTRUCTION instance and consumes the first step's " +
         "materials + stamina); subsequent calls advance an existing in-progress instance built " +
         "by this agent of this type on this node. The step that reaches the def's totalSteps " +
@@ -14,33 +15,22 @@ import java.util.UUID
 )
 data class BuildRequest(
     @JsonPropertyDescription(
-        "Building type id (e.g. CAMPFIRE, WORKBENCH, STORAGE_CHEST, SHELTER, FORGE, " +
-            "ALCHEMY_TABLE, FARM_PLOT, WELL, WOODEN_WALL, ROAD, BRIDGE).",
+        "Building type. Must be one of: CAMPFIRE, WORKBENCH, STORAGE_CHEST, SHELTER, FORGE, " +
+            "ALCHEMY_TABLE, FARM_PLOT, WELL, WOODEN_WALL, ROAD, BRIDGE.",
     )
-    val type: String,
+    val type: BuildingType,
 )
 
 /**
- * Response shape for `build`.
+ * Successful queue-and-ack response for `build`. The matching `BuildingPlaced`
+ * (first step), `BuildingProgressed` (intermediate step) or `BuildingCompleted`
+ * (final step) event arrives on the agent's event stream once the tick lands.
  *
- * - `kind = "queued"`: a BuildStructure command was queued; the result lands on `appliesAtTick`
- *   and arrives on the agent's event stream as `BuildingPlaced` (first step), `BuildingProgressed`
- *   (intermediate step) or `BuildingCompleted` (final step).
- * - `kind = "error"`: the requested type was not recognised. Reject at the boundary so a typo
- *   does not round-trip through the queue.
+ * Malformed inputs (unknown type, missing field) surface via the standard MCP
+ * tool-error path during Jackson deserialization, not as an in-band variant.
  */
 data class BuildResponse(
-    val kind: String,
-    val type: String,
-    val commandId: UUID? = null,
-    val appliesAtTick: Long? = null,
-    val error: String? = null,
-) {
-    companion object {
-        fun queued(commandId: UUID, appliesAtTick: Long, type: String) =
-            BuildResponse(kind = "queued", type = type, commandId = commandId, appliesAtTick = appliesAtTick)
-
-        fun error(type: String, message: String) =
-            BuildResponse(kind = "error", type = type, error = message)
-    }
-}
+    val commandId: UUID,
+    val appliesAtTick: Long,
+    val type: BuildingType,
+)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildToolIo.kt
@@ -1,0 +1,46 @@
+package dev.gvart.genesara.api.internal.mcp.tools.build
+
+import com.fasterxml.jackson.annotation.JsonClassDescription
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import java.util.UUID
+
+@JsonClassDescription(
+    "Spend one work step on a building type id at the agent's current node. The first call lays the " +
+        "foundation (creates an UNDER_CONSTRUCTION instance and consumes the first step's " +
+        "materials + stamina); subsequent calls advance an existing in-progress instance built " +
+        "by this agent of this type on this node. The step that reaches the def's totalSteps " +
+        "flips status to ACTIVE. Total step count and per-step cost vary per type — see " +
+        "`inspect` on an in-progress building to read its progress and remaining cost.",
+)
+data class BuildRequest(
+    @JsonPropertyDescription(
+        "Building type id (e.g. CAMPFIRE, WORKBENCH, STORAGE_CHEST, SHELTER, FORGE, " +
+            "ALCHEMY_TABLE, FARM_PLOT, WELL, WOODEN_WALL, ROAD, BRIDGE).",
+    )
+    val type: String,
+)
+
+/**
+ * Response shape for `build`.
+ *
+ * - `kind = "queued"`: a BuildStructure command was queued; the result lands on `appliesAtTick`
+ *   and arrives on the agent's event stream as `BuildingPlaced` (first step), `BuildingProgressed`
+ *   (intermediate step) or `BuildingCompleted` (final step).
+ * - `kind = "error"`: the requested type was not recognised. Reject at the boundary so a typo
+ *   does not round-trip through the queue.
+ */
+data class BuildResponse(
+    val kind: String,
+    val type: String,
+    val commandId: UUID? = null,
+    val appliesAtTick: Long? = null,
+    val error: String? = null,
+) {
+    companion object {
+        fun queued(commandId: UUID, appliesAtTick: Long, type: String) =
+            BuildResponse(kind = "queued", type = type, commandId = commandId, appliesAtTick = appliesAtTick)
+
+        fun error(type: String, message: String) =
+            BuildResponse(kind = "error", type = type, error = message)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/ChestToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/ChestToolIo.kt
@@ -11,49 +11,23 @@ import java.util.UUID
 )
 data class ChestTransferRequest(
     @JsonPropertyDescription("Building instance UUID of the target chest (from look_around / inspect).")
-    val chestId: String,
+    val chestId: UUID,
     @JsonPropertyDescription("Item id to transfer (e.g. WOOD, STONE, BERRY).")
     val itemId: String,
-    @JsonPropertyDescription("Quantity to transfer. Must be > 0.")
+    @JsonPropertyDescription("Quantity to transfer. Must be > 0; the reducer rejects 0 / negative as NonPositiveQuantity.")
     val quantity: Int,
 )
 
 /**
- * Response shape for chest transfers.
- *
- * - `kind = "queued"`: a Deposit/Withdraw command was queued; the result lands on `appliesAtTick`
- *   and arrives on the agent's event stream as `ItemDeposited` / `ItemWithdrawn`.
- * - `kind = "error"`: the request was rejected at the boundary (malformed UUID, blank item id,
- *   non-positive quantity). Reducer-level rejections (chest doesn't exist, capacity exceeded,
- *   etc.) surface via the event stream as a rejection event.
+ * Successful queue-and-ack response for chest transfers. The matching `ItemDeposited` /
+ * `ItemWithdrawn` event lands on the agent's event stream once the tick resolves; the
+ * reducer-level rejections (chest doesn't exist, capacity exceeded, etc.) surface via the
+ * event stream as a rejection event, not in-band on this response.
  */
 data class ChestTransferResponse(
-    val kind: String,
-    val chestId: String,
+    val commandId: UUID,
+    val appliesAtTick: Long,
+    val chestId: UUID,
     val itemId: String,
     val quantity: Int,
-    val commandId: UUID? = null,
-    val appliesAtTick: Long? = null,
-    val error: String? = null,
-) {
-    companion object {
-        fun queued(commandId: UUID, appliesAtTick: Long, chestId: String, itemId: String, quantity: Int) =
-            ChestTransferResponse(
-                kind = "queued",
-                chestId = chestId,
-                itemId = itemId,
-                quantity = quantity,
-                commandId = commandId,
-                appliesAtTick = appliesAtTick,
-            )
-
-        fun error(chestId: String, itemId: String, quantity: Int, message: String) =
-            ChestTransferResponse(
-                kind = "error",
-                chestId = chestId,
-                itemId = itemId,
-                quantity = quantity,
-                error = message,
-            )
-    }
-}
+)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/ChestToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/ChestToolIo.kt
@@ -1,0 +1,59 @@
+package dev.gvart.genesara.api.internal.mcp.tools.chest
+
+import com.fasterxml.jackson.annotation.JsonClassDescription
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import java.util.UUID
+
+@JsonClassDescription(
+    "Move items between the agent's inventory and a STORAGE_CHEST building owned by the agent. " +
+        "The chest must be ACTIVE and on the agent's current node. Used by both `deposit_to_chest` " +
+        "and `withdraw_from_chest`.",
+)
+data class ChestTransferRequest(
+    @JsonPropertyDescription("Building instance UUID of the target chest (from look_around / inspect).")
+    val chestId: String,
+    @JsonPropertyDescription("Item id to transfer (e.g. WOOD, STONE, BERRY).")
+    val itemId: String,
+    @JsonPropertyDescription("Quantity to transfer. Must be > 0.")
+    val quantity: Int,
+)
+
+/**
+ * Response shape for chest transfers.
+ *
+ * - `kind = "queued"`: a Deposit/Withdraw command was queued; the result lands on `appliesAtTick`
+ *   and arrives on the agent's event stream as `ItemDeposited` / `ItemWithdrawn`.
+ * - `kind = "error"`: the request was rejected at the boundary (malformed UUID, blank item id,
+ *   non-positive quantity). Reducer-level rejections (chest doesn't exist, capacity exceeded,
+ *   etc.) surface via the event stream as a rejection event.
+ */
+data class ChestTransferResponse(
+    val kind: String,
+    val chestId: String,
+    val itemId: String,
+    val quantity: Int,
+    val commandId: UUID? = null,
+    val appliesAtTick: Long? = null,
+    val error: String? = null,
+) {
+    companion object {
+        fun queued(commandId: UUID, appliesAtTick: Long, chestId: String, itemId: String, quantity: Int) =
+            ChestTransferResponse(
+                kind = "queued",
+                chestId = chestId,
+                itemId = itemId,
+                quantity = quantity,
+                commandId = commandId,
+                appliesAtTick = appliesAtTick,
+            )
+
+        fun error(chestId: String, itemId: String, quantity: Int, message: String) =
+            ChestTransferResponse(
+                kind = "error",
+                chestId = chestId,
+                itemId = itemId,
+                quantity = quantity,
+                error = message,
+            )
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/DepositToChestTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/DepositToChestTool.kt
@@ -1,0 +1,58 @@
+package dev.gvart.genesara.api.internal.mcp.tools.chest
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+internal class DepositToChestTool(
+    private val world: WorldCommandGateway,
+    private val engine: TickClock,
+    private val activity: AgentActivityTracker,
+) {
+
+    @Tool(
+        name = "deposit_to_chest",
+        description = "Deposit items from the agent's inventory into a STORAGE_CHEST. The chest must be " +
+            "ACTIVE, owned by the agent, and on the agent's current node. The deposit is rejected if it " +
+            "would push the chest above its weight cap or if the agent does not hold enough of the item.",
+    )
+    fun invoke(req: ChestTransferRequest, toolContext: ToolContext): ChestTransferResponse {
+        touchActivity(toolContext, activity, "deposit_to_chest")
+        val chest = parseChestId(req)
+            ?: return ChestTransferResponse.error(
+                req.chestId, req.itemId, req.quantity,
+                "chestId must be a UUID, got '${req.chestId}'",
+            )
+        val item = parseItemId(req)
+            ?: return ChestTransferResponse.error(
+                req.chestId, req.itemId, req.quantity,
+                "itemId must be non-blank, got '${req.itemId}'",
+            )
+        if (req.quantity <= 0) {
+            return ChestTransferResponse.error(
+                req.chestId, req.itemId, req.quantity,
+                "quantity must be > 0, got ${req.quantity}",
+            )
+        }
+        val agent = AgentContextHolder.current()
+        val command = WorldCommand.DepositToChest(agent = agent, chestId = chest, item = item, quantity = req.quantity)
+        val nextTick = engine.currentTick() + 1
+        world.submit(command, appliesAtTick = nextTick)
+        return ChestTransferResponse.queued(command.commandId, nextTick, chest.toString(), item.value, req.quantity)
+    }
+}
+
+internal fun parseChestId(req: ChestTransferRequest): UUID? =
+    runCatching { UUID.fromString(req.chestId.trim()) }.getOrNull()
+
+internal fun parseItemId(req: ChestTransferRequest): ItemId? =
+    req.itemId.trim().takeIf { it.isNotBlank() }?.let(::ItemId)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/DepositToChestTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/DepositToChestTool.kt
@@ -10,7 +10,6 @@ import dev.gvart.genesara.world.commands.WorldCommand
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.annotation.Tool
 import org.springframework.stereotype.Component
-import java.util.UUID
 
 @Component
 internal class DepositToChestTool(
@@ -27,32 +26,21 @@ internal class DepositToChestTool(
     )
     fun invoke(req: ChestTransferRequest, toolContext: ToolContext): ChestTransferResponse {
         touchActivity(toolContext, activity, "deposit_to_chest")
-        val chest = parseChestId(req)
-            ?: return ChestTransferResponse.error(
-                req.chestId, req.itemId, req.quantity,
-                "chestId must be a UUID, got '${req.chestId}'",
-            )
-        val item = parseItemId(req)
-            ?: return ChestTransferResponse.error(
-                req.chestId, req.itemId, req.quantity,
-                "itemId must be non-blank, got '${req.itemId}'",
-            )
-        if (req.quantity <= 0) {
-            return ChestTransferResponse.error(
-                req.chestId, req.itemId, req.quantity,
-                "quantity must be > 0, got ${req.quantity}",
-            )
-        }
         val agent = AgentContextHolder.current()
-        val command = WorldCommand.DepositToChest(agent = agent, chestId = chest, item = item, quantity = req.quantity)
+        val command = WorldCommand.DepositToChest(
+            agent = agent,
+            chestId = req.chestId,
+            item = ItemId(req.itemId),
+            quantity = req.quantity,
+        )
         val nextTick = engine.currentTick() + 1
         world.submit(command, appliesAtTick = nextTick)
-        return ChestTransferResponse.queued(command.commandId, nextTick, chest.toString(), item.value, req.quantity)
+        return ChestTransferResponse(
+            commandId = command.commandId,
+            appliesAtTick = nextTick,
+            chestId = req.chestId,
+            itemId = req.itemId,
+            quantity = req.quantity,
+        )
     }
 }
-
-internal fun parseChestId(req: ChestTransferRequest): UUID? =
-    runCatching { UUID.fromString(req.chestId.trim()) }.getOrNull()
-
-internal fun parseItemId(req: ChestTransferRequest): ItemId? =
-    req.itemId.trim().takeIf { it.isNotBlank() }?.let(::ItemId)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/WithdrawFromChestTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/WithdrawFromChestTool.kt
@@ -1,0 +1,50 @@
+package dev.gvart.genesara.api.internal.mcp.tools.chest
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.stereotype.Component
+
+@Component
+internal class WithdrawFromChestTool(
+    private val world: WorldCommandGateway,
+    private val engine: TickClock,
+    private val activity: AgentActivityTracker,
+) {
+
+    @Tool(
+        name = "withdraw_from_chest",
+        description = "Withdraw items from a STORAGE_CHEST back into the agent's inventory. The chest must be " +
+            "ACTIVE, owned by the agent, and on the agent's current node. Rejected if the chest holds fewer " +
+            "than the requested quantity of the item.",
+    )
+    fun invoke(req: ChestTransferRequest, toolContext: ToolContext): ChestTransferResponse {
+        touchActivity(toolContext, activity, "withdraw_from_chest")
+        val chest = parseChestId(req)
+            ?: return ChestTransferResponse.error(
+                req.chestId, req.itemId, req.quantity,
+                "chestId must be a UUID, got '${req.chestId}'",
+            )
+        val item = parseItemId(req)
+            ?: return ChestTransferResponse.error(
+                req.chestId, req.itemId, req.quantity,
+                "itemId must be non-blank, got '${req.itemId}'",
+            )
+        if (req.quantity <= 0) {
+            return ChestTransferResponse.error(
+                req.chestId, req.itemId, req.quantity,
+                "quantity must be > 0, got ${req.quantity}",
+            )
+        }
+        val agent = AgentContextHolder.current()
+        val command = WorldCommand.WithdrawFromChest(agent = agent, chestId = chest, item = item, quantity = req.quantity)
+        val nextTick = engine.currentTick() + 1
+        world.submit(command, appliesAtTick = nextTick)
+        return ChestTransferResponse.queued(command.commandId, nextTick, chest.toString(), item.value, req.quantity)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/WithdrawFromChestTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/WithdrawFromChestTool.kt
@@ -4,6 +4,7 @@ import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.WorldCommandGateway
 import dev.gvart.genesara.world.commands.WorldCommand
 import org.springframework.ai.chat.model.ToolContext
@@ -25,26 +26,21 @@ internal class WithdrawFromChestTool(
     )
     fun invoke(req: ChestTransferRequest, toolContext: ToolContext): ChestTransferResponse {
         touchActivity(toolContext, activity, "withdraw_from_chest")
-        val chest = parseChestId(req)
-            ?: return ChestTransferResponse.error(
-                req.chestId, req.itemId, req.quantity,
-                "chestId must be a UUID, got '${req.chestId}'",
-            )
-        val item = parseItemId(req)
-            ?: return ChestTransferResponse.error(
-                req.chestId, req.itemId, req.quantity,
-                "itemId must be non-blank, got '${req.itemId}'",
-            )
-        if (req.quantity <= 0) {
-            return ChestTransferResponse.error(
-                req.chestId, req.itemId, req.quantity,
-                "quantity must be > 0, got ${req.quantity}",
-            )
-        }
         val agent = AgentContextHolder.current()
-        val command = WorldCommand.WithdrawFromChest(agent = agent, chestId = chest, item = item, quantity = req.quantity)
+        val command = WorldCommand.WithdrawFromChest(
+            agent = agent,
+            chestId = req.chestId,
+            item = ItemId(req.itemId),
+            quantity = req.quantity,
+        )
         val nextTick = engine.currentTick() + 1
         world.submit(command, appliesAtTick = nextTick)
-        return ChestTransferResponse.queued(command.commandId, nextTick, chest.toString(), item.value, req.quantity)
+        return ChestTransferResponse(
+            commandId = command.commandId,
+            appliesAtTick = nextTick,
+            chestId = req.chestId,
+            itemId = req.itemId,
+            quantity = req.quantity,
+        )
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.inspect
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.api.internal.mcp.projection.vitalBand
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentId
@@ -38,8 +39,8 @@ internal class InspectTool(
 
     @Tool(
         name = "inspect",
-        description = "Inspect a single target (node, agent, or item) in detail. " +
-            "Vision-gated: nodes must be within sight, agents must be in the same node, " +
+        description = "Inspect a single target (node, agent, item, or building) in detail. " +
+            "Vision-gated: nodes and buildings must be within sight, agents must be in the same node, " +
             "items must be in the agent's own inventory. Response depth scales with Perception.",
     )
     fun invoke(req: InspectRequest, toolContext: ToolContext): InspectResponse {
@@ -58,7 +59,11 @@ internal class InspectTool(
             "node" -> inspectNode(agentId, targetId, depth)
             "agent" -> inspectAgent(agentId, targetId, depth)
             "item" -> inspectItem(agentId, targetId, depth)
-            "building" -> inspectBuilding(agentId, targetId, depth)
+            "building" -> {
+                val instanceId = runCatching { UUID.fromString(targetId) }.getOrNull()
+                    ?: return errorResponse(depth, InspectError.BAD_TARGET_ID, "building id must be a UUID")
+                inspectBuilding(agentId, instanceId, depth)
+            }
             else -> errorResponse(depth, InspectError.BAD_TARGET_TYPE, "unknown targetType: $targetType")
         }
     }
@@ -207,9 +212,7 @@ internal class InspectTool(
         )
     }
 
-    private fun inspectBuilding(agentId: AgentId, targetId: String, depth: InspectDepth): InspectResponse {
-        val instanceId = runCatching { UUID.fromString(targetId) }.getOrNull()
-            ?: return errorResponse(depth, InspectError.BAD_TARGET_ID, "building id must be a UUID")
+    private fun inspectBuilding(agentId: AgentId, instanceId: UUID, depth: InspectDepth): InspectResponse {
         val building = buildings.byId(instanceId)
             ?: return errorResponse(depth, InspectError.NOT_FOUND, "building not found")
 
@@ -243,7 +246,7 @@ internal class InspectTool(
             status = building.status.name,
             progressSteps = building.progressSteps,
             totalSteps = building.totalSteps,
-            hpBand = bandOf(building.hpCurrent, building.hpMax),
+            hpBand = vitalBand(building.hpCurrent, building.hpMax, zeroLabel = "destroyed"),
             nodeId = if (isDetailedPlus) building.nodeId.value else null,
             builderAgentId = if (isDetailedPlus) building.builtByAgentId.id.toString() else null,
             hpCurrent = if (isDetailedPlus) building.hpCurrent else null,
@@ -261,13 +264,7 @@ internal class InspectTool(
     private fun Map<ItemId, Int>.toMaterialViews(): List<BuildingMaterialView> =
         entries.map { BuildingMaterialView(itemId = it.key.value, quantity = it.value) }
 
-    private fun bandOf(current: Int, max: Int): String = when {
-        max <= 0 -> "unknown"
-        current <= 0 -> "dead"
-        current * 10 < max * 3 -> "low"
-        current * 10 < max * 7 -> "mid"
-        else -> "high"
-    }
+    private fun bandOf(current: Int, max: Int): String = vitalBand(current, max)
 
     private fun errorResponse(depth: InspectDepth, code: String, message: String): InspectResponse =
         InspectResponse(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
@@ -9,6 +9,11 @@ import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.ClassPropertiesLookup
 import dev.gvart.genesara.world.BodyView
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingDefLookup
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsLookup
+import dev.gvart.genesara.world.ChestContentsStore
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.NodeId
@@ -26,6 +31,9 @@ internal class InspectTool(
     private val items: ItemLookup,
     private val activity: AgentActivityTracker,
     private val tick: TickClock,
+    private val buildings: BuildingsLookup,
+    private val buildingDefs: BuildingDefLookup,
+    private val chestContents: ChestContentsStore,
 ) {
 
     @Tool(
@@ -50,6 +58,7 @@ internal class InspectTool(
             "node" -> inspectNode(agentId, targetId, depth)
             "agent" -> inspectAgent(agentId, targetId, depth)
             "item" -> inspectItem(agentId, targetId, depth)
+            "building" -> inspectBuilding(agentId, targetId, depth)
             else -> errorResponse(depth, InspectError.BAD_TARGET_TYPE, "unknown targetType: $targetType")
         }
     }
@@ -197,6 +206,60 @@ internal class InspectTool(
             activeEffects = activeEffects,
         )
     }
+
+    private fun inspectBuilding(agentId: AgentId, targetId: String, depth: InspectDepth): InspectResponse {
+        val instanceId = runCatching { UUID.fromString(targetId) }.getOrNull()
+            ?: return errorResponse(depth, InspectError.BAD_TARGET_ID, "building id must be a UUID")
+        val building = buildings.byId(instanceId)
+            ?: return errorResponse(depth, InspectError.NOT_FOUND, "building not found")
+
+        val currentNodeId = world.locationOf(agentId)
+            ?: return errorResponse(depth, InspectError.NOT_VISIBLE, "agent is not in the world")
+        val agent = agents.find(agentId) ?: error("Agent disappeared mid-call: $agentId")
+        if (!isNodeWithinSight(agent, currentNodeId, building.nodeId)) {
+            return errorResponse(depth, InspectError.NOT_VISIBLE, "building is outside sight range")
+        }
+
+        return InspectResponse(
+            kind = "building",
+            depth = depth.name.lowercase(),
+            building = projectBuilding(agentId, building, depth),
+        )
+    }
+
+    private fun projectBuilding(
+        agentId: AgentId,
+        building: Building,
+        depth: InspectDepth,
+    ): BuildingInspectView {
+        val def = buildingDefs.byType(building.type)
+        val isOwner = building.builtByAgentId == agentId
+        val isExpert = depth == InspectDepth.EXPERT
+        val isDetailedPlus = depth != InspectDepth.SHALLOW
+        val showChestContents = isExpert && isOwner && building.type == BuildingType.STORAGE_CHEST
+        return BuildingInspectView(
+            instanceId = building.instanceId.toString(),
+            type = building.type.name,
+            status = building.status.name,
+            progressSteps = building.progressSteps,
+            totalSteps = building.totalSteps,
+            hpBand = bandOf(building.hpCurrent, building.hpMax),
+            nodeId = if (isDetailedPlus) building.nodeId.value else null,
+            builderAgentId = if (isDetailedPlus) building.builtByAgentId.id.toString() else null,
+            hpCurrent = if (isDetailedPlus) building.hpCurrent else null,
+            hpMax = if (isDetailedPlus) building.hpMax else null,
+            lastProgressTick = if (isDetailedPlus) building.lastProgressTick else null,
+            builtAtTick = if (isExpert) building.builtAtTick else null,
+            requiredSkill = if (isExpert) def?.requiredSkill?.value else null,
+            requiredSkillLevel = if (isExpert) def?.requiredSkillLevel else null,
+            totalMaterials = if (isExpert) def?.totalMaterials?.toMaterialViews() else null,
+            stepMaterials = if (isExpert) def?.stepMaterials?.map { it.toMaterialViews() } else null,
+            chestContents = if (showChestContents) chestContents.contentsOf(building.instanceId).toMaterialViews() else null,
+        )
+    }
+
+    private fun Map<ItemId, Int>.toMaterialViews(): List<BuildingMaterialView> =
+        entries.map { BuildingMaterialView(itemId = it.key.value, quantity = it.value) }
 
     private fun bandOf(current: Int, max: Int): String = when {
         max <= 0 -> "unknown"

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
@@ -4,20 +4,20 @@ import com.fasterxml.jackson.annotation.JsonClassDescription
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
 
 @JsonClassDescription(
-    "Look at a single target (node, agent, or item) in detail. " +
-        "Visibility-gated: nodes must be within sight, agents must be in the same node, " +
+    "Look at a single target (node, agent, item, or building) in detail. " +
+        "Visibility-gated: nodes and buildings must be within sight, agents must be in the same node, " +
         "items must be in the agent's own inventory. The depth of the response scales with " +
         "the calling agent's Perception attribute (3 tiers).",
 )
 data class InspectRequest(
     @field:JsonPropertyDescription(
-        "Kind of target to inspect. Must be one of: \"node\", \"agent\", \"item\". " +
+        "Kind of target to inspect. Must be one of: \"node\", \"agent\", \"item\", \"building\". " +
             "Explicit so a numeric node id and a UUID agent id can never collide.",
     )
     val targetType: String?,
     @field:JsonPropertyDescription(
-        "Target id. For node/item this is the catalog/database id (numeric BIGINT for " +
-            "node, ItemId string for item); for agent this is the agent's UUID.",
+        "Target id. For node this is the numeric BIGINT id; for agent and building this is the UUID; " +
+            "for item this is the ItemId string.",
     )
     val targetId: String?,
 )
@@ -33,6 +33,7 @@ data class InspectResponse(
     val node: NodeInspectView? = null,
     val agent: AgentInspectView? = null,
     val item: ItemInspectView? = null,
+    val building: BuildingInspectView? = null,
     val error: InspectError? = null,
 )
 
@@ -145,3 +146,34 @@ data class ItemInspectView(
      */
     val gatheringSkill: String? = null,
 )
+
+/**
+ * Per-building inspect projection. Type, status, hp band, and progress (`progressSteps` /
+ * `totalSteps`) are always present — agents need progress to know whether to keep building.
+ * DETAILED+ adds the precise hp values, the node id, the builder agent id, and a tick-based
+ * `lastProgressTick`. EXPERT adds the per-step materials breakdown from the catalog and the
+ * required skill / level. Chest contents are EXPERT-only AND owner-only (Phase 1 personal
+ * stash).
+ */
+data class BuildingInspectView(
+    val instanceId: String,
+    val type: String,
+    val status: String,
+    val progressSteps: Int,
+    val totalSteps: Int,
+    val hpBand: String,
+    val nodeId: Long? = null,
+    val builderAgentId: String? = null,
+    val hpCurrent: Int? = null,
+    val hpMax: Int? = null,
+    val lastProgressTick: Long? = null,
+    val builtAtTick: Long? = null,
+    val requiredSkill: String? = null,
+    val requiredSkillLevel: Int? = null,
+    val totalMaterials: List<BuildingMaterialView>? = null,
+    val stepMaterials: List<List<BuildingMaterialView>>? = null,
+    /** EXPERT + owner-only: current chest contents. Null when not a chest, not owner, or below EXPERT. */
+    val chestContents: List<BuildingMaterialView>? = null,
+)
+
+data class BuildingMaterialView(val itemId: String, val quantity: Int)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.lookaround
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.api.internal.mcp.projection.vitalBand
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
@@ -147,15 +148,7 @@ private fun Building.toSummary(fogOfWar: Boolean): BuildingSummaryView =
             instanceId = instanceId.toString(),
             progressSteps = progressSteps,
             totalSteps = totalSteps,
-            hpBand = hpBandOf(hpCurrent, hpMax),
+            hpBand = vitalBand(hpCurrent, hpMax, zeroLabel = "destroyed"),
             builderAgentId = builtByAgentId.id.toString(),
         )
     }
-
-private fun hpBandOf(current: Int, max: Int): String = when {
-    max <= 0 -> "unknown"
-    current <= 0 -> "destroyed"
-    current * 10 < max * 3 -> "low"
-    current * 10 < max * 7 -> "mid"
-    else -> "high"
-}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
@@ -8,7 +8,10 @@ import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.ClassPropertiesLookup
 import dev.gvart.genesara.world.AgentMapMemoryGateway
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.NodeMemoryUpdate
 import dev.gvart.genesara.world.NodeResources
 import dev.gvart.genesara.world.Region
@@ -26,14 +29,17 @@ internal class LookAroundTool(
     private val activity: AgentActivityTracker,
     private val tick: TickClock,
     private val mapMemory: AgentMapMemoryGateway,
+    private val buildings: BuildingsLookup,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
     @Tool(
         name = "look_around",
-        description = "Return the agent's current node and visible adjacent nodes within sight range. The current node carries full resource counts; adjacent nodes carry only item ids (fog-of-war).",
+        description = "Return the agent's current node and visible adjacent nodes within sight range. " +
+            "The current node carries full resource counts and full per-building summaries; adjacent " +
+            "nodes carry only item ids and a fog-of-war building summary (type + status, no instance ids).",
     )
-    fun invoke(req: LookAroundRequest, toolContext: ToolContext): LookAroundResponse {
+    fun invoke(req: LookAroundRequest?, toolContext: ToolContext): LookAroundResponse {
         touchActivity(toolContext, activity, "look_around")
         val agentId = AgentContextHolder.current()
         val agent = agents.find(agentId) ?: error("Agent not registered: $agentId")
@@ -49,10 +55,14 @@ internal class LookAroundTool(
         val currentResources = world.resourcesAt(current.id, currentTick)
         val adjacent = adjacentVisibleNodes(nodeId, sight, currentTick)
 
+        // Single round-trip for every visible node's buildings — never call `byNode` in a loop.
+        val visibleNodeIds = (adjacent.map { it.first.id } + current.id).toSet()
+        val buildingsByNode = buildings.byNodes(visibleNodeIds)
+
         journalVisibleNodes(agentId, current, region, adjacent, currentTick)
 
         return LookAroundResponse(
-            currentNode = current.toView(region, currentResources),
+            currentNode = current.toView(region, currentResources, buildingsByNode[current.id].orEmpty(), fogOfWar = false),
             currentResources = currentResources.entries.values.map {
                 ResourceView(
                     itemId = it.itemId.value,
@@ -60,12 +70,14 @@ internal class LookAroundTool(
                     initialQuantity = it.initialQuantity,
                 )
             },
-            adjacent = adjacent.map { (n, r, res) -> n.toView(r, res) },
+            adjacent = adjacent.map { (n, r, res) ->
+                n.toView(r, res, buildingsByNode[n.id].orEmpty(), fogOfWar = true)
+            },
         )
     }
 
     private fun adjacentVisibleNodes(
-        nodeId: dev.gvart.genesara.world.NodeId,
+        nodeId: NodeId,
         sight: Int,
         currentTick: Long,
     ): List<Triple<Node, Region, NodeResources>> =
@@ -106,7 +118,12 @@ internal class LookAroundTool(
     }
 }
 
-private fun Node.toView(region: Region, resources: NodeResources) = NodeView(
+private fun Node.toView(
+    region: Region,
+    resources: NodeResources,
+    buildings: List<Building>,
+    fogOfWar: Boolean,
+) = NodeView(
     id = id.value,
     q = q,
     r = r,
@@ -115,4 +132,30 @@ private fun Node.toView(region: Region, resources: NodeResources) = NodeView(
     terrain = terrain.name,
     pvpEnabled = pvpEnabled,
     resources = resources.entries.keys.map { it.value }.sorted(),
+    buildings = buildings
+        .sortedBy { it.instanceId }
+        .map { it.toSummary(fogOfWar) },
 )
+
+private fun Building.toSummary(fogOfWar: Boolean): BuildingSummaryView =
+    if (fogOfWar) {
+        BuildingSummaryView(type = type.name, status = status.name)
+    } else {
+        BuildingSummaryView(
+            type = type.name,
+            status = status.name,
+            instanceId = instanceId.toString(),
+            progressSteps = progressSteps,
+            totalSteps = totalSteps,
+            hpBand = hpBandOf(hpCurrent, hpMax),
+            builderAgentId = builtByAgentId.id.toString(),
+        )
+    }
+
+private fun hpBandOf(current: Int, max: Int): String = when {
+    max <= 0 -> "unknown"
+    current <= 0 -> "destroyed"
+    current * 10 < max * 3 -> "low"
+    current * 10 < max * 7 -> "mid"
+    else -> "high"
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolIo.kt
@@ -26,10 +26,32 @@ data class NodeView(
     val pvpEnabled: Boolean,
     /** Item ids visible at this node. For the current node these accompany [LookAroundResponse.currentResources] which carries the quantities. */
     val resources: List<String>,
+    /**
+     * Buildings visible at this node. On the current tile every instance is enumerated with
+     * its full per-instance summary (id, type, status, progress, owner). Adjacent tiles carry
+     * only type + status + count (fog-of-war analogous to resources).
+     */
+    val buildings: List<BuildingSummaryView> = emptyList(),
 )
 
 data class ResourceView(
     val itemId: String,
     val quantity: Int,
     val initialQuantity: Int,
+)
+
+/**
+ * Per-building summary returned by `look_around`. On the agent's current node every field is
+ * populated with the live instance state. Adjacent-node entries use the same shape but
+ * intentionally omit `instanceId`, `progressSteps`, `totalSteps`, `hpBand`, and `builderAgentId`
+ * — fog-of-war keeps remote tiles to type + status + a node-local count.
+ */
+data class BuildingSummaryView(
+    val type: String,
+    val status: String,
+    val instanceId: String? = null,
+    val progressSteps: Int? = null,
+    val totalSteps: Int? = null,
+    val hpBand: String? = null,
+    val builderAgentId: String? = null,
 )

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/security/PlayerApiTokenAgentFilter.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/security/PlayerApiTokenAgentFilter.kt
@@ -18,6 +18,13 @@ internal class PlayerApiTokenAgentFilter(
     private val agents: AgentRegistry,
 ) : OncePerRequestFilter() {
 
+    /**
+     * Re-run on Servlet async dispatches (Streamable-HTTP / SSE for the MCP
+     * endpoint). Without this the auth context is gone by the time the
+     * dispatched response is rendered and Spring Security denies it.
+     */
+    override fun shouldNotFilterAsyncDispatch(): Boolean = false
+
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -60,7 +67,6 @@ internal class PlayerApiTokenAgentFilter(
             chain.doFilter(request, response)
         } finally {
             AgentContextHolder.clear()
-            SecurityContextHolder.clearContext()
         }
     }
 

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/security/jwt/JwtDecoderFilter.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/security/jwt/JwtDecoderFilter.kt
@@ -15,6 +15,13 @@ internal class JwtDecoderFilter(
     private val players: PlayerLookup,
 ) : OncePerRequestFilter() {
 
+    /**
+     * Re-run on async dispatches so the auth context is re-established before
+     * the response is rendered. Defensive — today these endpoints are pure
+     * REST, but matching the MCP filter avoids future surprises.
+     */
+    override fun shouldNotFilterAsyncDispatch(): Boolean = false
+
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -45,11 +52,7 @@ internal class JwtDecoderFilter(
             null,
             listOf(SimpleGrantedAuthority("ROLE_PLAYER")),
         )
-        try {
-            chain.doFilter(request, response)
-        } finally {
-            SecurityContextHolder.clearContext()
-        }
+        chain.doFilter(request, response)
     }
 
     private companion object {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildToolTest.kt
@@ -18,7 +18,6 @@ import java.time.ZoneOffset
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class BuildToolTest {
@@ -37,12 +36,10 @@ class BuildToolTest {
     fun `queues a BuildStructure command at the next tick and returns the ack`() {
         val tool = BuildTool(gateway, tickClock, activity)
 
-        val response = tool.invoke(BuildRequest(type = "CAMPFIRE"), toolContext)
+        val response = tool.invoke(BuildRequest(type = BuildingType.CAMPFIRE), toolContext)
 
-        assertEquals("queued", response.kind)
-        assertEquals("CAMPFIRE", response.type)
+        assertEquals(BuildingType.CAMPFIRE, response.type)
         assertEquals(51L, response.appliesAtTick)
-        assertNull(response.error)
         val (cmd, appliesAt) = gateway.submissions.single()
         val build = assertNotNull(cmd as? WorldCommand.BuildStructure)
         assertEquals(agent, build.agent)
@@ -52,51 +49,12 @@ class BuildToolTest {
     }
 
     @Test
-    fun `accepts lower-case + whitespace input via the boundary parse`() {
-        val tool = BuildTool(gateway, tickClock, activity)
-
-        val response = tool.invoke(BuildRequest(type = "  workbench  "), toolContext)
-
-        assertEquals("queued", response.kind)
-        assertEquals("WORKBENCH", response.type)
-        val build = assertNotNull(gateway.submissions.single().first as? WorldCommand.BuildStructure)
-        assertEquals(BuildingType.WORKBENCH, build.type)
-    }
-
-    @Test
-    fun `unknown building type rejects at the boundary without queueing a command`() {
-        val tool = BuildTool(gateway, tickClock, activity)
-
-        val response = tool.invoke(BuildRequest(type = "PHANTOM_TYPE"), toolContext)
-
-        assertEquals("error", response.kind)
-        assertEquals("PHANTOM_TYPE", response.type)
-        val errorMsg = assertNotNull(response.error)
-        assertTrue(errorMsg.contains("CAMPFIRE"), "error must enumerate valid types so the agent can recover")
-        assertNull(response.commandId)
-        assertNull(response.appliesAtTick)
-        assertTrue(gateway.submissions.isEmpty(), "no command should have been queued")
-    }
-
-    @Test
-    fun `empty and whitespace-only type strings reject without queueing`() {
-        val tool = BuildTool(gateway, tickClock, activity)
-
-        listOf("", "   ").forEach { input ->
-            val response = tool.invoke(BuildRequest(type = input), toolContext)
-            assertEquals("error", response.kind, "input='$input'")
-            assertNull(response.commandId, "input='$input'")
-        }
-        assertTrue(gateway.submissions.isEmpty())
-    }
-
-    @Test
     fun `touches activity registry on every successful invocation`() {
         val tool = BuildTool(gateway, tickClock, activity)
 
         assertTrue(agent !in activity.staleAgents(clock.instant().minusSeconds(60)))
 
-        tool.invoke(BuildRequest(type = "CAMPFIRE"), toolContext)
+        tool.invoke(BuildRequest(type = BuildingType.CAMPFIRE), toolContext)
 
         assertTrue(agent in activity.staleAgents(clock.instant().plusSeconds(60)))
     }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildToolTest.kt
@@ -1,0 +1,120 @@
+package dev.gvart.genesara.api.internal.mcp.tools.build
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BuildToolTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val clock = MutableTestClock(Instant.parse("2026-01-01T00:00:00Z"))
+    private val activity = AgentActivityRegistry(clock)
+    private val gateway = RecordingGateway()
+    private val tickClock = StubTickClock(currentTick = 50L)
+    private val toolContext = ToolContext(emptyMap())
+
+    @BeforeEach fun setUp() = AgentContextHolder.set(agent)
+    @AfterEach fun tearDown() = AgentContextHolder.clear()
+
+    @Test
+    fun `queues a BuildStructure command at the next tick and returns the ack`() {
+        val tool = BuildTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(BuildRequest(type = "CAMPFIRE"), toolContext)
+
+        assertEquals("queued", response.kind)
+        assertEquals("CAMPFIRE", response.type)
+        assertEquals(51L, response.appliesAtTick)
+        assertNull(response.error)
+        val (cmd, appliesAt) = gateway.submissions.single()
+        val build = assertNotNull(cmd as? WorldCommand.BuildStructure)
+        assertEquals(agent, build.agent)
+        assertEquals(BuildingType.CAMPFIRE, build.type)
+        assertEquals(51L, appliesAt)
+        assertEquals(build.commandId, response.commandId)
+    }
+
+    @Test
+    fun `accepts lower-case + whitespace input via the boundary parse`() {
+        val tool = BuildTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(BuildRequest(type = "  workbench  "), toolContext)
+
+        assertEquals("queued", response.kind)
+        assertEquals("WORKBENCH", response.type)
+        val build = assertNotNull(gateway.submissions.single().first as? WorldCommand.BuildStructure)
+        assertEquals(BuildingType.WORKBENCH, build.type)
+    }
+
+    @Test
+    fun `unknown building type rejects at the boundary without queueing a command`() {
+        val tool = BuildTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(BuildRequest(type = "PHANTOM_TYPE"), toolContext)
+
+        assertEquals("error", response.kind)
+        assertEquals("PHANTOM_TYPE", response.type)
+        val errorMsg = assertNotNull(response.error)
+        assertTrue(errorMsg.contains("CAMPFIRE"), "error must enumerate valid types so the agent can recover")
+        assertNull(response.commandId)
+        assertNull(response.appliesAtTick)
+        assertTrue(gateway.submissions.isEmpty(), "no command should have been queued")
+    }
+
+    @Test
+    fun `empty and whitespace-only type strings reject without queueing`() {
+        val tool = BuildTool(gateway, tickClock, activity)
+
+        listOf("", "   ").forEach { input ->
+            val response = tool.invoke(BuildRequest(type = input), toolContext)
+            assertEquals("error", response.kind, "input='$input'")
+            assertNull(response.commandId, "input='$input'")
+        }
+        assertTrue(gateway.submissions.isEmpty())
+    }
+
+    @Test
+    fun `touches activity registry on every successful invocation`() {
+        val tool = BuildTool(gateway, tickClock, activity)
+
+        assertTrue(agent !in activity.staleAgents(clock.instant().minusSeconds(60)))
+
+        tool.invoke(BuildRequest(type = "CAMPFIRE"), toolContext)
+
+        assertTrue(agent in activity.staleAgents(clock.instant().plusSeconds(60)))
+    }
+
+    private class RecordingGateway : WorldCommandGateway {
+        val submissions = mutableListOf<Pair<WorldCommand, Long>>()
+        override fun submit(command: WorldCommand, appliesAtTick: Long) {
+            submissions += command to appliesAtTick
+        }
+    }
+
+    private class StubTickClock(private val currentTick: Long) : TickClock {
+        override fun currentTick(): Long = currentTick
+    }
+
+    private class MutableTestClock(private var now: Instant) : Clock() {
+        override fun instant(): Instant = now
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/ChestToolsTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/ChestToolsTest.kt
@@ -1,0 +1,178 @@
+package dev.gvart.genesara.api.internal.mcp.tools.chest
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ChestToolsTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val chest = UUID.randomUUID()
+    private val clock = MutableTestClock(Instant.parse("2026-01-01T00:00:00Z"))
+    private val activity = AgentActivityRegistry(clock)
+    private val gateway = RecordingGateway()
+    private val tickClock = StubTickClock(currentTick = 50L)
+    private val toolContext = ToolContext(emptyMap())
+
+    @BeforeEach fun setUp() = AgentContextHolder.set(agent)
+    @AfterEach fun tearDown() = AgentContextHolder.clear()
+
+    // ─────────────────────── Deposit ───────────────────────
+
+    @Test
+    fun `deposit queues a DepositToChest command at the next tick`() {
+        val tool = DepositToChestTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(
+            ChestTransferRequest(chestId = chest.toString(), itemId = "WOOD", quantity = 5),
+            toolContext,
+        )
+
+        assertEquals("queued", response.kind)
+        assertEquals(51L, response.appliesAtTick)
+        val (cmd, appliesAt) = gateway.submissions.single()
+        val deposit = assertNotNull(cmd as? WorldCommand.DepositToChest)
+        assertEquals(agent, deposit.agent)
+        assertEquals(chest, deposit.chestId)
+        assertEquals(ItemId("WOOD"), deposit.item)
+        assertEquals(5, deposit.quantity)
+        assertEquals(51L, appliesAt)
+        assertEquals(deposit.commandId, response.commandId)
+    }
+
+    @Test
+    fun `deposit rejects malformed UUID at the boundary`() {
+        val tool = DepositToChestTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(
+            ChestTransferRequest(chestId = "not-a-uuid", itemId = "WOOD", quantity = 5),
+            toolContext,
+        )
+
+        assertEquals("error", response.kind)
+        assertNotNull(response.error)
+        assertNull(response.commandId)
+        assertTrue(gateway.submissions.isEmpty())
+    }
+
+    @Test
+    fun `deposit rejects blank itemId at the boundary`() {
+        val tool = DepositToChestTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(
+            ChestTransferRequest(chestId = chest.toString(), itemId = "   ", quantity = 5),
+            toolContext,
+        )
+
+        assertEquals("error", response.kind)
+        assertTrue(gateway.submissions.isEmpty())
+    }
+
+    @Test
+    fun `deposit rejects non-positive quantity at the boundary`() {
+        val tool = DepositToChestTool(gateway, tickClock, activity)
+
+        listOf(0, -1).forEach { qty ->
+            val response = tool.invoke(
+                ChestTransferRequest(chestId = chest.toString(), itemId = "WOOD", quantity = qty),
+                toolContext,
+            )
+            assertEquals("error", response.kind, "quantity=$qty")
+        }
+        assertTrue(gateway.submissions.isEmpty())
+    }
+
+    // ─────────────────────── Withdraw ───────────────────────
+
+    @Test
+    fun `withdraw queues a WithdrawFromChest command at the next tick`() {
+        val tool = WithdrawFromChestTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(
+            ChestTransferRequest(chestId = chest.toString(), itemId = "STONE", quantity = 3),
+            toolContext,
+        )
+
+        assertEquals("queued", response.kind)
+        val (cmd, _) = gateway.submissions.single()
+        val withdraw = assertNotNull(cmd as? WorldCommand.WithdrawFromChest)
+        assertEquals(agent, withdraw.agent)
+        assertEquals(chest, withdraw.chestId)
+        assertEquals(ItemId("STONE"), withdraw.item)
+        assertEquals(3, withdraw.quantity)
+    }
+
+    @Test
+    fun `withdraw rejects malformed UUID at the boundary`() {
+        val tool = WithdrawFromChestTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(
+            ChestTransferRequest(chestId = "garbage", itemId = "WOOD", quantity = 1),
+            toolContext,
+        )
+
+        assertEquals("error", response.kind)
+        assertTrue(gateway.submissions.isEmpty())
+    }
+
+    @Test
+    fun `withdraw rejects non-positive quantity`() {
+        val tool = WithdrawFromChestTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(
+            ChestTransferRequest(chestId = chest.toString(), itemId = "WOOD", quantity = 0),
+            toolContext,
+        )
+
+        assertEquals("error", response.kind)
+        assertTrue(gateway.submissions.isEmpty())
+    }
+
+    // ─────────────────────── Activity tracking ───────────────────────
+
+    @Test
+    fun `both tools touch activity registry on success`() {
+        val deposit = DepositToChestTool(gateway, tickClock, activity)
+        val withdraw = WithdrawFromChestTool(gateway, tickClock, activity)
+
+        deposit.invoke(ChestTransferRequest(chest.toString(), "WOOD", 1), toolContext)
+        AgentContextHolder.set(agent)
+        withdraw.invoke(ChestTransferRequest(chest.toString(), "WOOD", 1), toolContext)
+
+        assertTrue(agent in activity.staleAgents(clock.instant().plusSeconds(60)))
+    }
+
+    private class RecordingGateway : WorldCommandGateway {
+        val submissions = mutableListOf<Pair<WorldCommand, Long>>()
+        override fun submit(command: WorldCommand, appliesAtTick: Long) {
+            submissions += command to appliesAtTick
+        }
+    }
+
+    private class StubTickClock(private val currentTick: Long) : TickClock {
+        override fun currentTick(): Long = currentTick
+    }
+
+    private class MutableTestClock(private var now: Instant) : Clock() {
+        override fun instant(): Instant = now
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/ChestToolsTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/ChestToolsTest.kt
@@ -18,7 +18,6 @@ import java.time.ZoneOffset
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ChestToolsTest {
@@ -34,18 +33,18 @@ class ChestToolsTest {
     @BeforeEach fun setUp() = AgentContextHolder.set(agent)
     @AfterEach fun tearDown() = AgentContextHolder.clear()
 
-    // ─────────────────────── Deposit ───────────────────────
-
     @Test
     fun `deposit queues a DepositToChest command at the next tick`() {
         val tool = DepositToChestTool(gateway, tickClock, activity)
 
         val response = tool.invoke(
-            ChestTransferRequest(chestId = chest.toString(), itemId = "WOOD", quantity = 5),
+            ChestTransferRequest(chestId = chest, itemId = "WOOD", quantity = 5),
             toolContext,
         )
 
-        assertEquals("queued", response.kind)
+        assertEquals(chest, response.chestId)
+        assertEquals("WOOD", response.itemId)
+        assertEquals(5, response.quantity)
         assertEquals(51L, response.appliesAtTick)
         val (cmd, appliesAt) = gateway.submissions.single()
         val deposit = assertNotNull(cmd as? WorldCommand.DepositToChest)
@@ -58,59 +57,17 @@ class ChestToolsTest {
     }
 
     @Test
-    fun `deposit rejects malformed UUID at the boundary`() {
-        val tool = DepositToChestTool(gateway, tickClock, activity)
-
-        val response = tool.invoke(
-            ChestTransferRequest(chestId = "not-a-uuid", itemId = "WOOD", quantity = 5),
-            toolContext,
-        )
-
-        assertEquals("error", response.kind)
-        assertNotNull(response.error)
-        assertNull(response.commandId)
-        assertTrue(gateway.submissions.isEmpty())
-    }
-
-    @Test
-    fun `deposit rejects blank itemId at the boundary`() {
-        val tool = DepositToChestTool(gateway, tickClock, activity)
-
-        val response = tool.invoke(
-            ChestTransferRequest(chestId = chest.toString(), itemId = "   ", quantity = 5),
-            toolContext,
-        )
-
-        assertEquals("error", response.kind)
-        assertTrue(gateway.submissions.isEmpty())
-    }
-
-    @Test
-    fun `deposit rejects non-positive quantity at the boundary`() {
-        val tool = DepositToChestTool(gateway, tickClock, activity)
-
-        listOf(0, -1).forEach { qty ->
-            val response = tool.invoke(
-                ChestTransferRequest(chestId = chest.toString(), itemId = "WOOD", quantity = qty),
-                toolContext,
-            )
-            assertEquals("error", response.kind, "quantity=$qty")
-        }
-        assertTrue(gateway.submissions.isEmpty())
-    }
-
-    // ─────────────────────── Withdraw ───────────────────────
-
-    @Test
     fun `withdraw queues a WithdrawFromChest command at the next tick`() {
         val tool = WithdrawFromChestTool(gateway, tickClock, activity)
 
         val response = tool.invoke(
-            ChestTransferRequest(chestId = chest.toString(), itemId = "STONE", quantity = 3),
+            ChestTransferRequest(chestId = chest, itemId = "STONE", quantity = 3),
             toolContext,
         )
 
-        assertEquals("queued", response.kind)
+        assertEquals(chest, response.chestId)
+        assertEquals("STONE", response.itemId)
+        assertEquals(3, response.quantity)
         val (cmd, _) = gateway.submissions.single()
         val withdraw = assertNotNull(cmd as? WorldCommand.WithdrawFromChest)
         assertEquals(agent, withdraw.agent)
@@ -120,41 +77,25 @@ class ChestToolsTest {
     }
 
     @Test
-    fun `withdraw rejects malformed UUID at the boundary`() {
-        val tool = WithdrawFromChestTool(gateway, tickClock, activity)
+    fun `non-positive quantity is forwarded to the reducer (not rejected at the tool boundary)`() {
+        // Strong-typed inputs delegate validation to the reducer's NonPositiveQuantity rejection,
+        // which surfaces on the agent's event stream. Tool layer just queues.
+        val tool = DepositToChestTool(gateway, tickClock, activity)
 
-        val response = tool.invoke(
-            ChestTransferRequest(chestId = "garbage", itemId = "WOOD", quantity = 1),
-            toolContext,
-        )
+        tool.invoke(ChestTransferRequest(chestId = chest, itemId = "WOOD", quantity = 0), toolContext)
 
-        assertEquals("error", response.kind)
-        assertTrue(gateway.submissions.isEmpty())
+        val cmd = assertNotNull(gateway.submissions.single().first as? WorldCommand.DepositToChest)
+        assertEquals(0, cmd.quantity)
     }
-
-    @Test
-    fun `withdraw rejects non-positive quantity`() {
-        val tool = WithdrawFromChestTool(gateway, tickClock, activity)
-
-        val response = tool.invoke(
-            ChestTransferRequest(chestId = chest.toString(), itemId = "WOOD", quantity = 0),
-            toolContext,
-        )
-
-        assertEquals("error", response.kind)
-        assertTrue(gateway.submissions.isEmpty())
-    }
-
-    // ─────────────────────── Activity tracking ───────────────────────
 
     @Test
     fun `both tools touch activity registry on success`() {
         val deposit = DepositToChestTool(gateway, tickClock, activity)
         val withdraw = WithdrawFromChestTool(gateway, tickClock, activity)
 
-        deposit.invoke(ChestTransferRequest(chest.toString(), "WOOD", 1), toolContext)
+        deposit.invoke(ChestTransferRequest(chest, "WOOD", 1), toolContext)
         AgentContextHolder.set(agent)
-        withdraw.invoke(ChestTransferRequest(chest.toString(), "WOOD", 1), toolContext)
+        withdraw.invoke(ChestTransferRequest(chest, "WOOD", 1), toolContext)
 
         assertTrue(agent in activity.staleAgents(clock.instant().plusSeconds(60)))
     }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
@@ -1,0 +1,328 @@
+package dev.gvart.genesara.api.internal.mcp.tools.inspect
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.ClassPropertiesLookup
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.world.BodyView
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingDefLookup
+import dev.gvart.genesara.world.BuildingDefView
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsLookup
+import dev.gvart.genesara.world.ChestContentsStore
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NodeResources
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldQueryGateway
+import dev.gvart.genesara.world.InventoryView
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.Terrain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class InspectBuildingTest {
+
+    private val agentId = AgentId(UUID.randomUUID())
+    private val builderId = AgentId(UUID.randomUUID())
+    private val nodeId = NodeId(1L)
+    private val outOfSightNodeId = NodeId(99L)
+    private val regionId = RegionId(1L)
+
+    private val toolContext = ToolContext(emptyMap())
+    private val activity = AgentActivityRegistry(MutableTestClock(Instant.parse("2026-01-01T00:00:00Z")))
+
+    @BeforeEach fun setUp() = AgentContextHolder.set(agentId)
+    @AfterEach fun tearDown() = AgentContextHolder.clear()
+
+    @Test
+    fun `SHALLOW perception surfaces type, status, progress, hpBand only`() {
+        val chest = building(builder = agentId, type = BuildingType.STORAGE_CHEST)
+        val tool = tool(perception = 0, buildings = listOf(chest))
+
+        val resp = tool.invoke(req("building", chest.instanceId.toString()), toolContext)
+
+        val view = assertNotNull(resp.building)
+        assertEquals(chest.instanceId.toString(), view.instanceId)
+        assertEquals("STORAGE_CHEST", view.type)
+        assertEquals("ACTIVE", view.status)
+        assertEquals(8, view.progressSteps)
+        assertEquals(8, view.totalSteps)
+        assertEquals("high", view.hpBand)
+        assertNull(view.nodeId)
+        assertNull(view.builderAgentId)
+        assertNull(view.hpCurrent)
+        assertNull(view.totalMaterials)
+        assertNull(view.chestContents)
+    }
+
+    @Test
+    fun `DETAILED perception adds nodeId, builderAgentId, exact hp, lastProgressTick`() {
+        val chest = building(builder = builderId, type = BuildingType.STORAGE_CHEST)
+        val tool = tool(perception = 50, buildings = listOf(chest))
+
+        val resp = tool.invoke(req("building", chest.instanceId.toString()), toolContext)
+
+        val view = assertNotNull(resp.building)
+        assertEquals(nodeId.value, view.nodeId)
+        assertEquals(builderId.id.toString(), view.builderAgentId)
+        assertEquals(40, view.hpCurrent)
+        assertEquals(40, view.hpMax)
+        assertEquals(7L, view.lastProgressTick)
+        // EXPERT-only fields stay null at DETAILED.
+        assertNull(view.totalMaterials)
+        assertNull(view.requiredSkill)
+        assertNull(view.chestContents)
+    }
+
+    @Test
+    fun `EXPERT perception adds catalog materials breakdown and required skill`() {
+        val chest = building(builder = builderId, type = BuildingType.STORAGE_CHEST)
+        val def = stubChestDef()
+        val tool = tool(perception = 90, buildings = listOf(chest), defs = mapOf(BuildingType.STORAGE_CHEST to def))
+
+        val resp = tool.invoke(req("building", chest.instanceId.toString()), toolContext)
+
+        val view = assertNotNull(resp.building)
+        assertEquals("CARPENTRY", view.requiredSkill)
+        assertEquals(0, view.requiredSkillLevel)
+        val totals = assertNotNull(view.totalMaterials)
+        assertEquals(1, totals.size)
+        assertEquals("WOOD", totals.single().itemId)
+        assertEquals(20, totals.single().quantity)
+        val steps = assertNotNull(view.stepMaterials)
+        assertEquals(8, steps.size)
+    }
+
+    @Test
+    fun `EXPERT-and-owner sees chest contents — non-owner does not`() {
+        val chest = building(builder = agentId, type = BuildingType.STORAGE_CHEST)
+        val contents = StubChestContents().apply {
+            add(chest.instanceId, ItemId("WOOD"), 5)
+            add(chest.instanceId, ItemId("STONE"), 2)
+        }
+        val ownerTool = tool(perception = 90, buildings = listOf(chest), chestContents = contents)
+        val nonOwnerChest = chest.copy(builtByAgentId = builderId)
+        val nonOwnerTool = tool(perception = 90, buildings = listOf(nonOwnerChest), chestContents = contents)
+
+        val ownerResp = ownerTool.invoke(req("building", chest.instanceId.toString()), toolContext)
+        val nonOwnerResp = nonOwnerTool.invoke(req("building", nonOwnerChest.instanceId.toString()), toolContext)
+
+        val ownerContents = assertNotNull(ownerResp.building?.chestContents)
+        assertEquals(setOf("WOOD" to 5, "STONE" to 2), ownerContents.map { it.itemId to it.quantity }.toSet())
+        assertNull(nonOwnerResp.building?.chestContents, "non-owner must not see chest contents")
+    }
+
+    @Test
+    fun `EXPERT does NOT surface chestContents for non-chest types — only STORAGE_CHEST`() {
+        val workbench = building(builder = agentId, type = BuildingType.WORKBENCH)
+        val tool = tool(perception = 90, buildings = listOf(workbench))
+
+        val resp = tool.invoke(req("building", workbench.instanceId.toString()), toolContext)
+        assertNull(resp.building?.chestContents)
+    }
+
+    @Test
+    fun `unknown building id returns NOT_FOUND`() {
+        val tool = tool(perception = 90, buildings = emptyList())
+
+        val resp = tool.invoke(req("building", UUID.randomUUID().toString()), toolContext)
+
+        assertEquals("error", resp.kind)
+        assertEquals(InspectError.NOT_FOUND, resp.error?.code)
+    }
+
+    @Test
+    fun `non-UUID building id returns BAD_TARGET_ID`() {
+        val tool = tool(perception = 90, buildings = emptyList())
+
+        val resp = tool.invoke(req("building", "not-a-uuid"), toolContext)
+
+        assertEquals("error", resp.kind)
+        assertEquals(InspectError.BAD_TARGET_ID, resp.error?.code)
+    }
+
+    @Test
+    fun `building outside sight range returns NOT_VISIBLE`() {
+        val chest = building(builder = agentId, type = BuildingType.STORAGE_CHEST, node = outOfSightNodeId)
+        val tool = tool(perception = 90, buildings = listOf(chest))
+
+        val resp = tool.invoke(req("building", chest.instanceId.toString()), toolContext)
+
+        assertEquals("error", resp.kind)
+        assertEquals(InspectError.NOT_VISIBLE, resp.error?.code)
+    }
+
+    private fun building(
+        builder: AgentId,
+        type: BuildingType,
+        node: NodeId = nodeId,
+        progress: Int = 8,
+        totalSteps: Int = 8,
+        hp: Int = 40,
+    ): Building = Building(
+        instanceId = UUID.randomUUID(),
+        nodeId = node,
+        type = type,
+        status = if (progress == totalSteps) BuildingStatus.ACTIVE else BuildingStatus.UNDER_CONSTRUCTION,
+        builtByAgentId = builder,
+        builtAtTick = 1L,
+        lastProgressTick = 7L,
+        progressSteps = progress,
+        totalSteps = totalSteps,
+        hpCurrent = hp,
+        hpMax = hp,
+    )
+
+    private fun stubChestDef(): BuildingDefView = BuildingDefView(
+        type = BuildingType.STORAGE_CHEST,
+        totalMaterials = mapOf(ItemId("WOOD") to 20),
+        stepMaterials = (1..8).map { mapOf(ItemId("WOOD") to (if (it == 8) 6 else 2)) },
+        requiredSkill = SkillId("CARPENTRY"),
+        requiredSkillLevel = 0,
+        totalSteps = 8,
+        staminaPerStep = 8,
+        hp = 40,
+        categoryHint = BuildingCategoryHint.STORAGE,
+        chestCapacityGrams = 50_000,
+    )
+
+    private fun tool(
+        perception: Int,
+        buildings: List<Building>,
+        defs: Map<BuildingType, BuildingDefView> = emptyMap(),
+        chestContents: ChestContentsStore = StubChestContents(),
+    ): InspectTool {
+        val world = StubQuery(
+            location = nodeId,
+            nodes = mapOf(
+                nodeId to Node(nodeId, regionId, q = 0, r = 0, terrain = Terrain.FOREST, adjacency = emptySet()),
+                outOfSightNodeId to Node(outOfSightNodeId, regionId, q = 99, r = 99, terrain = Terrain.FOREST, adjacency = emptySet()),
+            ),
+            regions = mapOf(regionId to region),
+            within = mapOf((nodeId to 1) to setOf(nodeId)),
+        )
+        return InspectTool(
+            world = world,
+            agents = registry(caller(perception)),
+            classes = StubClasses(sight = 1),
+            items = StubItems,
+            activity = activity,
+            tick = FixedTickClock(0L),
+            buildings = StubBuildings(buildings),
+            buildingDefs = StubBuildingDefs(defs),
+            chestContents = chestContents,
+        )
+    }
+
+    private fun caller(perception: Int) = Agent(
+        id = agentId,
+        owner = PlayerId(UUID.randomUUID()),
+        name = "caller",
+        attributes = AgentAttributes(perception = perception),
+    )
+
+    private fun registry(vararg present: Agent) = object : AgentRegistry {
+        private val byId = present.associateBy { it.id }
+        override fun find(id: AgentId): Agent? = byId[id]
+        override fun listForOwner(owner: PlayerId): List<Agent> = present.filter { it.owner == owner }
+    }
+
+    private fun req(targetType: String, targetId: String) = InspectRequest(targetType, targetId)
+
+    private val region = Region(
+        id = regionId, worldId = WorldId(1L), sphereIndex = 0,
+        biome = Biome.FOREST, climate = Climate.OCEANIC,
+        centroid = Vec3(0.0, 0.0, 1.0), faceVertices = emptyList(), neighbors = emptySet(),
+    )
+
+    private class StubClasses(private val sight: Int) : ClassPropertiesLookup {
+        override fun sightRange(classId: AgentClass?): Int = sight
+    }
+
+    private object StubItems : ItemLookup {
+        override fun byId(id: ItemId): Item? = null
+        override fun all(): List<Item> = emptyList()
+    }
+
+    private class StubQuery(
+        private val location: NodeId?,
+        private val nodes: Map<NodeId, Node>,
+        private val regions: Map<RegionId, Region>,
+        private val within: Map<Pair<NodeId, Int>, Set<NodeId>>,
+    ) : WorldQueryGateway {
+        override fun locationOf(agent: AgentId): NodeId? = location
+        override fun activePositionOf(agent: AgentId): NodeId? = location
+        override fun node(id: NodeId): Node? = nodes[id]
+        override fun region(id: RegionId): Region? = regions[id]
+        override fun nodesWithin(origin: NodeId, radius: Int): Set<NodeId> = within[origin to radius] ?: emptySet()
+        override fun randomSpawnableNode(): NodeId? = null
+        override fun starterNodeFor(race: RaceId): NodeId? = null
+        override fun bodyOf(agent: AgentId): BodyView? = null
+        override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
+        override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
+    }
+
+    private class StubBuildings(private val rows: List<Building>) : BuildingsLookup {
+        override fun byId(id: UUID): Building? = rows.firstOrNull { it.instanceId == id }
+        override fun byNode(node: NodeId): List<Building> = rows.filter { it.nodeId == node }
+        override fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
+            rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }
+        override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> = emptyList()
+    }
+
+    private class StubBuildingDefs(private val defs: Map<BuildingType, BuildingDefView>) : BuildingDefLookup {
+        override fun byType(type: BuildingType): BuildingDefView? = defs[type]
+        override fun all(): List<BuildingDefView> = defs.values.toList()
+    }
+
+    private class StubChestContents : ChestContentsStore {
+        private val map = mutableMapOf<Pair<UUID, ItemId>, Int>()
+        override fun quantityOf(buildingId: UUID, item: ItemId): Int = map[buildingId to item] ?: 0
+        override fun contentsOf(buildingId: UUID): Map<ItemId, Int> =
+            map.entries.filter { it.key.first == buildingId }.associate { it.key.second to it.value }
+        override fun add(buildingId: UUID, item: ItemId, quantity: Int) {
+            map.merge(buildingId to item, quantity, Int::plus)
+        }
+        override fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean = error("not used")
+    }
+
+    private class MutableTestClock(private var now: Instant) : Clock() {
+        override fun instant(): Instant = now
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+
+    private class FixedTickClock(private val current: Long) : TickClock {
+        override fun currentTick(): Long = current
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
@@ -261,6 +261,9 @@ class InspectToolTest {
             items = StubItems,
             activity = activity,
             tick = FixedTickClock(0L),
+            buildings = NoBuildings,
+            buildingDefs = NoBuildingDefs,
+            chestContents = NoChestContents,
         )
 
         val resp = selfTool.invoke(req("agent", agentId.id.toString()), toolContext)
@@ -396,6 +399,9 @@ class InspectToolTest {
             items = StubItems,
             activity = activity,
             tick = FixedTickClock(0L),
+            buildings = NoBuildings,
+            buildingDefs = NoBuildingDefs,
+            chestContents = NoChestContents,
         )
     }
 
@@ -470,5 +476,29 @@ class InspectToolTest {
 
     private class FixedTickClock(private val current: Long) : TickClock {
         override fun currentTick(): Long = current
+    }
+
+    internal object NoBuildings : dev.gvart.genesara.world.BuildingsLookup {
+        override fun byId(id: java.util.UUID): dev.gvart.genesara.world.Building? = null
+        override fun byNode(node: NodeId): List<dev.gvart.genesara.world.Building> = emptyList()
+        override fun byNodes(
+            nodes: Set<NodeId>,
+        ): Map<NodeId, List<dev.gvart.genesara.world.Building>> = emptyMap()
+        override fun activeStationsAt(
+            node: NodeId,
+            hint: dev.gvart.genesara.world.BuildingCategoryHint,
+        ): List<dev.gvart.genesara.world.Building> = emptyList()
+    }
+
+    internal object NoBuildingDefs : dev.gvart.genesara.world.BuildingDefLookup {
+        override fun byType(type: dev.gvart.genesara.world.BuildingType): dev.gvart.genesara.world.BuildingDefView? = null
+        override fun all(): List<dev.gvart.genesara.world.BuildingDefView> = emptyList()
+    }
+
+    internal object NoChestContents : dev.gvart.genesara.world.ChestContentsStore {
+        override fun quantityOf(buildingId: java.util.UUID, item: ItemId): Int = 0
+        override fun contentsOf(buildingId: java.util.UUID): Map<ItemId, Int> = emptyMap()
+        override fun add(buildingId: java.util.UUID, item: ItemId, quantity: Int) = error("not used")
+        override fun remove(buildingId: java.util.UUID, item: ItemId, quantity: Int): Boolean = error("not used")
     }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
@@ -87,7 +87,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory())
+        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
 
         val response = tool.invoke(LookAroundRequest(), toolContext)
 
@@ -108,7 +108,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory())
+        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
 
         val response = tool.invoke(LookAroundRequest(), toolContext)
 
@@ -128,7 +128,7 @@ class LookAroundToolTest {
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
         val memory = RecordingMapMemory()
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(7L), memory)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(7L), memory, NoBuildings)
 
         tool.invoke(LookAroundRequest(), toolContext)
 
@@ -157,7 +157,7 @@ class LookAroundToolTest {
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
         val flaky = ThrowingMapMemory()
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), flaky)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), flaky, NoBuildings)
 
         // Should NOT throw — the read still returns successfully.
         val response = tool.invoke(LookAroundRequest(), toolContext)
@@ -172,11 +172,132 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory())
+        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
 
         val response = tool.invoke(LookAroundRequest(), toolContext)
 
         assertTrue(response.adjacent.none { it.id == currentNodeId.value })
+    }
+
+    @Test
+    fun `current-node buildings carry full per-instance summaries`() {
+        val world = StubQuery(
+            location = currentNodeId,
+            nodes = mapOf(currentNodeId to current, northNodeId to north),
+            regions = mapOf(regionId to region),
+            within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
+        )
+        val campfire = activeBuilding(currentNodeId, dev.gvart.genesara.world.BuildingType.CAMPFIRE)
+        val buildings = StubBuildingsLookup(byNode = mapOf(currentNodeId to listOf(campfire)))
+        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), buildings)
+
+        val response = tool.invoke(LookAroundRequest(), toolContext)
+
+        val view = response.currentNode.buildings.single()
+        assertEquals("CAMPFIRE", view.type)
+        assertEquals("ACTIVE", view.status)
+        assertEquals(campfire.instanceId.toString(), view.instanceId)
+        assertEquals(5, view.progressSteps)
+        assertEquals(5, view.totalSteps)
+        assertEquals("high", view.hpBand)
+        assertEquals(agentId.id.toString(), view.builderAgentId)
+    }
+
+    @Test
+    fun `adjacent buildings strip per-instance fields per fog-of-war`() {
+        val world = StubQuery(
+            location = currentNodeId,
+            nodes = mapOf(currentNodeId to current, northNodeId to north),
+            regions = mapOf(regionId to region),
+            within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
+        )
+        val workbench = activeBuilding(northNodeId, dev.gvart.genesara.world.BuildingType.WORKBENCH)
+        val buildings = StubBuildingsLookup(byNode = mapOf(northNodeId to listOf(workbench)))
+        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), buildings)
+
+        val response = tool.invoke(LookAroundRequest(), toolContext)
+
+        val adjacent = response.adjacent.single { it.id == northNodeId.value }
+        val view = adjacent.buildings.single()
+        assertEquals("WORKBENCH", view.type)
+        assertEquals("ACTIVE", view.status)
+        assertEquals(null, view.instanceId)
+        assertEquals(null, view.progressSteps)
+        assertEquals(null, view.hpBand)
+        assertEquals(null, view.builderAgentId)
+    }
+
+    @Test
+    fun `look_around fetches all visible buildings via a single batched byNodes call`() {
+        // The whole point of slice 1's batched method: ONE round-trip per look_around call.
+        // The 7-tile fog-of-war hot path turns into 1 query, not 7.
+        val world = StubQuery(
+            location = currentNodeId,
+            nodes = mapOf(currentNodeId to current, northNodeId to north),
+            regions = mapOf(regionId to region),
+            within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
+        )
+        val recordingBuildings = RecordingBuildingsLookup()
+        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), recordingBuildings)
+
+        tool.invoke(LookAroundRequest(), toolContext)
+
+        assertEquals(1, recordingBuildings.byNodesCalls.size)
+        assertEquals(setOf(currentNodeId, northNodeId), recordingBuildings.byNodesCalls.single())
+        assertEquals(0, recordingBuildings.byNodeCalls.size, "must not fall back to per-node lookups")
+    }
+
+    private fun activeBuilding(
+        node: NodeId,
+        type: dev.gvart.genesara.world.BuildingType,
+    ): dev.gvart.genesara.world.Building = dev.gvart.genesara.world.Building(
+        instanceId = java.util.UUID.randomUUID(),
+        nodeId = node,
+        type = type,
+        status = dev.gvart.genesara.world.BuildingStatus.ACTIVE,
+        builtByAgentId = agentId,
+        builtAtTick = 1L,
+        lastProgressTick = 1L,
+        progressSteps = 5,
+        totalSteps = 5,
+        hpCurrent = 30,
+        hpMax = 30,
+    )
+
+    private class StubBuildingsLookup(
+        private val byNode: Map<NodeId, List<dev.gvart.genesara.world.Building>>,
+    ) : dev.gvart.genesara.world.BuildingsLookup {
+        override fun byId(id: java.util.UUID): dev.gvart.genesara.world.Building? =
+            byNode.values.flatten().firstOrNull { it.instanceId == id }
+        override fun byNode(node: NodeId): List<dev.gvart.genesara.world.Building> = byNode[node].orEmpty()
+        override fun byNodes(
+            nodes: Set<NodeId>,
+        ): Map<NodeId, List<dev.gvart.genesara.world.Building>> =
+            nodes.associateWith { byNode[it].orEmpty() }.filterValues { it.isNotEmpty() }
+        override fun activeStationsAt(
+            node: NodeId,
+            hint: dev.gvart.genesara.world.BuildingCategoryHint,
+        ): List<dev.gvart.genesara.world.Building> = byNode[node].orEmpty()
+    }
+
+    private class RecordingBuildingsLookup : dev.gvart.genesara.world.BuildingsLookup {
+        val byNodesCalls = mutableListOf<Set<NodeId>>()
+        val byNodeCalls = mutableListOf<NodeId>()
+        override fun byId(id: java.util.UUID): dev.gvart.genesara.world.Building? = null
+        override fun byNode(node: NodeId): List<dev.gvart.genesara.world.Building> {
+            byNodeCalls += node
+            return emptyList()
+        }
+        override fun byNodes(
+            nodes: Set<NodeId>,
+        ): Map<NodeId, List<dev.gvart.genesara.world.Building>> {
+            byNodesCalls += nodes
+            return emptyMap()
+        }
+        override fun activeStationsAt(
+            node: NodeId,
+            hint: dev.gvart.genesara.world.BuildingCategoryHint,
+        ): List<dev.gvart.genesara.world.Building> = emptyList()
     }
 
     @Test
@@ -188,7 +309,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to unpainted),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory())
+        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
 
         val response = tool.invoke(LookAroundRequest(), toolContext)
 
@@ -204,7 +325,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = emptyMap(),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory())
+        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
 
         assertThrows<IllegalStateException> {
             tool.invoke(LookAroundRequest(), toolContext)
@@ -219,7 +340,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId)),
         )
-        val tool = LookAroundTool(world, EmptyRegistry, classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory())
+        val tool = LookAroundTool(world, EmptyRegistry, classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
 
         assertThrows<IllegalStateException> {
             tool.invoke(LookAroundRequest(), toolContext)
@@ -234,7 +355,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory())
+        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
 
         tool.invoke(LookAroundRequest(), toolContext)
 
@@ -307,5 +428,17 @@ class LookAroundToolTest {
             throw RuntimeException("simulated DB hiccup during map-memory journaling")
         }
         override fun recall(agentId: AgentId): List<dev.gvart.genesara.world.RecalledNode> = emptyList()
+    }
+
+    internal object NoBuildings : dev.gvart.genesara.world.BuildingsLookup {
+        override fun byId(id: java.util.UUID): dev.gvart.genesara.world.Building? = null
+        override fun byNode(node: NodeId): List<dev.gvart.genesara.world.Building> = emptyList()
+        override fun byNodes(
+            nodes: Set<NodeId>,
+        ): Map<NodeId, List<dev.gvart.genesara.world.Building>> = emptyMap()
+        override fun activeStationsAt(
+            node: NodeId,
+            hint: dev.gvart.genesara.world.BuildingCategoryHint,
+        ): List<dev.gvart.genesara.world.Building> = emptyList()
     }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/security/PlayerApiTokenAgentFilterTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/security/PlayerApiTokenAgentFilterTest.kt
@@ -37,7 +37,7 @@ class PlayerApiTokenAgentFilterTest {
 
     @Test
     fun `populates context when token + X-Agent-Id resolve to a player-owned agent`() {
-        val req = MockHttpServletRequest().apply {
+       val req = MockHttpServletRequest().apply {
             addHeader("Authorization", "Bearer plr_valid")
             addHeader("X-Agent-Id", agent.id.id.toString())
         }
@@ -49,7 +49,7 @@ class PlayerApiTokenAgentFilterTest {
         assertEquals(agent.id, captured.agentInContext)
         assertEquals(agent, captured.principal)
         assertTrue(captured.authorities.any { it.authority == "ROLE_AGENT" })
-        assertNull(SecurityContextHolder.getContext().authentication)
+        assertEquals(agent, SecurityContextHolder.getContext().authentication.principal)
         assertAgentContextCleared()
     }
 
@@ -103,8 +103,8 @@ class PlayerApiTokenAgentFilterTest {
     }
 
     @Test
-    fun `clears context when downstream chain throws`() {
-        val req = MockHttpServletRequest().apply {
+    fun `clears agent context when downstream chain throws`() {
+       val req = MockHttpServletRequest().apply {
             addHeader("Authorization", "Bearer plr_valid")
             addHeader("X-Agent-Id", agent.id.id.toString())
         }
@@ -112,7 +112,6 @@ class PlayerApiTokenAgentFilterTest {
 
         try { filter.doFilter(req, MockHttpServletResponse(), throwing) } catch (_: RuntimeException) {}
 
-        assertNull(SecurityContextHolder.getContext().authentication)
         assertAgentContextCleared()
     }
 

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/security/PlayerApiTokenAgentFilterTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/security/PlayerApiTokenAgentFilterTest.kt
@@ -49,7 +49,7 @@ class PlayerApiTokenAgentFilterTest {
         assertEquals(agent.id, captured.agentInContext)
         assertEquals(agent, captured.principal)
         assertTrue(captured.authorities.any { it.authority == "ROLE_AGENT" })
-        assertEquals(agent, SecurityContextHolder.getContext().authentication.principal)
+        assertEquals(agent, SecurityContextHolder.getContext().authentication!!.principal)
         assertAgentContextCleared()
     }
 

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/security/jwt/JwtDecoderFilterTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/security/jwt/JwtDecoderFilterTest.kt
@@ -40,7 +40,7 @@ class JwtDecoderFilterTest {
     }
 
     @Test
-    fun `populates context for a valid JWT then clears after the chain runs`() {
+    fun `populates context for a valid JWT and leaves it set for downstream`() {
         val token = issuer.issue(player.id)
         val request = MockHttpServletRequest().apply { addHeader("Authorization", "Bearer $token") }
         val response = MockHttpServletResponse()
@@ -51,7 +51,7 @@ class JwtDecoderFilterTest {
         val captured = chain.snapshot ?: error("chain saw no auth")
         assertEquals(player, captured.principal)
         assertTrue(captured.authorities.any { it.authority == "ROLE_PLAYER" })
-        assertNull(SecurityContextHolder.getContext().authentication)
+        assertEquals(player, SecurityContextHolder.getContext().authentication.principal)
     }
 
     @Test

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/security/jwt/JwtDecoderFilterTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/security/jwt/JwtDecoderFilterTest.kt
@@ -51,7 +51,7 @@ class JwtDecoderFilterTest {
         val captured = chain.snapshot ?: error("chain saw no auth")
         assertEquals(player, captured.principal)
         assertTrue(captured.authorities.any { it.authority == "ROLE_PLAYER" })
-        assertEquals(player, SecurityContextHolder.getContext().authentication.principal)
+        assertEquals(player, SecurityContextHolder.getContext().authentication!!.principal)
     }
 
     @Test

--- a/player/src/main/resources/player-definition/skills.yaml
+++ b/player/src/main/resources/player-definition/skills.yaml
@@ -70,6 +70,13 @@ skills:
 
     # ───────────────────────── Crafting (placeholders) ─────────────────────────
 
+    CARPENTRY:
+      display-name: Carpentry
+      description: >-
+        Wood-frame construction. Trains on building wooden structures
+        (workbench, shelter, storage chest, etc.).
+      category: CRAFTING
+
     SMITHING:
       display-name: Smithing
       description: Forging and metalworking. Future hook for craft quality on metal items.

--- a/world/build.gradle.kts
+++ b/world/build.gradle.kts
@@ -23,5 +23,5 @@ dependencies {
 
 jooqModule {
     migrationsSubdir.set("world")
-    tableIncludes.set("worlds|regions|region_neighbors|nodes|node_adjacency|agent_positions|agent_bodies|starter_nodes|agent_inventory|non_renewable_resources|agent_node_memory|agent_equipment_instances|agent_safe_nodes")
+    tableIncludes.set("worlds|regions|region_neighbors|nodes|node_adjacency|agent_positions|agent_bodies|starter_nodes|agent_inventory|non_renewable_resources|agent_node_memory|agent_equipment_instances|agent_safe_nodes|node_buildings|building_chest_inventory")
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/Building.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/Building.kt
@@ -1,0 +1,48 @@
+package dev.gvart.genesara.world
+
+import dev.gvart.genesara.player.AgentId
+import java.util.UUID
+
+/**
+ * A single physical instance of a built structure attached to a node. The
+ * domain analog of an `agent_equipment_instances` row — per-instance UUID,
+ * lifecycle state, originator signature.
+ *
+ * Backed by `world.node_buildings`. Built up step-by-step: the agent submits
+ * one `BuildStructure` command per step, paying per-step materials + stamina,
+ * until [progressSteps] reaches [totalSteps] and the row flips to
+ * [BuildingStatus.ACTIVE]. Behavioral effects gate on `ACTIVE`.
+ */
+data class Building(
+    val instanceId: UUID,
+    val nodeId: NodeId,
+    val type: BuildingType,
+    val status: BuildingStatus,
+    val builtByAgentId: AgentId,
+    val builtAtTick: Long,
+    val lastProgressTick: Long,
+    val progressSteps: Int,
+    val totalSteps: Int,
+    val hpCurrent: Int,
+    val hpMax: Int,
+) {
+    init {
+        require(totalSteps > 0) { "totalSteps ($totalSteps) must be positive" }
+        require(progressSteps in 0..totalSteps) {
+            "progressSteps ($progressSteps) must be in 0..totalSteps ($totalSteps)"
+        }
+        require(hpMax > 0) { "hpMax ($hpMax) must be positive" }
+        require(hpCurrent in 0..hpMax) {
+            "hpCurrent ($hpCurrent) must be in 0..hpMax ($hpMax)"
+        }
+        // Mirror the SQL CHECK so a hand-built domain object can't drift from the
+        // schema invariant: ACTIVE iff fully built.
+        val isActive = status == BuildingStatus.ACTIVE
+        val isComplete = progressSteps == totalSteps
+        require(isActive == isComplete) {
+            "status ($status) must match completion (progressSteps=$progressSteps, totalSteps=$totalSteps)"
+        }
+    }
+
+    val isActive: Boolean get() = status == BuildingStatus.ACTIVE
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/BuildingCategoryHint.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/BuildingCategoryHint.kt
@@ -1,0 +1,25 @@
+package dev.gvart.genesara.world
+
+/**
+ * Coarse functional grouping for a [BuildingType]. Lets cross-cutting reducers
+ * and future issues (#8 crafting, #18 cultivated resources) discover stations
+ * by intent without re-touching the [BuildingType] enum every time a new
+ * variant lands.
+ *
+ * Example: the movement reducer asks `BuildingsLookup.activeStationsAt(node,
+ * INFRASTRUCTURE_ROAD)` instead of branching on every concrete road sub-type
+ * we may add later (paved road, dirt road, train rail, ...).
+ */
+enum class BuildingCategoryHint {
+    COOKING,
+    STORAGE,
+    RESIDENCE,
+    CRAFTING_STATION_WOOD,
+    CRAFTING_STATION_METAL,
+    CRAFTING_STATION_POTION,
+    AGRICULTURE,
+    UTILITY_WATER,
+    DEFENSIVE,
+    INFRASTRUCTURE_ROAD,
+    INFRASTRUCTURE_BRIDGE,
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/BuildingDefLookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/BuildingDefLookup.kt
@@ -1,0 +1,32 @@
+package dev.gvart.genesara.world
+
+import dev.gvart.genesara.player.SkillId
+
+/**
+ * Public read-only surface over the building catalog. Lets `:api` projections (inspect)
+ * surface per-type spec data without touching the internal `BuildingsCatalog` directly.
+ * The internal catalog still owns the YAML binding + per-step material distribution.
+ */
+interface BuildingDefLookup {
+    fun byType(type: BuildingType): BuildingDefView?
+    fun all(): List<BuildingDefView>
+}
+
+/**
+ * Public-API projection of a [BuildingType]'s catalog spec. Includes everything an
+ * inspecting agent might want to know about how to build (or finish building) the type:
+ * total + per-step materials, the required skill + level gate (0 = no gate), per-step
+ * stamina and total step count, base HP, and the chest weight cap when applicable.
+ */
+data class BuildingDefView(
+    val type: BuildingType,
+    val totalMaterials: Map<ItemId, Int>,
+    val stepMaterials: List<Map<ItemId, Int>>,
+    val requiredSkill: SkillId,
+    val requiredSkillLevel: Int,
+    val totalSteps: Int,
+    val staminaPerStep: Int,
+    val hp: Int,
+    val categoryHint: BuildingCategoryHint,
+    val chestCapacityGrams: Int? = null,
+)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/BuildingStatus.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/BuildingStatus.kt
@@ -1,0 +1,13 @@
+package dev.gvart.genesara.world
+
+/**
+ * Lifecycle stage of a [Building]. Buildings are inserted at
+ * [UNDER_CONSTRUCTION] and flip to [ACTIVE] on the build step that pushes
+ * `progressSteps` to `totalSteps`. Behavioral effects (chest deposits,
+ * road discount, well water source, bridge traversability, shelter safe-node)
+ * gate on [ACTIVE] only — half-built structures are inert.
+ */
+enum class BuildingStatus {
+    UNDER_CONSTRUCTION,
+    ACTIVE,
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/BuildingType.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/BuildingType.kt
@@ -1,0 +1,45 @@
+package dev.gvart.genesara.world
+
+/**
+ * The Tier-1 (non-base) building catalog. Five behavioral types are wired in
+ * this slice; the rest are scaffolded with persistent state but their gameplay
+ * effect waits on a downstream substrate (cooking + crafting recipes from #8,
+ * cultivated resources from #18, PvP combat from Phase 2).
+ *
+ * The base-tier ladder (T1 outpost → T5 city — see mechanics-reference §13)
+ * is a separate concept and lands with the territory work in #23 Phase 3.
+ */
+enum class BuildingType {
+    /** TODO(#8): consult as a cooking station once recipes land; today inert. */
+    CAMPFIRE,
+
+    /** Owner-only personal stash backed by `building_chest_inventory`. */
+    STORAGE_CHEST,
+
+    /** On the build step that completes the shelter, the builder's safe-node is set to its node. */
+    SHELTER,
+
+    /** TODO(#8): consult as a wood crafting station; today inert. */
+    WORKBENCH,
+
+    /** TODO(#8): consult as a metal crafting station; today inert. */
+    FORGE,
+
+    /** TODO(#8): consult as a potion crafting station; today inert. */
+    ALCHEMY_TABLE,
+
+    /** TODO(#18): anchor for plant / tend / harvest verbs; today inert. */
+    FARM_PLOT,
+
+    /** Drink succeeds on this node even when terrain is not a water source. */
+    WELL,
+
+    /** TODO(#22 Phase 2 PvP): block enemy entry; today inert. */
+    WOODEN_WALL,
+
+    /** Halves outgoing-move stamina cost when an agent leaves the road's node. */
+    ROAD,
+
+    /** Overrides `TerrainNotTraversable` on the bridge's node. */
+    BRIDGE,
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/BuildingsLookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/BuildingsLookup.kt
@@ -1,0 +1,38 @@
+package dev.gvart.genesara.world
+
+import java.util.UUID
+
+/**
+ * Read-only public surface for buildings, consumed by projections (look_around,
+ * inspect) and cross-cutting reducers (movement, drink). Separated from
+ * [BuildingsStore] so callers that should not write — every consumer outside
+ * `internal/buildings` — only see the read methods.
+ *
+ * Same separation as [ItemLookup] vs the underlying item catalog, and
+ * [StarterNodeLookup] vs the starter-nodes table.
+ */
+// TODO(#9-slice8): wire `JooqBuildingsLookup` (or delegate to `BuildingsStore`)
+//   when the look_around projection lands. Today this interface has no
+//   Spring-managed impl — no consumer yet, so the empty graph is intentional.
+interface BuildingsLookup {
+
+    fun byId(id: UUID): Building?
+
+    fun byNode(node: NodeId): List<Building>
+
+    /**
+     * **Batched** read for the look_around hot path — one round-trip per call,
+     * not one per visible node. Always prefer this over a per-id loop on the
+     * read path.
+     */
+    fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>>
+
+    /**
+     * Active (not under construction) buildings on [node] whose category hint
+     * matches [hint]. Used by the cross-cutting reducers (movement, drink) to
+     * ask "is there a road here?" / "is there a well here?" / "is this a
+     * crafting station for #8?" without coupling to specific [BuildingType]
+     * variants.
+     */
+    fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building>
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/BuildingsStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/BuildingsStore.kt
@@ -1,0 +1,78 @@
+package dev.gvart.genesara.world
+
+import dev.gvart.genesara.player.AgentId
+import java.util.UUID
+
+/**
+ * Persistent store for [Building] instances. Mirrors the [EquipmentInstanceStore]
+ * shape: per-instance UUID PK, transactional reads/writes, no ORM caching.
+ *
+ * Side-channel writes during the build / progress / completion path — the build
+ * reducer calls into this store inside its own transaction (matches how
+ * `GatherReducer` decrements via `NodeResourceStore`). The immutable `WorldState`
+ * snapshot does not carry buildings; lookups always go through the store.
+ */
+interface BuildingsStore {
+
+    /**
+     * Insert a freshly-placed building (typically at `progressSteps = 1`,
+     * `status = UNDER_CONSTRUCTION`). PK uniqueness on `instance_id` rejects
+     * a double-insert with the same id; callers generate a fresh UUID per
+     * build event.
+     */
+    fun insert(building: Building)
+
+    /**
+     * Single-instance lookup by id. Returns `null` when no row exists. Used by
+     * the inspect tool and the chest deposit / withdraw reducers.
+     */
+    fun findById(id: UUID): Building?
+
+    /**
+     * Find an in-progress (UNDER_CONSTRUCTION) building of [type] at [node]
+     * built by [agent]. Drives the find-or-create-then-advance branch in the
+     * build reducer: an existing row is advanced, otherwise a new one is
+     * inserted. Returns `null` when no matching in-progress instance exists.
+     *
+     * Consequence: an agent can only have ONE in-progress instance of a given
+     * type on a given node at a time — a second call to `build CAMPFIRE`
+     * advances the first; to start a parallel campfire, finish the first.
+     */
+    fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building?
+
+    /**
+     * Every building (any status) attached to [node], ordered by `instance_id`
+     * for stability. Used by the inspect / look_around projections when only
+     * one node is needed.
+     */
+    fun listAtNode(node: NodeId): List<Building>
+
+    /**
+     * **Batched** read across [nodes] — one round-trip via `WHERE node_id = ANY(?)`.
+     * The look_around projection MUST use this rather than calling [listAtNode]
+     * in a per-node loop (see project memory `feedback_read_path_perf.md`).
+     * Nodes with no buildings are absent from the result map.
+     */
+    fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>>
+
+    /**
+     * Advance an existing UNDER_CONSTRUCTION instance by one (or more) step.
+     * Used for non-final steps only — [newProgress] must be strictly less
+     * than the row's `total_steps`. Returns the updated row, or `null` when
+     * no row matches [id] or the row is already ACTIVE.
+     *
+     * Calling this with `newProgress == total_steps` would violate the
+     * `(status = ACTIVE) = (progress_steps = total_steps)` schema CHECK; use
+     * [complete] for the terminal step instead.
+     */
+    fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building?
+
+    /**
+     * Atomically flip an UNDER_CONSTRUCTION instance to ACTIVE: sets
+     * `progress_steps = total_steps` AND `status = 'ACTIVE'` in one UPDATE.
+     * Two columns must move together to satisfy the schema CHECK that pins
+     * the equivalence between completion and active status. Returns the
+     * updated row, or `null` when no row matches [id].
+     */
+    fun complete(id: UUID, asOfTick: Long): Building?
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/ChestContentsStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/ChestContentsStore.kt
@@ -1,0 +1,40 @@
+package dev.gvart.genesara.world
+
+import java.util.UUID
+
+/**
+ * Persistent stash backed by `world.building_chest_inventory`. The persistent
+ * analog of the in-memory `AgentInventory` add/remove shape.
+ *
+ * Every chest variant (STORAGE_CHEST in Phase 1, future CLAN_STORAGE_CHEST in
+ * Phase 3, banker buildings, drop-boxes) writes rows keyed on its own
+ * `building_id`. Access semantics — who can deposit, who can withdraw — live
+ * in the per-variant reducer, NOT in this store. The store is a pure
+ * key-value bag of stack quantities.
+ */
+interface ChestContentsStore {
+
+    /** Quantity of [item] in the chest, or 0 when no row exists. */
+    fun quantityOf(buildingId: UUID, item: ItemId): Int
+
+    /**
+     * Full snapshot of the chest's contents. Empty for a chest that has never
+     * received a deposit. Returned map is read-only.
+     */
+    fun contentsOf(buildingId: UUID): Map<ItemId, Int>
+
+    /**
+     * Add [quantity] of [item] to the chest. Inserts a new row when none
+     * exists, otherwise increments the existing quantity. [quantity] must be
+     * positive — non-positive add is a programmer error and throws.
+     */
+    fun add(buildingId: UUID, item: ItemId, quantity: Int)
+
+    /**
+     * Remove [quantity] of [item] from the chest. Returns `true` if the
+     * removal succeeded, `false` if the chest holds fewer than [quantity] of
+     * [item] (no rows are mutated in that case). Removing the last unit
+     * deletes the row so an empty chest has zero rows in the table.
+     */
+    fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
@@ -129,4 +129,42 @@ sealed interface WorldRejection {
         val required: Int,
         val current: Int,
     ) : WorldRejection
+
+    /** Chest reducer target id does not resolve to any building row. */
+    data class BuildingNotFound(val building: java.util.UUID) : WorldRejection
+
+    /** Chest reducer target is a building, but it is not yet ACTIVE — operations are gated to completed structures. */
+    data class BuildingNotActive(val building: java.util.UUID, val status: BuildingStatus) : WorldRejection
+
+    /** Agent attempted to interact with a building whose node they are not standing on. */
+    data class NotOnBuildingNode(val agent: AgentId, val building: java.util.UUID) : WorldRejection
+
+    /**
+     * Agent attempted to deposit / withdraw against a chest they do not own. Phase 1
+     * chests are owner-only; clan-shared chests will land as a separate building type
+     * with its own access rules in Phase 3.
+     */
+    data class NotChestOwner(val agent: AgentId, val chest: java.util.UUID) : WorldRejection
+
+    /** Deposit would push the chest above its per-type weight cap. */
+    data class ChestCapacityExceeded(
+        val chest: java.util.UUID,
+        val attemptedGrams: Int,
+        val capacityGrams: Int,
+    ) : WorldRejection
+
+    /** Withdraw asked for more of [item] than the chest currently holds. */
+    data class ChestDoesNotContain(
+        val chest: java.util.UUID,
+        val item: ItemId,
+        val requested: Int,
+        val available: Int,
+    ) : WorldRejection
+
+    /**
+     * Reducer received a quantity of zero or less. The MCP boundary is the right place
+     * to filter this, but the reducer also rejects defensively so a buggy direct caller
+     * cannot crash the entire tick by tripping `require`.
+     */
+    data class NonPositiveQuantity(val agent: AgentId, val quantity: Int) : WorldRejection
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
@@ -102,4 +102,31 @@ sealed interface WorldRejection {
         val requested: Int,
         val capacity: Int,
     ) : WorldRejection
+
+    /**
+     * Agent submitted a build step but lacks at least one material this step costs.
+     * The reducer surfaces the FIRST missing material so an agent that's short on
+     * multiple ingredients gets a deterministic, actionable error rather than a
+     * synthetic aggregate.
+     */
+    data class InsufficientMaterials(
+        val agent: AgentId,
+        val type: BuildingType,
+        val item: ItemId,
+        val required: Int,
+        val available: Int,
+    ) : WorldRejection
+
+    /**
+     * Agent submitted a build step but their level in the building's required skill is
+     * below the catalog's `requiredSkillLevel`. Surfaced only when the gate is non-zero
+     * (Tier-1 v1 buildings have level 0 — basic actions skill-free).
+     */
+    data class BuildingSkillTooLow(
+        val agent: AgentId,
+        val type: BuildingType,
+        val skill: dev.gvart.genesara.player.SkillId,
+        val required: Int,
+        val current: Int,
+    ) : WorldRejection
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.world.commands
 
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.NodeId
 import java.util.UUID
@@ -66,6 +67,20 @@ sealed interface WorldCommand {
      */
     data class Respawn(
         override val agent: AgentId,
+        override val commandId: UUID = UUID.randomUUID(),
+    ) : WorldCommand
+
+    /**
+     * Spend one work step on building [type] at the agent's current node.
+     * The first call lays the foundation (creates an UNDER_CONSTRUCTION
+     * instance, deducts step 1's materials + stamina); subsequent calls
+     * advance the existing in-progress instance built by this agent of
+     * this type on this node. The step that reaches the def's totalSteps
+     * flips status to ACTIVE and triggers any per-type completion side-effect.
+     */
+    data class BuildStructure(
+        override val agent: AgentId,
+        val type: BuildingType,
         override val commandId: UUID = UUID.randomUUID(),
     ) : WorldCommand
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
@@ -83,4 +83,22 @@ sealed interface WorldCommand {
         val type: BuildingType,
         override val commandId: UUID = UUID.randomUUID(),
     ) : WorldCommand
+
+    /** Move [quantity] of [item] from the agent's inventory into the chest building [chestId]. */
+    data class DepositToChest(
+        override val agent: AgentId,
+        val chestId: UUID,
+        val item: ItemId,
+        val quantity: Int,
+        override val commandId: UUID = UUID.randomUUID(),
+    ) : WorldCommand
+
+    /** Move [quantity] of [item] from the chest building [chestId] back into the agent's inventory. */
+    data class WithdrawFromChest(
+        override val agent: AgentId,
+        val chestId: UUID,
+        val item: ItemId,
+        val quantity: Int,
+        override val commandId: UUID = UUID.randomUUID(),
+    ) : WorldCommand
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.world.events
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.world.BodyDelta
+import dev.gvart.genesara.world.Building
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.NodeId
@@ -149,6 +150,27 @@ sealed interface WorldEvent {
     data class SafeNodeSet(
         val agent: AgentId,
         val at: NodeId,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : WorldEvent
+
+    /** First step of a new building — the row was just inserted at progress 1, UNDER_CONSTRUCTION. */
+    data class BuildingPlaced(
+        val building: Building,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : WorldEvent
+
+    /** A non-final build step landed — the building's progress advanced but it is still UNDER_CONSTRUCTION. */
+    data class BuildingProgressed(
+        val building: Building,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : WorldEvent
+
+    /** The terminal step landed — the building flipped to ACTIVE on this tick. */
+    data class BuildingCompleted(
+        val building: Building,
         override val tick: Long,
         val causedBy: UUID,
     ) : WorldEvent

--- a/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
@@ -174,4 +174,24 @@ sealed interface WorldEvent {
         override val tick: Long,
         val causedBy: UUID,
     ) : WorldEvent
+
+    /** Agent successfully transferred items from their inventory into a chest building. */
+    data class ItemDeposited(
+        val agent: AgentId,
+        val chest: UUID,
+        val item: ItemId,
+        val quantity: Int,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : WorldEvent
+
+    /** Agent successfully transferred items from a chest building back into their inventory. */
+    data class ItemWithdrawn(
+        val agent: AgentId,
+        val chest: UUID,
+        val item: ItemId,
+        val quantity: Int,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : WorldEvent
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -5,12 +5,15 @@ import dev.gvart.genesara.player.AgentProfileLookup
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.BuildingsStore
 import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.buildings.BuildingsCatalog
+import dev.gvart.genesara.world.internal.buildings.reduceBuild
 import dev.gvart.genesara.world.internal.consume.reduceConsume
 import dev.gvart.genesara.world.internal.death.SafeNodeResolver
 import dev.gvart.genesara.world.internal.death.reduceRespawn
@@ -37,6 +40,8 @@ internal fun reduce(
     equipment: EquipmentInstanceStore,
     safeNodes: AgentSafeNodeGateway,
     safeNodeResolver: SafeNodeResolver,
+    buildings: BuildingsStore,
+    buildingsCatalog: BuildingsCatalog,
     publisher: ApplicationEventPublisher,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = when (command) {
@@ -51,4 +56,6 @@ internal fun reduce(
     is WorldCommand.Drink -> reduceDrink(state, command, balance, tick)
     is WorldCommand.SetSafeNode -> reduceSetSafeNode(state, command, safeNodes, tick)
     is WorldCommand.Respawn -> reduceRespawn(state, command, profiles, safeNodes, safeNodeResolver, tick)
+    is WorldCommand.BuildStructure ->
+        reduceBuild(state, command, buildingsCatalog, skills, buildings, safeNodes, publisher, tick)
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -6,6 +6,7 @@ import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.ChestContentsStore
 import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.WorldRejection
@@ -14,6 +15,8 @@ import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.buildings.BuildingsCatalog
 import dev.gvart.genesara.world.internal.buildings.reduceBuild
+import dev.gvart.genesara.world.internal.buildings.reduceDeposit
+import dev.gvart.genesara.world.internal.buildings.reduceWithdraw
 import dev.gvart.genesara.world.internal.consume.reduceConsume
 import dev.gvart.genesara.world.internal.death.SafeNodeResolver
 import dev.gvart.genesara.world.internal.death.reduceRespawn
@@ -42,6 +45,7 @@ internal fun reduce(
     safeNodeResolver: SafeNodeResolver,
     buildings: BuildingsStore,
     buildingsCatalog: BuildingsCatalog,
+    chestContents: ChestContentsStore,
     publisher: ApplicationEventPublisher,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = when (command) {
@@ -58,4 +62,8 @@ internal fun reduce(
     is WorldCommand.Respawn -> reduceRespawn(state, command, profiles, safeNodes, safeNodeResolver, tick)
     is WorldCommand.BuildStructure ->
         reduceBuild(state, command, buildingsCatalog, skills, buildings, safeNodes, publisher, tick)
+    is WorldCommand.DepositToChest ->
+        reduceDeposit(state, command, items, buildingsCatalog, buildings, chestContents, tick)
+    is WorldCommand.WithdrawFromChest ->
+        reduceWithdraw(state, command, buildings, chestContents, tick)
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -5,6 +5,7 @@ import dev.gvart.genesara.player.AgentProfileLookup
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.BuildingsStore
 import dev.gvart.genesara.world.ChestContentsStore
 import dev.gvart.genesara.world.EquipmentInstanceStore
@@ -44,20 +45,21 @@ internal fun reduce(
     safeNodes: AgentSafeNodeGateway,
     safeNodeResolver: SafeNodeResolver,
     buildings: BuildingsStore,
+    buildingsLookup: BuildingsLookup,
     buildingsCatalog: BuildingsCatalog,
     chestContents: ChestContentsStore,
     publisher: ApplicationEventPublisher,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = when (command) {
     is WorldCommand.SpawnAgent -> reduceSpawn(state, command, profiles, tick)
-    is WorldCommand.MoveAgent -> reduceMove(state, command, balance, tick)
+    is WorldCommand.MoveAgent -> reduceMove(state, command, balance, buildingsLookup, tick)
     is WorldCommand.UnspawnAgent -> reduceUnspawn(state, command, tick)
     is WorldCommand.GatherResource ->
         reduceGather(state, command, balance, items, resources, skills, agents, equipment, publisher, tick)
     is WorldCommand.MineResource ->
         reduceMine(state, command, balance, items, resources, skills, agents, equipment, publisher, tick)
     is WorldCommand.ConsumeItem -> reduceConsume(state, command, items, tick)
-    is WorldCommand.Drink -> reduceDrink(state, command, balance, tick)
+    is WorldCommand.Drink -> reduceDrink(state, command, balance, buildingsLookup, tick)
     is WorldCommand.SetSafeNode -> reduceSetSafeNode(state, command, safeNodes, tick)
     is WorldCommand.Respawn -> reduceRespawn(state, command, profiles, safeNodes, safeNodeResolver, tick)
     is WorldCommand.BuildStructure ->

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -98,6 +98,13 @@ internal interface BalanceLookup {
 
     /** Grams of carry capacity granted per point of Strength. */
     fun carryGramsPerStrengthPoint(): Int = 0
+
+    /**
+     * Multiplier applied to base move stamina cost when the agent is leaving a node
+     * that has an ACTIVE road building. `1.0` (default) = no discount; `0.5` halves
+     * the cost. The reducer floors the result at 1 so movement always costs something.
+     */
+    fun roadStaminaMultiplier(): Double = 1.0
 }
 
 @Component
@@ -165,6 +172,8 @@ internal class WorldDefinitionBalanceLookup(
 
     override fun carryGramsPerStrengthPoint(): Int = CARRY_GRAMS_PER_STRENGTH_POINT
 
+    override fun roadStaminaMultiplier(): Double = ROAD_STAMINA_MULTIPLIER
+
     private companion object {
         const val BASE_MOVE_COST = 1
         const val BASE_REGEN_PER_TICK = 1.0
@@ -180,5 +189,6 @@ internal class WorldDefinitionBalanceLookup(
         const val SLEEP_REGEN_PER_OFFLINE_TICK = 2
         const val XP_LOSS_ON_DEATH = 25
         const val CARRY_GRAMS_PER_STRENGTH_POINT = 5_000
+        const val ROAD_STAMINA_MULTIPLIER = 0.5
     }
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
@@ -1,0 +1,170 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import arrow.core.Either
+import arrow.core.raise.Raise
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import arrow.core.raise.ensureNotNull
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.inventory.AgentInventory
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+
+/**
+ * Find-or-create-then-advance reducer for [WorldCommand.BuildStructure]. The skill flow
+ * mirrors `GatherReducer.accrueXpOrRecommend`. Catalog enforces `totalSteps >= 2`, so the
+ * "insert at progress=1, then complete same call" trap (would violate the schema CHECK)
+ * cannot arise from a YAML-loaded def.
+ */
+internal fun reduceBuild(
+    state: WorldState,
+    command: WorldCommand.BuildStructure,
+    catalog: BuildingsCatalog,
+    skills: AgentSkillsRegistry,
+    buildings: BuildingsStore,
+    safeNodes: AgentSafeNodeGateway,
+    publisher: ApplicationEventPublisher,
+    tick: Long,
+): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+    val nodeId = ensureNotNull(state.positions[command.agent]) {
+        WorldRejection.NotInWorld(command.agent)
+    }
+    val def = catalog.def(command.type)
+
+    if (def.requiredSkillLevel > 0) {
+        val current = skills.snapshot(command.agent).perSkill[def.requiredSkill]?.level ?: 0
+        ensure(current >= def.requiredSkillLevel) {
+            WorldRejection.BuildingSkillTooLow(
+                agent = command.agent,
+                type = command.type,
+                skill = def.requiredSkill,
+                required = def.requiredSkillLevel,
+                current = current,
+            )
+        }
+    }
+
+    val body = state.bodyOf(command.agent)
+        ?: error("Invariant violated: agent ${command.agent} has a position but no body")
+    ensure(body.stamina >= def.staminaPerStep) {
+        WorldRejection.NotEnoughStamina(command.agent, def.staminaPerStep, body.stamina)
+    }
+
+    val existing = buildings.findInProgress(nodeId, command.agent, command.type)
+    val nextProgress = (existing?.progressSteps ?: 0) + 1
+    val stepCost = def.stepMaterials[nextProgress - 1]
+    val inventory = state.inventoryOf(command.agent)
+    requireMaterials(command.agent, command.type, inventory, stepCost)
+
+    val nextInventory = stepCost.entries.fold(inventory) { acc, (item, qty) -> acc.remove(item, qty) }
+    val isFinalStep = nextProgress == def.totalSteps
+
+    val (resultBuilding, event) = if (existing == null) {
+        val placed = Building(
+            instanceId = UUID.randomUUID(),
+            nodeId = nodeId,
+            type = command.type,
+            status = BuildingStatus.UNDER_CONSTRUCTION,
+            builtByAgentId = command.agent,
+            builtAtTick = tick,
+            lastProgressTick = tick,
+            progressSteps = 1,
+            totalSteps = def.totalSteps,
+            hpCurrent = def.hp,
+            hpMax = def.hp,
+        )
+        buildings.insert(placed)
+        placed to WorldEvent.BuildingPlaced(placed, tick, command.commandId)
+    } else if (isFinalStep) {
+        val completed = buildings.complete(existing.instanceId, tick)
+            ?: error("Building ${existing.instanceId} vanished between findInProgress and complete")
+        completed to WorldEvent.BuildingCompleted(completed, tick, command.commandId)
+    } else {
+        val advanced = buildings.advanceProgress(existing.instanceId, nextProgress, tick)
+            ?: error("Building ${existing.instanceId} vanished between findInProgress and advanceProgress")
+        advanced to WorldEvent.BuildingProgressed(advanced, tick, command.commandId)
+    }
+
+    if (event is WorldEvent.BuildingCompleted) applyCompletionSideEffects(resultBuilding, safeNodes, tick)
+
+    accrueXpOrRecommend(command.agent, command.commandId, def.requiredSkill, tick, skills, publisher)
+
+    val next = state
+        .updateBody(command.agent, body.spendStamina(def.staminaPerStep))
+        .updateInventory(command.agent, nextInventory)
+    next to event
+}
+
+private fun Raise<WorldRejection>.requireMaterials(
+    agent: AgentId,
+    type: BuildingType,
+    inventory: AgentInventory,
+    stepCost: Map<dev.gvart.genesara.world.ItemId, Int>,
+) {
+    for ((item, required) in stepCost) {
+        val have = inventory.quantityOf(item)
+        if (have < required) {
+            raise(WorldRejection.InsufficientMaterials(agent, type, item, required, have))
+        }
+    }
+}
+
+private fun applyCompletionSideEffects(
+    building: Building,
+    safeNodes: AgentSafeNodeGateway,
+    tick: Long,
+) {
+    when (building.type) {
+        BuildingType.SHELTER -> safeNodes.set(building.builtByAgentId, building.nodeId, tick)
+        else -> Unit
+    }
+}
+
+private fun accrueXpOrRecommend(
+    agent: AgentId,
+    commandId: UUID,
+    skill: SkillId,
+    tick: Long,
+    skills: AgentSkillsRegistry,
+    publisher: ApplicationEventPublisher,
+) {
+    when (val result = skills.addXpIfSlotted(agent, skill, delta = 1)) {
+        is AddXpResult.Accrued -> result.crossedMilestones.forEach { milestone ->
+            publisher.publishEvent(
+                WorldEvent.SkillMilestoneReached(
+                    agent = agent,
+                    skill = skill,
+                    milestone = milestone,
+                    tick = tick,
+                    causedBy = commandId,
+                ),
+            )
+        }
+        AddXpResult.Unslotted -> skills.maybeRecommend(agent, skill, tick)?.let { newCount ->
+            val snapshot = skills.snapshot(agent)
+            publisher.publishEvent(
+                WorldEvent.SkillRecommended(
+                    agent = agent,
+                    skill = skill,
+                    recommendCount = newCount,
+                    slotsFree = snapshot.slotCount - snapshot.slotsFilled,
+                    tick = tick,
+                    causedBy = commandId,
+                ),
+            )
+        }
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingDef.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingDef.kt
@@ -13,7 +13,16 @@ internal data class BuildingDef(
     val type: BuildingType,
     val totalMaterials: Map<ItemId, Int>,
     val stepMaterials: List<Map<ItemId, Int>>,
+    /**
+     * Skill the build action trains and is recommended for. Always used as an XP +
+     * recommendation hook; gated as a hard prerequisite when [requiredSkillLevel] > 0.
+     */
     val requiredSkill: SkillId,
+    /**
+     * Minimum [requiredSkill] level the agent must hold to start or advance this build.
+     * `0` (default) means "basic action, no level gate" — every Tier-1 building in v1.
+     * Higher tiers and certain Tier-1 specialty buildings may set this >0 in the future.
+     */
     val requiredSkillLevel: Int,
     val totalSteps: Int,
     val staminaPerStep: Int,

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingDef.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingDef.kt
@@ -1,0 +1,23 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.ItemId
+
+/**
+ * Resolved per-type build spec. Per-step math: `floor(total / steps)` for
+ * steps 1..N-1, remainder on step N so totals match exactly per material.
+ */
+internal data class BuildingDef(
+    val type: BuildingType,
+    val totalMaterials: Map<ItemId, Int>,
+    val stepMaterials: List<Map<ItemId, Int>>,
+    val requiredSkill: SkillId,
+    val requiredSkillLevel: Int,
+    val totalSteps: Int,
+    val staminaPerStep: Int,
+    val hp: Int,
+    val categoryHint: BuildingCategoryHint,
+    val chestCapacityGrams: Int? = null,
+)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingDefinitionProperties.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingDefinitionProperties.kt
@@ -1,0 +1,8 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "buildings")
+internal data class BuildingDefinitionProperties(
+    val catalog: Map<String, BuildingProperties> = emptyMap(),
+)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingProperties.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingProperties.kt
@@ -4,7 +4,8 @@ import dev.gvart.genesara.world.BuildingCategoryHint
 
 internal data class BuildingProperties(
     val requiredSkill: String,
-    val requiredSkillLevel: Int = 1,
+    /** Defaults to 0 — basic action, no skill-level gate. See [BuildingDef.requiredSkillLevel]. */
+    val requiredSkillLevel: Int = 0,
     val totalSteps: Int,
     val staminaPerStep: Int,
     val hp: Int,

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingProperties.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingProperties.kt
@@ -1,0 +1,14 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.world.BuildingCategoryHint
+
+internal data class BuildingProperties(
+    val requiredSkill: String,
+    val requiredSkillLevel: Int = 1,
+    val totalSteps: Int,
+    val staminaPerStep: Int,
+    val hp: Int,
+    val categoryHint: BuildingCategoryHint,
+    val totalMaterials: Map<String, Int> = emptyMap(),
+    val chestCapacityGrams: Int? = null,
+)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalog.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalog.kt
@@ -1,6 +1,8 @@
 package dev.gvart.genesara.world.internal.buildings
 
 import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.world.BuildingDefLookup
+import dev.gvart.genesara.world.BuildingDefView
 import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.ItemId
 import org.springframework.stereotype.Component
@@ -8,7 +10,7 @@ import org.springframework.stereotype.Component
 @Component
 internal class BuildingsCatalog(
     props: BuildingDefinitionProperties,
-) {
+) : BuildingDefLookup {
 
     private val byType: Map<BuildingType, BuildingDef> = props.catalog.entries.associate { (key, properties) ->
         val type = BuildingType.valueOf(key)
@@ -18,7 +20,24 @@ internal class BuildingsCatalog(
     fun def(type: BuildingType): BuildingDef =
         byType[type] ?: error("No building catalog entry for $type")
 
-    fun all(): List<BuildingDef> = byType.values.toList()
+    fun allDefs(): List<BuildingDef> = byType.values.toList()
+
+    override fun byType(type: BuildingType): BuildingDefView? = byType[type]?.toView()
+
+    override fun all(): List<BuildingDefView> = byType.values.map { it.toView() }
+
+    private fun BuildingDef.toView(): BuildingDefView = BuildingDefView(
+        type = type,
+        totalMaterials = totalMaterials,
+        stepMaterials = stepMaterials,
+        requiredSkill = requiredSkill,
+        requiredSkillLevel = requiredSkillLevel,
+        totalSteps = totalSteps,
+        staminaPerStep = staminaPerStep,
+        hp = hp,
+        categoryHint = categoryHint,
+        chestCapacityGrams = chestCapacityGrams,
+    )
 
     private fun toDef(type: BuildingType, props: BuildingProperties): BuildingDef {
         val totalMaterials = props.totalMaterials.entries.associate { (id, qty) -> ItemId(id) to qty }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalog.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalog.kt
@@ -1,0 +1,56 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.ItemId
+import org.springframework.stereotype.Component
+
+@Component
+internal class BuildingsCatalog(
+    props: BuildingDefinitionProperties,
+) {
+
+    private val byType: Map<BuildingType, BuildingDef> = props.catalog.entries.associate { (key, properties) ->
+        val type = BuildingType.valueOf(key)
+        type to toDef(type, properties)
+    }
+
+    fun def(type: BuildingType): BuildingDef =
+        byType[type] ?: error("No building catalog entry for $type")
+
+    fun all(): List<BuildingDef> = byType.values.toList()
+
+    private fun toDef(type: BuildingType, props: BuildingProperties): BuildingDef {
+        val totalMaterials = props.totalMaterials.entries.associate { (id, qty) -> ItemId(id) to qty }
+        return BuildingDef(
+            type = type,
+            totalMaterials = totalMaterials,
+            stepMaterials = computeStepMaterials(totalMaterials, props.totalSteps),
+            requiredSkill = SkillId(props.requiredSkill),
+            requiredSkillLevel = props.requiredSkillLevel,
+            totalSteps = props.totalSteps,
+            staminaPerStep = props.staminaPerStep,
+            hp = props.hp,
+            categoryHint = props.categoryHint,
+            chestCapacityGrams = props.chestCapacityGrams,
+        )
+    }
+
+    private fun computeStepMaterials(
+        totalMaterials: Map<ItemId, Int>,
+        totalSteps: Int,
+    ): List<Map<ItemId, Int>> {
+        require(totalSteps > 0) { "totalSteps must be positive, got $totalSteps" }
+        val stepsAccumulator = MutableList(totalSteps) { mutableMapOf<ItemId, Int>() }
+        for ((item, total) in totalMaterials) {
+            val perStep = total / totalSteps
+            val remainder = total - perStep * totalSteps
+            for (i in 0 until totalSteps - 1) {
+                if (perStep > 0) stepsAccumulator[i][item] = perStep
+            }
+            val tail = perStep + remainder
+            if (tail > 0) stepsAccumulator[totalSteps - 1][item] = tail
+        }
+        return stepsAccumulator.map { it.toMap() }
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalogValidator.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalogValidator.kt
@@ -19,13 +19,13 @@ internal class BuildingsCatalogValidator(
     fun validate() {
         val problems = mutableListOf<String>()
 
-        val present = catalog.all().map { it.type }.toSet()
+        val present = catalog.allDefs().map { it.type }.toSet()
         val missing = BuildingType.entries.filter { it !in present }
         if (missing.isNotEmpty()) {
             problems += "Missing catalog entries for: ${missing.joinToString { it.name }}"
         }
 
-        for (def in catalog.all()) {
+        for (def in catalog.allDefs()) {
             // totalSteps >= 2: a 1-step building completes on the first call, defeating
             // the active-loop design (project memory feedback_active_agent_loop). The
             // schema CHECK that pins UNDER_CONSTRUCTION ↔ progress<total also makes the

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalogValidator.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalogValidator.kt
@@ -1,0 +1,57 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.ItemLookup
+import jakarta.annotation.PostConstruct
+import org.springframework.stereotype.Component
+
+/**
+ * Cross-validates `buildings.yaml` at startup. Mirrors [dev.gvart.genesara.world.internal.balance.ConsumablesValidator]:
+ * fail fast with one error message naming every offending entry.
+ */
+@Component
+internal class BuildingsCatalogValidator(
+    private val catalog: BuildingsCatalog,
+    private val items: ItemLookup,
+) {
+
+    @PostConstruct
+    fun validate() {
+        val problems = mutableListOf<String>()
+
+        val present = catalog.all().map { it.type }.toSet()
+        val missing = BuildingType.entries.filter { it !in present }
+        if (missing.isNotEmpty()) {
+            problems += "Missing catalog entries for: ${missing.joinToString { it.name }}"
+        }
+
+        for (def in catalog.all()) {
+            if (def.totalSteps <= 0) problems += "${def.type}: totalSteps must be > 0 (got ${def.totalSteps})"
+            if (def.staminaPerStep <= 0) problems += "${def.type}: staminaPerStep must be > 0 (got ${def.staminaPerStep})"
+            if (def.hp <= 0) problems += "${def.type}: hp must be > 0 (got ${def.hp})"
+            if (def.requiredSkillLevel <= 0) problems += "${def.type}: requiredSkillLevel must be > 0 (got ${def.requiredSkillLevel})"
+
+            for ((itemId, total) in def.totalMaterials) {
+                if (total <= 0) problems += "${def.type}: material ${itemId.value} total must be > 0 (got $total)"
+                if (items.byId(itemId) == null) {
+                    problems += "${def.type}: material ${itemId.value} is not in the items catalog"
+                }
+            }
+
+            val isChest = def.type == BuildingType.STORAGE_CHEST
+            if (isChest && def.chestCapacityGrams == null) {
+                problems += "${def.type}: chestCapacityGrams must be set for STORAGE_CHEST"
+            }
+            if (!isChest && def.chestCapacityGrams != null) {
+                problems += "${def.type}: chestCapacityGrams must be null for non-chest types"
+            }
+        }
+
+        require(problems.isEmpty()) {
+            buildString {
+                append("Building catalog validation failed:\n")
+                problems.forEach { append("  - $it\n") }
+            }
+        }
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalogValidator.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalogValidator.kt
@@ -26,10 +26,14 @@ internal class BuildingsCatalogValidator(
         }
 
         for (def in catalog.all()) {
-            if (def.totalSteps <= 0) problems += "${def.type}: totalSteps must be > 0 (got ${def.totalSteps})"
+            // totalSteps >= 2: a 1-step building completes on the first call, defeating
+            // the active-loop design (project memory feedback_active_agent_loop). The
+            // schema CHECK that pins UNDER_CONSTRUCTION ↔ progress<total also makes the
+            // (insert-then-complete-same-tick) path unsafe for 1-step rows.
+            if (def.totalSteps < 2) problems += "${def.type}: totalSteps must be >= 2 (got ${def.totalSteps})"
             if (def.staminaPerStep <= 0) problems += "${def.type}: staminaPerStep must be > 0 (got ${def.staminaPerStep})"
             if (def.hp <= 0) problems += "${def.type}: hp must be > 0 (got ${def.hp})"
-            if (def.requiredSkillLevel <= 0) problems += "${def.type}: requiredSkillLevel must be > 0 (got ${def.requiredSkillLevel})"
+            if (def.requiredSkillLevel < 0) problems += "${def.type}: requiredSkillLevel must be >= 0 (got ${def.requiredSkillLevel})"
 
             for ((itemId, total) in def.totalMaterials) {
                 if (total <= 0) problems += "${def.type}: material ${itemId.value} total must be > 0 (got $total)"

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsConfiguration.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsConfiguration.kt
@@ -1,0 +1,16 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.world.internal.balance.YamlPropertySourceFactory
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.PropertySource
+
+@Configuration
+@PropertySource(
+    value = [
+        "classpath:world-definition/buildings.yaml",
+    ],
+    factory = YamlPropertySourceFactory::class,
+)
+@EnableConfigurationProperties(BuildingDefinitionProperties::class)
+internal class BuildingsConfiguration

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsLookupImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsLookupImpl.kt
@@ -17,7 +17,7 @@ internal class BuildingsLookupImpl(
 ) : BuildingsLookup {
 
     private val typesByHint: Map<BuildingCategoryHint, Set<BuildingType>> =
-        catalog.all().groupBy { it.categoryHint }.mapValues { (_, defs) -> defs.map { it.type }.toSet() }
+        catalog.allDefs().groupBy { it.categoryHint }.mapValues { (_, defs) -> defs.map { it.type }.toSet() }
 
     override fun byId(id: UUID): Building? = store.findById(id)
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsLookupImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsLookupImpl.kt
@@ -1,0 +1,33 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsLookup
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.NodeId
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+internal class BuildingsLookupImpl(
+    private val store: BuildingsStore,
+    catalog: BuildingsCatalog,
+) : BuildingsLookup {
+
+    private val typesByHint: Map<BuildingCategoryHint, Set<BuildingType>> =
+        catalog.all().groupBy { it.categoryHint }.mapValues { (_, defs) -> defs.map { it.type }.toSet() }
+
+    override fun byId(id: UUID): Building? = store.findById(id)
+
+    override fun byNode(node: NodeId): List<Building> = store.listAtNode(node)
+
+    override fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = store.listByNodes(nodes)
+
+    override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> {
+        val matchingTypes = typesByHint[hint] ?: return emptyList()
+        return store.listAtNode(node)
+            .filter { it.status == BuildingStatus.ACTIVE && it.type in matchingTypes }
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/ChestReducers.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/ChestReducers.kt
@@ -1,0 +1,121 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import arrow.core.Either
+import arrow.core.raise.Raise
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import arrow.core.raise.ensureNotNull
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.ChestContentsStore
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import java.util.UUID
+
+internal fun reduceDeposit(
+    state: WorldState,
+    command: WorldCommand.DepositToChest,
+    items: ItemLookup,
+    catalog: BuildingsCatalog,
+    buildings: BuildingsStore,
+    chestContents: ChestContentsStore,
+    tick: Long,
+): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+    ensure(command.quantity > 0) { WorldRejection.NonPositiveQuantity(command.agent, command.quantity) }
+    val agentNode = ensureNotNull(state.positions[command.agent]) {
+        WorldRejection.NotInWorld(command.agent)
+    }
+    val chest = resolveOwnedActiveChestAtAgentNode(command.agent, command.chestId, agentNode, buildings)
+    val def = catalog.def(BuildingType.STORAGE_CHEST)
+
+    val inventory = state.inventoryOf(command.agent)
+    val have = inventory.quantityOf(command.item)
+    ensure(have >= command.quantity) {
+        WorldRejection.ItemNotInInventory(command.agent, command.item)
+    }
+
+    val itemDef = ensureNotNull(items.byId(command.item)) { WorldRejection.UnknownItem(command.item) }
+    val capacity = def.chestCapacityGrams
+        ?: error("STORAGE_CHEST def is missing chestCapacityGrams (catalog validator should have caught this)")
+    val currentGrams = chestContents.contentsOf(chest.instanceId).entries.sumOf { (id, qty) ->
+        (items.byId(id)?.weightPerUnit ?: 0) * qty
+    }
+    val attemptedGrams = currentGrams + itemDef.weightPerUnit * command.quantity
+    ensure(attemptedGrams <= capacity) {
+        WorldRejection.ChestCapacityExceeded(chest.instanceId, attemptedGrams, capacity)
+    }
+
+    chestContents.add(chest.instanceId, command.item, command.quantity)
+    val nextInventory = inventory.remove(command.item, command.quantity)
+    val next = state.updateInventory(command.agent, nextInventory)
+    val event = WorldEvent.ItemDeposited(
+        agent = command.agent,
+        chest = chest.instanceId,
+        item = command.item,
+        quantity = command.quantity,
+        tick = tick,
+        causedBy = command.commandId,
+    )
+    next to event
+}
+
+internal fun reduceWithdraw(
+    state: WorldState,
+    command: WorldCommand.WithdrawFromChest,
+    buildings: BuildingsStore,
+    chestContents: ChestContentsStore,
+    tick: Long,
+): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+    ensure(command.quantity > 0) { WorldRejection.NonPositiveQuantity(command.agent, command.quantity) }
+    val agentNode = ensureNotNull(state.positions[command.agent]) {
+        WorldRejection.NotInWorld(command.agent)
+    }
+    val chest = resolveOwnedActiveChestAtAgentNode(command.agent, command.chestId, agentNode, buildings)
+
+    val available = chestContents.quantityOf(chest.instanceId, command.item)
+    ensure(available >= command.quantity) {
+        WorldRejection.ChestDoesNotContain(chest.instanceId, command.item, command.quantity, available)
+    }
+
+    // Within a single tick the queue serializes commands per agent and we just read
+    // `quantityOf >= command.quantity`, so a `false` here is a real invariant break.
+    val removed = chestContents.remove(chest.instanceId, command.item, command.quantity)
+    check(removed) { "chestContents.remove disagreed with quantityOf — store invariant violated for ${chest.instanceId}" }
+    val nextInventory = state.inventoryOf(command.agent).add(command.item, command.quantity)
+    val next = state.updateInventory(command.agent, nextInventory)
+    val event = WorldEvent.ItemWithdrawn(
+        agent = command.agent,
+        chest = chest.instanceId,
+        item = command.item,
+        quantity = command.quantity,
+        tick = tick,
+        causedBy = command.commandId,
+    )
+    next to event
+}
+
+private fun Raise<WorldRejection>.resolveOwnedActiveChestAtAgentNode(
+    agent: AgentId,
+    chestId: UUID,
+    agentNode: NodeId,
+    buildings: BuildingsStore,
+): Building {
+    val chest = ensureNotNull(buildings.findById(chestId)) { WorldRejection.BuildingNotFound(chestId) }
+    // Privacy: surface a "wrong type" hit as BuildingNotFound so an agent cannot probe
+    // what other building types live at an id they happened to learn.
+    ensure(chest.type == BuildingType.STORAGE_CHEST) { WorldRejection.BuildingNotFound(chestId) }
+    // Owner-before-location is intentional: ownership is the load-bearing access gate
+    // (Phase 1 chests are personal); leaking ownership-by-id is acceptable because chest
+    // ids aren't enumerable, but leaking a chest's location would not be.
+    ensure(chest.builtByAgentId == agent) { WorldRejection.NotChestOwner(agent, chestId) }
+    ensure(chest.nodeId == agentNode) { WorldRejection.NotOnBuildingNode(agent, chestId) }
+    ensure(chest.status == BuildingStatus.ACTIVE) { WorldRejection.BuildingNotActive(chestId, chest.status) }
+    return chest
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/JooqBuildingsStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/JooqBuildingsStore.kt
@@ -1,0 +1,115 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.internal.jooq.tables.references.NODE_BUILDINGS
+import org.jooq.DSLContext
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Component
+internal class JooqBuildingsStore(
+    private val dsl: DSLContext,
+) : BuildingsStore {
+
+    @Transactional
+    override fun insert(building: Building) {
+        dsl.insertInto(NODE_BUILDINGS)
+            .set(NODE_BUILDINGS.INSTANCE_ID, building.instanceId)
+            .set(NODE_BUILDINGS.NODE_ID, building.nodeId.value)
+            .set(NODE_BUILDINGS.BUILDING_TYPE, building.type.name)
+            .set(NODE_BUILDINGS.STATUS, building.status.name)
+            .set(NODE_BUILDINGS.BUILT_BY_AGENT_ID, building.builtByAgentId.id)
+            .set(NODE_BUILDINGS.BUILT_AT_TICK, building.builtAtTick)
+            .set(NODE_BUILDINGS.LAST_PROGRESS_TICK, building.lastProgressTick)
+            .set(NODE_BUILDINGS.PROGRESS_STEPS, building.progressSteps)
+            .set(NODE_BUILDINGS.TOTAL_STEPS, building.totalSteps)
+            .set(NODE_BUILDINGS.HP_CURRENT, building.hpCurrent)
+            .set(NODE_BUILDINGS.HP_MAX, building.hpMax)
+            .execute()
+    }
+
+    @Transactional(readOnly = true)
+    override fun findById(id: UUID): Building? =
+        dsl.selectFrom(NODE_BUILDINGS)
+            .where(NODE_BUILDINGS.INSTANCE_ID.eq(id))
+            .fetchOne(::toDomain)
+
+    @Transactional(readOnly = true)
+    override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? =
+        dsl.selectFrom(NODE_BUILDINGS)
+            .where(NODE_BUILDINGS.NODE_ID.eq(node.value))
+            .and(NODE_BUILDINGS.BUILT_BY_AGENT_ID.eq(agent.id))
+            .and(NODE_BUILDINGS.BUILDING_TYPE.eq(type.name))
+            .and(NODE_BUILDINGS.STATUS.eq(BuildingStatus.UNDER_CONSTRUCTION.name))
+            .fetchOne(::toDomain)
+
+    @Transactional(readOnly = true)
+    override fun listAtNode(node: NodeId): List<Building> =
+        dsl.selectFrom(NODE_BUILDINGS)
+            .where(NODE_BUILDINGS.NODE_ID.eq(node.value))
+            .orderBy(NODE_BUILDINGS.INSTANCE_ID.asc())
+            .fetch(::toDomain)
+
+    @Transactional(readOnly = true)
+    override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> {
+        if (nodes.isEmpty()) return emptyMap()
+        return dsl.selectFrom(NODE_BUILDINGS)
+            .where(NODE_BUILDINGS.NODE_ID.`in`(nodes.map { it.value }))
+            .orderBy(NODE_BUILDINGS.NODE_ID.asc(), NODE_BUILDINGS.INSTANCE_ID.asc())
+            .fetch(::toDomain)
+            .groupBy { it.nodeId }
+    }
+
+    /**
+     * `UPDATE ... RETURNING` rather than `UPDATE` + `SELECT` to close a race
+     * window: a concurrent delete between the two statements would leave the
+     * SELECT empty after a successful update, indistinguishable from "no such
+     * row." Same defense as `JooqEquipmentInstanceStore.decrementDurability`.
+     */
+    @Transactional
+    override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? =
+        dsl.update(NODE_BUILDINGS)
+            .set(NODE_BUILDINGS.PROGRESS_STEPS, newProgress)
+            .set(NODE_BUILDINGS.LAST_PROGRESS_TICK, asOfTick)
+            .where(NODE_BUILDINGS.INSTANCE_ID.eq(id))
+            .and(NODE_BUILDINGS.STATUS.eq(BuildingStatus.UNDER_CONSTRUCTION.name))
+            .returningResult(NODE_BUILDINGS.asterisk())
+            .fetchOne()
+            ?.into(NODE_BUILDINGS)
+            ?.let(::toDomain)
+
+    @Transactional
+    override fun complete(id: UUID, asOfTick: Long): Building? =
+        dsl.update(NODE_BUILDINGS)
+            .set(NODE_BUILDINGS.STATUS, BuildingStatus.ACTIVE.name)
+            .set(NODE_BUILDINGS.PROGRESS_STEPS, NODE_BUILDINGS.TOTAL_STEPS)
+            .set(NODE_BUILDINGS.LAST_PROGRESS_TICK, asOfTick)
+            .where(NODE_BUILDINGS.INSTANCE_ID.eq(id))
+            .and(NODE_BUILDINGS.STATUS.eq(BuildingStatus.UNDER_CONSTRUCTION.name))
+            .returningResult(NODE_BUILDINGS.asterisk())
+            .fetchOne()
+            ?.into(NODE_BUILDINGS)
+            ?.let(::toDomain)
+
+    private fun toDomain(
+        record: dev.gvart.genesara.world.internal.jooq.tables.records.NodeBuildingsRecord,
+    ): Building = Building(
+        instanceId = record.instanceId,
+        nodeId = NodeId(record.nodeId),
+        type = BuildingType.valueOf(record.buildingType),
+        status = BuildingStatus.valueOf(record.status),
+        builtByAgentId = AgentId(record.builtByAgentId),
+        builtAtTick = record.builtAtTick,
+        lastProgressTick = record.lastProgressTick,
+        progressSteps = record.progressSteps,
+        totalSteps = record.totalSteps,
+        hpCurrent = record.hpCurrent,
+        hpMax = record.hpMax,
+    )
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/JooqChestContentsStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/JooqChestContentsStore.kt
@@ -1,0 +1,73 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.world.ChestContentsStore
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.internal.jooq.tables.references.BUILDING_CHEST_INVENTORY
+import org.jooq.DSLContext
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Component
+internal class JooqChestContentsStore(
+    private val dsl: DSLContext,
+) : ChestContentsStore {
+
+    @Transactional(readOnly = true)
+    override fun quantityOf(buildingId: UUID, item: ItemId): Int =
+        dsl.select(BUILDING_CHEST_INVENTORY.QUANTITY)
+            .from(BUILDING_CHEST_INVENTORY)
+            .where(BUILDING_CHEST_INVENTORY.BUILDING_ID.eq(buildingId))
+            .and(BUILDING_CHEST_INVENTORY.ITEM_ID.eq(item.value))
+            .fetchOne(BUILDING_CHEST_INVENTORY.QUANTITY)
+            ?: 0
+
+    @Transactional(readOnly = true)
+    override fun contentsOf(buildingId: UUID): Map<ItemId, Int> =
+        dsl.selectFrom(BUILDING_CHEST_INVENTORY)
+            .where(BUILDING_CHEST_INVENTORY.BUILDING_ID.eq(buildingId))
+            .fetch()
+            .associate { ItemId(it.itemId) to it.quantity }
+
+    @Transactional
+    override fun add(buildingId: UUID, item: ItemId, quantity: Int) {
+        require(quantity > 0) { "quantity to add must be positive, got $quantity" }
+        // Postgres UPSERT — atomic insert-or-increment so two concurrent deposits
+        // can't read-modify-write past each other.
+        dsl.insertInto(BUILDING_CHEST_INVENTORY)
+            .set(BUILDING_CHEST_INVENTORY.BUILDING_ID, buildingId)
+            .set(BUILDING_CHEST_INVENTORY.ITEM_ID, item.value)
+            .set(BUILDING_CHEST_INVENTORY.QUANTITY, quantity)
+            .onConflict(BUILDING_CHEST_INVENTORY.BUILDING_ID, BUILDING_CHEST_INVENTORY.ITEM_ID)
+            .doUpdate()
+            .set(
+                BUILDING_CHEST_INVENTORY.QUANTITY,
+                BUILDING_CHEST_INVENTORY.QUANTITY.plus(quantity),
+            )
+            .execute()
+    }
+
+    @Transactional
+    override fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean {
+        require(quantity > 0) { "quantity to remove must be positive, got $quantity" }
+        // Two-pass under @Transactional. Delete-on-exact-match first to avoid
+        // tripping the QUANTITY > 0 CHECK that would fire on a decrement-to-zero
+        // UPDATE; otherwise decrement only when there's strictly more than asked.
+        // Each statement is atomic; the surrounding transaction provides the
+        // read-modify-write isolation against concurrent removes.
+        val deleted = dsl.deleteFrom(BUILDING_CHEST_INVENTORY)
+            .where(BUILDING_CHEST_INVENTORY.BUILDING_ID.eq(buildingId))
+            .and(BUILDING_CHEST_INVENTORY.ITEM_ID.eq(item.value))
+            .and(BUILDING_CHEST_INVENTORY.QUANTITY.eq(quantity))
+            .execute()
+        if (deleted > 0) return true
+
+        val updated = dsl.update(BUILDING_CHEST_INVENTORY)
+            .set(BUILDING_CHEST_INVENTORY.QUANTITY, BUILDING_CHEST_INVENTORY.QUANTITY.minus(quantity))
+            .where(BUILDING_CHEST_INVENTORY.BUILDING_ID.eq(buildingId))
+            .and(BUILDING_CHEST_INVENTORY.ITEM_ID.eq(item.value))
+            .and(BUILDING_CHEST_INVENTORY.QUANTITY.gt(quantity))
+            .execute()
+        return updated > 0
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/drink/DrinkReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/drink/DrinkReducer.kt
@@ -4,6 +4,8 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
@@ -31,6 +33,7 @@ internal fun reduceDrink(
     state: WorldState,
     command: WorldCommand.Drink,
     balance: BalanceLookup,
+    buildings: BuildingsLookup,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
@@ -38,7 +41,8 @@ internal fun reduceDrink(
     }
     val node = ensureNotNull(state.nodes[nodeId]) { WorldRejection.UnknownNode(nodeId) }
 
-    ensure(balance.isWaterSource(node.terrain)) {
+    val hasWell = buildings.activeStationsAt(nodeId, BuildingCategoryHint.UTILITY_WATER).isNotEmpty()
+    ensure(hasWell || balance.isWaterSource(node.terrain)) {
         WorldRejection.NotAWaterSource(command.agent, nodeId)
     }
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
@@ -4,6 +4,8 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
@@ -14,6 +16,7 @@ internal fun reduceMove(
     state: WorldState,
     command: WorldCommand.MoveAgent,
     balance: BalanceLookup,
+    buildings: BuildingsLookup,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
     val from = ensureNotNull(state.positions[command.agent]) {
@@ -28,14 +31,20 @@ internal fun reduceMove(
     ensure(state.isAdjacent(from, command.to)) {
         WorldRejection.NotAdjacent(from, command.to)
     }
-    ensure(balance.isTraversable(toNode.terrain)) {
+    // Bridge gates the TARGET (you cross INTO non-traversable terrain by stepping
+    // onto the bridge); road gates the SOURCE (you pay less stamina LEAVING the
+    // paved tile). Asymmetric by design — do not unify.
+    ensure(balance.isTraversable(toNode.terrain) || hasActiveBuilding(buildings, command.to, BuildingCategoryHint.INFRASTRUCTURE_BRIDGE)) {
         WorldRejection.TerrainNotTraversable(command.agent, command.to, toNode.terrain)
     }
     val biome = ensureNotNull(toRegion.biome) { WorldRejection.UnpaintedRegion(toRegion.id) }
     val climate = ensureNotNull(toRegion.climate) { WorldRejection.UnpaintedRegion(toRegion.id) }
 
     val body = state.bodyOf(command.agent)!!
-    val cost = balance.moveStaminaCost(biome, climate, toNode.terrain)
+    val baseCost = balance.moveStaminaCost(biome, climate, toNode.terrain)
+    val onRoad = hasActiveBuilding(buildings, from, BuildingCategoryHint.INFRASTRUCTURE_ROAD)
+    // Floor at 1 so road-hopping still costs stamina.
+    val cost = if (onRoad) (baseCost * balance.roadStaminaMultiplier()).toInt().coerceAtLeast(1) else baseCost
     ensure(body.stamina >= cost) {
         WorldRejection.NotEnoughStamina(command.agent, cost, body.stamina)
     }
@@ -46,3 +55,9 @@ internal fun reduceMove(
 
     next to event
 }
+
+private fun hasActiveBuilding(
+    buildings: BuildingsLookup,
+    node: dev.gvart.genesara.world.NodeId,
+    hint: BuildingCategoryHint,
+): Boolean = buildings.activeStationsAt(node, hint).isNotEmpty()

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
@@ -31,9 +31,6 @@ internal fun reduceMove(
     ensure(state.isAdjacent(from, command.to)) {
         WorldRejection.NotAdjacent(from, command.to)
     }
-    // Bridge gates the TARGET (you cross INTO non-traversable terrain by stepping
-    // onto the bridge); road gates the SOURCE (you pay less stamina LEAVING the
-    // paved tile). Asymmetric by design — do not unify.
     ensure(balance.isTraversable(toNode.terrain) || hasActiveBuilding(buildings, command.to, BuildingCategoryHint.INFRASTRUCTURE_BRIDGE)) {
         WorldRejection.TerrainNotTraversable(command.agent, command.to, toNode.terrain)
     }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -5,6 +5,7 @@ import dev.gvart.genesara.player.AgentProfileLookup
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.BuildingsStore
 import dev.gvart.genesara.world.ChestContentsStore
 import dev.gvart.genesara.world.EquipmentInstanceStore
@@ -39,6 +40,7 @@ internal class WorldTickHandler(
     private val safeNodes: AgentSafeNodeGateway,
     private val safeNodeResolver: SafeNodeResolver,
     private val buildings: BuildingsStore,
+    private val buildingsLookup: BuildingsLookup,
     private val buildingsCatalog: BuildingsCatalog,
     private val chestContents: ChestContentsStore,
 ) {
@@ -67,7 +69,8 @@ internal class WorldTickHandler(
         val (next, commandEvents) = commands.fold(afterDeaths to emptyList<WorldEvent>()) { (state, acc), command ->
             reduce(
                 state, command, balance, profiles, items, resources, skills, agents, equipment,
-                safeNodes, safeNodeResolver, buildings, buildingsCatalog, chestContents, publisher, tick.number,
+                safeNodes, safeNodeResolver, buildings, buildingsLookup, buildingsCatalog, chestContents,
+                publisher, tick.number,
             ).fold(
                 ifLeft = { rejection ->
                     log.info("Rejected {} at tick {}: {}", command, tick.number, rejection)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -6,6 +6,7 @@ import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.ChestContentsStore
 import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.events.WorldEvent
@@ -39,6 +40,7 @@ internal class WorldTickHandler(
     private val safeNodeResolver: SafeNodeResolver,
     private val buildings: BuildingsStore,
     private val buildingsCatalog: BuildingsCatalog,
+    private val chestContents: ChestContentsStore,
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -65,7 +67,7 @@ internal class WorldTickHandler(
         val (next, commandEvents) = commands.fold(afterDeaths to emptyList<WorldEvent>()) { (state, acc), command ->
             reduce(
                 state, command, balance, profiles, items, resources, skills, agents, equipment,
-                safeNodes, safeNodeResolver, buildings, buildingsCatalog, publisher, tick.number,
+                safeNodes, safeNodeResolver, buildings, buildingsCatalog, chestContents, publisher, tick.number,
             ).fold(
                 ifLeft = { rejection ->
                     log.info("Rejected {} at tick {}: {}", command, tick.number, rejection)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -5,10 +5,12 @@ import dev.gvart.genesara.player.AgentProfileLookup
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.BuildingsStore
 import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.buildings.BuildingsCatalog
 import dev.gvart.genesara.world.internal.death.SafeNodeResolver
 import dev.gvart.genesara.world.internal.death.processDeaths
 import dev.gvart.genesara.world.internal.passive.applyPassives
@@ -35,6 +37,8 @@ internal class WorldTickHandler(
     private val equipment: EquipmentInstanceStore,
     private val safeNodes: AgentSafeNodeGateway,
     private val safeNodeResolver: SafeNodeResolver,
+    private val buildings: BuildingsStore,
+    private val buildingsCatalog: BuildingsCatalog,
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -61,7 +65,7 @@ internal class WorldTickHandler(
         val (next, commandEvents) = commands.fold(afterDeaths to emptyList<WorldEvent>()) { (state, acc), command ->
             reduce(
                 state, command, balance, profiles, items, resources, skills, agents, equipment,
-                safeNodes, safeNodeResolver, publisher, tick.number,
+                safeNodes, safeNodeResolver, buildings, buildingsCatalog, publisher, tick.number,
             ).fold(
                 ifLeft = { rejection ->
                     log.info("Rejected {} at tick {}: {}", command, tick.number, rejection)

--- a/world/src/main/resources/db/migration/world/V12__node_buildings.sql
+++ b/world/src/main/resources/db/migration/world/V12__node_buildings.sql
@@ -1,0 +1,46 @@
+-- Phase 1 buildings slice: per-instance node-attached structures.
+--
+-- Per-instance UUID PK rather than a denormalized JSONB column on `nodes`
+-- so per-row HP / status / ownership updates (Phase 3 capture, repair) stay
+-- O(1) and a "buildings owned by clan X" query can use a B-tree index.
+--
+-- hp_current / hp_max are forward-compat for the #23 capture mechanic — no
+-- slice damages buildings yet. node_id and built_by_agent_id are soft refs
+-- (no cross-aggregate FK) per this schema's convention; orphan cleanup on
+-- node delete / agent permadeath lands in a future admin tool.
+CREATE TABLE node_buildings
+(
+    instance_id          UUID         NOT NULL,
+    node_id              BIGINT       NOT NULL,
+    building_type        VARCHAR(32)  NOT NULL,
+    status               VARCHAR(20)  NOT NULL,
+    built_by_agent_id    UUID         NOT NULL,
+    built_at_tick        BIGINT       NOT NULL,
+    last_progress_tick   BIGINT       NOT NULL,
+    progress_steps       INT          NOT NULL,
+    total_steps          INT          NOT NULL,
+    hp_current           INT          NOT NULL CHECK (hp_current >= 0),
+    hp_max               INT          NOT NULL CHECK (hp_max > 0),
+    PRIMARY KEY (instance_id),
+    -- Pin the status vocabulary at the schema level so a hand-fixed row cannot
+    -- poison BuildingStatus.valueOf(...) on read. The Kotlin enum is the
+    -- source of truth; this CHECK is the runtime fence.
+    CHECK (status IN ('UNDER_CONSTRUCTION', 'ACTIVE')),
+    CHECK (hp_current <= hp_max),
+    CHECK (progress_steps >= 0 AND progress_steps <= total_steps),
+    -- ACTIVE iff fully built. Prevents two illegal states: an ACTIVE row with
+    -- partial progress (partial structure granting full effect) and an
+    -- UNDER_CONSTRUCTION row at full progress (completed but not yet effective).
+    CHECK ((status = 'ACTIVE') = (progress_steps = total_steps))
+);
+
+CREATE INDEX idx_node_buildings_node    ON node_buildings (node_id);
+CREATE INDEX idx_node_buildings_builder ON node_buildings (built_by_agent_id);
+
+-- Drives the find-or-create-then-advance lookup in BuildReducer: when an agent
+-- calls `build CAMPFIRE`, find their in-progress campfire on this node (if
+-- any) and advance it; otherwise insert a new instance. Partial because most
+-- rows over time will be ACTIVE — narrow index keeps the lookup cheap.
+CREATE INDEX idx_node_buildings_in_progress
+    ON node_buildings (node_id, built_by_agent_id, building_type)
+    WHERE status = 'UNDER_CONSTRUCTION';

--- a/world/src/main/resources/db/migration/world/V13__building_chest_inventory.sql
+++ b/world/src/main/resources/db/migration/world/V13__building_chest_inventory.sql
@@ -1,0 +1,21 @@
+-- Phase 1 buildings slice: per-instance storage-chest contents.
+--
+-- Mirrors the agent_inventory shape: one row per (chest, item) with a stack
+-- quantity. STORAGE_CHEST is the only consumer in Phase 1 (personal owner-
+-- only stash). Future chest variants — CLAN_STORAGE_CHEST in Phase 3, banker
+-- buildings, drop-boxes — reuse this table by writing rows keyed on their
+-- own building_id; access semantics live in the per-variant reducer, not
+-- here.
+--
+-- building_id is a soft reference (no FK) to node_buildings(instance_id) —
+-- matches the convention. Orphan-row cleanup is the responsibility of a
+-- future destroy/repair flow that touches the parent building.
+CREATE TABLE building_chest_inventory
+(
+    building_id UUID        NOT NULL,
+    item_id     VARCHAR(32) NOT NULL,
+    quantity    INT         NOT NULL CHECK (quantity > 0),
+    PRIMARY KEY (building_id, item_id)
+);
+
+CREATE INDEX idx_building_chest_inventory_building ON building_chest_inventory (building_id);

--- a/world/src/main/resources/world-definition/buildings.yaml
+++ b/world/src/main/resources/world-definition/buildings.yaml
@@ -6,7 +6,6 @@ buildings:
 
     CAMPFIRE:
       required-skill: SURVIVAL
-      required-skill-level: 1
       total-steps: 5
       stamina-per-step: 8
       hp: 30
@@ -17,7 +16,6 @@ buildings:
 
     WORKBENCH:
       required-skill: CARPENTRY
-      required-skill-level: 1
       total-steps: 10
       stamina-per-step: 10
       hp: 60
@@ -28,7 +26,6 @@ buildings:
 
     FORGE:
       required-skill: SMITHING
-      required-skill-level: 1
       total-steps: 15
       stamina-per-step: 12
       hp: 100
@@ -40,7 +37,6 @@ buildings:
 
     ALCHEMY_TABLE:
       required-skill: ALCHEMY
-      required-skill-level: 1
       total-steps: 12
       stamina-per-step: 10
       hp: 50
@@ -52,7 +48,6 @@ buildings:
 
     FARM_PLOT:
       required-skill: SURVIVAL
-      required-skill-level: 1
       total-steps: 6
       stamina-per-step: 8
       hp: 25
@@ -63,7 +58,6 @@ buildings:
 
     WOODEN_WALL:
       required-skill: CARPENTRY
-      required-skill-level: 1
       total-steps: 8
       stamina-per-step: 10
       hp: 120
@@ -75,7 +69,6 @@ buildings:
 
     STORAGE_CHEST:
       required-skill: CARPENTRY
-      required-skill-level: 1
       total-steps: 8
       stamina-per-step: 8
       hp: 40
@@ -86,7 +79,6 @@ buildings:
 
     SHELTER:
       required-skill: CARPENTRY
-      required-skill-level: 1
       total-steps: 12
       stamina-per-step: 10
       hp: 80
@@ -97,7 +89,6 @@ buildings:
 
     WELL:
       required-skill: CARPENTRY
-      required-skill-level: 1
       total-steps: 14
       stamina-per-step: 10
       hp: 70
@@ -109,7 +100,6 @@ buildings:
 
     ROAD:
       required-skill: SURVIVAL
-      required-skill-level: 1
       total-steps: 6
       stamina-per-step: 8
       hp: 50
@@ -120,7 +110,6 @@ buildings:
 
     BRIDGE:
       required-skill: CARPENTRY
-      required-skill-level: 1
       total-steps: 16
       stamina-per-step: 12
       hp: 90

--- a/world/src/main/resources/world-definition/buildings.yaml
+++ b/world/src/main/resources/world-definition/buildings.yaml
@@ -1,0 +1,130 @@
+buildings:
+  catalog:
+
+    # ───────────────────────── Inert (Phase 1 substrate-pending) ─────────────────────────
+    # CAMPFIRE: cooking station hook for #8; warmth waits on a temperature gauge.
+
+    CAMPFIRE:
+      required-skill: SURVIVAL
+      required-skill-level: 1
+      total-steps: 5
+      stamina-per-step: 8
+      hp: 30
+      category-hint: COOKING
+      total-materials:
+        WOOD: 10
+        STONE: 5
+
+    WORKBENCH:
+      required-skill: CARPENTRY
+      required-skill-level: 1
+      total-steps: 10
+      stamina-per-step: 10
+      hp: 60
+      category-hint: CRAFTING_STATION_WOOD
+      total-materials:
+        WOOD: 25
+        STONE: 10
+
+    FORGE:
+      required-skill: SMITHING
+      required-skill-level: 1
+      total-steps: 15
+      stamina-per-step: 12
+      hp: 100
+      category-hint: CRAFTING_STATION_METAL
+      total-materials:
+        STONE: 30
+        COAL: 10
+        CLAY: 5
+
+    ALCHEMY_TABLE:
+      required-skill: ALCHEMY
+      required-skill-level: 1
+      total-steps: 12
+      stamina-per-step: 10
+      hp: 50
+      category-hint: CRAFTING_STATION_POTION
+      total-materials:
+        WOOD: 15
+        CLAY: 10
+        STONE: 5
+
+    FARM_PLOT:
+      required-skill: SURVIVAL
+      required-skill-level: 1
+      total-steps: 6
+      stamina-per-step: 8
+      hp: 25
+      category-hint: AGRICULTURE
+      total-materials:
+        WOOD: 5
+        CLAY: 10
+
+    WOODEN_WALL:
+      required-skill: CARPENTRY
+      required-skill-level: 1
+      total-steps: 8
+      stamina-per-step: 10
+      hp: 120
+      category-hint: DEFENSIVE
+      total-materials:
+        WOOD: 40
+
+    # ───────────────────────── Behavioral (wired this slice) ─────────────────────────
+
+    STORAGE_CHEST:
+      required-skill: CARPENTRY
+      required-skill-level: 1
+      total-steps: 8
+      stamina-per-step: 8
+      hp: 40
+      category-hint: STORAGE
+      chest-capacity-grams: 50000
+      total-materials:
+        WOOD: 20
+
+    SHELTER:
+      required-skill: CARPENTRY
+      required-skill-level: 1
+      total-steps: 12
+      stamina-per-step: 10
+      hp: 80
+      category-hint: RESIDENCE
+      total-materials:
+        WOOD: 30
+        STONE: 5
+
+    WELL:
+      required-skill: CARPENTRY
+      required-skill-level: 1
+      total-steps: 14
+      stamina-per-step: 10
+      hp: 70
+      category-hint: UTILITY_WATER
+      total-materials:
+        STONE: 20
+        WOOD: 10
+        CLAY: 5
+
+    ROAD:
+      required-skill: SURVIVAL
+      required-skill-level: 1
+      total-steps: 6
+      stamina-per-step: 8
+      hp: 50
+      category-hint: INFRASTRUCTURE_ROAD
+      total-materials:
+        STONE: 15
+        CLAY: 5
+
+    BRIDGE:
+      required-skill: CARPENTRY
+      required-skill-level: 1
+      total-steps: 16
+      stamina-per-step: 12
+      hp: 90
+      category-hint: INFRASTRUCTURE_BRIDGE
+      total-materials:
+        WOOD: 40
+        STONE: 20

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
@@ -1,0 +1,539 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentSkillState
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.inventory.AgentInventory
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BuildReducerTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val regionId = RegionId(1L)
+    private val nodeId = NodeId(1L)
+    private val wood = ItemId("WOOD")
+    private val stone = ItemId("STONE")
+    private val carpentry = SkillId("CARPENTRY")
+
+    private val region = Region(
+        id = regionId,
+        worldId = WorldId(1L),
+        sphereIndex = 0,
+        biome = Biome.PLAINS,
+        climate = Climate.OCEANIC,
+        centroid = Vec3(0.0, 0.0, 1.0),
+        faceVertices = emptyList(),
+        neighbors = emptySet(),
+    )
+
+    private val campfireDef = BuildingProperties(
+        requiredSkill = "CARPENTRY",
+        totalSteps = 5,
+        staminaPerStep = 8,
+        hp = 30,
+        categoryHint = BuildingCategoryHint.COOKING,
+        totalMaterials = mapOf("WOOD" to 10, "STONE" to 5),
+    )
+    private val shelterDef = BuildingProperties(
+        requiredSkill = "CARPENTRY",
+        totalSteps = 2,
+        staminaPerStep = 8,
+        hp = 80,
+        categoryHint = BuildingCategoryHint.RESIDENCE,
+        totalMaterials = mapOf("WOOD" to 4),
+    )
+
+    private val catalog = BuildingsCatalog(
+        BuildingDefinitionProperties(catalog = mapOf("CAMPFIRE" to campfireDef, "SHELTER" to shelterDef)),
+    )
+
+    private fun stateWith(
+        positioned: Boolean = true,
+        stamina: Int = 50,
+        inventory: Map<ItemId, Int> = mapOf(wood to 100, stone to 100),
+    ): WorldState {
+        var inv = AgentInventory()
+        for ((item, qty) in inventory) inv = inv.add(item, qty)
+        return WorldState(
+            regions = mapOf(regionId to region),
+            nodes = mapOf(nodeId to Node(nodeId, regionId, q = 0, r = 0, terrain = Terrain.FOREST, adjacency = emptySet())),
+            positions = if (positioned) mapOf(agent to nodeId) else emptyMap(),
+            bodies = mapOf(agent to AgentBody(hp = 50, maxHp = 50, stamina = stamina, maxStamina = 50, mana = 0, maxMana = 0)),
+            inventories = mapOf(agent to inv),
+        )
+    }
+
+    @Test
+    fun `first call inserts the building UNDER_CONSTRUCTION at progress 1 and emits BuildingPlaced`() {
+        val state = stateWith()
+        val store = StubBuildingsStore()
+        val safeNodes = StubSafeNodes()
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+
+        val (next, event) = assertNotNull(
+            reduceBuild(
+                state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+                catalog, skills, store, safeNodes, publisher, tick = 7,
+            ).getOrNull(),
+        )
+
+        val placed = assertIs<WorldEvent.BuildingPlaced>(event)
+        assertEquals(BuildingStatus.UNDER_CONSTRUCTION, placed.building.status)
+        assertEquals(1, placed.building.progressSteps)
+        assertEquals(5, placed.building.totalSteps)
+        assertEquals(7L, placed.building.builtAtTick)
+        assertEquals(7L, placed.building.lastProgressTick)
+        assertEquals(30, placed.building.hpCurrent)
+        assertEquals(1, store.inserted.size)
+        // step 1 of CAMPFIRE: floor(10/5)=2 wood, floor(5/5)=1 stone
+        assertEquals(98, next.inventoryOf(agent).quantityOf(wood))
+        assertEquals(99, next.inventoryOf(agent).quantityOf(stone))
+        assertEquals(42, next.bodyOf(agent)!!.stamina)
+    }
+
+    @Test
+    fun `subsequent call advances an existing in-progress instance by one step and emits BuildingProgressed`() {
+        val state = stateWith()
+        val existing = sampleBuilding(progress = 2)
+        val store = StubBuildingsStore(rows = mutableListOf(existing))
+        val safeNodes = StubSafeNodes()
+        val publisher = RecordingPublisher()
+
+        val (next, event) = assertNotNull(
+            reduceBuild(
+                state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+                catalog, StubSkillsRegistry(), store, safeNodes, publisher, tick = 9,
+            ).getOrNull(),
+        )
+
+        val progressed = assertIs<WorldEvent.BuildingProgressed>(event)
+        assertEquals(3, progressed.building.progressSteps)
+        assertEquals(BuildingStatus.UNDER_CONSTRUCTION, progressed.building.status)
+        assertEquals(9L, progressed.building.lastProgressTick)
+        assertEquals(1, store.advanced.size)
+        assertEquals(0, store.completed.size)
+        assertEquals(98, next.inventoryOf(agent).quantityOf(wood))
+        assertEquals(99, next.inventoryOf(agent).quantityOf(stone))
+    }
+
+    @Test
+    fun `terminal step flips status to ACTIVE and emits BuildingCompleted`() {
+        val state = stateWith()
+        val nearlyDone = sampleBuilding(progress = 4)
+        val store = StubBuildingsStore(rows = mutableListOf(nearlyDone))
+        val publisher = RecordingPublisher()
+
+        val (_, event) = assertNotNull(
+            reduceBuild(
+                state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+                catalog, StubSkillsRegistry(), store, StubSafeNodes(), publisher, tick = 11,
+            ).getOrNull(),
+        )
+
+        val completed = assertIs<WorldEvent.BuildingCompleted>(event)
+        assertEquals(BuildingStatus.ACTIVE, completed.building.status)
+        assertEquals(5, completed.building.progressSteps)
+        assertEquals(0, store.advanced.size)
+        assertEquals(1, store.completed.size)
+    }
+
+    @Test
+    fun `final step charges the leftover material remainder, not floor(total over steps)`() {
+        val customCatalog = BuildingsCatalog(
+            BuildingDefinitionProperties(
+                catalog = mapOf(
+                    "CAMPFIRE" to campfireDef.copy(totalSteps = 3, totalMaterials = mapOf("WOOD" to 10)),
+                ),
+            ),
+        )
+        val state = stateWith(inventory = mapOf(wood to 10))
+        val nearlyDone = sampleBuilding(progress = 2, totalSteps = 3)
+        val store = StubBuildingsStore(rows = mutableListOf(nearlyDone))
+
+        val (next, _) = assertNotNull(
+            reduceBuild(
+                state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+                customCatalog, StubSkillsRegistry(), store, StubSafeNodes(), RecordingPublisher(), tick = 1,
+            ).getOrNull(),
+        )
+
+        assertEquals(6, next.inventoryOf(agent).quantityOf(wood))
+    }
+
+    @Test
+    fun `SHELTER completion sets the builder's safe node to the shelter's node`() {
+        val state = stateWith(inventory = mapOf(wood to 10))
+        val nearlyDone = sampleBuilding(type = BuildingType.SHELTER, progress = 1, totalSteps = 2, hp = 80)
+        val store = StubBuildingsStore(rows = mutableListOf(nearlyDone))
+        val safeNodes = StubSafeNodes()
+
+        reduceBuild(
+            state, WorldCommand.BuildStructure(agent, BuildingType.SHELTER),
+            catalog, StubSkillsRegistry(), store, safeNodes, RecordingPublisher(), tick = 11,
+        )
+
+        assertEquals(nodeId, safeNodes.set[agent])
+    }
+
+    @Test
+    fun `non-SHELTER completion leaves safe node untouched`() {
+        val state = stateWith()
+        val nearlyDone = sampleBuilding(progress = 4)
+        val store = StubBuildingsStore(rows = mutableListOf(nearlyDone))
+        val safeNodes = StubSafeNodes()
+
+        reduceBuild(
+            state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+            catalog, StubSkillsRegistry(), store, safeNodes, RecordingPublisher(), tick = 11,
+        )
+
+        assertEquals(emptyMap(), safeNodes.set)
+    }
+
+    @Test
+    fun `rejects when agent is not in the world`() {
+        val state = stateWith(positioned = false)
+        val result = reduceBuild(
+            state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+            catalog, StubSkillsRegistry(), StubBuildingsStore(), StubSafeNodes(), RecordingPublisher(), tick = 1,
+        )
+
+        assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
+    }
+
+    @Test
+    fun `rejects when stamina is below the per-step cost`() {
+        val state = stateWith(stamina = 3)
+        val result = reduceBuild(
+            state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+            catalog, StubSkillsRegistry(), StubBuildingsStore(), StubSafeNodes(), RecordingPublisher(), tick = 1,
+        )
+
+        assertEquals(WorldRejection.NotEnoughStamina(agent, required = 8, available = 3), result.leftOrNull())
+    }
+
+    @Test
+    fun `rejects with InsufficientMaterials and reports the missing item`() {
+        // Step 1 of CAMPFIRE needs 2 wood + 1 stone. Agent has wood but no stone, so the
+        // single-missing case pins exactly which material the rejection names.
+        val state = stateWith(inventory = mapOf(wood to 100))
+        val store = StubBuildingsStore()
+
+        val result = reduceBuild(
+            state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+            catalog, StubSkillsRegistry(), store, StubSafeNodes(), RecordingPublisher(), tick = 1,
+        )
+
+        val rejection = assertIs<WorldRejection.InsufficientMaterials>(result.leftOrNull())
+        assertEquals(BuildingType.CAMPFIRE, rejection.type)
+        assertEquals(stone, rejection.item)
+        assertEquals(1, rejection.required)
+        assertEquals(0, rejection.available)
+        assertTrue(store.inserted.isEmpty(), "no row inserted on a rejected step")
+    }
+
+    @Test
+    fun `agent B starting a build of the same type does NOT advance agent A's in-progress row`() {
+        val agentB = AgentId(UUID.randomUUID())
+        val state = WorldState(
+            regions = mapOf(regionId to region),
+            nodes = mapOf(nodeId to Node(nodeId, regionId, q = 0, r = 0, terrain = Terrain.FOREST, adjacency = emptySet())),
+            positions = mapOf(agent to nodeId, agentB to nodeId),
+            bodies = mapOf(
+                agent to AgentBody(50, 50, 50, 50, 0, 0),
+                agentB to AgentBody(50, 50, 50, 50, 0, 0),
+            ),
+            inventories = mapOf(
+                agentB to AgentInventory().add(wood, 100).add(stone, 100),
+            ),
+        )
+        val agentARow = sampleBuilding(progress = 2)
+        val store = StubBuildingsStore(rows = mutableListOf(agentARow))
+
+        val (_, event) = assertNotNull(
+            reduceBuild(
+                state, WorldCommand.BuildStructure(agentB, BuildingType.CAMPFIRE),
+                catalog, StubSkillsRegistry(), store, StubSafeNodes(), RecordingPublisher(), tick = 5,
+            ).getOrNull(),
+        )
+
+        assertIs<WorldEvent.BuildingPlaced>(event)
+        assertEquals(2, store.rows.size)
+        assertEquals(2, store.rows.first { it.builtByAgentId == agent }.progressSteps)
+    }
+
+    @Test
+    fun `after completion a follow-up build call starts a fresh UNDER_CONSTRUCTION instance`() {
+        val state = stateWith()
+        val finished = sampleBuilding(progress = 5, totalSteps = 5)
+        val store = StubBuildingsStore(rows = mutableListOf(finished))
+
+        val (_, event) = assertNotNull(
+            reduceBuild(
+                state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+                catalog, StubSkillsRegistry(), store, StubSafeNodes(), RecordingPublisher(), tick = 12,
+            ).getOrNull(),
+        )
+
+        assertIs<WorldEvent.BuildingPlaced>(event)
+        assertEquals(2, store.rows.size)
+        assertEquals(0, store.completed.size)
+    }
+
+    @Test
+    fun `rejects with BuildingSkillTooLow when the def gates on a level the agent has not reached`() {
+        // Forward-compat path: v1 buildings ship with requiredSkillLevel=0 (no gate).
+        // Future tiers will set >0; assert the reducer enforces the threshold via the
+        // agent's snapshot.
+        val gatedCatalog = BuildingsCatalog(
+            BuildingDefinitionProperties(
+                catalog = mapOf(
+                    "CAMPFIRE" to campfireDef.copy(requiredSkillLevel = 5),
+                ),
+            ),
+        )
+        val state = stateWith()
+        val skills = StubSkillsRegistry().apply { slot(carpentry, level = 2) }
+
+        val result = reduceBuild(
+            state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+            gatedCatalog, skills, StubBuildingsStore(), StubSafeNodes(), RecordingPublisher(), tick = 1,
+        )
+
+        val rejection = assertIs<WorldRejection.BuildingSkillTooLow>(result.leftOrNull())
+        assertEquals(carpentry, rejection.skill)
+        assertEquals(5, rejection.required)
+        assertEquals(2, rejection.current)
+    }
+
+    @Test
+    fun `accepts a build when the agent meets the gated requiredSkillLevel`() {
+        val gatedCatalog = BuildingsCatalog(
+            BuildingDefinitionProperties(
+                catalog = mapOf(
+                    "CAMPFIRE" to campfireDef.copy(requiredSkillLevel = 2),
+                ),
+            ),
+        )
+        val state = stateWith()
+        val skills = StubSkillsRegistry().apply { slot(carpentry, level = 2) }
+
+        val result = reduceBuild(
+            state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+            gatedCatalog, skills, StubBuildingsStore(), StubSafeNodes(), RecordingPublisher(), tick = 1,
+        )
+
+        assertNotNull(result.getOrNull())
+    }
+
+    @Test
+    fun `walking the full step ladder accumulates per-step stamina cost and ends ACTIVE`() {
+        var state = stateWith(inventory = mapOf(wood to 100, stone to 100))
+        val store = StubBuildingsStore()
+        val initialStamina = state.bodyOf(agent)!!.stamina
+        var lastEvent: WorldEvent? = null
+
+        repeat(5) { i ->
+            val (next, event) = assertNotNull(
+                reduceBuild(
+                    state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+                    catalog, StubSkillsRegistry(), store, StubSafeNodes(), RecordingPublisher(), tick = (10 + i).toLong(),
+                ).getOrNull(),
+            )
+            state = next
+            lastEvent = event
+        }
+
+        assertIs<WorldEvent.BuildingCompleted>(lastEvent)
+        assertEquals(initialStamina - 5 * 8, state.bodyOf(agent)!!.stamina)
+        assertEquals(1, store.rows.size)
+        assertEquals(BuildingStatus.ACTIVE, store.rows.single().status)
+        assertEquals(5, store.rows.single().progressSteps)
+        assertEquals(90, state.inventoryOf(agent).quantityOf(wood))
+        assertEquals(95, state.inventoryOf(agent).quantityOf(stone))
+    }
+
+    @Test
+    fun `slotted skill receives one XP per build step`() {
+        val state = stateWith()
+        val skills = StubSkillsRegistry().apply { slot(carpentry) }
+
+        reduceBuild(
+            state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+            catalog, skills, StubBuildingsStore(), StubSafeNodes(), RecordingPublisher(), tick = 1,
+        )
+
+        assertEquals(listOf(carpentry to 1), skills.xpAddCalls)
+    }
+
+    @Test
+    fun `unslotted skill triggers a SkillRecommended event when maybeRecommend says yes`() {
+        val state = stateWith()
+        val skills = StubSkillsRegistry().apply { recommendOnNext[carpentry] = 1 }
+        val publisher = RecordingPublisher()
+
+        reduceBuild(
+            state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+            catalog, skills, StubBuildingsStore(), StubSafeNodes(), publisher, tick = 5,
+        )
+
+        val rec = publisher.events.filterIsInstance<WorldEvent.SkillRecommended>().single()
+        assertEquals(carpentry, rec.skill)
+        assertEquals(1, rec.recommendCount)
+    }
+
+    private fun sampleBuilding(
+        type: BuildingType = BuildingType.CAMPFIRE,
+        progress: Int = 1,
+        totalSteps: Int = 5,
+        hp: Int = 30,
+    ): Building = Building(
+        instanceId = UUID.randomUUID(),
+        nodeId = nodeId,
+        type = type,
+        status = if (progress == totalSteps) BuildingStatus.ACTIVE else BuildingStatus.UNDER_CONSTRUCTION,
+        builtByAgentId = agent,
+        builtAtTick = 1L,
+        lastProgressTick = 1L,
+        progressSteps = progress,
+        totalSteps = totalSteps,
+        hpCurrent = hp,
+        hpMax = hp,
+    )
+
+    private inner class StubBuildingsStore(
+        val rows: MutableList<Building> = mutableListOf(),
+    ) : BuildingsStore {
+        val inserted = mutableListOf<Building>()
+        val advanced = mutableListOf<UUID>()
+        val completed = mutableListOf<UUID>()
+
+        override fun insert(building: Building) {
+            inserted += building
+            rows += building
+        }
+        override fun findById(id: UUID): Building? = rows.firstOrNull { it.instanceId == id }
+        override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? =
+            rows.firstOrNull {
+                it.nodeId == node && it.builtByAgentId == agent && it.type == type &&
+                    it.status == BuildingStatus.UNDER_CONSTRUCTION
+            }
+        override fun listAtNode(node: NodeId): List<Building> = rows.filter { it.nodeId == node }
+        override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
+            rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }
+
+        override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? {
+            val idx = rows.indexOfFirst { it.instanceId == id }.takeIf { it >= 0 } ?: return null
+            advanced += id
+            val updated = rows[idx].copy(progressSteps = newProgress, lastProgressTick = asOfTick)
+            rows[idx] = updated
+            return updated
+        }
+
+        override fun complete(id: UUID, asOfTick: Long): Building? {
+            val idx = rows.indexOfFirst { it.instanceId == id }.takeIf { it >= 0 } ?: return null
+            completed += id
+            val original = rows[idx]
+            val updated = original.copy(
+                status = BuildingStatus.ACTIVE,
+                progressSteps = original.totalSteps,
+                lastProgressTick = asOfTick,
+            )
+            rows[idx] = updated
+            return updated
+        }
+    }
+
+    private class StubSafeNodes : AgentSafeNodeGateway {
+        val set = mutableMapOf<AgentId, NodeId>()
+        override fun set(agentId: AgentId, nodeId: NodeId, tick: Long) {
+            set[agentId] = nodeId
+        }
+        override fun find(agentId: AgentId): NodeId? = set[agentId]
+        override fun clear(agentId: AgentId) {
+            set.remove(agentId)
+        }
+    }
+
+    private class StubSkillsRegistry : AgentSkillsRegistry {
+        private val slottedSkills = mutableSetOf<SkillId>()
+        private val levels = mutableMapOf<SkillId, Int>()
+        val xpAddCalls = mutableListOf<Pair<SkillId, Int>>()
+        val recommendOnNext = mutableMapOf<SkillId, Int?>()
+        var slotCount: Int = 8
+        var slotsFilled: Int = 0
+
+        fun slot(skill: SkillId, level: Int = 0) {
+            slottedSkills += skill
+            levels[skill] = level
+            slotsFilled = slottedSkills.size
+        }
+
+        override fun snapshot(agent: AgentId): AgentSkillsSnapshot = AgentSkillsSnapshot(
+            perSkill = slottedSkills.associateWith { skillId ->
+                AgentSkillState(
+                    skill = skillId,
+                    xp = 0,
+                    level = levels[skillId] ?: 0,
+                    slotIndex = slottedSkills.indexOf(skillId),
+                    recommendCount = 0,
+                )
+            },
+            slotCount = slotCount,
+            slotsFilled = slotsFilled,
+        )
+
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int): AddXpResult {
+            if (skill !in slottedSkills) return AddXpResult.Unslotted
+            xpAddCalls += skill to delta
+            return AddXpResult.Accrued(emptyList())
+        }
+
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? =
+            if (skill in slottedSkills) null else recommendOnNext.remove(skill)
+
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? = null
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+}
+
+private fun <L, R> arrow.core.Either<L, R>.leftOrNull(): L? = (this as? arrow.core.Either.Left<L>)?.value

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalogTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalogTest.kt
@@ -1,0 +1,124 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.ItemId
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class BuildingsCatalogTest {
+
+    @Test
+    fun `def returns the resolved BuildingDef for a known type`() {
+        val catalog = catalogOf(
+            "CAMPFIRE" to BuildingProperties(
+                requiredSkill = "SURVIVAL",
+                totalSteps = 5,
+                staminaPerStep = 8,
+                hp = 30,
+                categoryHint = BuildingCategoryHint.COOKING,
+                totalMaterials = mapOf("WOOD" to 10, "STONE" to 5),
+            ),
+        )
+
+        val def = catalog.def(BuildingType.CAMPFIRE)
+        assertEquals(SkillId("SURVIVAL"), def.requiredSkill)
+        assertEquals(1, def.requiredSkillLevel)
+        assertEquals(5, def.totalSteps)
+        assertEquals(8, def.staminaPerStep)
+        assertEquals(30, def.hp)
+        assertEquals(BuildingCategoryHint.COOKING, def.categoryHint)
+        assertEquals(mapOf(ItemId("WOOD") to 10, ItemId("STONE") to 5), def.totalMaterials)
+    }
+
+    @Test
+    fun `stepMaterials evenly distributes when total divides cleanly`() {
+        val catalog = catalogOf(
+            "CAMPFIRE" to props(
+                totalSteps = 5,
+                materials = mapOf("WOOD" to 10),
+            ),
+        )
+
+        val def = catalog.def(BuildingType.CAMPFIRE)
+        assertEquals(List(5) { mapOf(ItemId("WOOD") to 2) }, def.stepMaterials)
+    }
+
+    @Test
+    fun `stepMaterials concentrates the remainder on the final step`() {
+        val catalog = catalogOf(
+            "WORKBENCH" to props(
+                totalSteps = 10,
+                materials = mapOf("WOOD" to 25, "STONE" to 10),
+            ),
+        )
+
+        val def = catalog.def(BuildingType.WORKBENCH)
+        for (i in 0 until 9) {
+            assertEquals(mapOf(ItemId("WOOD") to 2, ItemId("STONE") to 1), def.stepMaterials[i], "step $i")
+        }
+        assertEquals(mapOf(ItemId("WOOD") to 7, ItemId("STONE") to 1), def.stepMaterials[9])
+
+        val sum = def.stepMaterials.flatMap { it.entries }.groupingBy { it.key }
+            .fold(0) { acc, e -> acc + e.value }
+        assertEquals(def.totalMaterials, sum)
+    }
+
+    @Test
+    fun `stepMaterials lands every unit on the final step when total is less than steps`() {
+        // Critical guard: a naive `total / steps` would silently drop materials and
+        // let an agent build for free.
+        val catalog = catalogOf(
+            "FARM_PLOT" to props(
+                totalSteps = 10,
+                materials = mapOf("WOOD" to 3),
+            ),
+        )
+
+        val def = catalog.def(BuildingType.FARM_PLOT)
+        for (i in 0 until 9) {
+            assertEquals(emptyMap(), def.stepMaterials[i], "step $i")
+        }
+        assertEquals(mapOf(ItemId("WOOD") to 3), def.stepMaterials[9])
+    }
+
+    @Test
+    fun `def fails for an unknown type`() {
+        val catalog = catalogOf("CAMPFIRE" to props())
+        assertFailsWith<IllegalStateException> { catalog.def(BuildingType.SHELTER) }
+    }
+
+    @Test
+    fun `chestCapacityGrams round-trips through the def`() {
+        val catalog = catalogOf(
+            "STORAGE_CHEST" to BuildingProperties(
+                requiredSkill = "CARPENTRY",
+                totalSteps = 8,
+                staminaPerStep = 8,
+                hp = 40,
+                categoryHint = BuildingCategoryHint.STORAGE,
+                totalMaterials = mapOf("WOOD" to 20),
+                chestCapacityGrams = 50_000,
+            ),
+        )
+
+        assertEquals(50_000, catalog.def(BuildingType.STORAGE_CHEST).chestCapacityGrams)
+    }
+
+    private fun catalogOf(vararg entries: Pair<String, BuildingProperties>): BuildingsCatalog =
+        BuildingsCatalog(BuildingDefinitionProperties(catalog = mapOf(*entries)))
+
+    private fun props(
+        totalSteps: Int = 5,
+        materials: Map<String, Int> = mapOf("WOOD" to 5),
+    ): BuildingProperties = BuildingProperties(
+        requiredSkill = "SURVIVAL",
+        totalSteps = totalSteps,
+        staminaPerStep = 8,
+        hp = 30,
+        categoryHint = BuildingCategoryHint.COOKING,
+        totalMaterials = materials,
+    )
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalogTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalogTest.kt
@@ -25,7 +25,6 @@ class BuildingsCatalogTest {
 
         val def = catalog.def(BuildingType.CAMPFIRE)
         assertEquals(SkillId("SURVIVAL"), def.requiredSkill)
-        assertEquals(1, def.requiredSkillLevel)
         assertEquals(5, def.totalSteps)
         assertEquals(8, def.staminaPerStep)
         assertEquals(30, def.hp)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalogValidatorTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalogValidatorTest.kt
@@ -97,6 +97,24 @@ class BuildingsCatalogValidatorTest {
         assertTrue(ex.message?.contains("totalSteps") == true)
     }
 
+    @Test
+    fun `rejects single-step buildings — they would defeat the active-loop design`() {
+        val catalog = catalogFromMap(
+            BuildingType.entries.associate { type ->
+                type.name to if (type == BuildingType.CAMPFIRE) {
+                    defProps(type).copy(totalSteps = 1)
+                } else {
+                    defProps(type)
+                }
+            },
+        )
+
+        val ex = assertThrows<IllegalArgumentException> {
+            BuildingsCatalogValidator(catalog, items).validate()
+        }
+        assertTrue(ex.message?.contains("totalSteps must be >= 2") == true)
+    }
+
     private fun catalogFromMap(map: Map<String, BuildingProperties>): BuildingsCatalog =
         BuildingsCatalog(BuildingDefinitionProperties(catalog = map))
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalogValidatorTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsCatalogValidatorTest.kt
@@ -1,0 +1,127 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertTrue
+
+class BuildingsCatalogValidatorTest {
+
+    private val items = StubItemLookup(setOf("WOOD", "STONE", "CLAY", "COAL"))
+
+    @Test
+    fun `accepts the production catalog when every type is present and materials resolve`() {
+        val catalog = catalogFromMap(BuildingType.entries.associate { it.name to defProps(it) })
+
+        BuildingsCatalogValidator(catalog, items).validate()
+    }
+
+    @Test
+    fun `rejects when a BuildingType enum variant is missing from the catalog`() {
+        val partial = BuildingType.entries.drop(1).associate { it.name to defProps(it) }
+        val catalog = catalogFromMap(partial)
+
+        val ex = assertThrows<IllegalArgumentException> {
+            BuildingsCatalogValidator(catalog, items).validate()
+        }
+        assertTrue(ex.message?.contains(BuildingType.entries.first().name) == true)
+    }
+
+    @Test
+    fun `rejects materials referencing items not in the catalog`() {
+        val catalog = catalogFromMap(
+            BuildingType.entries.associate { type ->
+                type.name to if (type == BuildingType.CAMPFIRE) {
+                    defProps(type).copy(totalMaterials = mapOf("PHANTOM" to 5))
+                } else {
+                    defProps(type)
+                }
+            },
+        )
+
+        val ex = assertThrows<IllegalArgumentException> {
+            BuildingsCatalogValidator(catalog, items).validate()
+        }
+        assertTrue(ex.message?.contains("PHANTOM") == true)
+    }
+
+    @Test
+    fun `rejects STORAGE_CHEST without a chestCapacityGrams`() {
+        val catalog = catalogFromMap(
+            BuildingType.entries.associate { type ->
+                type.name to if (type == BuildingType.STORAGE_CHEST) {
+                    defProps(type).copy(chestCapacityGrams = null)
+                } else {
+                    defProps(type)
+                }
+            },
+        )
+
+        val ex = assertThrows<IllegalArgumentException> {
+            BuildingsCatalogValidator(catalog, items).validate()
+        }
+        assertTrue(ex.message?.contains("STORAGE_CHEST") == true)
+        assertTrue(ex.message?.contains("chestCapacityGrams") == true)
+    }
+
+    @Test
+    fun `rejects non-chest types that wrongly carry a chestCapacityGrams`() {
+        val catalog = catalogFromMap(
+            BuildingType.entries.associate { type ->
+                type.name to if (type == BuildingType.WORKBENCH) {
+                    defProps(type).copy(chestCapacityGrams = 10_000)
+                } else {
+                    defProps(type)
+                }
+            },
+        )
+
+        val ex = assertThrows<IllegalArgumentException> {
+            BuildingsCatalogValidator(catalog, items).validate()
+        }
+        assertTrue(ex.message?.contains("WORKBENCH") == true)
+    }
+
+    @Test
+    fun `catalog itself rejects non-positive totalSteps before the validator sees it`() {
+        // Belt-and-suspenders: catalog construction trips first; validator's parallel
+        // check is a fence in case a future seam bypasses BuildingsCatalog.
+        val ex = assertThrows<IllegalArgumentException> {
+            catalogFromMap(mapOf("CAMPFIRE" to defProps(BuildingType.CAMPFIRE).copy(totalSteps = 0)))
+        }
+        assertTrue(ex.message?.contains("totalSteps") == true)
+    }
+
+    private fun catalogFromMap(map: Map<String, BuildingProperties>): BuildingsCatalog =
+        BuildingsCatalog(BuildingDefinitionProperties(catalog = map))
+
+    private fun defProps(type: BuildingType): BuildingProperties = BuildingProperties(
+        requiredSkill = "SURVIVAL",
+        totalSteps = 5,
+        staminaPerStep = 8,
+        hp = 30,
+        categoryHint = BuildingCategoryHint.COOKING,
+        totalMaterials = mapOf("WOOD" to 5),
+        chestCapacityGrams = if (type == BuildingType.STORAGE_CHEST) 50_000 else null,
+    )
+
+    private class StubItemLookup(private val ids: Set<String>) : ItemLookup {
+        override fun byId(id: ItemId): Item? =
+            if (id.value in ids) {
+                Item(
+                    id = id,
+                    displayName = id.value,
+                    description = "",
+                    category = ItemCategory.RESOURCE,
+                    weightPerUnit = 100,
+                    maxStack = 100,
+                )
+            } else null
+        override fun all(): List<Item> = emptyList()
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsLookupImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsLookupImplTest.kt
@@ -1,0 +1,93 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.NodeId
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class BuildingsLookupImplTest {
+
+    private val node = NodeId(1L)
+    private val agent = AgentId(UUID.randomUUID())
+
+    @Test
+    fun `activeStationsAt returns ACTIVE buildings whose categoryHint matches`() {
+        val workbench = building(BuildingType.WORKBENCH, BuildingStatus.ACTIVE)
+        val campfire = building(BuildingType.CAMPFIRE, BuildingStatus.ACTIVE)
+        val store = FakeBuildingsStore(listOf(workbench, campfire))
+        val lookup = BuildingsLookupImpl(store, catalogWithDefaults())
+
+        val cooking = lookup.activeStationsAt(node, BuildingCategoryHint.COOKING)
+        assertEquals(listOf(campfire), cooking)
+    }
+
+    @Test
+    fun `activeStationsAt excludes UNDER_CONSTRUCTION matches`() {
+        val halfBuilt = building(BuildingType.CAMPFIRE, BuildingStatus.UNDER_CONSTRUCTION, progress = 2)
+        val store = FakeBuildingsStore(listOf(halfBuilt))
+        val lookup = BuildingsLookupImpl(store, catalogWithDefaults())
+
+        assertEquals(emptyList(), lookup.activeStationsAt(node, BuildingCategoryHint.COOKING))
+    }
+
+    @Test
+    fun `activeStationsAt returns empty when no def carries the hint`() {
+        val store = FakeBuildingsStore(emptyList())
+        val lookup = BuildingsLookupImpl(store, catalogWithDefaults())
+
+        assertEquals(emptyList(), lookup.activeStationsAt(node, BuildingCategoryHint.DEFENSIVE))
+    }
+
+    private fun catalogWithDefaults() = BuildingsCatalog(
+        BuildingDefinitionProperties(
+            catalog = mapOf(
+                "CAMPFIRE" to defProps(BuildingCategoryHint.COOKING),
+                "WORKBENCH" to defProps(BuildingCategoryHint.CRAFTING_STATION_WOOD),
+            ),
+        ),
+    )
+
+    private fun defProps(hint: BuildingCategoryHint) = BuildingProperties(
+        requiredSkill = "SURVIVAL",
+        totalSteps = 5,
+        staminaPerStep = 8,
+        hp = 30,
+        categoryHint = hint,
+        totalMaterials = mapOf("WOOD" to 5),
+    )
+
+    private fun building(
+        type: BuildingType,
+        status: BuildingStatus,
+        progress: Int = 5,
+    ): Building = Building(
+        instanceId = UUID.randomUUID(),
+        nodeId = node,
+        type = type,
+        status = status,
+        builtByAgentId = agent,
+        builtAtTick = 1L,
+        lastProgressTick = 1L,
+        progressSteps = if (status == BuildingStatus.ACTIVE) 5 else progress,
+        totalSteps = 5,
+        hpCurrent = 30,
+        hpMax = 30,
+    )
+
+    private class FakeBuildingsStore(private val rows: List<Building>) : BuildingsStore {
+        override fun insert(building: Building) = error("unused")
+        override fun findById(id: UUID): Building? = rows.firstOrNull { it.instanceId == id }
+        override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? = error("unused")
+        override fun listAtNode(node: NodeId): List<Building> = rows.filter { it.nodeId == node }
+        override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
+            rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }
+        override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = error("unused")
+        override fun complete(id: UUID, asOfTick: Long): Building? = error("unused")
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsYamlLoadingTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsYamlLoadingTest.kt
@@ -20,13 +20,13 @@ class BuildingsYamlLoadingTest {
             val props = ctx.getBean(BuildingDefinitionProperties::class.java)
             val catalog = BuildingsCatalog(props)
 
-            assertEquals(BuildingType.entries.toSet(), catalog.all().map { it.type }.toSet())
+            assertEquals(BuildingType.entries.toSet(), catalog.allDefs().map { it.type }.toSet())
 
             val storageChest = assertNotNull(catalog.def(BuildingType.STORAGE_CHEST))
             assertEquals(BuildingCategoryHint.STORAGE, storageChest.categoryHint)
             assertNotNull(storageChest.chestCapacityGrams).also { assertEquals(true, it > 0) }
 
-            for (def in catalog.all()) {
+            for (def in catalog.allDefs()) {
                 val summed = def.stepMaterials
                     .flatMap { it.entries }
                     .groupingBy { it.key }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsYamlLoadingTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsYamlLoadingTest.kt
@@ -1,0 +1,38 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingType
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class BuildingsYamlLoadingTest {
+
+    @Test
+    fun `production buildings_yaml binds cleanly into the catalog with every BuildingType`() {
+        AnnotationConfigApplicationContext().use { ctx ->
+            ConfigurationPropertiesBindingPostProcessor.register(ctx)
+            ctx.register(BuildingsConfiguration::class.java)
+            ctx.refresh()
+
+            val props = ctx.getBean(BuildingDefinitionProperties::class.java)
+            val catalog = BuildingsCatalog(props)
+
+            assertEquals(BuildingType.entries.toSet(), catalog.all().map { it.type }.toSet())
+
+            val storageChest = assertNotNull(catalog.def(BuildingType.STORAGE_CHEST))
+            assertEquals(BuildingCategoryHint.STORAGE, storageChest.categoryHint)
+            assertNotNull(storageChest.chestCapacityGrams).also { assertEquals(true, it > 0) }
+
+            for (def in catalog.all()) {
+                val summed = def.stepMaterials
+                    .flatMap { it.entries }
+                    .groupingBy { it.key }
+                    .fold(0) { acc, e -> acc + e.value }
+                assertEquals(def.totalMaterials, summed, "step totals must sum to total for ${def.type}")
+            }
+        }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/ChestReducersTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/ChestReducersTest.kt
@@ -1,0 +1,426 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.ChestContentsStore
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.inventory.AgentInventory
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+class ChestReducersTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val otherAgent = AgentId(UUID.randomUUID())
+    private val regionId = RegionId(1L)
+    private val nodeId = NodeId(1L)
+    private val otherNodeId = NodeId(2L)
+    private val wood = ItemId("WOOD")
+    private val stone = ItemId("STONE")
+
+    private val region = Region(
+        id = regionId, worldId = WorldId(1L), sphereIndex = 0,
+        biome = Biome.PLAINS, climate = Climate.OCEANIC,
+        centroid = Vec3(0.0, 0.0, 1.0), faceVertices = emptyList(), neighbors = emptySet(),
+    )
+
+    private val items = StubItemLookup(
+        mapOf(
+            wood to itemFor(wood, weightPerUnit = 800),
+            stone to itemFor(stone, weightPerUnit = 1500),
+        ),
+    )
+    private val catalog = BuildingsCatalog(
+        BuildingDefinitionProperties(
+            catalog = mapOf(
+                "STORAGE_CHEST" to BuildingProperties(
+                    requiredSkill = "CARPENTRY",
+                    totalSteps = 8,
+                    staminaPerStep = 8,
+                    hp = 40,
+                    categoryHint = BuildingCategoryHint.STORAGE,
+                    totalMaterials = mapOf("WOOD" to 20),
+                    chestCapacityGrams = 50_000,
+                ),
+            ),
+        ),
+    )
+
+    private fun stateAt(
+        node: NodeId = nodeId,
+        inventory: Map<ItemId, Int> = mapOf(wood to 50),
+        positioned: Boolean = true,
+    ): WorldState {
+        var inv = AgentInventory()
+        for ((item, qty) in inventory) inv = inv.add(item, qty)
+        return WorldState(
+            regions = mapOf(regionId to region),
+            nodes = mapOf(
+                nodeId to Node(nodeId, regionId, q = 0, r = 0, terrain = Terrain.FOREST, adjacency = emptySet()),
+                otherNodeId to Node(otherNodeId, regionId, q = 1, r = 0, terrain = Terrain.FOREST, adjacency = emptySet()),
+            ),
+            positions = if (positioned) mapOf(agent to node) else emptyMap(),
+            bodies = mapOf(agent to AgentBody(50, 50, 50, 50, 0, 0)),
+            inventories = mapOf(agent to inv),
+        )
+    }
+
+    private fun chest(
+        owner: AgentId = agent,
+        node: NodeId = nodeId,
+        status: BuildingStatus = BuildingStatus.ACTIVE,
+        type: BuildingType = BuildingType.STORAGE_CHEST,
+    ): Building = Building(
+        instanceId = UUID.randomUUID(),
+        nodeId = node,
+        type = type,
+        status = status,
+        builtByAgentId = owner,
+        builtAtTick = 1L,
+        lastProgressTick = 1L,
+        progressSteps = if (status == BuildingStatus.ACTIVE) 8 else 1,
+        totalSteps = 8,
+        hpCurrent = 40,
+        hpMax = 40,
+    )
+
+    // ─────────────────────── Deposit ───────────────────────
+
+    @Test
+    fun `deposit moves items from inventory to chest and emits ItemDeposited`() {
+        val c = chest()
+        val store = StubBuildings(c)
+        val contents = StubChestContents()
+
+        val (next, event) = assertNotNull(
+            reduceDeposit(
+                stateAt(), WorldCommand.DepositToChest(agent, c.instanceId, wood, 5),
+                items, catalog, store, contents, tick = 7,
+            ).getOrNull(),
+        )
+
+        assertEquals(45, next.inventoryOf(agent).quantityOf(wood))
+        assertEquals(5, contents.quantityOf(c.instanceId, wood))
+        val deposited = assertIs<WorldEvent.ItemDeposited>(event)
+        assertEquals(c.instanceId, deposited.chest)
+        assertEquals(wood, deposited.item)
+        assertEquals(5, deposited.quantity)
+        assertEquals(7L, deposited.tick)
+    }
+
+    @Test
+    fun `deposit rejects when chest does not exist`() {
+        val store = StubBuildings()
+        val phantom = UUID.randomUUID()
+
+        val result = reduceDeposit(
+            stateAt(), WorldCommand.DepositToChest(agent, phantom, wood, 1),
+            items, catalog, store, StubChestContents(), tick = 1,
+        )
+
+        assertEquals(WorldRejection.BuildingNotFound(phantom), result.leftOrNull())
+    }
+
+    @Test
+    fun `deposit rejects when target building is not a chest`() {
+        val notChest = chest(type = BuildingType.WORKBENCH)
+        val store = StubBuildings(notChest)
+
+        val result = reduceDeposit(
+            stateAt(), WorldCommand.DepositToChest(agent, notChest.instanceId, wood, 1),
+            items, catalog, store, StubChestContents(), tick = 1,
+        )
+
+        // Surfaces as BuildingNotFound to avoid leaking what other building types are at this id.
+        assertEquals(WorldRejection.BuildingNotFound(notChest.instanceId), result.leftOrNull())
+    }
+
+    @Test
+    fun `deposit rejects when chest is owned by another agent`() {
+        val theirs = chest(owner = otherAgent)
+        val store = StubBuildings(theirs)
+
+        val result = reduceDeposit(
+            stateAt(), WorldCommand.DepositToChest(agent, theirs.instanceId, wood, 1),
+            items, catalog, store, StubChestContents(), tick = 1,
+        )
+
+        assertEquals(WorldRejection.NotChestOwner(agent, theirs.instanceId), result.leftOrNull())
+    }
+
+    @Test
+    fun `deposit rejects when agent is not on the chest's node`() {
+        val c = chest()
+        val store = StubBuildings(c)
+
+        val result = reduceDeposit(
+            stateAt(node = otherNodeId), WorldCommand.DepositToChest(agent, c.instanceId, wood, 1),
+            items, catalog, store, StubChestContents(), tick = 1,
+        )
+
+        assertEquals(WorldRejection.NotOnBuildingNode(agent, c.instanceId), result.leftOrNull())
+    }
+
+    @Test
+    fun `deposit rejects against an UNDER_CONSTRUCTION chest`() {
+        val halfBuilt = chest(status = BuildingStatus.UNDER_CONSTRUCTION)
+        val store = StubBuildings(halfBuilt)
+
+        val result = reduceDeposit(
+            stateAt(), WorldCommand.DepositToChest(agent, halfBuilt.instanceId, wood, 1),
+            items, catalog, store, StubChestContents(), tick = 1,
+        )
+
+        assertEquals(
+            WorldRejection.BuildingNotActive(halfBuilt.instanceId, BuildingStatus.UNDER_CONSTRUCTION),
+            result.leftOrNull(),
+        )
+    }
+
+    @Test
+    fun `deposit rejects when agent does not have enough of the item`() {
+        val c = chest()
+        val store = StubBuildings(c)
+
+        val result = reduceDeposit(
+            stateAt(inventory = mapOf(wood to 2)),
+            WorldCommand.DepositToChest(agent, c.instanceId, wood, 5),
+            items, catalog, store, StubChestContents(), tick = 1,
+        )
+
+        assertEquals(WorldRejection.ItemNotInInventory(agent, wood), result.leftOrNull())
+    }
+
+    @Test
+    fun `deposit rejects when the chest's weight cap would be exceeded`() {
+        // Capacity 50_000g; wood is 800g/unit. Pre-load 60 units (48_000g) so a deposit of
+        // 5 more (4_000g) would push to 52_000 — over cap.
+        val c = chest()
+        val store = StubBuildings(c)
+        val contents = StubChestContents().also { it.add(c.instanceId, wood, 60) }
+
+        val result = reduceDeposit(
+            stateAt(inventory = mapOf(wood to 50)),
+            WorldCommand.DepositToChest(agent, c.instanceId, wood, 5),
+            items, catalog, store, contents, tick = 1,
+        )
+
+        val rejection = assertIs<WorldRejection.ChestCapacityExceeded>(result.leftOrNull())
+        assertEquals(c.instanceId, rejection.chest)
+        assertEquals(52_000, rejection.attemptedGrams)
+        assertEquals(50_000, rejection.capacityGrams)
+        assertEquals(60, contents.quantityOf(c.instanceId, wood), "no add on rejection")
+    }
+
+    @Test
+    fun `deposit accepts when totals land exactly at the chest's weight cap`() {
+        // 50_000 / 800 = 62.5 → 62 units = 49_600g ≤ cap.
+        val c = chest()
+        val store = StubBuildings(c)
+        val contents = StubChestContents()
+
+        val (_, event) = assertNotNull(
+            reduceDeposit(
+                stateAt(inventory = mapOf(wood to 100)),
+                WorldCommand.DepositToChest(agent, c.instanceId, wood, 62),
+                items, catalog, store, contents, tick = 1,
+            ).getOrNull(),
+        )
+
+        assertIs<WorldEvent.ItemDeposited>(event)
+        assertEquals(62, contents.quantityOf(c.instanceId, wood))
+    }
+
+    @Test
+    fun `deposit rejects non-positive quantity as a WorldRejection — never an exception`() {
+        val c = chest()
+        val store = StubBuildings(c)
+
+        val zero = reduceDeposit(
+            stateAt(), WorldCommand.DepositToChest(agent, c.instanceId, wood, 0),
+            items, catalog, store, StubChestContents(), tick = 1,
+        )
+        assertEquals(WorldRejection.NonPositiveQuantity(agent, 0), zero.leftOrNull())
+
+        val negative = reduceDeposit(
+            stateAt(), WorldCommand.DepositToChest(agent, c.instanceId, wood, -3),
+            items, catalog, store, StubChestContents(), tick = 1,
+        )
+        assertEquals(WorldRejection.NonPositiveQuantity(agent, -3), negative.leftOrNull())
+    }
+
+    @Test
+    fun `withdraw rejects non-positive quantity as a WorldRejection`() {
+        val c = chest()
+        val store = StubBuildings(c)
+
+        val result = reduceWithdraw(
+            stateAt(), WorldCommand.WithdrawFromChest(agent, c.instanceId, wood, 0),
+            store, StubChestContents(), tick = 1,
+        )
+        assertEquals(WorldRejection.NonPositiveQuantity(agent, 0), result.leftOrNull())
+    }
+
+    // ─────────────────────── Withdraw ───────────────────────
+
+    @Test
+    fun `withdraw moves items from chest into inventory and emits ItemWithdrawn`() {
+        val c = chest()
+        val store = StubBuildings(c)
+        val contents = StubChestContents().also { it.add(c.instanceId, wood, 10) }
+
+        val (next, event) = assertNotNull(
+            reduceWithdraw(
+                stateAt(inventory = emptyMap()),
+                WorldCommand.WithdrawFromChest(agent, c.instanceId, wood, 4),
+                store, contents, tick = 7,
+            ).getOrNull(),
+        )
+
+        assertEquals(4, next.inventoryOf(agent).quantityOf(wood))
+        assertEquals(6, contents.quantityOf(c.instanceId, wood))
+        val withdrawn = assertIs<WorldEvent.ItemWithdrawn>(event)
+        assertEquals(c.instanceId, withdrawn.chest)
+        assertEquals(wood, withdrawn.item)
+        assertEquals(4, withdrawn.quantity)
+        assertEquals(7L, withdrawn.tick)
+    }
+
+    @Test
+    fun `withdraw rejects when chest does not contain enough of the item`() {
+        val c = chest()
+        val store = StubBuildings(c)
+        val contents = StubChestContents().also { it.add(c.instanceId, wood, 2) }
+
+        val result = reduceWithdraw(
+            stateAt(), WorldCommand.WithdrawFromChest(agent, c.instanceId, wood, 5),
+            store, contents, tick = 1,
+        )
+
+        val rejection = assertIs<WorldRejection.ChestDoesNotContain>(result.leftOrNull())
+        assertEquals(c.instanceId, rejection.chest)
+        assertEquals(5, rejection.requested)
+        assertEquals(2, rejection.available)
+        assertEquals(2, contents.quantityOf(c.instanceId, wood), "no decrement on rejection")
+    }
+
+    @Test
+    fun `withdraw rejects when chest holds zero of the item`() {
+        val c = chest()
+        val store = StubBuildings(c)
+
+        val result = reduceWithdraw(
+            stateAt(), WorldCommand.WithdrawFromChest(agent, c.instanceId, wood, 1),
+            store, StubChestContents(), tick = 1,
+        )
+
+        assertEquals(
+            WorldRejection.ChestDoesNotContain(c.instanceId, wood, 1, 0),
+            result.leftOrNull(),
+        )
+    }
+
+    @Test
+    fun `withdraw rejects when agent is not the chest owner`() {
+        val theirs = chest(owner = otherAgent)
+        val store = StubBuildings(theirs)
+        val contents = StubChestContents().also { it.add(theirs.instanceId, wood, 10) }
+
+        val result = reduceWithdraw(
+            stateAt(), WorldCommand.WithdrawFromChest(agent, theirs.instanceId, wood, 1),
+            store, contents, tick = 1,
+        )
+
+        assertEquals(WorldRejection.NotChestOwner(agent, theirs.instanceId), result.leftOrNull())
+    }
+
+    @Test
+    fun `withdraw rejects against an UNDER_CONSTRUCTION chest`() {
+        val halfBuilt = chest(status = BuildingStatus.UNDER_CONSTRUCTION)
+        val store = StubBuildings(halfBuilt)
+
+        val result = reduceWithdraw(
+            stateAt(), WorldCommand.WithdrawFromChest(agent, halfBuilt.instanceId, wood, 1),
+            store, StubChestContents(), tick = 1,
+        )
+
+        assertEquals(
+            WorldRejection.BuildingNotActive(halfBuilt.instanceId, BuildingStatus.UNDER_CONSTRUCTION),
+            result.leftOrNull(),
+        )
+    }
+
+    private fun itemFor(id: ItemId, weightPerUnit: Int) = Item(
+        id = id,
+        displayName = id.value,
+        description = "",
+        category = ItemCategory.RESOURCE,
+        weightPerUnit = weightPerUnit,
+        maxStack = 200,
+    )
+
+    private class StubItemLookup(private val map: Map<ItemId, Item>) : ItemLookup {
+        override fun byId(id: ItemId): Item? = map[id]
+        override fun all(): List<Item> = map.values.toList()
+    }
+
+    private inner class StubBuildings(vararg seed: Building) : BuildingsStore {
+        private val rows: MutableList<Building> = seed.toMutableList()
+        override fun insert(building: Building) {
+            rows += building
+        }
+        override fun findById(id: UUID): Building? = rows.firstOrNull { it.instanceId == id }
+        override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? =
+            rows.firstOrNull {
+                it.nodeId == node && it.builtByAgentId == agent && it.type == type &&
+                    it.status == BuildingStatus.UNDER_CONSTRUCTION
+            }
+        override fun listAtNode(node: NodeId): List<Building> = rows.filter { it.nodeId == node }
+        override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
+            rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }
+        override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = error("not used")
+        override fun complete(id: UUID, asOfTick: Long): Building? = error("not used")
+    }
+
+    private class StubChestContents : ChestContentsStore {
+        private val map = mutableMapOf<Pair<UUID, ItemId>, Int>()
+        override fun quantityOf(buildingId: UUID, item: ItemId): Int = map[buildingId to item] ?: 0
+        override fun contentsOf(buildingId: UUID): Map<ItemId, Int> =
+            map.entries.filter { it.key.first == buildingId }.associate { it.key.second to it.value }
+        override fun add(buildingId: UUID, item: ItemId, quantity: Int) {
+            map.merge(buildingId to item, quantity, Int::plus)
+        }
+        override fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean {
+            val current = map[buildingId to item] ?: return false
+            if (current < quantity) return false
+            val next = current - quantity
+            if (next == 0) map.remove(buildingId to item) else map[buildingId to item] = next
+            return true
+        }
+    }
+}
+

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/JooqBuildingsStoreIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/JooqBuildingsStoreIntegrationTest.kt
@@ -1,0 +1,290 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.internal.jooq.tables.references.NODE_BUILDINGS
+import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.exception.DataAccessException
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@Testcontainers
+class JooqBuildingsStoreIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("buildings_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = WorldFlyway.pooledDataSource(postgres)
+            WorldFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private lateinit var store: JooqBuildingsStore
+    private val node1 = NodeId(1L)
+    private val node2 = NodeId(2L)
+    private val node3 = NodeId(3L)
+    private val agent = AgentId(UUID.randomUUID())
+    private val otherAgent = AgentId(UUID.randomUUID())
+
+    @BeforeEach
+    fun reset() {
+        dsl.truncate(NODE_BUILDINGS).cascade().execute()
+        store = JooqBuildingsStore(dsl)
+    }
+
+    @Test
+    fun `insert and findById round-trip a full UNDER_CONSTRUCTION instance`() {
+        val b = sampleBuilding(progress = 1, totalSteps = 5, status = BuildingStatus.UNDER_CONSTRUCTION)
+        store.insert(b)
+
+        assertEquals(b, store.findById(b.instanceId))
+    }
+
+    @Test
+    fun `findById returns null for a missing instance`() {
+        assertNull(store.findById(UUID.randomUUID()))
+    }
+
+    @Test
+    fun `findInProgress returns the matching agent's in-progress instance`() {
+        val mine = sampleBuilding(progress = 2, totalSteps = 5, status = BuildingStatus.UNDER_CONSTRUCTION)
+        store.insert(mine)
+
+        assertEquals(mine, store.findInProgress(node1, agent, BuildingType.CAMPFIRE))
+    }
+
+    @Test
+    fun `findInProgress is scoped per agent — another agent's in-progress instance is invisible`() {
+        val theirs = sampleBuilding(
+            agent = otherAgent,
+            progress = 2,
+            totalSteps = 5,
+            status = BuildingStatus.UNDER_CONSTRUCTION,
+        )
+        store.insert(theirs)
+
+        assertNull(store.findInProgress(node1, agent, BuildingType.CAMPFIRE))
+    }
+
+    @Test
+    fun `findInProgress is scoped per type — same agent same node different type is invisible`() {
+        val campfire = sampleBuilding(
+            type = BuildingType.CAMPFIRE,
+            progress = 2,
+            totalSteps = 5,
+            status = BuildingStatus.UNDER_CONSTRUCTION,
+        )
+        store.insert(campfire)
+
+        assertNull(store.findInProgress(node1, agent, BuildingType.STORAGE_CHEST))
+    }
+
+    @Test
+    fun `findInProgress excludes ACTIVE rows — completed buildings don't shadow new starts`() {
+        val finished = sampleBuilding(
+            type = BuildingType.CAMPFIRE,
+            progress = 5,
+            totalSteps = 5,
+            status = BuildingStatus.ACTIVE,
+        )
+        store.insert(finished)
+
+        assertNull(store.findInProgress(node1, agent, BuildingType.CAMPFIRE))
+    }
+
+    @Test
+    fun `listAtNode returns every status, ordered by instance_id for stability`() {
+        val ids = listOf(
+            UUID.fromString("00000000-0000-0000-0000-000000000003"),
+            UUID.fromString("00000000-0000-0000-0000-000000000001"),
+            UUID.fromString("00000000-0000-0000-0000-000000000002"),
+        )
+        ids.forEach { id ->
+            store.insert(sampleBuilding(instanceId = id, progress = 5, totalSteps = 5, status = BuildingStatus.ACTIVE))
+        }
+
+        assertEquals(ids.sorted(), store.listAtNode(node1).map { it.instanceId })
+    }
+
+    @Test
+    fun `listByNodes batches across nodes and omits nodes with no buildings`() {
+        store.insert(sampleBuilding(nodeId = node1, type = BuildingType.CAMPFIRE, progress = 5, totalSteps = 5, status = BuildingStatus.ACTIVE))
+        store.insert(sampleBuilding(nodeId = node1, type = BuildingType.SHELTER, progress = 1, totalSteps = 12, status = BuildingStatus.UNDER_CONSTRUCTION))
+        store.insert(sampleBuilding(nodeId = node2, type = BuildingType.WORKBENCH, progress = 5, totalSteps = 10, status = BuildingStatus.UNDER_CONSTRUCTION))
+
+        val byNode = store.listByNodes(setOf(node1, node2, node3))
+
+        assertEquals(2, byNode[node1]?.size)
+        assertEquals(1, byNode[node2]?.size)
+        assertEquals(null, byNode[node3])
+    }
+
+    @Test
+    fun `listByNodes with empty input returns an empty map without hitting the DB`() {
+        assertEquals(emptyMap(), store.listByNodes(emptySet()))
+    }
+
+    @Test
+    fun `advanceProgress increments steps and stamps the tick`() {
+        val b = sampleBuilding(progress = 3, totalSteps = 5, lastProgressTick = 10L, status = BuildingStatus.UNDER_CONSTRUCTION)
+        store.insert(b)
+
+        val advanced = assertNotNull(store.advanceProgress(b.instanceId, newProgress = 4, asOfTick = 12L))
+        assertEquals(4, advanced.progressSteps)
+        assertEquals(12L, advanced.lastProgressTick)
+        assertEquals(BuildingStatus.UNDER_CONSTRUCTION, advanced.status)
+    }
+
+    @Test
+    fun `advanceProgress refuses to roll back an already-ACTIVE row`() {
+        val b = sampleBuilding(progress = 5, totalSteps = 5, status = BuildingStatus.ACTIVE)
+        store.insert(b)
+
+        assertNull(store.advanceProgress(b.instanceId, newProgress = 4, asOfTick = 12L))
+    }
+
+    @Test
+    fun `complete flips status and progress in one statement`() {
+        val b = sampleBuilding(progress = 4, totalSteps = 5, lastProgressTick = 10L, status = BuildingStatus.UNDER_CONSTRUCTION)
+        store.insert(b)
+
+        val active = assertNotNull(store.complete(b.instanceId, asOfTick = 12L))
+        assertEquals(BuildingStatus.ACTIVE, active.status)
+        assertEquals(b.totalSteps, active.progressSteps)
+        assertEquals(12L, active.lastProgressTick)
+    }
+
+    @Test
+    fun `complete is a no-op for an already-ACTIVE row`() {
+        // The `WHERE status = UNDER_CONSTRUCTION` predicate keeps `complete`
+        // idempotent for a future Phase 3 collaborative-build flow where two
+        // agents could race to finish the last step; the second call gets null
+        // and the reducer treats the row as already done.
+        val b = sampleBuilding(progress = 5, totalSteps = 5, status = BuildingStatus.ACTIVE)
+        store.insert(b)
+
+        assertNull(store.complete(b.instanceId, asOfTick = 12L))
+    }
+
+    @Test
+    fun `insert with duplicate instance_id throws DataAccessException on PK conflict`() {
+        val b = sampleBuilding()
+        store.insert(b)
+
+        assertFailsWith<DataAccessException> { store.insert(b) }
+    }
+
+    @Test
+    fun `status CHECK rejects an unknown status string at the DB level`() {
+        // Bypass the Kotlin enum to confirm the schema fence — defense against
+        // a future hand-fixed row poisoning BuildingStatus.valueOf on read.
+        val b = sampleBuilding()
+        store.insert(b)
+
+        assertFailsWith<DataAccessException> {
+            dsl.update(NODE_BUILDINGS)
+                .set(NODE_BUILDINGS.STATUS, "GIBBERISH")
+                .where(NODE_BUILDINGS.INSTANCE_ID.eq(b.instanceId))
+                .execute()
+        }
+    }
+
+    @Test
+    fun `biconditional CHECK rejects ACTIVE with incomplete progress`() {
+        val b = sampleBuilding(progress = 3, totalSteps = 5, status = BuildingStatus.UNDER_CONSTRUCTION)
+        store.insert(b)
+
+        assertFailsWith<DataAccessException> {
+            dsl.update(NODE_BUILDINGS)
+                .set(NODE_BUILDINGS.STATUS, BuildingStatus.ACTIVE.name)
+                .where(NODE_BUILDINGS.INSTANCE_ID.eq(b.instanceId))
+                .execute()
+        }
+    }
+
+    @Test
+    fun `biconditional CHECK rejects UNDER_CONSTRUCTION at full progress`() {
+        val b = sampleBuilding(progress = 5, totalSteps = 5, status = BuildingStatus.ACTIVE)
+        store.insert(b)
+
+        assertFailsWith<DataAccessException> {
+            dsl.update(NODE_BUILDINGS)
+                .set(NODE_BUILDINGS.STATUS, BuildingStatus.UNDER_CONSTRUCTION.name)
+                .where(NODE_BUILDINGS.INSTANCE_ID.eq(b.instanceId))
+                .execute()
+        }
+    }
+
+    @Test
+    fun `hp CHECK rejects hp_current greater than hp_max at the DB level`() {
+        val b = sampleBuilding(hp = 30)
+        store.insert(b)
+
+        assertFailsWith<DataAccessException> {
+            dsl.update(NODE_BUILDINGS)
+                .set(NODE_BUILDINGS.HP_CURRENT, 999)
+                .where(NODE_BUILDINGS.INSTANCE_ID.eq(b.instanceId))
+                .execute()
+        }
+    }
+
+    private fun sampleBuilding(
+        instanceId: UUID = UUID.randomUUID(),
+        nodeId: NodeId = node1,
+        type: BuildingType = BuildingType.CAMPFIRE,
+        agent: AgentId = this.agent,
+        progress: Int = 1,
+        totalSteps: Int = 5,
+        status: BuildingStatus = BuildingStatus.UNDER_CONSTRUCTION,
+        builtAtTick: Long = 1L,
+        lastProgressTick: Long = 1L,
+        hp: Int = 30,
+    ): Building = Building(
+        instanceId = instanceId,
+        nodeId = nodeId,
+        type = type,
+        status = status,
+        builtByAgentId = agent,
+        builtAtTick = builtAtTick,
+        lastProgressTick = lastProgressTick,
+        progressSteps = if (status == BuildingStatus.ACTIVE) totalSteps else progress,
+        totalSteps = totalSteps,
+        hpCurrent = hp,
+        hpMax = hp,
+    )
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/JooqChestContentsStoreIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/JooqChestContentsStoreIntegrationTest.kt
@@ -1,0 +1,157 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.internal.jooq.tables.references.BUILDING_CHEST_INVENTORY
+import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@Testcontainers
+class JooqChestContentsStoreIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("chest_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = WorldFlyway.pooledDataSource(postgres)
+            WorldFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private lateinit var store: JooqChestContentsStore
+    private val chest = UUID.randomUUID()
+    private val otherChest = UUID.randomUUID()
+    private val wood = ItemId("WOOD")
+    private val stone = ItemId("STONE")
+
+    @BeforeEach
+    fun reset() {
+        dsl.truncate(BUILDING_CHEST_INVENTORY).cascade().execute()
+        store = JooqChestContentsStore(dsl)
+    }
+
+    @Test
+    fun `quantityOf is zero for a never-touched chest-item pair`() {
+        assertEquals(0, store.quantityOf(chest, wood))
+    }
+
+    @Test
+    fun `add inserts a new row and quantityOf reads it back`() {
+        store.add(chest, wood, 5)
+        assertEquals(5, store.quantityOf(chest, wood))
+    }
+
+    @Test
+    fun `add increments an existing row atomically — repeated adds accumulate`() {
+        store.add(chest, wood, 3)
+        store.add(chest, wood, 4)
+        assertEquals(7, store.quantityOf(chest, wood))
+    }
+
+    @Test
+    fun `add is per-(chest, item) — a different item gets its own row`() {
+        store.add(chest, wood, 5)
+        store.add(chest, stone, 2)
+
+        assertEquals(5, store.quantityOf(chest, wood))
+        assertEquals(2, store.quantityOf(chest, stone))
+    }
+
+    @Test
+    fun `add is scoped per chest — another chest's contents are invisible`() {
+        store.add(chest, wood, 5)
+        assertEquals(0, store.quantityOf(otherChest, wood))
+    }
+
+    @Test
+    fun `add rejects a non-positive quantity`() {
+        assertFailsWith<IllegalArgumentException> { store.add(chest, wood, 0) }
+        assertFailsWith<IllegalArgumentException> { store.add(chest, wood, -1) }
+    }
+
+    @Test
+    fun `remove decrements the quantity and returns true on success`() {
+        store.add(chest, wood, 5)
+        assertTrue(store.remove(chest, wood, 2))
+        assertEquals(3, store.quantityOf(chest, wood))
+    }
+
+    @Test
+    fun `remove returns false when the chest doesn't have enough — no row mutated`() {
+        store.add(chest, wood, 2)
+        assertFalse(store.remove(chest, wood, 5))
+        // Original quantity preserved — partial-removal would corrupt the bag's invariants.
+        assertEquals(2, store.quantityOf(chest, wood))
+    }
+
+    @Test
+    fun `remove returns false when the chest has no row at all`() {
+        assertFalse(store.remove(chest, wood, 1))
+    }
+
+    @Test
+    fun `remove deletes the row when quantity drops to zero`() {
+        store.add(chest, wood, 3)
+        store.remove(chest, wood, 3)
+
+        // Empty chests must hold zero rows so look-ups stay fast and counts
+        // (e.g. "items in chest") are accurate without filtering.
+        val rowCount = dsl.fetchCount(
+            BUILDING_CHEST_INVENTORY,
+            BUILDING_CHEST_INVENTORY.BUILDING_ID.eq(chest),
+        )
+        assertEquals(0, rowCount)
+        assertEquals(0, store.quantityOf(chest, wood))
+    }
+
+    @Test
+    fun `remove rejects a non-positive quantity`() {
+        assertFailsWith<IllegalArgumentException> { store.remove(chest, wood, 0) }
+        assertFailsWith<IllegalArgumentException> { store.remove(chest, wood, -1) }
+    }
+
+    @Test
+    fun `contentsOf returns every row for the chest as an ItemId-keyed map`() {
+        store.add(chest, wood, 5)
+        store.add(chest, stone, 2)
+        store.add(otherChest, wood, 99)
+
+        assertEquals(mapOf(wood to 5, stone to 2), store.contentsOf(chest))
+    }
+
+    @Test
+    fun `contentsOf returns an empty map for a never-touched chest`() {
+        assertEquals(emptyMap(), store.contentsOf(chest))
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/drink/DrinkReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/drink/DrinkReducerTest.kt
@@ -12,6 +12,11 @@ import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.Terrain
 import dev.gvart.genesara.world.Vec3
 import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
@@ -73,12 +78,12 @@ class DrinkReducerTest {
         val state = stateWith(terrain = Terrain.RIVER_DELTA, thirst = 50)
         val command = WorldCommand.Drink(agent)
 
-        val result = reduceDrink(state, command, balance, tick = 9)
+        val result = reduceDrink(state, command, balance, NoBuildings, tick = 9)
 
         val (next, event) = assertNotNull(result.getOrNull())
         val nextBody = next.bodyOf(agent)!!
-        assertEquals(75, nextBody.thirst)        // 50 + 25
-        assertEquals(29, nextBody.stamina)       // 30 - 1
+        assertEquals(75, nextBody.thirst)
+        assertEquals(29, nextBody.stamina)
         val drank = assertIs<WorldEvent.AgentDrank>(event)
         assertEquals(agent, drank.agent)
         assertEquals(nodeId, drank.at)
@@ -91,7 +96,7 @@ class DrinkReducerTest {
     fun `rejects when agent is not in the world`() {
         val state = stateWith(positioned = false)
 
-        val result = reduceDrink(state, WorldCommand.Drink(agent), balance, tick = 1)
+        val result = reduceDrink(state, WorldCommand.Drink(agent), balance, NoBuildings, tick = 1)
 
         assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
     }
@@ -100,7 +105,7 @@ class DrinkReducerTest {
     fun `rejects on a non-water-source terrain`() {
         val state = stateWith(terrain = Terrain.FOREST)
 
-        val result = reduceDrink(state, WorldCommand.Drink(agent), balance, tick = 1)
+        val result = reduceDrink(state, WorldCommand.Drink(agent), balance, NoBuildings, tick = 1)
 
         assertEquals(WorldRejection.NotAWaterSource(agent, nodeId), result.leftOrNull())
     }
@@ -109,7 +114,7 @@ class DrinkReducerTest {
     fun `rejects when stamina is below the drink cost`() {
         val state = stateWith(stamina = 0)
 
-        val result = reduceDrink(state, WorldCommand.Drink(agent), balance, tick = 1)
+        val result = reduceDrink(state, WorldCommand.Drink(agent), balance, NoBuildings, tick = 1)
 
         assertEquals(
             WorldRejection.NotEnoughStamina(agent, required = 1, available = 0),
@@ -121,10 +126,9 @@ class DrinkReducerTest {
     fun `clamps refill at max thirst — drinking already full still emits with refilled=0`() {
         val state = stateWith(thirst = 100, maxThirst = 100)
 
-        val result = reduceDrink(state, WorldCommand.Drink(agent), balance, tick = 3)
+        val result = reduceDrink(state, WorldCommand.Drink(agent), balance, NoBuildings, tick = 3)
 
         val (next, event) = assertNotNull(result.getOrNull())
-        // Thirst stays at max, stamina still spent (drinking was attempted).
         assertEquals(100, next.bodyOf(agent)!!.thirst)
         assertEquals(29, next.bodyOf(agent)!!.stamina)
         val drank = assertIs<WorldEvent.AgentDrank>(event)
@@ -133,10 +137,9 @@ class DrinkReducerTest {
 
     @Test
     fun `partial refill clamped to max emits the actual delta`() {
-        // 90 + 25 would overflow 100; expected refill is 10.
         val state = stateWith(thirst = 90, maxThirst = 100)
 
-        val result = reduceDrink(state, WorldCommand.Drink(agent), balance, tick = 4)
+        val result = reduceDrink(state, WorldCommand.Drink(agent), balance, NoBuildings, tick = 4)
 
         val (next, event) = assertNotNull(result.getOrNull())
         assertEquals(100, next.bodyOf(agent)!!.thirst)
@@ -148,9 +151,68 @@ class DrinkReducerTest {
     fun `every default water-source terrain accepts drink`() {
         listOf(Terrain.COASTAL, Terrain.RIVER_DELTA, Terrain.WETLANDS, Terrain.SHORELINE).forEach { terrain ->
             val state = stateWith(terrain = terrain, thirst = 50)
-            val result = reduceDrink(state, WorldCommand.Drink(agent), balance, tick = 1)
+            val result = reduceDrink(state, WorldCommand.Drink(agent), balance, NoBuildings, tick = 1)
             assertNotNull(result.getOrNull(), "expected $terrain to be a water source")
         }
+    }
+
+    @Test
+    fun `drink succeeds on a non-water-source terrain when an active well is on the node`() {
+        val state = stateWith(terrain = Terrain.FOREST, thirst = 50)
+        val well = activeWell(nodeId)
+        val buildings = StubBuildingsLookup(byNode = mapOf(nodeId to listOf(well)))
+
+        val result = reduceDrink(state, WorldCommand.Drink(agent), balance, buildings, tick = 1)
+
+        val (next, _) = assertNotNull(result.getOrNull())
+        assertEquals(75, next.bodyOf(agent)!!.thirst)
+    }
+
+    @Test
+    fun `drink rejects on a non-water-source terrain when only an UNDER_CONSTRUCTION well is present`() {
+        val state = stateWith(terrain = Terrain.FOREST, thirst = 50)
+        val unfinished = activeWell(nodeId).copy(
+            status = BuildingStatus.UNDER_CONSTRUCTION,
+            progressSteps = 4,
+            totalSteps = 14,
+        )
+        val buildings = StubBuildingsLookup(byNode = mapOf(nodeId to listOf(unfinished)))
+
+        val result = reduceDrink(state, WorldCommand.Drink(agent), balance, buildings, tick = 1)
+
+        assertEquals(WorldRejection.NotAWaterSource(agent, nodeId), result.leftOrNull())
+    }
+
+    private fun activeWell(node: NodeId): Building = Building(
+        instanceId = UUID.randomUUID(),
+        nodeId = node,
+        type = BuildingType.WELL,
+        status = BuildingStatus.ACTIVE,
+        builtByAgentId = agent,
+        builtAtTick = 1L,
+        lastProgressTick = 1L,
+        progressSteps = 14,
+        totalSteps = 14,
+        hpCurrent = 70,
+        hpMax = 70,
+    )
+
+    private object NoBuildings : BuildingsLookup {
+        override fun byId(id: UUID): Building? = null
+        override fun byNode(node: NodeId): List<Building> = emptyList()
+        override fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = emptyMap()
+        override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> = emptyList()
+    }
+
+    private class StubBuildingsLookup(
+        private val byNode: Map<NodeId, List<Building>>,
+    ) : BuildingsLookup {
+        override fun byId(id: UUID): Building? = byNode.values.flatten().firstOrNull { it.instanceId == id }
+        override fun byNode(node: NodeId): List<Building> = byNode[node].orEmpty()
+        override fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
+            nodes.associateWith { byNode[it].orEmpty() }.filterValues { it.isNotEmpty() }
+        override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> =
+            byNode[node].orEmpty().filter { it.status == BuildingStatus.ACTIVE }
     }
 
     private fun balance(

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
@@ -10,6 +10,9 @@ import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.Terrain
 import dev.gvart.genesara.world.Vec3
 import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
@@ -58,7 +61,7 @@ class MovementReducerTest {
     @Test
     fun `accepts move to adjacent node, deducts stamina, and emits AgentMoved`() {
         val command = WorldCommand.MoveAgent(agent, b)
-        val result = reduceMove(world, command, flatCost, tick = 1)
+        val result = reduceMove(world, command, flatCost, NoBuildings, tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
@@ -76,7 +79,7 @@ class MovementReducerTest {
     @Test
     fun `rejects move when agent is unknown`() {
         val unknown = AgentId(UUID.randomUUID())
-        val result = reduceMove(world, WorldCommand.MoveAgent(unknown, b), flatCost, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(unknown, b), flatCost, NoBuildings, tick = 1)
 
         assertTrue(result.isLeft())
         assertEquals(WorldRejection.UnknownAgent(unknown), result.leftOrNull())
@@ -85,14 +88,14 @@ class MovementReducerTest {
     @Test
     fun `rejects move to unknown node`() {
         val ghost = NodeId(99L)
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, ghost), flatCost, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, ghost), flatCost, NoBuildings, tick = 1)
 
         assertEquals(WorldRejection.UnknownNode(ghost), result.leftOrNull())
     }
 
     @Test
     fun `rejects move to non-adjacent node`() {
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, c), flatCost, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, c), flatCost, NoBuildings, tick = 1)
 
         assertEquals(WorldRejection.NotAdjacent(a, c), result.leftOrNull())
     }
@@ -100,7 +103,7 @@ class MovementReducerTest {
     @Test
     fun `rejects move when stamina is below cost`() {
         val expensive = balanceLookup(cost = 99)
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), expensive, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), expensive, NoBuildings, tick = 1)
 
         assertEquals(
             WorldRejection.NotEnoughStamina(agent, required = 99, available = 10),
@@ -113,14 +116,13 @@ class MovementReducerTest {
         val unpainted = world.copy(
             regions = world.regions.mapValues { (_, r) -> r.copy(biome = null) },
         )
-        val result = reduceMove(unpainted, WorldCommand.MoveAgent(agent, b), flatCost, tick = 1)
+        val result = reduceMove(unpainted, WorldCommand.MoveAgent(agent, b), flatCost, NoBuildings, tick = 1)
 
         assertEquals(WorldRejection.UnpaintedRegion(region), result.leftOrNull())
     }
 
     @Test
     fun `rejects move onto a non-traversable terrain (ocean before boats unlock)`() {
-        // Override isTraversable to model OCEAN's "boats unlock in Phase 3" rule.
         val sea = world.copy(
             nodes = world.nodes.mapValues { (id, n) ->
                 if (id == b) n.copy(terrain = Terrain.OCEAN) else n
@@ -129,7 +131,7 @@ class MovementReducerTest {
         val balance = object : BalanceLookup by flatCost {
             override fun isTraversable(terrain: Terrain): Boolean = terrain != Terrain.OCEAN
         }
-        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, tick = 1)
+        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, NoBuildings, tick = 1)
 
         assertEquals(
             WorldRejection.TerrainNotTraversable(agent, b, Terrain.OCEAN),
@@ -151,6 +153,7 @@ class MovementReducerTest {
         override fun drinkThirstRefill(): Int = 25
         override fun sleepRegenPerOfflineTick(): Int = 0
         override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun roadStaminaMultiplier(): Double = 0.5
     }
 
     private fun body(stamina: Int, maxStamina: Int) = AgentBody(
@@ -158,4 +161,89 @@ class MovementReducerTest {
         stamina = stamina, maxStamina = maxStamina,
         mana = 0, maxMana = 0,
     )
+
+    @Test
+    fun `move from a node with an active road halves the stamina cost`() {
+        val cost10 = balanceLookup(cost = 10)
+        val road = activeBuilding(node = a, hint = BuildingCategoryHint.INFRASTRUCTURE_ROAD)
+        val buildings = StubBuildingsLookup(byNode = mapOf(a to listOf(road)))
+
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost10, buildings, tick = 1)
+
+        result.fold(
+            ifLeft = { error("expected Right but got $it") },
+            ifRight = { (next, _) -> assertEquals(5, 10 - next.bodyOf(agent)!!.stamina) },
+        )
+    }
+
+    @Test
+    fun `road discount floors stamina cost at 1 — no zero-cost movement`() {
+        val cost1 = balanceLookup(cost = 1)
+        val road = activeBuilding(node = a, hint = BuildingCategoryHint.INFRASTRUCTURE_ROAD)
+        val buildings = StubBuildingsLookup(byNode = mapOf(a to listOf(road)))
+
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost1, buildings, tick = 1)
+
+        result.fold(
+            ifLeft = { error("expected Right but got $it") },
+            ifRight = { (next, _) -> assertEquals(1, 10 - next.bodyOf(agent)!!.stamina) },
+        )
+    }
+
+    @Test
+    fun `move into a non-traversable tile succeeds when an active bridge sits on the destination`() {
+        val sea = world.copy(
+            nodes = world.nodes.mapValues { (id, n) ->
+                if (id == b) n.copy(terrain = Terrain.OCEAN) else n
+            },
+        )
+        val balance = object : BalanceLookup by flatCost {
+            override fun isTraversable(terrain: Terrain): Boolean = terrain != Terrain.OCEAN
+        }
+        val bridge = activeBuilding(node = b, hint = BuildingCategoryHint.INFRASTRUCTURE_BRIDGE)
+        val buildings = StubBuildingsLookup(byNode = mapOf(b to listOf(bridge)))
+
+        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, buildings, tick = 1)
+
+        result.fold(
+            ifLeft = { error("expected Right but got $it") },
+            ifRight = { (next, _) -> assertEquals(b, next.positions[agent]) },
+        )
+    }
+
+    private fun activeBuilding(node: NodeId, hint: BuildingCategoryHint): Building = Building(
+        instanceId = UUID.randomUUID(),
+        nodeId = node,
+        type = when (hint) {
+            BuildingCategoryHint.INFRASTRUCTURE_ROAD -> dev.gvart.genesara.world.BuildingType.ROAD
+            BuildingCategoryHint.INFRASTRUCTURE_BRIDGE -> dev.gvart.genesara.world.BuildingType.BRIDGE
+            else -> error("unsupported hint for this stub")
+        },
+        status = dev.gvart.genesara.world.BuildingStatus.ACTIVE,
+        builtByAgentId = agent,
+        builtAtTick = 1L,
+        lastProgressTick = 1L,
+        progressSteps = 5,
+        totalSteps = 5,
+        hpCurrent = 50,
+        hpMax = 50,
+    )
+
+    private object NoBuildings : BuildingsLookup {
+        override fun byId(id: UUID): Building? = null
+        override fun byNode(node: NodeId): List<Building> = emptyList()
+        override fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = emptyMap()
+        override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> = emptyList()
+    }
+
+    private class StubBuildingsLookup(
+        private val byNode: Map<NodeId, List<Building>>,
+    ) : BuildingsLookup {
+        override fun byId(id: UUID): Building? = byNode.values.flatten().firstOrNull { it.instanceId == id }
+        override fun byNode(node: NodeId): List<Building> = byNode[node].orEmpty()
+        override fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
+            nodes.associateWith { byNode[it].orEmpty() }.filterValues { it.isNotEmpty() }
+        override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> =
+            byNode[node].orEmpty().filter { it.status == dev.gvart.genesara.world.BuildingStatus.ACTIVE }
+    }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -88,7 +88,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 7)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog, NoopChestContentsStore)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore)
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -109,7 +109,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, ghostId), appliesAtTick = 1)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog, NoopChestContentsStore)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore)
 
         handler.onTick(Tick(1, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -140,7 +140,7 @@ class WorldTickHandlerTest {
             override fun sleepRegenPerOfflineTick(): Int = 0
             override fun isTraversable(terrain: Terrain): Boolean = true
         }
-        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog, NoopChestContentsStore)
+        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore)
 
         handler.onTick(Tick(2, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -156,7 +156,7 @@ class WorldTickHandlerTest {
         val queue = CommandQueue()
         val publisher = RecordingPublisher()
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 99)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog, NoopChestContentsStore)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore)
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -272,6 +272,18 @@ class WorldTickHandlerTest {
         ): Map<NodeId, List<dev.gvart.genesara.world.Building>> = emptyMap()
         override fun advanceProgress(id: java.util.UUID, newProgress: Int, asOfTick: Long): dev.gvart.genesara.world.Building? = null
         override fun complete(id: java.util.UUID, asOfTick: Long): dev.gvart.genesara.world.Building? = null
+    }
+
+    private object NoopBuildingsLookup : dev.gvart.genesara.world.BuildingsLookup {
+        override fun byId(id: java.util.UUID): dev.gvart.genesara.world.Building? = null
+        override fun byNode(node: NodeId): List<dev.gvart.genesara.world.Building> = emptyList()
+        override fun byNodes(
+            nodes: Set<NodeId>,
+        ): Map<NodeId, List<dev.gvart.genesara.world.Building>> = emptyMap()
+        override fun activeStationsAt(
+            node: NodeId,
+            hint: dev.gvart.genesara.world.BuildingCategoryHint,
+        ): List<dev.gvart.genesara.world.Building> = emptyList()
     }
 
     private val EmptyBuildingsCatalog: dev.gvart.genesara.world.internal.buildings.BuildingsCatalog =

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -88,7 +88,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 7)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog)
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -109,7 +109,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, ghostId), appliesAtTick = 1)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog)
 
         handler.onTick(Tick(1, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -140,7 +140,7 @@ class WorldTickHandlerTest {
             override fun sleepRegenPerOfflineTick(): Int = 0
             override fun isTraversable(terrain: Terrain): Boolean = true
         }
-        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver)
+        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog)
 
         handler.onTick(Tick(2, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -156,7 +156,7 @@ class WorldTickHandlerTest {
         val queue = CommandQueue()
         val publisher = RecordingPublisher()
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 99)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog)
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -257,4 +257,25 @@ class WorldTickHandlerTest {
     private object NoopSafeNodeResolver : dev.gvart.genesara.world.internal.death.SafeNodeResolver {
         override fun resolveFor(agentId: AgentId): dev.gvart.genesara.world.internal.death.SafeNodeResolution? = null
     }
+
+    private object NoopBuildingsStore : dev.gvart.genesara.world.BuildingsStore {
+        override fun insert(building: dev.gvart.genesara.world.Building) = error("not used")
+        override fun findById(id: java.util.UUID): dev.gvart.genesara.world.Building? = null
+        override fun findInProgress(
+            node: NodeId,
+            agent: AgentId,
+            type: dev.gvart.genesara.world.BuildingType,
+        ): dev.gvart.genesara.world.Building? = null
+        override fun listAtNode(node: NodeId): List<dev.gvart.genesara.world.Building> = emptyList()
+        override fun listByNodes(
+            nodes: Set<NodeId>,
+        ): Map<NodeId, List<dev.gvart.genesara.world.Building>> = emptyMap()
+        override fun advanceProgress(id: java.util.UUID, newProgress: Int, asOfTick: Long): dev.gvart.genesara.world.Building? = null
+        override fun complete(id: java.util.UUID, asOfTick: Long): dev.gvart.genesara.world.Building? = null
+    }
+
+    private val EmptyBuildingsCatalog: dev.gvart.genesara.world.internal.buildings.BuildingsCatalog =
+        dev.gvart.genesara.world.internal.buildings.BuildingsCatalog(
+            dev.gvart.genesara.world.internal.buildings.BuildingDefinitionProperties(catalog = emptyMap()),
+        )
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -88,7 +88,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 7)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog, NoopChestContentsStore)
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -109,7 +109,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, ghostId), appliesAtTick = 1)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog, NoopChestContentsStore)
 
         handler.onTick(Tick(1, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -140,7 +140,7 @@ class WorldTickHandlerTest {
             override fun sleepRegenPerOfflineTick(): Int = 0
             override fun isTraversable(terrain: Terrain): Boolean = true
         }
-        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog)
+        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog, NoopChestContentsStore)
 
         handler.onTick(Tick(2, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -156,7 +156,7 @@ class WorldTickHandlerTest {
         val queue = CommandQueue()
         val publisher = RecordingPublisher()
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 99)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, EmptyBuildingsCatalog, NoopChestContentsStore)
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -278,4 +278,13 @@ class WorldTickHandlerTest {
         dev.gvart.genesara.world.internal.buildings.BuildingsCatalog(
             dev.gvart.genesara.world.internal.buildings.BuildingDefinitionProperties(catalog = emptyMap()),
         )
+
+    private object NoopChestContentsStore : dev.gvart.genesara.world.ChestContentsStore {
+        override fun quantityOf(buildingId: java.util.UUID, item: dev.gvart.genesara.world.ItemId): Int = 0
+        override fun contentsOf(buildingId: java.util.UUID): Map<dev.gvart.genesara.world.ItemId, Int> = emptyMap()
+        override fun add(buildingId: java.util.UUID, item: dev.gvart.genesara.world.ItemId, quantity: Int) =
+            error("not used")
+        override fun remove(buildingId: java.util.UUID, item: dev.gvart.genesara.world.ItemId, quantity: Int): Boolean =
+            error("not used")
+    }
 }


### PR DESCRIPTION
## Summary

Implements [issue #9](https://github.com/Genesara/genesara-engine/issues/9) — Tier-1 (non-base) buildings.

- **11 building types** in a YAML catalog (`buildings.yaml`): CAMPFIRE, STORAGE_CHEST, SHELTER, WORKBENCH, FORGE, ALCHEMY_TABLE, FARM_PLOT, WELL, WOODEN_WALL, ROAD, BRIDGE.
- **Active step-loop construction** — agents call `build TYPE` once per step, paying per-step stamina + materials. No passive completion sweep; completion is data-driven by `progress_steps == total_steps`.
- **Behavioral types wired this slice:**
  - `STORAGE_CHEST` — owner-only `deposit_to_chest` / `withdraw_from_chest` MCP tools, weight-capped at 50 kg.
  - `SHELTER` — completion sets the builder's safe-node.
  - `WELL` — drink succeeds on the node even when terrain isn't a water source.
  - `ROAD` — leaving a road tile halves the move stamina cost (floored at 1).
  - `BRIDGE` — overrides `TerrainNotTraversable` on the bridge's node.
- **Inert types (substrate not yet shipped):** WORKBENCH/FORGE/ALCHEMY_TABLE (#8 crafting), FARM_PLOT (#18 cultivated resources), WOODEN_WALL (Phase 2 PvP), CAMPFIRE (#8 cooking + temperature gauge). Each carries a `categoryHint` so future issues can discover stations without touching the enum.
- **Normalized schema** with batched `BuildingsLookup.byNodes(Set<NodeId>)` for the look_around hot path — single round-trip per call, not one query per visible node.
- New `CARPENTRY` skill in `player-definition/skills.yaml`. Building emits SkillRecommended/MilestoneReached events through the same `addXpIfSlotted`/`maybeRecommend` flow as gather.
- `look_around` and `inspect` extensions surface buildings (full per-instance summaries on the agent's tile, fog-of-war on adjacent; depth-gated detail on inspect; chest contents EXPERT + owner-only).

Drive-by: bumped two pre-existing security tests for nullable `Authentication` so `:api:test` compiles on this branch.

## Sub-slices (9 commits)

1. `5f55616` schema + domain primitives + Jooq stores
2. `47cdb63` YAML catalog + lookup + CARPENTRY skill
3. `846db79` build reducer (find-or-create-then-advance)
4. `f99407d` chest deposit/withdraw reducers
5. `d36f4be` movement + drink reducer extensions (ROAD/BRIDGE/WELL)
6. `926c7fb` MCP build tool
7. `03e5890` MCP deposit_to_chest + withdraw_from_chest tools
8. `85b7709` look_around extension
9. `390c8ce` inspect extension

Each sub-slice landed unit + integration tests in the same commit and went through `code-quality-reviewer` before commit.

## Acceptance criteria status

- [x] `BuildingType` enum in `:world` (11 variants)
- [x] Flyway `node_buildings` migration (V12) — biconditional CHECK pins ACTIVE ⇔ progress complete
- [x] YAML catalog with materials / requiredSkill / HP / per-step stamina / chest capacity
- [x] `build` MCP tool (queue-and-ack)
- [x] `BuildingsLookup` / store with batched `byNodes`
- [x] `look_around` extended with visible buildings
- [x] `inspect(building_id)` variant with Perception-tier gating

## Test plan

- [ ] `./gradlew :world:test :api:test` — all green locally on commit
- [ ] Smoke test against `app:bootRun` with the verification script from the plan (`/Users/v.gladis/.claude/plans/let-s-plan-and-imeplement-woolly-dongarra.md` — verification section): build CAMPFIRE step-by-step, build SHELTER → safe-node, build WELL → drink on FOREST, build ROAD → halved stamina, build BRIDGE → cross OCEAN, build STORAGE_CHEST → deposit/withdraw + non-owner rejection.
- [ ] Confirm `BuildingsLookup` `@Component` impl is picked up by Spring (`BuildingsLookupImpl` from slice 2).

## Out of scope (deferred per plan)

- Building destruction / repair / capture HP threshold logic — Phase 3 (#23). HP columns ship for forward-compat.
- `CLAN_STORAGE_CHEST` — separate `BuildingType`, Phase 3.
- Crafting station effects, farm-plot plant/harvest, wall enemy-entry blocking, campfire warmth — substrate not yet shipped.
- `app/build.gradle.kts` devtools comment — unrelated change present in working tree at session start, left for separate PR.