### PR TITLE
refactor(world,api)!: move spawn policy into a SpawnLocationResolver

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/spawn/SpawnTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/spawn/SpawnTool.kt
@@ -4,9 +4,7 @@ import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
-import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.world.WorldCommandGateway
-import dev.gvart.genesara.world.WorldQueryGateway
 import dev.gvart.genesara.world.commands.WorldCommand
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.annotation.Tool
@@ -15,30 +13,20 @@ import org.springframework.stereotype.Component
 @Component
 internal class SpawnTool(
     private val world: WorldCommandGateway,
-    private val query: WorldQueryGateway,
-    private val agents: AgentRegistry,
     private val engine: TickClock,
     private val activity: AgentActivityTracker,
 ) {
 
     @Tool(
         name = "spawn",
-        description = "Login: enter the world. Resumes at the last node if the agent has played before; otherwise places them at their race's starter node, falling back to a random node if no starter is configured. No-op if already in the world.",
+        description = "Login: enter the world. The simulation chooses the destination — last node if the agent has played before, otherwise their race's starter node, falling back to a random spawnable node. The resolved node is reported on the resulting agent.spawned event.",
     )
     fun invoke(req: SpawnRequest?, toolContext: ToolContext): SpawnResponse {
         touchActivity(toolContext, activity, "spawn")
-
         val agentId = AgentContextHolder.current()
-
-        query.activePositionOf(agentId)?.let { return SpawnResponse.alreadyPresent(it.value) }
-
-        val target = query.locationOf(agentId)
-            ?: agents.find(agentId)?.let { query.starterNodeFor(it.race) }
-            ?: query.randomSpawnableNode()
-            ?: error("World has no spawnable nodes")
-        val command = WorldCommand.SpawnAgent(agent = agentId, at = target)
+        val command = WorldCommand.SpawnAgent(agent = agentId)
         val nextTick = engine.currentTick() + 1
         world.submit(command, appliesAtTick = nextTick)
-        return SpawnResponse.queued(command.commandId, nextTick, target.value)
+        return SpawnResponse(commandId = command.commandId, appliesAtTick = nextTick)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/spawn/SpawnToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/spawn/SpawnToolIo.kt
@@ -3,26 +3,14 @@ package dev.gvart.genesara.api.internal.mcp.tools.spawn
 import com.fasterxml.jackson.annotation.JsonClassDescription
 import java.util.UUID
 
-@JsonClassDescription("Login: enter the world. Resumes at last node, or picks a random one for first-time agents.")
+@JsonClassDescription("Login: enter the world. The simulation picks the destination; the resolved node arrives on the agent.spawned event.")
 class SpawnRequest
 
 /**
- * Response shape for `spawn`.
- *
- * - `kind = "queued"`: a SpawnAgent command was queued; the agent appears at `at` on `appliesAtTick`.
- * - `kind = "already_present"`: the agent is already in the world at `at`; no command was queued.
+ * Response shape for `spawn`. A SpawnAgent command is queued; the resolved node lands
+ * on the resulting `agent.spawned` event tagged with [commandId] as `causedBy`.
  */
 data class SpawnResponse(
-    val kind: String,
-    val at: Long,
-    val commandId: UUID? = null,
-    val appliesAtTick: Long? = null,
-) {
-    companion object {
-        fun queued(commandId: UUID, appliesAtTick: Long, at: Long) =
-            SpawnResponse("queued", at, commandId, appliesAtTick)
-
-        fun alreadyPresent(at: Long) =
-            SpawnResponse("already_present", at)
-    }
-}
+    val commandId: UUID,
+    val appliesAtTick: Long,
+)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeController.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeController.kt
@@ -44,12 +44,9 @@ internal class AgentRuntimeController(
     data class CommandResponse(val commandId: UUID, val appliesAtTick: Long)
 
     @PostMapping("/spawn")
-    fun spawn(
-        @AuthenticationPrincipal agent: Agent,
-        @Valid @RequestBody req: CommandRequest,
-    ): ResponseEntity<CommandResponse> {
+    fun spawn(@AuthenticationPrincipal agent: Agent): ResponseEntity<CommandResponse> {
         val nextTick = tick.currentTick() + 1
-        val cmd = WorldCommand.SpawnAgent(agent.id, NodeId(req.nodeId))
+        val cmd = WorldCommand.SpawnAgent(agent.id)
         command.submit(cmd, appliesAtTick = nextTick)
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(CommandResponse(cmd.commandId, nextTick))
     }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/spawn/SpawnToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/spawn/SpawnToolTest.kt
@@ -1,25 +1,14 @@
 package dev.gvart.genesara.api.internal.mcp.tools.spawn
 
-import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
 import dev.gvart.genesara.engine.TickClock
-import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentId
-import dev.gvart.genesara.player.AgentRegistry
-import dev.gvart.genesara.player.RaceId
-import dev.gvart.genesara.world.BodyView
-import dev.gvart.genesara.world.Node
-import dev.gvart.genesara.world.NodeId
-import dev.gvart.genesara.world.Region
-import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.WorldCommandGateway
-import dev.gvart.genesara.world.WorldQueryGateway
 import dev.gvart.genesara.world.commands.WorldCommand
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.springframework.ai.chat.model.ToolContext
 import java.time.Clock
 import java.time.Instant
@@ -28,25 +17,11 @@ import java.time.ZoneOffset
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SpawnToolTest {
 
     private val agentId = AgentId(UUID.randomUUID())
-    private val ownerId = PlayerId(UUID.randomUUID())
-    private val saved = NodeId(7L)
-    private val starter = NodeId(11L)
-    private val random = NodeId(42L)
-    private val raceId = RaceId("human_steppe")
-
-    private val baseAgent = Agent(
-        id = agentId,
-        owner = ownerId,
-        name = "Komar",
-        race = raceId,
-    )
-
     private val clock = MutableTestClock(Instant.parse("2026-01-01T00:00:00Z"))
     private val activity = AgentActivityRegistry(clock)
     private val gateway = RecordingGateway()
@@ -57,104 +32,37 @@ class SpawnToolTest {
     @AfterEach fun tearDown() = AgentContextHolder.clear()
 
     @Test
-    fun `returns already_present and submits no command when agent is already spawned`() {
-        val query = StubQuery(activePosition = saved)
-        val tool = SpawnTool(gateway, query, StubRegistry(baseAgent), tickClock, activity)
+    fun `queues a SpawnAgent command at the next tick and returns the ack`() {
+        val tool = SpawnTool(gateway, tickClock, activity)
 
         val response = tool.invoke(SpawnRequest(), toolContext)
 
-        assertEquals("already_present", response.kind)
-        assertEquals(saved.value, response.at)
-        assertNull(response.commandId)
-        assertNull(response.appliesAtTick)
-        assertTrue(gateway.submissions.isEmpty())
-    }
-
-    @Test
-    fun `queues spawn at the agent's last known location when not currently active`() {
-        val query = StubQuery(activePosition = null, lastLocation = saved)
-        val tool = SpawnTool(gateway, query, StubRegistry(baseAgent), tickClock, activity)
-
-        val response = tool.invoke(SpawnRequest(), toolContext)
-
-        assertEquals("queued", response.kind)
-        assertEquals(saved.value, response.at)
         assertEquals(101L, response.appliesAtTick)
         val (cmd, appliesAt) = gateway.submissions.single()
-        val spawnCmd = assertNotNull(cmd as? WorldCommand.SpawnAgent)
-        assertEquals(agentId, spawnCmd.agent)
-        assertEquals(saved, spawnCmd.at)
+        val spawn = assertNotNull(cmd as? WorldCommand.SpawnAgent)
+        assertEquals(agentId, spawn.agent)
         assertEquals(101L, appliesAt)
-        assertEquals(spawnCmd.commandId, response.commandId)
+        assertEquals(spawn.commandId, response.commandId)
     }
 
     @Test
-    fun `queues spawn at the race-keyed starter node when agent has no history`() {
-        val query = StubQuery(
-            activePosition = null,
-            lastLocation = null,
-            starterByRace = mapOf(raceId to starter),
-            randomNode = random,
-        )
-        val tool = SpawnTool(gateway, query, StubRegistry(baseAgent), tickClock, activity)
+    fun `accepts a null request body — the tool takes no parameters`() {
+        val tool = SpawnTool(gateway, tickClock, activity)
 
-        val response = tool.invoke(SpawnRequest(), toolContext)
+        val response = tool.invoke(null, toolContext)
 
-        assertEquals("queued", response.kind)
-        assertEquals(starter.value, response.at)
-        val cmd = gateway.submissions.single().first as WorldCommand.SpawnAgent
-        assertEquals(starter, cmd.at)
-    }
-
-    @Test
-    fun `falls back to a random spawnable node when no starter is configured for the race`() {
-        val query = StubQuery(
-            activePosition = null,
-            lastLocation = null,
-            starterByRace = emptyMap(),
-            randomNode = random,
-        )
-        val tool = SpawnTool(gateway, query, StubRegistry(baseAgent), tickClock, activity)
-
-        val response = tool.invoke(SpawnRequest(), toolContext)
-
-        assertEquals("queued", response.kind)
-        assertEquals(random.value, response.at)
-        val cmd = gateway.submissions.single().first as WorldCommand.SpawnAgent
-        assertEquals(random, cmd.at)
-    }
-
-    @Test
-    fun `falls back to a random spawnable node when the agent is unknown to the registry`() {
-        val query = StubQuery(activePosition = null, lastLocation = null, randomNode = random)
-        val tool = SpawnTool(gateway, query, StubRegistry(null), tickClock, activity)
-
-        val response = tool.invoke(SpawnRequest(), toolContext)
-
-        assertEquals("queued", response.kind)
-        assertEquals(random.value, response.at)
-    }
-
-    @Test
-    fun `errors when the world has no spawnable nodes`() {
-        val query = StubQuery(activePosition = null, lastLocation = null, randomNode = null)
-        val tool = SpawnTool(gateway, query, StubRegistry(baseAgent), tickClock, activity)
-
-        assertThrows<IllegalStateException> { tool.invoke(SpawnRequest(), toolContext) }
+        assertEquals(101L, response.appliesAtTick)
+        assertEquals(1, gateway.submissions.size)
     }
 
     @Test
     fun `touches activity registry on every successful invocation`() {
-        val query = StubQuery(activePosition = saved)
-        val tool = SpawnTool(gateway, query, StubRegistry(baseAgent), tickClock, activity)
+        val tool = SpawnTool(gateway, tickClock, activity)
 
-        val cutoff = clock.instant().plusSeconds(60)
-        assertTrue(agentId !in activity.staleAgents(cutoff))
+        assertTrue(agentId !in activity.staleAgents(clock.instant().minusSeconds(60)))
 
         tool.invoke(SpawnRequest(), toolContext)
 
-        val past = clock.instant().minusSeconds(60)
-        assertTrue(agentId !in activity.staleAgents(past))
         assertTrue(agentId in activity.staleAgents(clock.instant().plusSeconds(60)))
     }
 
@@ -163,31 +71,6 @@ class SpawnToolTest {
         override fun submit(command: WorldCommand, appliesAtTick: Long) {
             submissions += command to appliesAtTick
         }
-    }
-
-    private class StubRegistry(private val agent: Agent?) : AgentRegistry {
-        override fun find(id: AgentId): Agent? = agent
-        override fun listForOwner(owner: PlayerId): List<Agent> = listOfNotNull(agent)
-    }
-
-    private class StubQuery(
-        private val activePosition: NodeId? = null,
-        private val lastLocation: NodeId? = null,
-        private val starterByRace: Map<RaceId, NodeId> = emptyMap(),
-        private val randomNode: NodeId? = null,
-    ) : WorldQueryGateway {
-        override fun locationOf(agent: AgentId): NodeId? = lastLocation
-        override fun activePositionOf(agent: AgentId): NodeId? = activePosition
-        override fun node(id: NodeId): Node? = null
-        override fun region(id: RegionId): Region? = null
-        override fun nodesWithin(origin: NodeId, radius: Int): Set<NodeId> = emptySet()
-        override fun randomSpawnableNode(): NodeId? = randomNode
-        override fun starterNodeFor(race: RaceId): NodeId? = starterByRace[race]
-        override fun bodyOf(agent: AgentId): BodyView? = null
-        override fun inventoryOf(agent: AgentId): dev.gvart.genesara.world.InventoryView =
-            dev.gvart.genesara.world.InventoryView(emptyList())
-        override fun resourcesAt(nodeId: NodeId, tick: Long): dev.gvart.genesara.world.NodeResources =
-            dev.gvart.genesara.world.NodeResources.EMPTY
     }
 
     private class StubTickClock(private val currentTick: Long) : TickClock {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeControllerTest.kt
@@ -58,13 +58,12 @@ class AgentRuntimeControllerTest {
     fun `spawn returns 202 ACCEPTED with command id and applies-at tick`() {
         val controller = controller(query = StubQuery())
 
-        val response = controller.spawn(agent, AgentRuntimeController.CommandRequest(currentNodeId.value))
+        val response = controller.spawn(agent)
 
         assertEquals(HttpStatus.ACCEPTED, response.statusCode)
         val (cmd, appliesAt) = recordingGateway.submissions.single()
         val spawn = cmd as WorldCommand.SpawnAgent
         assertEquals(agentId, spawn.agent)
-        assertEquals(currentNodeId, spawn.at)
         assertEquals(101L, appliesAt)
         assertEquals(spawn.commandId, response.body!!.commandId)
         assertEquals(101L, response.body!!.appliesAtTick)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldQueryGateway.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldQueryGateway.kt
@@ -26,13 +26,15 @@ interface WorldQueryGateway {
 
     /**
      * Returns a random spawnable node id from the world, or `null` if the world has no nodes.
-     * Used by the spawn tool as the final fallback when no race starter node is configured.
+     * Used by `SpawnLocationResolver` and `SafeNodeResolver` as the final fallback in their
+     * respective fallback chains.
      */
     fun randomSpawnableNode(): NodeId?
 
     /**
      * The designated starter node for [race], or `null` if no starter node has been assigned
-     * (table empty during early dev — spawn falls back to [randomSpawnableNode]).
+     * (table empty during early dev — both `SpawnLocationResolver` and `SafeNodeResolver`
+     * fall through to [randomSpawnableNode]).
      */
     fun starterNodeFor(race: RaceId): NodeId?
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
@@ -11,9 +11,14 @@ sealed interface WorldCommand {
     val agent: AgentId
     val commandId: UUID
 
+    /**
+     * Enter the world. The reducer resolves the destination via the canonical
+     * fallback chain (resume last-known position → race-keyed starter node →
+     * random spawnable node); the resolved node is reported on the resulting
+     * [dev.gvart.genesara.world.events.WorldEvent.AgentSpawned].
+     */
     data class SpawnAgent(
         override val agent: AgentId,
-        val at: NodeId,
         override val commandId: UUID = UUID.randomUUID(),
     ) : WorldCommand
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -30,6 +30,7 @@ import dev.gvart.genesara.world.internal.harvest.reduceHarvest
 import dev.gvart.genesara.world.internal.movement.reduceMove
 import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
+import dev.gvart.genesara.world.internal.spawn.SpawnLocationResolver
 import dev.gvart.genesara.world.internal.spawn.reduceSpawn
 import dev.gvart.genesara.world.internal.spawn.reduceUnspawn
 import dev.gvart.genesara.world.internal.worldstate.WorldState
@@ -53,9 +54,10 @@ internal fun reduce(
     chestContents: ChestContentsStore,
     rarityRoller: RarityRoller,
     progression: SkillProgression,
+    spawnLocationResolver: SpawnLocationResolver,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = when (command) {
-    is WorldCommand.SpawnAgent -> reduceSpawn(state, command, profiles, tick)
+    is WorldCommand.SpawnAgent -> reduceSpawn(state, command, profiles, spawnLocationResolver, tick)
     is WorldCommand.MoveAgent -> reduceMove(state, command, balance, buildingsLookup, tick)
     is WorldCommand.UnspawnAgent -> reduceUnspawn(state, command, tick)
     is WorldCommand.Harvest ->

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnLocationResolver.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnLocationResolver.kt
@@ -1,0 +1,36 @@
+package dev.gvart.genesara.world.internal.spawn
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.WorldQueryGateway
+import org.springframework.stereotype.Component
+
+/**
+ * Resolves a spawn target through the canonical fallback chain so the spawn reducer
+ * stays focused on body/position mutation. Order: last-known position (resume) →
+ * race-keyed starter node → random spawnable node. Mirrors [SafeNodeResolver][dev.gvart.genesara.world.internal.death.SafeNodeResolver]
+ * for the respawn flow.
+ */
+internal interface SpawnLocationResolver {
+    fun resolveFor(agentId: AgentId): NodeId?
+}
+
+@Component
+internal class SpawnLocationResolverImpl(
+    private val agents: AgentRegistry,
+    private val world: WorldQueryGateway,
+) : SpawnLocationResolver {
+
+    override fun resolveFor(agentId: AgentId): NodeId? =
+        tryResume(agentId)
+            ?: tryRaceStarterNode(agentId)
+            ?: world.randomSpawnableNode()
+
+    private fun tryResume(agentId: AgentId): NodeId? = world.locationOf(agentId)
+
+    private fun tryRaceStarterNode(agentId: AgentId): NodeId? {
+        val agent = agents.find(agentId) ?: return null
+        return world.starterNodeFor(agent.race)
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnReducer.kt
@@ -15,19 +15,31 @@ import dev.gvart.genesara.world.internal.worldstate.WorldState
  * Spawns or resumes an agent. Despawn removes only the position — the body persists, so
  * character progress (HP, stamina, future XP/skills) carries across sessions. Falls
  * through to a fresh body from [AgentBody.fromProfile] only on the agent's first-ever
- * spawn.
+ * spawn. The destination node is decided by [SpawnLocationResolver] so the reducer
+ * stays focused on body/position mutation.
+ *
+ * Rejection priority: `AlreadySpawned` → `NoSpawnableNode` → `UnknownNode` →
+ * `UnknownProfile`. `UnknownNode` here is a defensive guard — the resolver reads from
+ * the same backing store as `state.nodes`, so a returned-but-missing node is unreachable
+ * in production today; we surface a rejection rather than self-heal because there is no
+ * `safeNodes.clear`-like escape hatch (mirrors `RespawnReducer`'s checkpoint-stale
+ * handling, with `agent_positions` integrity covered by FK constraints).
  */
 internal fun reduceSpawn(
     state: WorldState,
     command: WorldCommand.SpawnAgent,
     profiles: AgentProfileLookup,
+    resolver: SpawnLocationResolver,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
     ensure(command.agent !in state.positions) {
         WorldRejection.AlreadySpawned(command.agent)
     }
-    ensure(state.nodes.containsKey(command.at)) {
-        WorldRejection.UnknownNode(command.at)
+    val target = ensureNotNull(resolver.resolveFor(command.agent)) {
+        WorldRejection.NoSpawnableNode(command.agent)
+    }
+    ensure(state.nodes.containsKey(target)) {
+        WorldRejection.UnknownNode(target)
     }
     val profile = ensureNotNull(profiles.find(command.agent)) {
         WorldRejection.UnknownProfile(command.agent)
@@ -35,8 +47,8 @@ internal fun reduceSpawn(
 
     val body = state.bodyOf(command.agent) ?: AgentBody.fromProfile(profile)
     val next = state
-        .copy(positions = state.positions + (command.agent to command.at))
+        .copy(positions = state.positions + (command.agent to target))
         .updateBody(command.agent, body)
-    val event = WorldEvent.AgentSpawned(command.agent, command.at, tick, causedBy = command.commandId)
+    val event = WorldEvent.AgentSpawned(command.agent, target, tick, causedBy = command.commandId)
     next to event
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -21,6 +21,7 @@ import dev.gvart.genesara.world.internal.passive.applyPassives
 import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.reduce
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
+import dev.gvart.genesara.world.internal.spawn.SpawnLocationResolver
 import dev.gvart.genesara.world.internal.worldstate.WorldStateRepository
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
@@ -49,6 +50,7 @@ internal class WorldTickHandler(
     private val chestContents: ChestContentsStore,
     private val rarityRoller: RarityRoller,
     private val progression: SkillProgression,
+    private val spawnLocationResolver: SpawnLocationResolver,
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -76,7 +78,7 @@ internal class WorldTickHandler(
             reduce(
                 state, command, balance, profiles, items, recipes, resources, skills, agents, equipment,
                 safeNodes, safeNodeResolver, buildings, buildingsLookup, buildingsCatalog, chestContents,
-                rarityRoller, progression, tick.number,
+                rarityRoller, progression, spawnLocationResolver, tick.number,
             ).fold(
                 ifLeft = { rejection ->
                     log.info("Rejected {} at tick {}: {}", command, tick.number, rejection)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnLocationResolverTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnLocationResolverTest.kt
@@ -1,0 +1,109 @@
+package dev.gvart.genesara.world.internal.spawn
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.world.BodyView
+import dev.gvart.genesara.world.InventoryView
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NodeResources
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.WorldQueryGateway
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SpawnLocationResolverTest {
+
+    private val agentId = AgentId(UUID.randomUUID())
+    private val race = RaceId("human_steppe")
+    private val resume = NodeId(7L)
+    private val starter = NodeId(11L)
+    private val random = NodeId(42L)
+
+    private val baseAgent = Agent(
+        id = agentId,
+        owner = PlayerId(UUID.randomUUID()),
+        name = "Komar",
+        race = race,
+        attributes = AgentAttributes(),
+    )
+
+    @Test
+    fun `prefers the agent's last-known location when one exists`() {
+        val resolver = SpawnLocationResolverImpl(
+            agents = StubAgents(baseAgent),
+            world = StubQuery(lastLocation = resume, starterByRace = mapOf(race to starter), randomNode = random),
+        )
+
+        assertEquals(resume, resolver.resolveFor(agentId))
+    }
+
+    @Test
+    fun `falls back to the race-keyed starter node when no last location is known`() {
+        val resolver = SpawnLocationResolverImpl(
+            agents = StubAgents(baseAgent),
+            world = StubQuery(lastLocation = null, starterByRace = mapOf(race to starter), randomNode = random),
+        )
+
+        assertEquals(starter, resolver.resolveFor(agentId))
+    }
+
+    @Test
+    fun `falls back to a random spawnable node when the race has no starter mapping`() {
+        val resolver = SpawnLocationResolverImpl(
+            agents = StubAgents(baseAgent),
+            world = StubQuery(lastLocation = null, starterByRace = emptyMap(), randomNode = random),
+        )
+
+        assertEquals(random, resolver.resolveFor(agentId))
+    }
+
+    @Test
+    fun `skips the starter step when the agent is unknown to the registry`() {
+        val resolver = SpawnLocationResolverImpl(
+            agents = StubAgents(null),
+            world = StubQuery(lastLocation = null, starterByRace = mapOf(race to starter), randomNode = random),
+        )
+
+        assertEquals(random, resolver.resolveFor(agentId))
+    }
+
+    @Test
+    fun `returns null when the world has no spawnable node anywhere`() {
+        val resolver = SpawnLocationResolverImpl(
+            agents = StubAgents(baseAgent),
+            world = StubQuery(lastLocation = null, starterByRace = emptyMap(), randomNode = null),
+        )
+
+        assertNull(resolver.resolveFor(agentId))
+    }
+
+    private class StubAgents(private val agent: Agent?) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = agent
+        override fun listForOwner(owner: PlayerId): List<Agent> = listOfNotNull(agent)
+    }
+
+    private class StubQuery(
+        private val lastLocation: NodeId? = null,
+        private val starterByRace: Map<RaceId, NodeId> = emptyMap(),
+        private val randomNode: NodeId? = null,
+    ) : WorldQueryGateway {
+        override fun locationOf(agent: AgentId): NodeId? = lastLocation
+        override fun activePositionOf(agent: AgentId): NodeId? = null
+        override fun node(id: NodeId): Node? = null
+        override fun region(id: RegionId): Region? = null
+        override fun nodesWithin(origin: NodeId, radius: Int): Set<NodeId> = emptySet()
+        override fun randomSpawnableNode(): NodeId? = randomNode
+        override fun starterNodeFor(race: RaceId): NodeId? = starterByRace[race]
+        override fun bodyOf(agent: AgentId): BodyView? = null
+        override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
+        override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnReducerTest.kt
@@ -52,9 +52,9 @@ class SpawnReducerTest {
     private val profiles = profileLookup(profile)
 
     @Test
-    fun `spawns agent at node, initializes body from profile, emits AgentSpawned`() {
-        val command = WorldCommand.SpawnAgent(agent, home)
-        val result = reduceSpawn(world, command, profiles, tick = 1)
+    fun `spawns agent at resolver target, initializes body from profile, emits AgentSpawned`() {
+        val command = WorldCommand.SpawnAgent(agent)
+        val result = reduceSpawn(world, command, profiles, fixedResolver(home), tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
@@ -76,33 +76,39 @@ class SpawnReducerTest {
     @Test
     fun `rejects spawn when agent already spawned`() {
         val already = world.copy(positions = mapOf(agent to home))
-        val result = reduceSpawn(already, WorldCommand.SpawnAgent(agent, home), profiles, tick = 1)
+        val result = reduceSpawn(already, WorldCommand.SpawnAgent(agent), profiles, fixedResolver(home), tick = 1)
 
         assertEquals(WorldRejection.AlreadySpawned(agent), result.leftOrNull())
     }
 
     @Test
-    fun `rejects spawn at unknown node`() {
+    fun `rejects with NoSpawnableNode when the resolver returns null`() {
+        val result = reduceSpawn(world, WorldCommand.SpawnAgent(agent), profiles, fixedResolver(null), tick = 1)
+
+        assertEquals(WorldRejection.NoSpawnableNode(agent), result.leftOrNull())
+    }
+
+    @Test
+    fun `rejects with UnknownNode when the resolver returns a node missing from state`() {
         val ghost = NodeId(99L)
-        val result = reduceSpawn(world, WorldCommand.SpawnAgent(agent, ghost), profiles, tick = 1)
+        val result = reduceSpawn(world, WorldCommand.SpawnAgent(agent), profiles, fixedResolver(ghost), tick = 1)
 
         assertEquals(WorldRejection.UnknownNode(ghost), result.leftOrNull())
     }
 
     @Test
     fun `resumes existing body on respawn instead of resetting from profile`() {
-        // Persisted body from a prior session: HP/stamina lower than profile defaults
         val survivor = AgentBody(hp = 30, maxHp = 100, stamina = 5, maxStamina = 50, mana = 0, maxMana = 0)
         val resumed = world.copy(bodies = mapOf(agent to survivor))
 
-        val command = WorldCommand.SpawnAgent(agent, home)
-        val result = reduceSpawn(resumed, command, profiles, tick = 1)
+        val command = WorldCommand.SpawnAgent(agent)
+        val result = reduceSpawn(resumed, command, profiles, fixedResolver(home), tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
             ifRight = { (next, _) ->
                 val body = assertNotNull(next.bodyOf(agent))
-                assertEquals(survivor, body) // not refreshed from profile
+                assertEquals(survivor, body)
             },
         )
     }
@@ -110,7 +116,7 @@ class SpawnReducerTest {
     @Test
     fun `rejects spawn when profile is missing`() {
         val empty = profileLookup()
-        val result = reduceSpawn(world, WorldCommand.SpawnAgent(agent, home), empty, tick = 1)
+        val result = reduceSpawn(world, WorldCommand.SpawnAgent(agent), empty, fixedResolver(home), tick = 1)
 
         assertEquals(WorldRejection.UnknownProfile(agent), result.leftOrNull())
     }
@@ -118,5 +124,9 @@ class SpawnReducerTest {
     private fun profileLookup(vararg entries: AgentProfile) = object : AgentProfileLookup {
         private val map = entries.associateBy { it.id }
         override fun find(id: AgentId): AgentProfile? = map[id]
+    }
+
+    private fun fixedResolver(target: NodeId?) = object : SpawnLocationResolver {
+        override fun resolveFor(agentId: AgentId): NodeId? = target
     }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -89,7 +89,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 7)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher))
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver)
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -111,7 +111,7 @@ class WorldTickHandlerTest {
 
         val cmd = WorldCommand.MoveAgent(agent, ghostId)
         queue.submit(cmd, appliesAtTick = 1)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher))
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver)
 
         handler.onTick(Tick(1, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -147,7 +147,7 @@ class WorldTickHandlerTest {
             override fun sleepRegenPerOfflineTick(): Int = 0
             override fun isTraversable(terrain: Terrain): Boolean = true
         }
-        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher))
+        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver)
 
         handler.onTick(Tick(2, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -163,7 +163,7 @@ class WorldTickHandlerTest {
         val queue = CommandQueue()
         val publisher = RecordingPublisher()
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 99)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher))
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver)
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -263,6 +263,10 @@ class WorldTickHandlerTest {
 
     private object NoopSafeNodeResolver : dev.gvart.genesara.world.internal.death.SafeNodeResolver {
         override fun resolveFor(agentId: AgentId): dev.gvart.genesara.world.internal.death.SafeNodeResolution? = null
+    }
+
+    private object NoopSpawnLocationResolver : dev.gvart.genesara.world.internal.spawn.SpawnLocationResolver {
+        override fun resolveFor(agentId: AgentId): NodeId? = null
     }
 
     private object NoopBuildingsStore : dev.gvart.genesara.world.BuildingsStore {


### PR DESCRIPTION
## Summary

- Moves the resume → starter → random spawn fallback chain out of the MCP `SpawnTool` and into a new `SpawnLocationResolver` next to the spawn reducer in `:world/internal/spawn/`. Mirrors the existing `SafeNodeResolver` for the respawn flow.
- `WorldCommand.SpawnAgent` drops its `at: NodeId` field. The reducer asks the resolver, validates the result, and folds. The resolved node arrives on the existing `agent.spawned` event tagged with `causedBy = commandId`.
- `SpawnTool` collapses to a thin queue-and-ack translator (~10 lines, no longer reaches `WorldQueryGateway` or `AgentRegistry`). `SpawnResponse` simplifies to `{ commandId, appliesAtTick }`.
- REST `POST /api/agent/me/spawn` no longer accepts a body.
- Reducer rejection priority documented in KDoc: `AlreadySpawned` → `NoSpawnableNode` → `UnknownNode` (defensive) → `UnknownProfile`. The defensive `UnknownNode` is intentionally not paired with a `RespawnReducer`-style self-heal — KDoc explains why (FK coverage on `agent_positions`).

## Why this matters

`docs/mcp-api.md` documents queue-and-ack tools as thin translators that "translate calls to commands and return `{ commandId, appliesAtTick }`." The pre-refactor `SpawnTool` violated this by embedding spawn-location *policy* (resume / starter / random selection) in `:api`. After this slice, that policy lives in `:world` where simulation rules belong; `:api` translates only.

## Agent-visible breaking changes

- `spawn` MCP tool: response shape collapses to `{ commandId, appliesAtTick }`. The former `kind = \"already_present\"` synchronous branch is gone — agents now learn they were already spawned via the `command.rejected` event stream (`AlreadySpawned` rejection), consistent with how `UnspawnTool` already behaves.
- REST `POST /api/agent/me/spawn`: no longer accepts a body.

## Test plan

- [x] `./gradlew :world:test :api:test :app:test` green locally
- [x] New `SpawnLocationResolverTest` covers the fallback matrix: resume hit, starter hit, random fallback, agent-unknown-to-registry skips starter step, world-with-no-spawnable-node returns null
- [x] `SpawnReducerTest` keeps happy-path / already-spawned / profile-missing cases and gains coverage for resolver-returns-null (`NoSpawnableNode`) and resolver-returns-stale-node (`UnknownNode`)
- [x] `SpawnToolTest` collapses to focused unit checks: queues a `SpawnAgent` command, accepts a null request body, touches the activity registry
- [x] `code-quality-reviewer` agent run; flagged stale gateway KDocs tightened to credit both resolvers, test setup commentary trimmed per the self-explanatory-code rule, rejection-priority KDoc added to `SpawnReducer`
- [ ] CI green