### PR TITLE
refactor(world): extract skill progression into a single module

### DIFF
--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -28,11 +28,11 @@ import dev.gvart.genesara.world.internal.death.reduceSetSafeNode
 import dev.gvart.genesara.world.internal.drink.reduceDrink
 import dev.gvart.genesara.world.internal.harvest.reduceHarvest
 import dev.gvart.genesara.world.internal.movement.reduceMove
+import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.spawn.reduceSpawn
 import dev.gvart.genesara.world.internal.spawn.reduceUnspawn
 import dev.gvart.genesara.world.internal.worldstate.WorldState
-import org.springframework.context.ApplicationEventPublisher
 
 internal fun reduce(
     state: WorldState,
@@ -52,20 +52,20 @@ internal fun reduce(
     buildingsCatalog: BuildingsCatalog,
     chestContents: ChestContentsStore,
     rarityRoller: RarityRoller,
-    publisher: ApplicationEventPublisher,
+    progression: SkillProgression,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = when (command) {
     is WorldCommand.SpawnAgent -> reduceSpawn(state, command, profiles, tick)
     is WorldCommand.MoveAgent -> reduceMove(state, command, balance, buildingsLookup, tick)
     is WorldCommand.UnspawnAgent -> reduceUnspawn(state, command, tick)
     is WorldCommand.Harvest ->
-        reduceHarvest(state, command, balance, items, resources, skills, agents, equipment, publisher, tick)
+        reduceHarvest(state, command, balance, items, resources, agents, equipment, progression, tick)
     is WorldCommand.ConsumeItem -> reduceConsume(state, command, items, tick)
     is WorldCommand.Drink -> reduceDrink(state, command, balance, buildingsLookup, tick)
     is WorldCommand.SetSafeNode -> reduceSetSafeNode(state, command, safeNodes, tick)
     is WorldCommand.Respawn -> reduceRespawn(state, command, profiles, safeNodes, safeNodeResolver, tick)
     is WorldCommand.BuildStructure ->
-        reduceBuild(state, command, buildingsCatalog, skills, buildings, safeNodes, publisher, tick)
+        reduceBuild(state, command, buildingsCatalog, skills, buildings, safeNodes, progression, tick)
     is WorldCommand.DepositToChest ->
         reduceDeposit(state, command, items, buildingsCatalog, buildings, chestContents, tick)
     is WorldCommand.WithdrawFromChest ->
@@ -73,6 +73,6 @@ internal fun reduce(
     is WorldCommand.CraftItem ->
         reduceCraft(
             state, command, balance, items, recipes, equipment, buildingsLookup,
-            skills, agents, rarityRoller, publisher, tick,
+            skills, agents, rarityRoller, progression, tick,
         )
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
@@ -5,29 +5,25 @@ import arrow.core.raise.Raise
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
-import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentSkillsRegistry
-import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.Building
 import dev.gvart.genesara.world.BuildingStatus
 import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.BuildingsStore
-import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.inventory.AgentInventory
+import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.worldstate.WorldState
-import org.springframework.context.ApplicationEventPublisher
 import java.util.UUID
 
 /**
- * Find-or-create-then-advance reducer for [WorldCommand.BuildStructure]. The skill flow
- * mirrors `HarvestReducer.accrueXpOrRecommend`. Catalog enforces `totalSteps >= 2`, so the
- * "insert at progress=1, then complete same call" trap (would violate the schema CHECK)
- * cannot arise from a YAML-loaded def.
+ * Find-or-create-then-advance reducer for [WorldCommand.BuildStructure]. Catalog
+ * enforces `totalSteps >= 2`, so the "insert at progress=1, then complete same call"
+ * trap (would violate the schema CHECK) cannot arise from a YAML-loaded def.
  */
 internal fun reduceBuild(
     state: WorldState,
@@ -36,7 +32,7 @@ internal fun reduceBuild(
     skills: AgentSkillsRegistry,
     buildings: BuildingsStore,
     safeNodes: AgentSafeNodeGateway,
-    publisher: ApplicationEventPublisher,
+    progression: SkillProgression,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
@@ -100,7 +96,7 @@ internal fun reduceBuild(
 
     if (event is WorldEvent.BuildingCompleted) applyCompletionSideEffects(resultBuilding, safeNodes, tick)
 
-    accrueXpOrRecommend(command.agent, command.commandId, def.requiredSkill, tick, skills, publisher)
+    progression.accrueXp(command.agent, def.requiredSkill, delta = 1, tick, command.commandId)
 
     val next = state
         .updateBody(command.agent, body.spendStamina(def.staminaPerStep))
@@ -133,38 +129,3 @@ private fun applyCompletionSideEffects(
     }
 }
 
-private fun accrueXpOrRecommend(
-    agent: AgentId,
-    commandId: UUID,
-    skill: SkillId,
-    tick: Long,
-    skills: AgentSkillsRegistry,
-    publisher: ApplicationEventPublisher,
-) {
-    when (val result = skills.addXpIfSlotted(agent, skill, delta = 1)) {
-        is AddXpResult.Accrued -> result.crossedMilestones.forEach { milestone ->
-            publisher.publishEvent(
-                WorldEvent.SkillMilestoneReached(
-                    agent = agent,
-                    skill = skill,
-                    milestone = milestone,
-                    tick = tick,
-                    causedBy = commandId,
-                ),
-            )
-        }
-        AddXpResult.Unslotted -> skills.maybeRecommend(agent, skill, tick)?.let { newCount ->
-            val snapshot = skills.snapshot(agent)
-            publisher.publishEvent(
-                WorldEvent.SkillRecommended(
-                    agent = agent,
-                    skill = skill,
-                    recommendCount = newCount,
-                    slotsFree = snapshot.slotCount - snapshot.slotsFilled,
-                    tick = tick,
-                    causedBy = commandId,
-                ),
-            )
-        }
-    }
-}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
@@ -5,11 +5,9 @@ import arrow.core.raise.Raise
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
-import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
-import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.EquipmentInstance
 import dev.gvart.genesara.world.EquipmentInstanceStore
@@ -27,8 +25,8 @@ import dev.gvart.genesara.world.internal.inventory.AgentInventory
 import dev.gvart.genesara.world.internal.inventory.enforceCarryCap
 import dev.gvart.genesara.world.internal.inventory.equippedGrams
 import dev.gvart.genesara.world.internal.inventory.totalGrams
+import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.worldstate.WorldState
-import org.springframework.context.ApplicationEventPublisher
 import java.util.UUID
 
 /**
@@ -48,7 +46,7 @@ internal fun reduceCraft(
     skills: AgentSkillsRegistry,
     agents: AgentRegistry,
     rarityRoller: RarityRoller,
-    publisher: ApplicationEventPublisher,
+    progression: SkillProgression,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
@@ -112,7 +110,7 @@ internal fun reduceCraft(
 
     mutation.equipmentToInsert?.let(equipment::insert)
 
-    accrueXpOrRecommend(command.agent, command.commandId, recipe.requiredSkill, tick, skills, publisher)
+    progression.accrueXp(command.agent, recipe.requiredSkill, delta = 1, tick, command.commandId)
 
     val next = state
         .updateBody(command.agent, body.spendStamina(recipe.staminaCost))
@@ -264,38 +262,3 @@ private fun Raise<WorldRejection>.stackableMutation(
     return CraftMutation(nextInventory, event, equipmentToInsert = null)
 }
 
-private fun accrueXpOrRecommend(
-    agent: AgentId,
-    commandId: UUID,
-    skill: SkillId,
-    tick: Long,
-    skills: AgentSkillsRegistry,
-    publisher: ApplicationEventPublisher,
-) {
-    when (val result = skills.addXpIfSlotted(agent, skill, delta = 1)) {
-        is AddXpResult.Accrued -> result.crossedMilestones.forEach { milestone ->
-            publisher.publishEvent(
-                WorldEvent.SkillMilestoneReached(
-                    agent = agent,
-                    skill = skill,
-                    milestone = milestone,
-                    tick = tick,
-                    causedBy = commandId,
-                ),
-            )
-        }
-        AddXpResult.Unslotted -> skills.maybeRecommend(agent, skill, tick)?.let { newCount ->
-            val snapshot = skills.snapshot(agent)
-            publisher.publishEvent(
-                WorldEvent.SkillRecommended(
-                    agent = agent,
-                    skill = skill,
-                    recommendCount = newCount,
-                    slotsFree = snapshot.slotCount - snapshot.slotsFilled,
-                    tick = tick,
-                    causedBy = commandId,
-                ),
-            )
-        }
-    }
-}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
@@ -5,10 +5,8 @@ import arrow.core.raise.Raise
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
-import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
-import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.ItemId
@@ -21,11 +19,10 @@ import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.inventory.enforceCarryCap
 import dev.gvart.genesara.world.internal.inventory.equippedGrams
 import dev.gvart.genesara.world.internal.inventory.totalGrams
+import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.resources.NodeResourceCell
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.worldstate.WorldState
-import org.springframework.context.ApplicationEventPublisher
-import java.util.UUID
 
 /**
  * Reducer for [WorldCommand.Harvest].
@@ -40,10 +37,9 @@ internal fun reduceHarvest(
     balance: BalanceLookup,
     items: ItemLookup,
     resources: NodeResourceStore,
-    skills: AgentSkillsRegistry,
     agents: AgentRegistry,
     equipment: EquipmentInstanceStore,
-    publisher: ApplicationEventPublisher,
+    progression: SkillProgression,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
@@ -73,7 +69,9 @@ internal fun reduceHarvest(
     enforceCarryCap(command.agent, agentRecord.attributes.strength, currentGrams, additionalGrams, balance)
 
     resources.decrement(nodeId, command.item, quantity, tick)
-    accrueXpOrRecommend(command.agent, command.commandId, itemDef.gatheringSkill, quantity, tick, skills, publisher)
+    itemDef.gatheringSkill?.let { skillKey ->
+        progression.accrueXp(command.agent, SkillId(skillKey), delta = quantity, tick, command.commandId)
+    }
 
     // TODO(max-stack): reject (StackFull) when adding `quantity` would exceed maxStack.
     // TODO(events): emit WorldEvent.NodeResourceDepleted alongside ResourceHarvested when
@@ -109,48 +107,4 @@ private fun Raise<WorldRejection>.requireAvailableDeposit(
         ?: raise(WorldRejection.ResourceNotAvailableHere(agent, nodeId, item))
     if (cell.quantity == 0) raise(WorldRejection.NodeResourceDepleted(agent, nodeId, item))
     return cell
-}
-
-/**
- * Routed through the publisher rather than the reducer's `Either` return so the
- * single-event return shape stays unchanged when XP grants fan out into milestone
- * or recommendation events. Items with no `gathering-skill` skip silently.
- */
-private fun accrueXpOrRecommend(
-    agent: AgentId,
-    commandId: UUID,
-    gatheringSkill: String?,
-    quantity: Int,
-    tick: Long,
-    skills: AgentSkillsRegistry,
-    publisher: ApplicationEventPublisher,
-) {
-    val skillIdString = gatheringSkill ?: return
-    val skillId = SkillId(skillIdString)
-    when (val result = skills.addXpIfSlotted(agent, skillId, delta = quantity)) {
-        is AddXpResult.Accrued -> result.crossedMilestones.forEach { milestone ->
-            publisher.publishEvent(
-                WorldEvent.SkillMilestoneReached(
-                    agent = agent,
-                    skill = skillId,
-                    milestone = milestone,
-                    tick = tick,
-                    causedBy = commandId,
-                ),
-            )
-        }
-        AddXpResult.Unslotted -> skills.maybeRecommend(agent, skillId, tick)?.let { newCount ->
-            val snapshot = skills.snapshot(agent)
-            publisher.publishEvent(
-                WorldEvent.SkillRecommended(
-                    agent = agent,
-                    skill = skillId,
-                    recommendCount = newCount,
-                    slotsFree = snapshot.slotCount - snapshot.slotsFilled,
-                    tick = tick,
-                    causedBy = commandId,
-                ),
-            )
-        }
-    }
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/progression/SkillProgression.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/progression/SkillProgression.kt
@@ -1,0 +1,63 @@
+package dev.gvart.genesara.world.internal.progression
+
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.world.events.WorldEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * Owns the "grant XP, fan out milestone or recommendation events" rule used by every
+ * skill-emitting reducer (harvest, build, craft, …).
+ */
+@Component
+internal class SkillProgression(
+    private val skills: AgentSkillsRegistry,
+    private val publisher: ApplicationEventPublisher,
+) {
+
+    /**
+     * Grant [delta] XP toward [skill] for [agent]. If the skill is slotted, fans out one
+     * [WorldEvent.SkillMilestoneReached] per crossed milestone; if it is unslotted and
+     * [AgentSkillsRegistry.maybeRecommend] decides to fire, emits a single
+     * [WorldEvent.SkillRecommended]. Both event types tag [commandId] as `causedBy` so
+     * agents can correlate.
+     */
+    fun accrueXp(
+        agent: AgentId,
+        skill: SkillId,
+        delta: Int,
+        tick: Long,
+        commandId: UUID,
+    ) {
+        when (val result = skills.addXpIfSlotted(agent, skill, delta)) {
+            is AddXpResult.Accrued -> result.crossedMilestones.forEach { milestone ->
+                publisher.publishEvent(
+                    WorldEvent.SkillMilestoneReached(
+                        agent = agent,
+                        skill = skill,
+                        milestone = milestone,
+                        tick = tick,
+                        causedBy = commandId,
+                    ),
+                )
+            }
+            AddXpResult.Unslotted -> skills.maybeRecommend(agent, skill, tick)?.let { newCount ->
+                val snapshot = skills.snapshot(agent)
+                publisher.publishEvent(
+                    WorldEvent.SkillRecommended(
+                        agent = agent,
+                        skill = skill,
+                        recommendCount = newCount,
+                        slotsFree = snapshot.slotCount - snapshot.slotsFilled,
+                        tick = tick,
+                        causedBy = commandId,
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -18,6 +18,7 @@ import dev.gvart.genesara.world.internal.crafting.RarityRoller
 import dev.gvart.genesara.world.internal.death.SafeNodeResolver
 import dev.gvart.genesara.world.internal.death.processDeaths
 import dev.gvart.genesara.world.internal.passive.applyPassives
+import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.reduce
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.worldstate.WorldStateRepository
@@ -47,6 +48,7 @@ internal class WorldTickHandler(
     private val buildingsCatalog: BuildingsCatalog,
     private val chestContents: ChestContentsStore,
     private val rarityRoller: RarityRoller,
+    private val progression: SkillProgression,
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -74,7 +76,7 @@ internal class WorldTickHandler(
             reduce(
                 state, command, balance, profiles, items, recipes, resources, skills, agents, equipment,
                 safeNodes, safeNodeResolver, buildings, buildingsLookup, buildingsCatalog, chestContents,
-                rarityRoller, publisher, tick.number,
+                rarityRoller, progression, tick.number,
             ).fold(
                 ifLeft = { rejection ->
                     log.info("Rejected {} at tick {}: {}", command, tick.number, rejection)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
@@ -28,6 +28,7 @@ import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.inventory.AgentInventory
+import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
@@ -106,7 +107,7 @@ class BuildReducerTest {
         val (next, event) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                catalog, skills, store, safeNodes, publisher, tick = 7,
+                catalog, skills, store, safeNodes, SkillProgression(skills, publisher), tick = 7,
             ).getOrNull(),
         )
 
@@ -130,12 +131,13 @@ class BuildReducerTest {
         val existing = sampleBuilding(progress = 2)
         val store = StubBuildingsStore(rows = mutableListOf(existing))
         val safeNodes = StubSafeNodes()
+        val skills = StubSkillsRegistry()
         val publisher = RecordingPublisher()
 
         val (next, event) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                catalog, StubSkillsRegistry(), store, safeNodes, publisher, tick = 9,
+                catalog, skills, store, safeNodes, SkillProgression(skills, publisher), tick = 9,
             ).getOrNull(),
         )
 
@@ -154,12 +156,13 @@ class BuildReducerTest {
         val state = stateWith()
         val nearlyDone = sampleBuilding(progress = 4)
         val store = StubBuildingsStore(rows = mutableListOf(nearlyDone))
+        val skills = StubSkillsRegistry()
         val publisher = RecordingPublisher()
 
         val (_, event) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                catalog, StubSkillsRegistry(), store, StubSafeNodes(), publisher, tick = 11,
+                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, publisher), tick = 11,
             ).getOrNull(),
         )
 
@@ -182,11 +185,12 @@ class BuildReducerTest {
         val state = stateWith(inventory = mapOf(wood to 10))
         val nearlyDone = sampleBuilding(progress = 2, totalSteps = 3)
         val store = StubBuildingsStore(rows = mutableListOf(nearlyDone))
+        val skills = StubSkillsRegistry()
 
         val (next, _) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                customCatalog, StubSkillsRegistry(), store, StubSafeNodes(), RecordingPublisher(), tick = 1,
+                customCatalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 1,
             ).getOrNull(),
         )
 
@@ -199,10 +203,11 @@ class BuildReducerTest {
         val nearlyDone = sampleBuilding(type = BuildingType.SHELTER, progress = 1, totalSteps = 2, hp = 80)
         val store = StubBuildingsStore(rows = mutableListOf(nearlyDone))
         val safeNodes = StubSafeNodes()
+        val skills = StubSkillsRegistry()
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.SHELTER),
-            catalog, StubSkillsRegistry(), store, safeNodes, RecordingPublisher(), tick = 11,
+            catalog, skills, store, safeNodes, SkillProgression(skills, RecordingPublisher()), tick = 11,
         )
 
         assertEquals(nodeId, safeNodes.set[agent])
@@ -214,10 +219,11 @@ class BuildReducerTest {
         val nearlyDone = sampleBuilding(progress = 4)
         val store = StubBuildingsStore(rows = mutableListOf(nearlyDone))
         val safeNodes = StubSafeNodes()
+        val skills = StubSkillsRegistry()
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, StubSkillsRegistry(), store, safeNodes, RecordingPublisher(), tick = 11,
+            catalog, skills, store, safeNodes, SkillProgression(skills, RecordingPublisher()), tick = 11,
         )
 
         assertEquals(emptyMap(), safeNodes.set)
@@ -226,9 +232,10 @@ class BuildReducerTest {
     @Test
     fun `rejects when agent is not in the world`() {
         val state = stateWith(positioned = false)
+        val skills = StubSkillsRegistry()
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, StubSkillsRegistry(), StubBuildingsStore(), StubSafeNodes(), RecordingPublisher(), tick = 1,
+            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 1,
         )
 
         assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
@@ -237,9 +244,10 @@ class BuildReducerTest {
     @Test
     fun `rejects when stamina is below the per-step cost`() {
         val state = stateWith(stamina = 3)
+        val skills = StubSkillsRegistry()
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, StubSkillsRegistry(), StubBuildingsStore(), StubSafeNodes(), RecordingPublisher(), tick = 1,
+            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 1,
         )
 
         assertEquals(WorldRejection.NotEnoughStamina(agent, required = 8, available = 3), result.leftOrNull())
@@ -251,10 +259,11 @@ class BuildReducerTest {
         // single-missing case pins exactly which material the rejection names.
         val state = stateWith(inventory = mapOf(wood to 100))
         val store = StubBuildingsStore()
+        val skills = StubSkillsRegistry()
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, StubSkillsRegistry(), store, StubSafeNodes(), RecordingPublisher(), tick = 1,
+            catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 1,
         )
 
         val rejection = assertIs<WorldRejection.InsufficientMaterials>(result.leftOrNull())
@@ -282,11 +291,12 @@ class BuildReducerTest {
         )
         val agentARow = sampleBuilding(progress = 2)
         val store = StubBuildingsStore(rows = mutableListOf(agentARow))
+        val skills = StubSkillsRegistry()
 
         val (_, event) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agentB, BuildingType.CAMPFIRE),
-                catalog, StubSkillsRegistry(), store, StubSafeNodes(), RecordingPublisher(), tick = 5,
+                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 5,
             ).getOrNull(),
         )
 
@@ -300,11 +310,12 @@ class BuildReducerTest {
         val state = stateWith()
         val finished = sampleBuilding(progress = 5, totalSteps = 5)
         val store = StubBuildingsStore(rows = mutableListOf(finished))
+        val skills = StubSkillsRegistry()
 
         val (_, event) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                catalog, StubSkillsRegistry(), store, StubSafeNodes(), RecordingPublisher(), tick = 12,
+                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 12,
             ).getOrNull(),
         )
 
@@ -330,7 +341,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            gatedCatalog, skills, StubBuildingsStore(), StubSafeNodes(), RecordingPublisher(), tick = 1,
+            gatedCatalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 1,
         )
 
         val rejection = assertIs<WorldRejection.BuildingSkillTooLow>(result.leftOrNull())
@@ -353,7 +364,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            gatedCatalog, skills, StubBuildingsStore(), StubSafeNodes(), RecordingPublisher(), tick = 1,
+            gatedCatalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 1,
         )
 
         assertNotNull(result.getOrNull())
@@ -363,6 +374,7 @@ class BuildReducerTest {
     fun `walking the full step ladder accumulates per-step stamina cost and ends ACTIVE`() {
         var state = stateWith(inventory = mapOf(wood to 100, stone to 100))
         val store = StubBuildingsStore()
+        val skills = StubSkillsRegistry()
         val initialStamina = state.bodyOf(agent)!!.stamina
         var lastEvent: WorldEvent? = null
 
@@ -370,7 +382,7 @@ class BuildReducerTest {
             val (next, event) = assertNotNull(
                 reduceBuild(
                     state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                    catalog, StubSkillsRegistry(), store, StubSafeNodes(), RecordingPublisher(), tick = (10 + i).toLong(),
+                    catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = (10 + i).toLong(),
                 ).getOrNull(),
             )
             state = next
@@ -393,7 +405,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, StubBuildingsStore(), StubSafeNodes(), RecordingPublisher(), tick = 1,
+            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 1,
         )
 
         assertEquals(listOf(carpentry to 1), skills.xpAddCalls)
@@ -407,7 +419,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, StubBuildingsStore(), StubSafeNodes(), publisher, tick = 5,
+            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, publisher), tick = 5,
         )
 
         val rec = publisher.events.filterIsInstance<WorldEvent.SkillRecommended>().single()

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
@@ -45,6 +45,7 @@ import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.inventory.AgentInventory
+import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
@@ -156,7 +157,7 @@ class CraftReducerTest {
                 skills,
                 StubAgents(luckyAgent(luck = 5)),
                 fixedRoller(Rarity.UNCOMMON),
-                publisher,
+                SkillProgression(skills, publisher),
                 tick = 7,
             ).getOrNull(),
         )
@@ -199,7 +200,7 @@ class CraftReducerTest {
                 skills,
                 StubAgents(luckyAgent(luck = 1)),
                 fixedRoller(Rarity.RARE),
-                RecordingPublisher(),
+                SkillProgression(skills, RecordingPublisher()),
                 tick = 3,
             ).getOrNull(),
         )
@@ -239,7 +240,7 @@ class CraftReducerTest {
             skills,
             StubAgents(luckyAgent()),
             fixedRoller(Rarity.COMMON),
-            RecordingPublisher(),
+            SkillProgression(skills, RecordingPublisher()),
             tick = 1,
         )
         val rejection = assertIs<WorldRejection.StackFull>(result.leftOrNull())
@@ -290,6 +291,7 @@ class CraftReducerTest {
     fun `accepts when the gate is zero and the agent has no slot in the skill`() {
         val recipeNoGate = ironSwordRecipe.copy(requiredSkillLevel = 0)
         val recipes = StubRecipeLookup(listOf(recipeNoGate))
+        val skills = StubSkillsRegistry()
         val result = reduceCraft(
             stateWith(),
             WorldCommand.CraftItem(agent, recipeNoGate.id),
@@ -298,10 +300,10 @@ class CraftReducerTest {
             recipes,
             StubEquipmentStore(),
             StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_METAL))),
-            StubSkillsRegistry(),
+            skills,
             StubAgents(luckyAgent()),
             fixedRoller(Rarity.COMMON),
-            RecordingPublisher(),
+            SkillProgression(skills, RecordingPublisher()),
             tick = 1,
         )
         assertNotNull(result.getOrNull())
@@ -349,7 +351,7 @@ class CraftReducerTest {
             skills,
             StubAgents(weakAgent),
             fixedRoller(Rarity.COMMON),
-            RecordingPublisher(),
+            SkillProgression(skills, RecordingPublisher()),
             tick = 1,
         )
         assertIs<WorldRejection.OverEncumbered>(result.leftOrNull())
@@ -379,7 +381,7 @@ class CraftReducerTest {
             skills,
             StubAgents(luckyAgent()),
             fixedRoller(Rarity.COMMON),
-            publisher,
+            SkillProgression(skills, publisher),
             tick = 5,
         )
         val rec = publisher.events.filterIsInstance<WorldEvent.SkillRecommended>().single()
@@ -402,7 +404,7 @@ class CraftReducerTest {
             skills,
             StubAgents(luckyAgent(luck = 7)),
             capturingRoller,
-            RecordingPublisher(),
+            SkillProgression(skills, RecordingPublisher()),
             tick = 1,
         )
         assertEquals(25, capturingRoller.lastSkill)
@@ -427,7 +429,7 @@ class CraftReducerTest {
         skills,
         StubAgents(luckyAgent()),
         fixedRoller(Rarity.COMMON),
-        RecordingPublisher(),
+        SkillProgression(skills, RecordingPublisher()),
         tick = 1,
     )
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
@@ -36,6 +36,7 @@ import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.resources.InitialResourceRow
 import dev.gvart.genesara.world.internal.resources.NodeResourceCell
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
@@ -104,7 +105,7 @@ class HarvestReducerTest {
         val publisher = RecordingPublisher()
 
         val result = reduceHarvest(
-            state, command, balance, items, store, skills, agents, equipment, publisher, tick = 7,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
         )
 
         val (next, event) = assertNotNull(result.getOrNull())
@@ -129,7 +130,7 @@ class HarvestReducerTest {
         val publisher = RecordingPublisher()
 
         val result = reduceHarvest(
-            state, command, balance, items, store, skills, agents, equipment, publisher, tick = 1,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), tick = 1,
         )
 
         val (next, event) = assertNotNull(result.getOrNull())
@@ -165,7 +166,7 @@ class HarvestReducerTest {
         val skills = StubSkillsRegistry().apply { slot(mining) }
 
         val result = reduceHarvest(
-            state, command, balance, regenItems, store, skills, agents, equipment, RecordingPublisher(), tick = 1,
+            state, command, balance, regenItems, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -181,7 +182,7 @@ class HarvestReducerTest {
         val skills = StubSkillsRegistry().apply { slot(foraging) }
 
         val result = reduceHarvest(
-            state, command, balance, items, store, skills, agents, equipment, RecordingPublisher(), tick = 1,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -195,7 +196,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            StubResourceStore(), StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
+            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
         )
 
         assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
@@ -209,7 +210,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, unknown), balance, emptyCatalog,
-            StubResourceStore(), StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
+            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
         )
 
         assertEquals(WorldRejection.UnknownItem(unknown), result.leftOrNull())
@@ -222,7 +223,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, berry), balance, items,
-            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
         )
 
         assertEquals(
@@ -238,7 +239,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
         )
 
         assertEquals(
@@ -254,7 +255,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
         )
 
         assertEquals(
@@ -270,7 +271,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -286,7 +287,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), highYield, items,
-            store, StubSkillsRegistry(), agents, equipment, RecordingPublisher(), tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
         )
 
         val (next, event) = assertNotNull(result.getOrNull())
@@ -309,7 +310,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), tightBalance, items, store,
-            StubSkillsRegistry(), skinnyAgents, equipment, RecordingPublisher(), tick = 1,
+            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
         )
 
         assertEquals(
@@ -328,7 +329,7 @@ class HarvestReducerTest {
         val result = reduceHarvest(
             state = stateWith(),
             WorldCommand.Harvest(agent, wood), tightBalance, items, store,
-            StubSkillsRegistry(), skinnyAgents, equipment, RecordingPublisher(), tick = 1,
+            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -371,7 +372,7 @@ class HarvestReducerTest {
         val result = reduceHarvest(
             state = stateWith(),
             WorldCommand.Harvest(agent, wood), tightBalance, itemsWithHelmet, store,
-            StubSkillsRegistry(), skinnyAgents, helmetEquipped, RecordingPublisher(), tick = 1,
+            skinnyAgents, helmetEquipped, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
         )
 
         assertEquals(
@@ -389,7 +390,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, skills, agents, equipment, publisher, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
         )
 
         assertEquals(listOf(lumberjacking to 1), skills.xpAddCalls)
@@ -409,7 +410,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, skills, agents, equipment, publisher, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
         )
 
         val ev = publisher.events.filterIsInstance<WorldEvent.SkillMilestoneReached>().single()
@@ -430,7 +431,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, skills, agents, equipment, publisher, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
         )
 
         val rec = publisher.events.filterIsInstance<WorldEvent.SkillRecommended>().single()
@@ -447,7 +448,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, skills, agents, equipment, publisher, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
         )
 
         assertTrue(publisher.events.none { it is WorldEvent.SkillRecommended })
@@ -464,7 +465,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, skillFreeItems,
-            store, skills, agents, equipment, publisher, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
         )
 
         assertEquals(0, skills.xpAddCalls.size)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/progression/SkillProgressionTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/progression/SkillProgressionTest.kt
@@ -1,0 +1,168 @@
+package dev.gvart.genesara.world.internal.progression
+
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentSkillState
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.world.events.WorldEvent
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SkillProgressionTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val skill = SkillId("LUMBERJACKING")
+    private val commandId = UUID.randomUUID()
+
+    @Test
+    fun `slotted skill addXp with no milestone fires no events`() {
+        val skills = StubSkillsRegistry().apply { slot(skill) }
+        val publisher = RecordingPublisher()
+
+        SkillProgression(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 7, commandId = commandId)
+
+        assertEquals(listOf(skill to 1), skills.xpAddCalls)
+        assertTrue(publisher.events.isEmpty())
+    }
+
+    @Test
+    fun `slotted skill crossing one milestone publishes one SkillMilestoneReached`() {
+        val skills = StubSkillsRegistry().apply {
+            slot(skill)
+            crossedMilestonesOnNextAdd[skill] = listOf(50)
+        }
+        val publisher = RecordingPublisher()
+
+        SkillProgression(skills, publisher).accrueXp(agent, skill, delta = 5, tick = 11, commandId = commandId)
+
+        val event = publisher.events.filterIsInstance<WorldEvent.SkillMilestoneReached>().single()
+        assertEquals(agent, event.agent)
+        assertEquals(skill, event.skill)
+        assertEquals(50, event.milestone)
+        assertEquals(11L, event.tick)
+        assertEquals(commandId, event.causedBy)
+        assertEquals(listOf(skill to 5), skills.xpAddCalls)
+    }
+
+    @Test
+    fun `slotted skill crossing multiple milestones in one accrual emits one event per milestone`() {
+        val skills = StubSkillsRegistry().apply {
+            slot(skill)
+            crossedMilestonesOnNextAdd[skill] = listOf(50, 100)
+        }
+        val publisher = RecordingPublisher()
+
+        SkillProgression(skills, publisher).accrueXp(agent, skill, delta = 60, tick = 1, commandId = commandId)
+
+        val milestones = publisher.events.filterIsInstance<WorldEvent.SkillMilestoneReached>().map { it.milestone }
+        assertEquals(listOf(50, 100), milestones)
+    }
+
+    @Test
+    fun `unslotted skill with maybeRecommend value emits SkillRecommended carrying snapshot slotsFree`() {
+        val skills = StubSkillsRegistry().apply {
+            recommendOnNext[skill] = 2
+            slotCount = 8
+            slotsFilled = 3
+        }
+        val publisher = RecordingPublisher()
+
+        SkillProgression(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 4, commandId = commandId)
+
+        val rec = publisher.events.filterIsInstance<WorldEvent.SkillRecommended>().single()
+        assertEquals(agent, rec.agent)
+        assertEquals(skill, rec.skill)
+        assertEquals(2, rec.recommendCount)
+        assertEquals(5, rec.slotsFree)
+        assertEquals(4L, rec.tick)
+        assertEquals(commandId, rec.causedBy)
+        assertTrue(skills.xpAddCalls.isEmpty())
+    }
+
+    @Test
+    fun `unslotted skill with maybeRecommend null emits no event`() {
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+
+        SkillProgression(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 1, commandId = commandId)
+
+        assertTrue(publisher.events.isEmpty())
+        assertEquals(listOf(skill to 1L), skills.recommendCalls)
+    }
+
+    @Test
+    fun `slotted skill never triggers maybeRecommend even when it's scripted`() {
+        val skills = StubSkillsRegistry().apply {
+            slot(skill)
+            recommendOnNext[skill] = 1
+        }
+        val publisher = RecordingPublisher()
+
+        SkillProgression(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 1, commandId = commandId)
+
+        assertTrue(publisher.events.none { it is WorldEvent.SkillRecommended })
+        assertTrue(skills.recommendCalls.isEmpty())
+    }
+
+    private class StubSkillsRegistry : AgentSkillsRegistry {
+        private val slottedSkills = mutableSetOf<SkillId>()
+        val xpAddCalls = mutableListOf<Pair<SkillId, Int>>()
+        val recommendCalls = mutableListOf<Pair<SkillId, Long>>()
+        val crossedMilestonesOnNextAdd = mutableMapOf<SkillId, List<Int>>()
+        val recommendOnNext = mutableMapOf<SkillId, Int?>()
+        var slotCount: Int = 8
+        var slotsFilled: Int = 0
+
+        fun slot(skill: SkillId) {
+            slottedSkills += skill
+            slotsFilled = slottedSkills.size
+        }
+
+        override fun snapshot(agent: AgentId): AgentSkillsSnapshot =
+            AgentSkillsSnapshot(
+                perSkill = slottedSkills.associateWith { skillId ->
+                    AgentSkillState(
+                        skill = skillId,
+                        xp = 0,
+                        level = 0,
+                        slotIndex = slottedSkills.indexOf(skillId),
+                        recommendCount = 0,
+                    )
+                }.mapKeys { it.key },
+                slotCount = slotCount,
+                slotsFilled = slotsFilled,
+            )
+
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int): AddXpResult {
+            if (skill !in slottedSkills) return AddXpResult.Unslotted
+            xpAddCalls += skill to delta
+            val crossed = crossedMilestonesOnNextAdd.remove(skill) ?: emptyList()
+            return AddXpResult.Accrued(crossed)
+        }
+
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? {
+            if (skill in slottedSkills) return null
+            recommendCalls += skill to tick
+            return recommendOnNext.remove(skill)
+        }
+
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? {
+            slottedSkills += skill
+            slotsFilled = slottedSkills.size
+            return null
+        }
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -20,6 +20,7 @@ import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import dev.gvart.genesara.world.internal.worldstate.WorldStateRepository
 import org.junit.jupiter.api.Test
@@ -88,7 +89,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 7)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher))
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -110,7 +111,7 @@ class WorldTickHandlerTest {
 
         val cmd = WorldCommand.MoveAgent(agent, ghostId)
         queue.submit(cmd, appliesAtTick = 1)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher))
 
         handler.onTick(Tick(1, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -146,7 +147,7 @@ class WorldTickHandlerTest {
             override fun sleepRegenPerOfflineTick(): Int = 0
             override fun isTraversable(terrain: Terrain): Boolean = true
         }
-        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller)
+        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher))
 
         handler.onTick(Tick(2, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -162,7 +163,7 @@ class WorldTickHandlerTest {
         val queue = CommandQueue()
         val publisher = RecordingPublisher()
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 99)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher))
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 


### PR DESCRIPTION
## Summary

- Extracts three near-identical `accrueXpOrRecommend` helpers (one per skill-emitting reducer: harvest, build, craft) into a single `SkillProgression` `@Component` at `world/internal/progression/`.
- The module owns one method, `accrueXp(agent, skill, delta, tick, commandId)`, which emits `WorldEvent.SkillMilestoneReached` per crossed milestone (slotted path) or one `WorldEvent.SkillRecommended` (unslotted, when `maybeRecommend` fires). Routed through `ApplicationEventPublisher` so reducers' single-event return shape stays unchanged.
- Three reducer signatures shed the publisher dependency. `HarvestReducer` also sheds its `skills` parameter — the `String? → SkillId` null-guard moves to the call site (catalog-specific concern). `BuildReducer` and `CraftReducer` keep `skills` for the level-gate.
- `WorldTickHandler` keeps `ApplicationEventPublisher` directly for shell-emitted events (`PassivesApplied`, `AgentDied`, `CommandRejected`).

## Why this matters

Future progression rule changes — recommendation cooldown tuning, milestone-bonus mechanics, class-specific XP adjustments — collapse to one file. New XP-emitting verbs become one `progression.accrueXp(...)` line instead of a fresh copy of the helper.

## Test plan

- [x] `./gradlew :world:test :api:test :app:test` green locally
- [x] New `SkillProgressionTest` exhaustively covers the contract: slotted no-op, single milestone, multi-milestone fan-out, unslotted with recommend hit, unslotted with recommend null, slotted skipping the recommend path
- [x] All existing reducer-test publisher-event assertions preserved verbatim — migration uses real `SkillProgression(skills, publisher)` at each call site instead of a new test double
- [x] `code-quality-reviewer` agent run; flagged divergent-stub foot-gun in build/craft tests fixed by hoisting a single `skills` local at each site
- [ ] CI green