### PR TITLE
chore(world,api): align identifiers with the unified harvest verb

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
@@ -183,7 +183,7 @@ internal class InspectTool(
                 regenerating = if (depth != InspectDepth.SHALLOW) item.regenerating else null,
                 rarity = if (depth != InspectDepth.SHALLOW) item.rarity.name else null,
                 maxDurability = if (depth != InspectDepth.SHALLOW) item.maxDurability else null,
-                gatheringSkill = if (depth == InspectDepth.EXPERT) item.gatheringSkill else null,
+                harvestSkill = if (depth == InspectDepth.EXPERT) item.harvestSkill else null,
             ),
         )
     }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
@@ -141,10 +141,10 @@ data class ItemInspectView(
      */
     val maxDurability: Int? = null,
     /**
-     * EXPERT-only: skill that gathering this item trains, if any. Useful for an agent
+     * EXPERT-only: skill that harvesting this item trains, if any. Useful for an agent
      * deciding whether picking up an item also helps progression.
      */
-    val gatheringSkill: String? = null,
+    val harvestSkill: String? = null,
 )
 
 /**

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
@@ -300,14 +300,14 @@ class InspectToolTest {
         val view = assertNotNull(resp.item)
         assertEquals(5, view.quantity)
         assertNull(view.weightPerUnit, "weight is DETAILED+")
-        assertNull(view.gatheringSkill, "gatheringSkill is EXPERT-only")
+        assertNull(view.harvestSkill, "harvestSkill is EXPERT-only")
     }
 
     @Test
-    fun `inspect item at EXPERT exposes gatheringSkill`() {
+    fun `inspect item at EXPERT exposes harvestSkill`() {
         val tool = tool(perception = 20, inventory = listOf(InventoryEntry(ItemId("WOOD"), 5)))
         val resp = tool.invoke(req("item", "WOOD"), toolContext)
-        assertEquals("FORESTRY", resp.item?.gatheringSkill)
+        assertEquals("FORESTRY", resp.item?.harvestSkill)
     }
 
     @Test
@@ -424,7 +424,7 @@ class InspectToolTest {
                 category = ItemCategory.RESOURCE,
                 weightPerUnit = 200,
                 maxStack = 99,
-                gatheringSkill = "FORESTRY",
+                harvestSkill = "FORESTRY",
             ),
         )
         override fun byId(id: ItemId): Item? = catalog[id.value]

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -74,7 +74,7 @@ sequenceDiagram
 
 The tool returns `{ commandId, appliesAtTick }` synchronously and resolves nothing. The actual outcome arrives on the event stream, tagged with `causedBy = commandId` so the agent can correlate. The tool *does not block the tick*; queuing decouples request rate from world rate, gives fair scheduling, and keeps reductions deterministic.
 
-Rejections (e.g. `NotAdjacent`, `NotEnoughStamina`) are produced by the reducer at apply time, logged, and dropped. They are not surfaced back to the agent today — that's a known gap. When the rejection-event channel lands, agents will receive a tagged `causedBy` rejection on the same stream.
+Rejections (e.g. `NotAdjacent`, `NotEnoughStamina`) are produced by the reducer at apply time and surfaced as `WorldEvent.CommandRejected` on the agent's event stream as `command.rejected`, tagged with `causedBy = commandId` so the agent can correlate the rejection with the original tool call. The wire payload carries `kind` (the rejection's class simple name — agents branch on it) and `rejection` (the structured fields).
 
 ### Sync-read (pure read tools)
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/Item.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/Item.kt
@@ -51,7 +51,7 @@ data class Item(
      * for non-harvestable items or for resources that aren't tied to a skill (none
      * today). Cross-validated against the skill catalog at startup.
      */
-    val gatheringSkill: String? = null,
+    val harvestSkill: String? = null,
     /**
      * Default rarity for instances of this item. Stackable resources always emit
      * COMMON; equipment items can declare a higher floor here (e.g. an artifact

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldQueryGateway.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldQueryGateway.kt
@@ -54,7 +54,7 @@ interface WorldQueryGateway {
     /**
      * Live per-node resource availability at [nodeId], with lazy-regen applied at
      * [tick]. Returns [NodeResources.EMPTY] when the node has no rows (nothing ever
-     * spawned). The returned snapshot is read-only — gather mutations go through the
+     * spawned). The returned snapshot is read-only — harvest mutations go through the
      * reducer path, not this gateway.
      */
     fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources

--- a/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
@@ -35,7 +35,7 @@ sealed interface WorldCommand {
 
     /**
      * Extract a single yield of [item] from the agent's current node. The item's
-     * catalog entry (`Item.gatheringSkill`) selects which skill is trained, if any.
+     * catalog entry (`Item.harvestSkill`) selects which skill is trained, if any.
      */
     data class Harvest(
         override val agent: AgentId,

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemLookupImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemLookupImpl.kt
@@ -32,14 +32,14 @@ internal class ItemLookupImpl(
         regenerating = regenerating,
         regenIntervalTicks = regenIntervalTicks,
         regenAmount = regenAmount,
-        gatheringSkill = gatheringSkill,
+        harvestSkill = harvestSkill,
         rarity = rarity,
         maxDurability = maxDurability,
         validSlots = validSlots,
         twoHanded = twoHanded,
         requiredAttributes = requiredAttributes,
         // Convert string keys → typed SkillId once at catalog load. Keeping
-        // the YAML side stringly-typed (matches `gathering-skill: ...`) while
+        // the YAML side stringly-typed (matches `harvest-skill: ...`) while
         // the public `Item` carries `Map<SkillId, Int>` saves an allocation
         // per equip-time iteration.
         requiredSkills = requiredSkills.mapKeys { (id, _) -> SkillId(id) },

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemProperties.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemProperties.kt
@@ -23,8 +23,8 @@ internal data class ItemProperties(
     val regenIntervalTicks: Int = 0,
     /** Quantity added per regen interval. */
     val regenAmount: Int = 0,
-    /** Skill id (from `:player`'s catalog) trained on a gather. Null for non-gatherables. */
-    val gatheringSkill: String? = null,
+    /** Skill id (from `:player`'s catalog) trained on a harvest. Null for non-harvestables. */
+    val harvestSkill: String? = null,
     /** Default rarity for instances of this item; defaults to [Rarity.COMMON]. */
     val rarity: Rarity = Rarity.COMMON,
     /** Max durability for instances of this item. Null = no durability (stackable). */

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -23,13 +23,13 @@ internal interface BalanceLookup {
      * Stamina cost of a single `harvest` invocation. Flat in this slice; tuning per
      * (item × terrain × skill) lands when skills do.
      */
-    fun gatherStaminaCost(item: ItemId): Int
+    fun harvestStaminaCost(item: ItemId): Int
     /**
      * Quantity yielded by a single `harvest` invocation. Flat (1) in this slice; the
      * call shape exists so skill scaling can route through here when the skill slice
      * lands without touching the harvest reducer.
      */
-    fun gatherYield(item: ItemId): Int
+    fun harvestYield(item: ItemId): Int
 
     /**
      * Per-tick depletion of the named survival gauge. Always positive; the passive
@@ -142,9 +142,9 @@ internal class WorldDefinitionBalanceLookup(
             )
         }
 
-    override fun gatherStaminaCost(item: ItemId): Int = BASE_GATHER_COST
+    override fun harvestStaminaCost(item: ItemId): Int = BASE_HARVEST_COST
 
-    override fun gatherYield(item: ItemId): Int = BASE_GATHER_YIELD
+    override fun harvestYield(item: ItemId): Int = BASE_HARVEST_YIELD
 
     override fun gaugeDrainPerTick(gauge: Gauge): Int = GAUGE_DRAIN_PER_TICK
 
@@ -177,8 +177,8 @@ internal class WorldDefinitionBalanceLookup(
     private companion object {
         const val BASE_MOVE_COST = 1
         const val BASE_REGEN_PER_TICK = 1.0
-        const val BASE_GATHER_COST = 5
-        const val BASE_GATHER_YIELD = 1
+        const val BASE_HARVEST_COST = 5
+        const val BASE_HARVEST_YIELD = 1
         const val GAUGE_DRAIN_PER_TICK = 1
         const val GAUGE_LOW_THRESHOLD = 25
         const val GAUGE_BUFF_THRESHOLD = 75

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ResourceSpawnsValidator.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ResourceSpawnsValidator.kt
@@ -2,7 +2,6 @@ package dev.gvart.genesara.world.internal.balance
 
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillLookup
-import dev.gvart.genesara.world.Item
 import dev.gvart.genesara.world.ItemLookup
 import jakarta.annotation.PostConstruct
 import org.springframework.stereotype.Component
@@ -11,7 +10,7 @@ import org.springframework.stereotype.Component
  * Cross-validates `terrains.yaml` and `items.yaml` against sibling catalogs at startup.
  * Fails fast on misconfiguration so the runtime hot path stays branch-free. Catches:
  * unknown item ids in spawn rules, malformed quantity ranges, out-of-bounds spawn
- * chances, unknown gathering-skill references (XP grants would silently no-op), and
+ * chances, unknown harvest-skill references (XP grants would silently no-op), and
  * unknown required-skills keys (items would be permanently un-equippable).
  */
 @Component
@@ -27,7 +26,7 @@ internal class ResourceSpawnsValidator(
         val problems = mutableListOf<String>()
 
         problems += spawnRuleProblems(knownIds)
-        problems += unknownGatheringSkillProblems()
+        problems += unknownHarvestSkillProblems()
         problems += unknownRequiredSkillProblems()
 
         require(problems.isEmpty()) {
@@ -65,11 +64,11 @@ internal class ResourceSpawnsValidator(
         return problems
     }
 
-    private fun unknownGatheringSkillProblems(): List<String> =
+    private fun unknownHarvestSkillProblems(): List<String> =
         items.all().mapNotNull { item ->
-            val skillId = item.gatheringSkill ?: return@mapNotNull null
+            val skillId = item.harvestSkill ?: return@mapNotNull null
             if (skills.byId(SkillId(skillId)) == null) {
-                "  item ${item.id.value} declares gathering-skill='$skillId' which is not in the skill catalog"
+                "  item ${item.id.value} declares harvest-skill='$skillId' which is not in the skill catalog"
             } else null
         }
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
@@ -54,12 +54,12 @@ internal fun reduceHarvest(
 
     val body = state.bodyOf(command.agent)
         ?: error("Invariant violated: agent ${command.agent} has a position but no body")
-    val cost = balance.gatherStaminaCost(command.item)
+    val cost = balance.harvestStaminaCost(command.item)
     ensure(body.stamina >= cost) {
         WorldRejection.NotEnoughStamina(command.agent, cost, body.stamina)
     }
 
-    val quantity = balance.gatherYield(command.item).coerceAtMost(cell.quantity)
+    val quantity = balance.harvestYield(command.item).coerceAtMost(cell.quantity)
 
     val agentRecord = agents.find(command.agent)
         ?: error("Invariant violated: agent ${command.agent} has a position but no registry row")
@@ -69,7 +69,7 @@ internal fun reduceHarvest(
     enforceCarryCap(command.agent, agentRecord.attributes.strength, currentGrams, additionalGrams, balance)
 
     resources.decrement(nodeId, command.item, quantity, tick)
-    itemDef.gatheringSkill?.let { skillKey ->
+    itemDef.harvestSkill?.let { skillKey ->
         progression.accrueXp(command.agent, SkillId(skillKey), delta = quantity, tick, command.commandId)
     }
 

--- a/world/src/main/resources/world-definition/items.yaml
+++ b/world/src/main/resources/world-definition/items.yaml
@@ -13,7 +13,7 @@ items:
       regenerating: true
       regen-interval-ticks: 500
       regen-amount: 5
-      gathering-skill: LUMBERJACKING
+      harvest-skill: LUMBERJACKING
 
     BERRY:
       display-name: Wild Berries
@@ -26,7 +26,7 @@ items:
       regenerating: true
       regen-interval-ticks: 100
       regen-amount: 5
-      gathering-skill: FORAGING
+      harvest-skill: FORAGING
       consumable:
         gauge: HUNGER
         amount: 20
@@ -42,7 +42,7 @@ items:
       regenerating: true
       regen-interval-ticks: 100
       regen-amount: 5
-      gathering-skill: FORAGING
+      harvest-skill: FORAGING
       consumable:
         gauge: HUNGER
         amount: 10
@@ -58,7 +58,7 @@ items:
       regenerating: true
       regen-interval-ticks: 100
       regen-amount: 5
-      gathering-skill: FORAGING
+      harvest-skill: FORAGING
       consumable:
         gauge: HUNGER
         amount: 15
@@ -74,7 +74,7 @@ items:
       regenerating: true
       regen-interval-ticks: 200
       regen-amount: 3
-      gathering-skill: FISHING
+      harvest-skill: FISHING
       consumable:
         gauge: HUNGER
         amount: 30
@@ -113,7 +113,7 @@ items:
       regenerating: true
       regen-interval-ticks: 500
       regen-amount: 4
-      gathering-skill: MINING
+      harvest-skill: MINING
 
     PEAT:
       display-name: Peat
@@ -126,7 +126,7 @@ items:
       regenerating: true
       regen-interval-ticks: 800
       regen-amount: 3
-      gathering-skill: MINING
+      harvest-skill: MINING
 
     SAND:
       display-name: Sand
@@ -139,7 +139,7 @@ items:
       regenerating: true
       regen-interval-ticks: 2000
       regen-amount: 2
-      gathering-skill: MINING
+      harvest-skill: MINING
 
     # ─────────────────── Non-regenerating geological ──────────────────────
 
@@ -153,7 +153,7 @@ items:
       weight-per-unit: 1500
       max-stack: 100
       regenerating: false
-      gathering-skill: MINING
+      harvest-skill: MINING
 
     ORE:
       display-name: Ore
@@ -164,7 +164,7 @@ items:
       weight-per-unit: 2000
       max-stack: 50
       regenerating: false
-      gathering-skill: MINING
+      harvest-skill: MINING
 
     COAL:
       display-name: Coal
@@ -175,7 +175,7 @@ items:
       weight-per-unit: 1800
       max-stack: 80
       regenerating: false
-      gathering-skill: MINING
+      harvest-skill: MINING
 
     GEM:
       display-name: Gemstone
@@ -186,7 +186,7 @@ items:
       weight-per-unit: 200
       max-stack: 30
       regenerating: false
-      gathering-skill: MINING
+      harvest-skill: MINING
 
     SALT:
       display-name: Salt
@@ -197,7 +197,7 @@ items:
       weight-per-unit: 1000
       max-stack: 100
       regenerating: false
-      gathering-skill: MINING
+      harvest-skill: MINING
 
     # ────────────────── Refined intermediates (craftable) ─────────────────
     # These exist only as outputs of the crafting layer (#8). They are RESOURCE

--- a/world/src/main/resources/world-definition/recipes-intermediates.yaml
+++ b/world/src/main/resources/world-definition/recipes-intermediates.yaml
@@ -1,4 +1,4 @@
-# Refining recipes — raw gathers → stackable intermediates that gate T2 equipment
+# Refining recipes — raw harvests → stackable intermediates that gate T2 equipment
 # (and forward-compatible with future T2/T3 building costs). All RESOURCE outputs;
 # no rarity / durability roll, no creator signature.
 #

--- a/world/src/main/resources/world-definition/recipes-weapons.yaml
+++ b/world/src/main/resources/world-definition/recipes-weapons.yaml
@@ -1,5 +1,5 @@
 # Weapon recipes — main-hand melee, ranged, two-handed, off-hand defenses, utility.
-# T1 uses raw gathers (workbench / forge with skill 0). T2 demands intermediates
+# T1 uses raw harvests (workbench / forge with skill 0). T2 demands intermediates
 # (IRON_INGOT) and a non-zero skill level so the catalog gates progression.
 
 recipes:

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/ResourceSpawnsValidatorTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/ResourceSpawnsValidatorTest.kt
@@ -100,9 +100,9 @@ class ResourceSpawnsValidatorTest {
     }
 
     @Test
-    fun `rejects items declaring a gathering-skill that's not in the catalog`() {
+    fun `rejects items declaring a harvest-skill that's not in the catalog`() {
         // Items declaring a phantom skill would silently no-op every XP grant — fail fast.
-        val itemsWithBadSkill = StubItemLookup(setOf("WOOD"), gatheringSkillFor = mapOf("WOOD" to "PHANTOM_SKILL"))
+        val itemsWithBadSkill = StubItemLookup(setOf("WOOD"), harvestSkillFor = mapOf("WOOD" to "PHANTOM_SKILL"))
         val knownSkills = StubSkillLookup(setOf("FORAGING")) // PHANTOM_SKILL not present
 
         val ex = assertThrows<IllegalArgumentException> {
@@ -112,8 +112,8 @@ class ResourceSpawnsValidatorTest {
     }
 
     @Test
-    fun `accepts items declaring a gathering-skill that's in the catalog`() {
-        val itemsWithGoodSkill = StubItemLookup(setOf("WOOD"), gatheringSkillFor = mapOf("WOOD" to "LUMBERJACKING"))
+    fun `accepts items declaring a harvest-skill that's in the catalog`() {
+        val itemsWithGoodSkill = StubItemLookup(setOf("WOOD"), harvestSkillFor = mapOf("WOOD" to "LUMBERJACKING"))
         val knownSkills = StubSkillLookup(setOf("LUMBERJACKING"))
 
         ResourceSpawnsValidator(WorldDefinitionProperties(), itemsWithGoodSkill, knownSkills).validate()
@@ -138,7 +138,7 @@ class ResourceSpawnsValidatorTest {
 
     private class StubItemLookup(
         ids: Set<String>,
-        gatheringSkillFor: Map<String, String> = emptyMap(),
+        harvestSkillFor: Map<String, String> = emptyMap(),
     ) : ItemLookup {
         private val byId = ids.associateWith { id ->
             Item(
@@ -148,7 +148,7 @@ class ResourceSpawnsValidatorTest {
                 category = ItemCategory.RESOURCE,
                 weightPerUnit = 100,
                 maxStack = 100,
-                gatheringSkill = gatheringSkillFor[id],
+                harvestSkill = harvestSkillFor[id],
             )
         }
         override fun byId(id: ItemId): Item? = byId[id.value]
@@ -168,7 +168,7 @@ class ResourceSpawnsValidatorTest {
         override fun all(): List<Skill> = byId.values.toList()
     }
 
-    /** Validator only consults [SkillLookup] when an item declares a `gathering-skill`; the test items don't, so an empty lookup is sufficient. */
+    /** Validator only consults [SkillLookup] when an item declares a `harvest-skill`; the test items don't, so an empty lookup is sufficient. */
     private object EmptySkillLookup : SkillLookup {
         override fun byId(id: SkillId): Skill? = null
         override fun all(): List<Skill> = emptyList()

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/WorldDefinitionBalanceLookupTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/WorldDefinitionBalanceLookupTest.kt
@@ -39,16 +39,15 @@ class WorldDefinitionBalanceLookupTest {
     }
 
     @Test
-    fun `drink stamina cost is cheaper than a single gather — invariant the reducer relies on`() {
-        // Drinking should never be more expensive than gathering; this is a load-bearing
-        // balance assumption (an agent finding a river should never choose to gather over
-        // drink for hydration). Pinning the relative ordering, not the absolute values.
+    fun `drink stamina cost is cheaper than a single harvest — invariant the reducer relies on`() {
+        // Load-bearing balance assumption: an agent finding a river should never prefer
+        // harvesting for hydration over the dedicated drink path.
         val lookup = WorldDefinitionBalanceLookup(WorldDefinitionProperties())
 
         assertTrue(lookup.drinkStaminaCost() > 0, "drink must cost something to prevent zero-cost spam")
         assertTrue(
-            lookup.drinkStaminaCost() < lookup.gatherStaminaCost(dev.gvart.genesara.world.ItemId("WOOD")),
-            "drink (${lookup.drinkStaminaCost()}) must be cheaper than gather (${lookup.gatherStaminaCost(dev.gvart.genesara.world.ItemId("WOOD"))})",
+            lookup.drinkStaminaCost() < lookup.harvestStaminaCost(dev.gvart.genesara.world.ItemId("WOOD")),
+            "drink (${lookup.drinkStaminaCost()}) must be cheaper than harvest (${lookup.harvestStaminaCost(dev.gvart.genesara.world.ItemId("WOOD"))})",
         )
     }
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
@@ -462,7 +462,7 @@ class CraftReducerTest {
         regenerating = false,
         regenIntervalTicks = 0,
         regenAmount = 0,
-        gatheringSkill = null,
+        harvestSkill = null,
         rarity = Rarity.COMMON,
         maxDurability = maxDurability,
         validSlots = validSlots,
@@ -476,8 +476,8 @@ class CraftReducerTest {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain): Int = error("unused")
         override fun staminaRegenPerTick(climate: Climate): Int = error("unused")
         override fun resourceSpawnsFor(terrain: Terrain): List<dev.gvart.genesara.world.ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: ItemId): Int = error("unused")
-        override fun gatherYield(item: ItemId): Int = error("unused")
+        override fun harvestStaminaCost(item: ItemId): Int = error("unused")
+        override fun harvestYield(item: ItemId): Int = error("unused")
         override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = error("unused")
         override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = error("unused")
         override fun starvationDamagePerTick(): Int = 0

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/DeathSweepTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/DeathSweepTest.kt
@@ -205,8 +205,8 @@ class DeathSweepTest {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
         override fun staminaRegenPerTick(climate: Climate) = 0
         override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: ItemId): Int = 5
-        override fun gatherYield(item: ItemId): Int = 1
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
         override fun gaugeLowThreshold(gauge: Gauge): Int = 25
         override fun starvationDamagePerTick(): Int = 1

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/StarvationDeathRespawnIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/StarvationDeathRespawnIntegrationTest.kt
@@ -162,8 +162,8 @@ class StarvationDeathRespawnIntegrationTest {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain): Int = 1
         override fun staminaRegenPerTick(climate: Climate): Int = 0
         override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: ItemId): Int = 5
-        override fun gatherYield(item: ItemId): Int = 1
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
         override fun gaugeLowThreshold(gauge: Gauge): Int = 25
         override fun starvationDamagePerTick(): Int = starvationDamage

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/drink/DrinkReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/drink/DrinkReducerTest.kt
@@ -223,8 +223,8 @@ class DrinkReducerTest {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
         override fun staminaRegenPerTick(climate: Climate) = 0
         override fun resourceSpawnsFor(terrain: Terrain): List<dev.gvart.genesara.world.ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: ItemId): Int = 5
-        override fun gatherYield(item: ItemId): Int = 1
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
         override fun gaugeLowThreshold(gauge: Gauge): Int = 25
         override fun starvationDamagePerTick(): Int = 0

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/editor/JooqWorldEditingGatewayCreateWorldIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/editor/JooqWorldEditingGatewayCreateWorldIntegrationTest.kt
@@ -265,8 +265,8 @@ class JooqWorldEditingGatewayCreateWorldIntegrationTest {
         ): Int = 1
         override fun staminaRegenPerTick(climate: dev.gvart.genesara.world.Climate): Int = 0
         override fun resourceSpawnsFor(terrain: Terrain): List<dev.gvart.genesara.world.ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: ItemId): Int = 5
-        override fun gatherYield(item: ItemId): Int = 1
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
         override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
         override fun starvationDamagePerTick(): Int = 0

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/editor/JooqWorldEditingGatewayStarterNodesIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/editor/JooqWorldEditingGatewayStarterNodesIntegrationTest.kt
@@ -286,8 +286,8 @@ class JooqWorldEditingGatewayStarterNodesIntegrationTest {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain): Int = 1
         override fun staminaRegenPerTick(climate: Climate): Int = 0
         override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: ItemId): Int = 5
-        override fun gatherYield(item: ItemId): Int = 1
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
         override fun gaugeLowThreshold(gauge: Gauge): Int = 25
         override fun starvationDamagePerTick(): Int = 0

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
@@ -87,9 +87,9 @@ class HarvestReducerTest {
     private val balance = balance(staminaCost = 5)
     private val items = StubItemLookup(
         mapOf(
-            wood to itemFor(wood, gatheringSkill = "LUMBERJACKING"),
-            stone to itemFor(stone, gatheringSkill = "MINING"),
-            berry to itemFor(berry, gatheringSkill = "FORAGING"),
+            wood to itemFor(wood, harvestSkill = "LUMBERJACKING"),
+            stone to itemFor(stone, harvestSkill = "MINING"),
+            berry to itemFor(berry, harvestSkill = "FORAGING"),
         ),
     )
 
@@ -155,7 +155,7 @@ class HarvestReducerTest {
                     category = ItemCategory.RESOURCE,
                     weightPerUnit = 100,
                     maxStack = 100,
-                    gatheringSkill = "MINING",
+                    harvestSkill = "MINING",
                     regenerating = true,
                     regenIntervalTicks = 100,
                     regenAmount = 1,
@@ -353,9 +353,9 @@ class HarvestReducerTest {
         )
         val itemsWithHelmet = StubItemLookup(
             mapOf(
-                wood to itemFor(wood, gatheringSkill = "LUMBERJACKING"),
-                stone to itemFor(stone, gatheringSkill = "MINING"),
-                berry to itemFor(berry, gatheringSkill = "FORAGING"),
+                wood to itemFor(wood, harvestSkill = "LUMBERJACKING"),
+                stone to itemFor(stone, harvestSkill = "MINING"),
+                berry to itemFor(berry, harvestSkill = "FORAGING"),
                 ItemId("HEAVY_HELMET") to Item(
                     id = ItemId("HEAVY_HELMET"),
                     displayName = "Heavy Helmet",
@@ -456,10 +456,10 @@ class HarvestReducerTest {
     }
 
     @Test
-    fun `item without gathering-skill triggers neither XP nor recommendation`() {
+    fun `item without harvest-skill triggers neither XP nor recommendation`() {
         val state = stateWith()
         val store = StubResourceStore(initial = mapOf(wood to 50))
-        val skillFreeItems = StubItemLookup(mapOf(wood to itemFor(wood, gatheringSkill = null)))
+        val skillFreeItems = StubItemLookup(mapOf(wood to itemFor(wood, harvestSkill = null)))
         val skills = StubSkillsRegistry()
         val publisher = RecordingPublisher()
 
@@ -482,8 +482,8 @@ class HarvestReducerTest {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
         override fun staminaRegenPerTick(climate: Climate) = 0
         override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: ItemId): Int = staminaCost
-        override fun gatherYield(item: ItemId): Int = yield
+        override fun harvestStaminaCost(item: ItemId): Int = staminaCost
+        override fun harvestYield(item: ItemId): Int = yield
         override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
         override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
         override fun starvationDamagePerTick(): Int = 0
@@ -495,14 +495,14 @@ class HarvestReducerTest {
         override fun carryGramsPerStrengthPoint(): Int = carryGramsPerStrengthPoint
     }
 
-    private fun itemFor(id: ItemId, gatheringSkill: String? = null) = Item(
+    private fun itemFor(id: ItemId, harvestSkill: String? = null) = Item(
         id = id,
         displayName = id.value,
         description = "",
         category = ItemCategory.RESOURCE,
         weightPerUnit = 100,
         maxStack = 100,
-        gatheringSkill = gatheringSkill,
+        harvestSkill = harvestSkill,
     )
 
     private class StubItemLookup(private val byId: Map<ItemId, Item>) : ItemLookup {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/inventory/CarryCapTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/inventory/CarryCapTest.kt
@@ -165,8 +165,8 @@ class CarryCapTest {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
         override fun staminaRegenPerTick(climate: Climate) = 0
         override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: ItemId): Int = 1
-        override fun gatherYield(item: ItemId): Int = 1
+        override fun harvestStaminaCost(item: ItemId): Int = 1
+        override fun harvestYield(item: ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
         override fun gaugeLowThreshold(gauge: Gauge): Int = 25
         override fun starvationDamagePerTick(): Int = 0

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
@@ -143,8 +143,8 @@ class MovementReducerTest {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = cost
         override fun staminaRegenPerTick(climate: Climate) = 0
         override fun resourceSpawnsFor(terrain: Terrain): List<dev.gvart.genesara.world.ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: dev.gvart.genesara.world.ItemId): Int = 5
-        override fun gatherYield(item: dev.gvart.genesara.world.ItemId): Int = 1
+        override fun harvestStaminaCost(item: dev.gvart.genesara.world.ItemId): Int = 5
+        override fun harvestYield(item: dev.gvart.genesara.world.ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
         override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
         override fun starvationDamagePerTick(): Int = 0

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/passive/PassivesTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/passive/PassivesTest.kt
@@ -106,8 +106,8 @@ class PassivesTest {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
         override fun staminaRegenPerTick(climate: Climate) = regen
         override fun resourceSpawnsFor(terrain: Terrain): List<dev.gvart.genesara.world.ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: dev.gvart.genesara.world.ItemId): Int = 5
-        override fun gatherYield(item: dev.gvart.genesara.world.ItemId): Int = 1
+        override fun harvestStaminaCost(item: dev.gvart.genesara.world.ItemId): Int = 5
+        override fun harvestYield(item: dev.gvart.genesara.world.ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
         override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
         override fun starvationDamagePerTick(): Int = 0

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/passive/SleepPassiveTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/passive/SleepPassiveTest.kt
@@ -152,8 +152,8 @@ class SleepPassiveTest {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
         override fun staminaRegenPerTick(climate: Climate) = 0
         override fun resourceSpawnsFor(terrain: Terrain): List<dev.gvart.genesara.world.ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: ItemId): Int = 5
-        override fun gatherYield(item: ItemId): Int = 1
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: Gauge): Int = when (gauge) {
             Gauge.SLEEP -> sleepDrain
             else -> hungerThirstDrain

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/passive/SurvivalPassivesTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/passive/SurvivalPassivesTest.kt
@@ -67,8 +67,8 @@ class SurvivalPassivesTest {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
         override fun staminaRegenPerTick(climate: Climate) = regen
         override fun resourceSpawnsFor(terrain: Terrain): List<dev.gvart.genesara.world.ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: ItemId): Int = 5
-        override fun gatherYield(item: ItemId): Int = 1
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: Gauge): Int = drain
         override fun gaugeLowThreshold(gauge: Gauge): Int = threshold
         override fun gaugeBuffThreshold(gauge: Gauge): Int = buffThreshold

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/resources/ResourceSpawnerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/resources/ResourceSpawnerTest.kt
@@ -28,8 +28,8 @@ class ResourceSpawnerTest {
         override fun staminaRegenPerTick(climate: Climate) = 0
         override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> =
             rules[terrain].orEmpty()
-        override fun gatherStaminaCost(item: ItemId): Int = 5
-        override fun gatherYield(item: ItemId): Int = 1
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
         override fun gaugeLowThreshold(gauge: Gauge): Int = 25
         override fun starvationDamagePerTick(): Int = 0

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -64,8 +64,8 @@ class WorldTickHandlerTest {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
         override fun staminaRegenPerTick(climate: Climate) = 0
         override fun resourceSpawnsFor(terrain: Terrain): List<dev.gvart.genesara.world.ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: ItemId): Int = 5
-        override fun gatherYield(item: ItemId): Int = 1
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
         override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
         override fun starvationDamagePerTick(): Int = 0
@@ -136,8 +136,8 @@ class WorldTickHandlerTest {
             override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
             override fun staminaRegenPerTick(climate: Climate) = 1
             override fun resourceSpawnsFor(terrain: Terrain): List<dev.gvart.genesara.world.ResourceSpawnRule> = emptyList()
-            override fun gatherStaminaCost(item: ItemId): Int = 5
-            override fun gatherYield(item: ItemId): Int = 1
+            override fun harvestStaminaCost(item: ItemId): Int = 5
+            override fun harvestYield(item: ItemId): Int = 1
             override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
             override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
             override fun starvationDamagePerTick(): Int = 0

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayBodyViewIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayBodyViewIntegrationTest.kt
@@ -132,8 +132,8 @@ class WorldStateQueryGatewayBodyViewIntegrationTest {
         ): Int = 1
         override fun staminaRegenPerTick(climate: dev.gvart.genesara.world.Climate): Int = 0
         override fun resourceSpawnsFor(terrain: dev.gvart.genesara.world.Terrain): List<dev.gvart.genesara.world.ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: dev.gvart.genesara.world.ItemId): Int = 5
-        override fun gatherYield(item: dev.gvart.genesara.world.ItemId): Int = 1
+        override fun harvestStaminaCost(item: dev.gvart.genesara.world.ItemId): Int = 5
+        override fun harvestYield(item: dev.gvart.genesara.world.ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
         override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
         override fun starvationDamagePerTick(): Int = 0

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayInventoryIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayInventoryIntegrationTest.kt
@@ -142,8 +142,8 @@ class WorldStateQueryGatewayInventoryIntegrationTest {
         ): Int = 1
         override fun staminaRegenPerTick(climate: dev.gvart.genesara.world.Climate): Int = 0
         override fun resourceSpawnsFor(terrain: dev.gvart.genesara.world.Terrain): List<dev.gvart.genesara.world.ResourceSpawnRule> = emptyList()
-        override fun gatherStaminaCost(item: ItemId): Int = 5
-        override fun gatherYield(item: ItemId): Int = 1
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
         override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
         override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
         override fun starvationDamagePerTick(): Int = 0


### PR DESCRIPTION
## Summary

Trailing cleanup of the architecture-deepening pass (#49 / #50 / #51). Three identifiers were left vestigial after slice 1 collapsed `gather` + `mine` into a single `harvest` verb; this PR renames them mechanically across `:world` + `:api` + the YAML catalog, fixes a small cluster of stale verb-comments the reviewer surfaced, and updates one pre-existing stale doc paragraph that the spawn slice's design depended on.

## What changed

- `BalanceLookup.gatherStaminaCost` / `gatherYield` (and their `BASE_GATHER_COST` / `BASE_GATHER_YIELD` constants) → `harvestStaminaCost` / `harvestYield` / `BASE_HARVEST_COST` / `BASE_HARVEST_YIELD`.
- `Item.gatheringSkill` field + the YAML key `gathering-skill` → `harvestSkill` / `harvest-skill`. Touches `ItemProperties` decoder, `ItemLookupImpl`, every entry in `world-definition/items.yaml`. Spring's relaxed-binding handles the kebab→camel conversion automatically — no Jackson `@JsonProperty` needed.
- Private validator helper `ResourceSpawnsValidator.unknownGatheringSkillProblems` → `unknownHarvestSkillProblems`.
- KDoc / comment / YAML-header / test-name references to "gather" where the verb is now `harvest` (HarvestReducer, BalanceLookup, ItemProperties, InspectToolIo, recipes-intermediates.yaml, recipes-weapons.yaml, WorldDefinitionBalanceLookupTest, etc.).
- `docs/mcp-api.md:77` rewritten: the prior claim that reducer rejections were "logged and dropped" was stale; rejections flow through `WorldEvent.CommandRejected` → `command.rejected` on the agent stream tagged with `causedBy = commandId`.

## What's deliberately *not* changed

- "Mined out" in `WorldRejection.kt`, the resource store, and the `R__` migration is idiomatic English for a depleted deposit, not a reference to the dropped `mine` verb. Left as-is.
- Lore-doc references to "gathering habits" / "gather actions" in `docs/lore/mechanics-reference.md` — separate concern, low urgency.

## Test plan

- [x] `./gradlew :world:test :api:test :app:test` green locally
- [x] `code-quality-reviewer` agent run (mechanical rename + small comment cleanup); flagged identifier `unknownGatheringSkillProblems` renamed; flagged KDoc / comment hits cleaned up
- [x] No behavior change — 33 files, 102/104 insertions/deletions
- [ ] CI green

## Closes the architecture-deepening pass

After this PR lands, the four-PR sequence is complete:

| PR | Surface |
|---|---|
| #49 | Harvest collapse (gather + mine → one verb) |
| #50 | SkillProgression module (extract triplicated XP helper) |
| #51 | SpawnLocationResolver (move spawn policy out of the tool) |
| this | Identifier + doc alignment with the new verb |