### PR TITLE
refactor(player,world,api)!: extract AgentEvent for skill progression events

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.events
 
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.events.AgentEvent
 import dev.gvart.genesara.world.BodyDelta
 import dev.gvart.genesara.world.events.WorldEvent
 import io.modelcontextprotocol.server.McpSyncServer
@@ -11,7 +12,7 @@ import org.springframework.stereotype.Component
 import tools.jackson.databind.ObjectMapper
 
 /**
- * Listens for [WorldEvent]s on the Spring bus, appends a per-agent envelope into the event log,
+ * Listens for [WorldEvent]s and [AgentEvent]s on the Spring bus, appends a per-agent envelope into the event log,
  * and triggers `notifications/resources/updated` on `agent://{id}/events` so subscribed agents
  * pull the new entries via `resources/read?after={seq}`.
  *
@@ -47,10 +48,10 @@ internal class AgentEventDispatcher(
     fun on(event: WorldEvent.AgentDrank) = publish(event.agent, "agent.drank", event)
 
     @EventListener
-    fun on(event: WorldEvent.SkillMilestoneReached) = publish(event.agent, "skill.milestone", event)
+    fun on(event: AgentEvent.SkillMilestoneReached) = publish(event.agent, "skill.milestone", event)
 
     @EventListener
-    fun on(event: WorldEvent.SkillRecommended) = publish(event.agent, "skill.recommended", event)
+    fun on(event: AgentEvent.SkillRecommended) = publish(event.agent, "skill.recommended", event)
 
     @EventListener
     fun on(event: WorldEvent.ItemCrafted) = publish(event.agent, "item.crafted", event)
@@ -66,7 +67,10 @@ internal class AgentEventDispatcher(
     }
 
     private fun publish(agent: AgentId, type: String, payload: Any) {
-        val tick = (payload as? WorldEvent)?.tick ?: (payload as? PassivesPayload)?.tick ?: 0L
+        val tick = (payload as? WorldEvent)?.tick
+            ?: (payload as? AgentEvent)?.tick
+            ?: (payload as? PassivesPayload)?.tick
+            ?: 0L
         log.append(agent, type, tick, mapper.valueToTree(payload))
         val uri = "agent://${agent.id}/events"
         try {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp.events
 
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.events.AgentEvent
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.NodeId
@@ -100,7 +101,7 @@ class AgentEventDispatcherTest {
         val cmdId = UUID.randomUUID()
         val recCmdId = UUID.randomUUID()
         dispatcher.on(
-            WorldEvent.SkillMilestoneReached(
+            AgentEvent.SkillMilestoneReached(
                 agent = agent,
                 skill = SkillId("FORAGING"),
                 milestone = 50,
@@ -109,7 +110,7 @@ class AgentEventDispatcherTest {
             ),
         )
         dispatcher.on(
-            WorldEvent.SkillRecommended(
+            AgentEvent.SkillRecommended(
                 agent = agent,
                 skill = SkillId("MINING"),
                 recommendCount = 1,
@@ -121,6 +122,10 @@ class AgentEventDispatcherTest {
 
         val all = log.since(agent, 0)
         assertEquals(listOf("skill.milestone", "skill.recommended"), all.map { it.type })
+        // Locks the AgentEvent branch in publish()'s tick cast — without this assert,
+        // dropping that branch would silently log AgentEvent envelopes with tick=0.
+        assertEquals(5L, all[0].tick)
+        assertEquals(6L, all[1].tick)
         // The whole payload should at minimum carry the milestone fields. Asserting on
         // the structural shape is fragile across Jackson versions for value classes; the
         // important contract is that the event lands and types are right.

--- a/player/src/main/kotlin/dev/gvart/genesara/player/SkillProgression.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/SkillProgression.kt
@@ -1,0 +1,39 @@
+package dev.gvart.genesara.player
+
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.player.internal.progression.SkillProgressionImpl
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+
+/**
+ * Owns the "grant XP, fan out milestone or recommendation events" rule used by every
+ * skill-emitting reducer (harvest, build, craft, …).
+ */
+interface SkillProgression {
+
+    /**
+     * Grant [delta] XP toward [skill] for [agent]. If the skill is slotted, fans out one
+     * [AgentEvent.SkillMilestoneReached] per crossed milestone; if it is unslotted and
+     * [AgentSkillsRegistry.maybeRecommend] decides to fire, emits a single
+     * [AgentEvent.SkillRecommended]. Both event types tag [commandId] as `causedBy` so
+     * agents can correlate.
+     */
+    fun accrueXp(
+        agent: AgentId,
+        skill: SkillId,
+        delta: Int,
+        tick: Long,
+        commandId: UUID,
+    )
+}
+
+/**
+ * Fake-constructor for tests that want a real publishing instance without reaching
+ * into [SkillProgressionImpl]'s `internal/` package. Production code receives the
+ * Spring-managed [SkillProgressionImpl] bean by interface type.
+ */
+@Suppress("FunctionName")
+fun SkillProgression(
+    skills: AgentSkillsRegistry,
+    publisher: ApplicationEventPublisher,
+): SkillProgression = SkillProgressionImpl(skills, publisher)

--- a/player/src/main/kotlin/dev/gvart/genesara/player/events/AgentEvent.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/events/AgentEvent.kt
@@ -1,0 +1,39 @@
+package dev.gvart.genesara.player.events
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.SkillId
+import java.util.UUID
+
+sealed interface AgentEvent {
+    val tick: Long
+
+    /**
+     * Emitted when an agent's slotted skill XP crosses one of the milestone thresholds
+     * (50, 100, 150) as a result of [causedBy]. Only fires for skills currently in a
+     * slot — unslotted skills don't accrue XP. Perk-selection prompts will hang off
+     * this event in a future slice.
+     */
+    data class SkillMilestoneReached(
+        val agent: AgentId,
+        val skill: SkillId,
+        val milestone: Int,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : AgentEvent
+
+    /**
+     * Emitted when an agent does an action mapped to a skill they haven't slotted
+     * yet, suggesting they consider slotting it. Capped at 3 per (agent, skill) and
+     * gated by a per-skill cooldown. Suppressed entirely once all slots are filled.
+     */
+    data class SkillRecommended(
+        val agent: AgentId,
+        val skill: SkillId,
+        /** New recommend count after this firing — 1, 2, or 3. */
+        val recommendCount: Int,
+        /** How many slots remain open at the time of the event. */
+        val slotsFree: Int,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : AgentEvent
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/progression/SkillProgressionImpl.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/progression/SkillProgressionImpl.kt
@@ -1,32 +1,22 @@
-package dev.gvart.genesara.world.internal.progression
+package dev.gvart.genesara.player.internal.progression
 
 import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.SkillId
-import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.player.events.AgentEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import java.util.UUID
 
-/**
- * Owns the "grant XP, fan out milestone or recommendation events" rule used by every
- * skill-emitting reducer (harvest, build, craft, …).
- */
 @Component
-internal class SkillProgression(
+internal class SkillProgressionImpl(
     private val skills: AgentSkillsRegistry,
     private val publisher: ApplicationEventPublisher,
-) {
+) : SkillProgression {
 
-    /**
-     * Grant [delta] XP toward [skill] for [agent]. If the skill is slotted, fans out one
-     * [WorldEvent.SkillMilestoneReached] per crossed milestone; if it is unslotted and
-     * [AgentSkillsRegistry.maybeRecommend] decides to fire, emits a single
-     * [WorldEvent.SkillRecommended]. Both event types tag [commandId] as `causedBy` so
-     * agents can correlate.
-     */
-    fun accrueXp(
+    override fun accrueXp(
         agent: AgentId,
         skill: SkillId,
         delta: Int,
@@ -36,7 +26,7 @@ internal class SkillProgression(
         when (val result = skills.addXpIfSlotted(agent, skill, delta)) {
             is AddXpResult.Accrued -> result.crossedMilestones.forEach { milestone ->
                 publisher.publishEvent(
-                    WorldEvent.SkillMilestoneReached(
+                    AgentEvent.SkillMilestoneReached(
                         agent = agent,
                         skill = skill,
                         milestone = milestone,
@@ -48,7 +38,7 @@ internal class SkillProgression(
             AddXpResult.Unslotted -> skills.maybeRecommend(agent, skill, tick)?.let { newCount ->
                 val snapshot = skills.snapshot(agent)
                 publisher.publishEvent(
-                    WorldEvent.SkillRecommended(
+                    AgentEvent.SkillRecommended(
                         agent = agent,
                         skill = skill,
                         recommendCount = newCount,

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/progression/SkillProgressionImplTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/progression/SkillProgressionImplTest.kt
@@ -1,4 +1,4 @@
-package dev.gvart.genesara.world.internal.progression
+package dev.gvart.genesara.player.internal.progression
 
 import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.AgentId
@@ -7,14 +7,14 @@ import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.AgentSkillsSnapshot
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillSlotError
-import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.player.events.AgentEvent
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class SkillProgressionTest {
+class SkillProgressionImplTest {
 
     private val agent = AgentId(UUID.randomUUID())
     private val skill = SkillId("LUMBERJACKING")
@@ -25,7 +25,7 @@ class SkillProgressionTest {
         val skills = StubSkillsRegistry().apply { slot(skill) }
         val publisher = RecordingPublisher()
 
-        SkillProgression(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 7, commandId = commandId)
+        SkillProgressionImpl(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 7, commandId = commandId)
 
         assertEquals(listOf(skill to 1), skills.xpAddCalls)
         assertTrue(publisher.events.isEmpty())
@@ -39,9 +39,9 @@ class SkillProgressionTest {
         }
         val publisher = RecordingPublisher()
 
-        SkillProgression(skills, publisher).accrueXp(agent, skill, delta = 5, tick = 11, commandId = commandId)
+        SkillProgressionImpl(skills, publisher).accrueXp(agent, skill, delta = 5, tick = 11, commandId = commandId)
 
-        val event = publisher.events.filterIsInstance<WorldEvent.SkillMilestoneReached>().single()
+        val event = publisher.events.filterIsInstance<AgentEvent.SkillMilestoneReached>().single()
         assertEquals(agent, event.agent)
         assertEquals(skill, event.skill)
         assertEquals(50, event.milestone)
@@ -58,9 +58,9 @@ class SkillProgressionTest {
         }
         val publisher = RecordingPublisher()
 
-        SkillProgression(skills, publisher).accrueXp(agent, skill, delta = 60, tick = 1, commandId = commandId)
+        SkillProgressionImpl(skills, publisher).accrueXp(agent, skill, delta = 60, tick = 1, commandId = commandId)
 
-        val milestones = publisher.events.filterIsInstance<WorldEvent.SkillMilestoneReached>().map { it.milestone }
+        val milestones = publisher.events.filterIsInstance<AgentEvent.SkillMilestoneReached>().map { it.milestone }
         assertEquals(listOf(50, 100), milestones)
     }
 
@@ -73,9 +73,9 @@ class SkillProgressionTest {
         }
         val publisher = RecordingPublisher()
 
-        SkillProgression(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 4, commandId = commandId)
+        SkillProgressionImpl(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 4, commandId = commandId)
 
-        val rec = publisher.events.filterIsInstance<WorldEvent.SkillRecommended>().single()
+        val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()
         assertEquals(agent, rec.agent)
         assertEquals(skill, rec.skill)
         assertEquals(2, rec.recommendCount)
@@ -90,7 +90,7 @@ class SkillProgressionTest {
         val skills = StubSkillsRegistry()
         val publisher = RecordingPublisher()
 
-        SkillProgression(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 1, commandId = commandId)
+        SkillProgressionImpl(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 1, commandId = commandId)
 
         assertTrue(publisher.events.isEmpty())
         assertEquals(listOf(skill to 1L), skills.recommendCalls)
@@ -104,9 +104,9 @@ class SkillProgressionTest {
         }
         val publisher = RecordingPublisher()
 
-        SkillProgression(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 1, commandId = commandId)
+        SkillProgressionImpl(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 1, commandId = commandId)
 
-        assertTrue(publisher.events.none { it is WorldEvent.SkillRecommended })
+        assertTrue(publisher.events.none { it is AgentEvent.SkillRecommended })
         assertTrue(skills.recommendCalls.isEmpty())
     }
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
@@ -1,7 +1,6 @@
 package dev.gvart.genesara.world.events
 
 import dev.gvart.genesara.player.AgentId
-import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.world.BodyDelta
 import dev.gvart.genesara.world.Building
 import dev.gvart.genesara.world.Gauge
@@ -73,36 +72,6 @@ sealed interface WorldEvent {
         val agent: AgentId,
         val at: NodeId,
         val refilled: Int,
-        override val tick: Long,
-        val causedBy: UUID,
-    ) : WorldEvent
-
-    /**
-     * Emitted when an agent's slotted skill XP crosses one of the milestone thresholds
-     * (50, 100, 150) as a result of [causedBy]. Only fires for skills currently in a
-     * slot — unslotted skills don't accrue XP. Perk-selection prompts will hang off
-     * this event in a future slice.
-     */
-    data class SkillMilestoneReached(
-        val agent: AgentId,
-        val skill: SkillId,
-        val milestone: Int,
-        override val tick: Long,
-        val causedBy: UUID,
-    ) : WorldEvent
-
-    /**
-     * Emitted when an agent does an action mapped to a skill they haven't slotted
-     * yet, suggesting they consider slotting it. Capped at 3 per (agent, skill) and
-     * gated by a per-skill cooldown. Suppressed entirely once all slots are filled.
-     */
-    data class SkillRecommended(
-        val agent: AgentId,
-        val skill: SkillId,
-        /** New recommend count after this firing — 1, 2, or 3. */
-        val recommendCount: Int,
-        /** How many slots remain open at the time of the event. */
-        val slotsFree: Int,
         override val tick: Long,
         val causedBy: UUID,
     ) : WorldEvent

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import dev.gvart.genesara.player.AgentProfileLookup
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.BuildingsStore
@@ -28,7 +29,6 @@ import dev.gvart.genesara.world.internal.death.reduceSetSafeNode
 import dev.gvart.genesara.world.internal.drink.reduceDrink
 import dev.gvart.genesara.world.internal.harvest.reduceHarvest
 import dev.gvart.genesara.world.internal.movement.reduceMove
-import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.spawn.SpawnLocationResolver
 import dev.gvart.genesara.world.internal.spawn.reduceSpawn

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
@@ -7,6 +7,7 @@ import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.Building
 import dev.gvart.genesara.world.BuildingStatus
@@ -16,7 +17,6 @@ import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.inventory.AgentInventory
-import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import java.util.UUID
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
@@ -8,6 +8,7 @@ import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.EquipmentInstance
 import dev.gvart.genesara.world.EquipmentInstanceStore
@@ -25,7 +26,6 @@ import dev.gvart.genesara.world.internal.inventory.AgentInventory
 import dev.gvart.genesara.world.internal.inventory.enforceCarryCap
 import dev.gvart.genesara.world.internal.inventory.equippedGrams
 import dev.gvart.genesara.world.internal.inventory.totalGrams
-import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import java.util.UUID
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
@@ -8,6 +8,7 @@ import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.ItemLookup
@@ -19,7 +20,6 @@ import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.inventory.enforceCarryCap
 import dev.gvart.genesara.world.internal.inventory.equippedGrams
 import dev.gvart.genesara.world.internal.inventory.totalGrams
-import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.resources.NodeResourceCell
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.worldstate.WorldState

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -4,6 +4,7 @@ import dev.gvart.genesara.engine.Tick
 import dev.gvart.genesara.player.AgentProfileLookup
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.BuildingsStore
@@ -18,7 +19,6 @@ import dev.gvart.genesara.world.internal.crafting.RarityRoller
 import dev.gvart.genesara.world.internal.death.SafeNodeResolver
 import dev.gvart.genesara.world.internal.death.processDeaths
 import dev.gvart.genesara.world.internal.passive.applyPassives
-import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.reduce
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.spawn.SpawnLocationResolver

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
@@ -6,7 +6,9 @@ import dev.gvart.genesara.player.AgentSkillState
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.AgentSkillsSnapshot
 import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.player.events.AgentEvent
 import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Building
@@ -28,7 +30,6 @@ import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.inventory.AgentInventory
-import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
@@ -422,7 +423,7 @@ class BuildReducerTest {
             catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, publisher), tick = 5,
         )
 
-        val rec = publisher.events.filterIsInstance<WorldEvent.SkillRecommended>().single()
+        val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()
         assertEquals(carpentry, rec.skill)
         assertEquals(1, rec.recommendCount)
     }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
@@ -11,7 +11,9 @@ import dev.gvart.genesara.player.AgentSkillState
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.AgentSkillsSnapshot
 import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.player.events.AgentEvent
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Building
 import dev.gvart.genesara.world.BuildingCategoryHint
@@ -45,7 +47,6 @@ import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.inventory.AgentInventory
-import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
@@ -384,7 +385,7 @@ class CraftReducerTest {
             SkillProgression(skills, publisher),
             tick = 5,
         )
-        val rec = publisher.events.filterIsInstance<WorldEvent.SkillRecommended>().single()
+        val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()
         assertEquals(alchemy, rec.skill)
         assertEquals(1, rec.recommendCount)
     }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
@@ -10,7 +10,9 @@ import dev.gvart.genesara.player.AgentSkillState
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.AgentSkillsSnapshot
 import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.player.events.AgentEvent
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Climate
 import dev.gvart.genesara.world.EquipSlot
@@ -36,7 +38,6 @@ import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
-import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.resources.InitialResourceRow
 import dev.gvart.genesara.world.internal.resources.NodeResourceCell
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
@@ -394,8 +395,8 @@ class HarvestReducerTest {
         )
 
         assertEquals(listOf(lumberjacking to 1), skills.xpAddCalls)
-        assertTrue(publisher.events.none { it is WorldEvent.SkillMilestoneReached })
-        assertTrue(publisher.events.none { it is WorldEvent.SkillRecommended })
+        assertTrue(publisher.events.none { it is AgentEvent.SkillMilestoneReached })
+        assertTrue(publisher.events.none { it is AgentEvent.SkillRecommended })
     }
 
     @Test
@@ -413,7 +414,7 @@ class HarvestReducerTest {
             store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
         )
 
-        val ev = publisher.events.filterIsInstance<WorldEvent.SkillMilestoneReached>().single()
+        val ev = publisher.events.filterIsInstance<AgentEvent.SkillMilestoneReached>().single()
         assertEquals(agent, ev.agent)
         assertEquals(lumberjacking, ev.skill)
         assertEquals(50, ev.milestone)
@@ -434,7 +435,7 @@ class HarvestReducerTest {
             store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
         )
 
-        val rec = publisher.events.filterIsInstance<WorldEvent.SkillRecommended>().single()
+        val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()
         assertEquals(lumberjacking, rec.skill)
         assertEquals(1, rec.recommendCount)
     }
@@ -451,8 +452,8 @@ class HarvestReducerTest {
             store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
         )
 
-        assertTrue(publisher.events.none { it is WorldEvent.SkillRecommended })
-        assertTrue(publisher.events.none { it is WorldEvent.SkillMilestoneReached })
+        assertTrue(publisher.events.none { it is AgentEvent.SkillRecommended })
+        assertTrue(publisher.events.none { it is AgentEvent.SkillMilestoneReached })
     }
 
     @Test
@@ -470,8 +471,8 @@ class HarvestReducerTest {
 
         assertEquals(0, skills.xpAddCalls.size)
         assertEquals(0, skills.recommendCalls.size)
-        assertTrue(publisher.events.none { it is WorldEvent.SkillRecommended })
-        assertTrue(publisher.events.none { it is WorldEvent.SkillMilestoneReached })
+        assertTrue(publisher.events.none { it is AgentEvent.SkillRecommended })
+        assertTrue(publisher.events.none { it is AgentEvent.SkillMilestoneReached })
     }
 
     private fun balance(

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -4,6 +4,7 @@ import dev.gvart.genesara.engine.Tick
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentProfile
 import dev.gvart.genesara.player.AgentProfileLookup
+import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Climate
 import dev.gvart.genesara.world.Item
@@ -20,7 +21,6 @@ import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
-import dev.gvart.genesara.world.internal.progression.SkillProgression
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import dev.gvart.genesara.world.internal.worldstate.WorldStateRepository
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
## Summary

- Pulls `SkillMilestoneReached` and `SkillRecommended` out of `WorldEvent` into a new `AgentEvent` sealed interface in `:player` — the only two existing variants whose fields reference no `:world` types, so the move keeps the `:world → :player` dependency direction intact.
- Promotes `SkillProgression` to a public interface in `:player` with an `internal` `SkillProgressionImpl`. Reducers in `:world` import from `:player`; Spring autowires by interface type, so production wiring is unchanged.
- Adds an `AgentEvent` arm to `AgentEventDispatcher.publish()`'s tick cast so the new envelopes log with the correct tick. Test asserts pin this branch.

The 17 other `WorldEvent` variants stay put — they carry `NodeId`, `ItemId`, `Building`, etc., which would force a dependency flip. A wider split is its own refactor.

## Why

`:player` should own state and events that are intrinsically about agents (skills, attributes, progression). Mixing those into `WorldEvent` made `:world` the only event-publisher even for changes that don't touch the world substrate. This slice extracts the two that can move cleanly without dragging types along.

## Test plan

- [x] `./gradlew test` — green across `:player`, `:world`, `:api`, `:app`
- [x] Unit: `SkillProgressionImplTest` covers slotted/unslotted/milestone-fanout paths against `AgentEvent` types
- [x] Integration: reducer tests (`HarvestReducerTest`, `BuildReducerTest`, `CraftReducerTest`) still drive a real `SkillProgression` via the fake-constructor and observe `AgentEvent` outputs
- [x] Dispatcher: `AgentEventDispatcherTest` pins the new `AgentEvent` tick-cast branch with explicit `assertEquals(tick, envelope.tick)` assertions
- [x] `code-quality-reviewer` agent run clean after the two follow-ups

## Out of scope

- Issue #6 (Phase 1 attribute allocation tool) — this slice clears the path; #6 will land on top.
- Wider `WorldEvent` → `AgentEvent` split for variants that carry `:world` types.