### PR TITLE
feat(api,player): allocate_points MCP tool + typed enum/UUID inputs

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp
 
 import dev.gvart.genesara.api.internal.mcp.events.EventLogProperties
 import dev.gvart.genesara.api.internal.mcp.presence.PresenceProperties
+import dev.gvart.genesara.api.internal.mcp.tools.attributes.AllocatePointsTool
 import dev.gvart.genesara.api.internal.mcp.tools.build.BuildTool
 import dev.gvart.genesara.api.internal.mcp.tools.chest.DepositToChestTool
 import dev.gvart.genesara.api.internal.mcp.tools.chest.WithdrawFromChestTool
@@ -47,6 +48,7 @@ internal class McpServerConfiguration {
         drink: DrinkTool,
         getSkills: GetSkillsTool,
         equipSkill: EquipSkillTool,
+        allocatePoints: AllocatePointsTool,
         inspect: InspectTool,
         getMap: GetMapTool,
         equipItem: EquipItemTool,
@@ -62,7 +64,7 @@ internal class McpServerConfiguration {
         MethodToolCallbackProvider.builder()
             .toolObjects(
                 spawn, move, lookAround, unspawn, getStatus, harvest, getInventory,
-                consume, drink, getSkills, equipSkill, inspect, getMap,
+                consume, drink, getSkills, equipSkill, allocatePoints, inspect, getMap,
                 equipItem, unequipSlot, getEquipment,
                 setSafeNode, respawn, build, depositToChest, withdrawFromChest, craft,
             )

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -54,6 +54,9 @@ internal class AgentEventDispatcher(
     fun on(event: AgentEvent.SkillRecommended) = publish(event.agent, "skill.recommended", event)
 
     @EventListener
+    fun on(event: AgentEvent.AttributeMilestoneReached) = publish(event.agent, "attribute.milestone", event)
+
+    @EventListener
     fun on(event: WorldEvent.ItemCrafted) = publish(event.agent, "item.crafted", event)
 
     @EventListener

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsTool.kt
@@ -1,0 +1,80 @@
+package dev.gvart.genesara.api.internal.mcp.tools.attributes
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AllocateAttributesOutcome
+import dev.gvart.genesara.player.events.AgentEvent
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+internal class AllocatePointsTool(
+    private val registry: AgentRegistry,
+    private val activity: AgentActivityTracker,
+    private val publisher: ApplicationEventPublisher,
+    private val tickClock: TickClock,
+) {
+
+    @Tool(
+        name = "allocate_points",
+        description = "Permanently spend unspent attribute points to raise attributes. IRREVERSIBLE — there is no respec. Validates the sum of deltas against the agent's `unspentAttributePoints` pool, atomically applies all deltas, and recomputes derived pools (maxHp, maxStamina, maxMana). Current HP/Stamina/Mana values are NOT auto-restored. Crossing 50, 100, or 200 in any attribute fires an AttributeMilestoneReached event.",
+    )
+    fun invoke(req: AllocatePointsRequest, toolContext: ToolContext): AllocatePointsResponse {
+        touchActivity(toolContext, activity, "allocate_points")
+        val agent = AgentContextHolder.current()
+
+        // Negative-delta check has to run before sum-zero, otherwise a request like
+        // `{STR: 2, LUCK: -2}` would be rejected as `no_points_requested` instead of
+        // the more accurate `negative_delta`.
+        if (req.deltas.values.any { it < 0 }) {
+            return AllocatePointsResponse.rejected(
+                reason = "negative_delta",
+                detail = "all deltas must be >= 0; no respec in v1",
+            )
+        }
+        if (req.deltas.values.sum() == 0) {
+            return AllocatePointsResponse.rejected(
+                reason = "no_points_requested",
+                detail = "deltas must include at least one positive entry",
+            )
+        }
+
+        return when (val outcome = registry.allocateAttributes(agent, req.deltas)) {
+            null -> AllocatePointsResponse.rejected(
+                reason = "agent_missing",
+                detail = "agent ${agent.id} not found in the registry",
+            )
+            AllocateAttributesOutcome.NegativeDelta -> AllocatePointsResponse.rejected(
+                reason = "negative_delta",
+                detail = "all deltas must be >= 0; no respec in v1",
+            )
+            is AllocateAttributesOutcome.InsufficientPoints -> AllocatePointsResponse.rejected(
+                reason = "insufficient_points",
+                detail = "requested ${outcome.requested} but only ${outcome.unspent} unspent",
+            )
+            is AllocateAttributesOutcome.Allocated -> {
+                val tick = tickClock.currentTick()
+                outcome.crossedMilestones.forEach { crossing ->
+                    publisher.publishEvent(
+                        AgentEvent.AttributeMilestoneReached(
+                            agent = agent,
+                            attribute = crossing.attribute,
+                            milestone = crossing.milestone,
+                            tick = tick,
+                        ),
+                    )
+                }
+                AllocatePointsResponse.ok(
+                    attrs = outcome.attributes,
+                    remainingUnspent = outcome.remainingUnspent,
+                    crossings = outcome.crossedMilestones,
+                )
+            }
+        }
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsTool.kt
@@ -22,39 +22,23 @@ internal class AllocatePointsTool(
 
     @Tool(
         name = "allocate_points",
-        description = "Permanently spend unspent attribute points to raise attributes. IRREVERSIBLE — there is no respec. Validates the sum of deltas against the agent's `unspentAttributePoints` pool, atomically applies all deltas, and recomputes derived pools (maxHp, maxStamina, maxMana). Current HP/Stamina/Mana values are NOT auto-restored. Crossing 50, 100, or 200 in any attribute fires an AttributeMilestoneReached event.",
+        description = "Permanently spend unspent attribute points to raise attributes. IRREVERSIBLE. Validates the sum of deltas against the agent's `unspentAttributePoints` pool, atomically applies all deltas, and recomputes derived pools (maxHp, maxStamina, maxMana). Current HP/Stamina/Mana values are NOT auto-restored. Crossing 50, 100, or 200 in any attribute fires an AttributeMilestoneReached event.",
     )
     fun invoke(req: AllocatePointsRequest, toolContext: ToolContext): AllocatePointsResponse {
         touchActivity(toolContext, activity, "allocate_points")
         val agent = AgentContextHolder.current()
 
-        // Negative-delta check has to run before sum-zero, otherwise a request like
-        // `{STR: 2, LUCK: -2}` would be rejected as `no_points_requested` instead of
-        // the more accurate `negative_delta`.
-        if (req.deltas.values.any { it < 0 }) {
-            return AllocatePointsResponse.rejected(
-                reason = "negative_delta",
-                detail = "all deltas must be >= 0; no respec in v1",
-            )
-        }
-        if (req.deltas.values.sum() == 0) {
-            return AllocatePointsResponse.rejected(
-                reason = "no_points_requested",
-                detail = "deltas must include at least one positive entry",
-            )
-        }
-
         return when (val outcome = registry.allocateAttributes(agent, req.deltas)) {
             null -> AllocatePointsResponse.rejected(
-                reason = "agent_missing",
+                reason = AllocatePointsRejectionReason.AGENT_MISSING,
                 detail = "agent ${agent.id} not found in the registry",
             )
             AllocateAttributesOutcome.NegativeDelta -> AllocatePointsResponse.rejected(
-                reason = "negative_delta",
-                detail = "all deltas must be >= 0; no respec in v1",
+                reason = AllocatePointsRejectionReason.NEGATIVE_DELTA,
+                detail = "deltas must be >= 0",
             )
             is AllocateAttributesOutcome.InsufficientPoints -> AllocatePointsResponse.rejected(
-                reason = "insufficient_points",
+                reason = AllocatePointsRejectionReason.INSUFFICIENT_POINTS,
                 detail = "requested ${outcome.requested} but only ${outcome.unspent} unspent",
             )
             is AllocateAttributesOutcome.Allocated -> {

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolIo.kt
@@ -15,23 +15,22 @@ data class AllocatePointsRequest(
     @JsonPropertyDescription(
         "Map of attribute (STRENGTH, DEXTERITY, CONSTITUTION, PERCEPTION, INTELLIGENCE, LUCK) " +
             "to non-negative points to add. Sum must be <= the agent's current " +
-            "unspentAttributePoints. Negative values are rejected.",
+            "unspentAttributePoints.",
     )
     val deltas: Map<Attribute, Int>,
 )
 
-/**
- * Response shape for `allocate_points`.
- *
- *  - `kind = "ok"`: points were spent. `attributes` reflects the new totals;
- *    `remainingUnspent` is the pool after the deduction; `crossedMilestones` lists
- *    every (attribute, threshold) pair the allocation pushed across (50 / 100 / 200).
- *  - `kind = "rejected"`: nothing was spent. `reason` is one of `no_points_requested`,
- *    `negative_delta`, `insufficient_points`, `agent_missing`.
- */
+enum class AllocatePointsKind { OK, REJECTED }
+
+enum class AllocatePointsRejectionReason {
+    NEGATIVE_DELTA,
+    INSUFFICIENT_POINTS,
+    AGENT_MISSING,
+}
+
 data class AllocatePointsResponse(
-    val kind: String,
-    val reason: String? = null,
+    val kind: AllocatePointsKind,
+    val reason: AllocatePointsRejectionReason? = null,
     val detail: String? = null,
     val attributes: Map<Attribute, Int>? = null,
     val remainingUnspent: Int? = null,
@@ -45,13 +44,13 @@ data class AllocatePointsResponse(
             remainingUnspent: Int,
             crossings: List<AttributeMilestoneCrossing>,
         ): AllocatePointsResponse = AllocatePointsResponse(
-            kind = "ok",
+            kind = AllocatePointsKind.OK,
             attributes = Attribute.entries.associateWith { it.valueOn(attrs) },
             remainingUnspent = remainingUnspent,
             crossedMilestones = crossings.map { MilestoneEntry(it.attribute, it.milestone) },
         )
 
-        fun rejected(reason: String, detail: String): AllocatePointsResponse =
-            AllocatePointsResponse(kind = "rejected", reason = reason, detail = detail)
+        fun rejected(reason: AllocatePointsRejectionReason, detail: String): AllocatePointsResponse =
+            AllocatePointsResponse(kind = AllocatePointsKind.REJECTED, reason = reason, detail = detail)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolIo.kt
@@ -1,0 +1,57 @@
+package dev.gvart.genesara.api.internal.mcp.tools.attributes
+
+import com.fasterxml.jackson.annotation.JsonClassDescription
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.Attribute
+import dev.gvart.genesara.player.AttributeMilestoneCrossing
+
+@JsonClassDescription(
+    "Spend unspent attribute points to permanently raise attributes. THIS IS IRREVERSIBLE — " +
+        "there is no respec or unallocate. Each attribute increase is locked in. " +
+        "Verify the agent's unspent pool with `get_status` before calling.",
+)
+data class AllocatePointsRequest(
+    @JsonPropertyDescription(
+        "Map of attribute (STRENGTH, DEXTERITY, CONSTITUTION, PERCEPTION, INTELLIGENCE, LUCK) " +
+            "to non-negative points to add. Sum must be <= the agent's current " +
+            "unspentAttributePoints. Negative values are rejected.",
+    )
+    val deltas: Map<Attribute, Int>,
+)
+
+/**
+ * Response shape for `allocate_points`.
+ *
+ *  - `kind = "ok"`: points were spent. `attributes` reflects the new totals;
+ *    `remainingUnspent` is the pool after the deduction; `crossedMilestones` lists
+ *    every (attribute, threshold) pair the allocation pushed across (50 / 100 / 200).
+ *  - `kind = "rejected"`: nothing was spent. `reason` is one of `no_points_requested`,
+ *    `negative_delta`, `insufficient_points`, `agent_missing`.
+ */
+data class AllocatePointsResponse(
+    val kind: String,
+    val reason: String? = null,
+    val detail: String? = null,
+    val attributes: Map<Attribute, Int>? = null,
+    val remainingUnspent: Int? = null,
+    val crossedMilestones: List<MilestoneEntry>? = null,
+) {
+    data class MilestoneEntry(val attribute: Attribute, val milestone: Int)
+
+    companion object {
+        fun ok(
+            attrs: AgentAttributes,
+            remainingUnspent: Int,
+            crossings: List<AttributeMilestoneCrossing>,
+        ): AllocatePointsResponse = AllocatePointsResponse(
+            kind = "ok",
+            attributes = Attribute.entries.associateWith { it.valueOn(attrs) },
+            remainingUnspent = remainingUnspent,
+            crossedMilestones = crossings.map { MilestoneEntry(it.attribute, it.milestone) },
+        )
+
+        fun rejected(reason: String, detail: String): AllocatePointsResponse =
+            AllocatePointsResponse(kind = "rejected", reason = reason, detail = detail)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemTool.kt
@@ -10,7 +10,6 @@ import dev.gvart.genesara.world.EquipmentService
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.annotation.Tool
 import org.springframework.stereotype.Component
-import java.util.UUID
 
 @Component
 internal class EquipItemTool(
@@ -31,49 +30,18 @@ internal class EquipItemTool(
         touchActivity(toolContext, activity, "equip_item")
         val agent = AgentContextHolder.current()
 
-        val instanceId = parseInstanceId(req) ?: return req.badInstanceIdResponse()
-        val slot = parseSlot(req, instanceId) ?: return req.badSlotResponse(instanceId)
-
-        return when (val result = equipment.equip(agent, instanceId, slot)) {
+        return when (val result = equipment.equip(agent, req.instanceId, req.slot)) {
             is EquipResult.Equipped -> EquipItemResponse.equipped(
                 instanceId = result.instance.instanceId,
-                slot = slot.name,
+                slot = req.slot,
             )
             is EquipResult.Rejected -> EquipItemResponse.rejected(
-                instanceId = instanceId.toString(),
-                slot = slot.name,
+                instanceId = req.instanceId,
+                slot = req.slot,
                 reason = result.reason.toReasonCode(),
-                detail = result.detail ?: result.reason.detailFor(slot),
+                detail = result.detail ?: result.reason.detailFor(req.slot),
             )
         }
-    }
-
-    private fun parseInstanceId(req: EquipItemRequest): UUID? =
-        req.instanceId?.takeIf { it.isNotBlank() }
-            ?.let { runCatching { UUID.fromString(it) }.getOrNull() }
-
-    private fun parseSlot(req: EquipItemRequest, instanceId: UUID): EquipSlot? =
-        req.slot?.takeIf { it.isNotBlank() }
-            ?.let { runCatching { EquipSlot.valueOf(it.uppercase()) }.getOrNull() }
-
-    private fun EquipItemRequest.badInstanceIdResponse(): EquipItemResponse {
-        val raw = instanceId
-        return EquipItemResponse.rejected(
-            instanceId = raw,
-            slot = slot,
-            reason = "bad_request",
-            detail = if (raw.isNullOrBlank()) "instanceId is required" else "instanceId is not a valid UUID: $raw",
-        )
-    }
-
-    private fun EquipItemRequest.badSlotResponse(instanceId: UUID): EquipItemResponse {
-        val raw = slot
-        return EquipItemResponse.rejected(
-            instanceId = instanceId.toString(),
-            slot = raw,
-            reason = "bad_request",
-            detail = if (raw.isNullOrBlank()) "slot is required" else "slot '$raw' is not a known slot id",
-        )
     }
 
     private fun EquipRejection.toReasonCode(): String = name.lowercase()

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemToolIo.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.equipment
 
 import com.fasterxml.jackson.annotation.JsonClassDescription
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import dev.gvart.genesara.world.EquipSlot
 import java.util.UUID
 
 @JsonClassDescription(
@@ -12,9 +13,9 @@ import java.util.UUID
 )
 data class EquipItemRequest(
     @JsonPropertyDescription("Equipment instance UUID (from get_equipment / your event stream).")
-    val instanceId: String?,
+    val instanceId: UUID,
     @JsonPropertyDescription("Target slot id (e.g. MAIN_HAND, HELMET, RING_LEFT).")
-    val slot: String?,
+    val slot: EquipSlot,
 )
 
 /**
@@ -23,21 +24,20 @@ data class EquipItemRequest(
  *  - `kind = "rejected"`: validation failed; `reason` carries an enum-string code
  *    (`instance_not_found`, `not_your_instance`, `unknown_item`, `not_equipment`,
  *    `invalid_slot_for_item`, `two_handed_not_main_hand`, `already_equipped`,
- *    `off_hand_occupied`, `off_hand_blocked_by_two_handed`, `slot_occupied`,
- *    `bad_request`).
+ *    `off_hand_occupied`, `off_hand_blocked_by_two_handed`, `slot_occupied`).
  */
 data class EquipItemResponse(
     val kind: String,
-    val instanceId: String?,
-    val slot: String?,
+    val instanceId: UUID,
+    val slot: EquipSlot,
     val reason: String? = null,
     val detail: String? = null,
 ) {
     companion object {
-        fun equipped(instanceId: UUID, slot: String) =
-            EquipItemResponse("equipped", instanceId.toString(), slot)
+        fun equipped(instanceId: UUID, slot: EquipSlot) =
+            EquipItemResponse("equipped", instanceId, slot)
 
-        fun rejected(instanceId: String?, slot: String?, reason: String, detail: String) =
+        fun rejected(instanceId: UUID, slot: EquipSlot, reason: String, detail: String) =
             EquipItemResponse("rejected", instanceId, slot, reason, detail)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotTool.kt
@@ -3,7 +3,6 @@ package dev.gvart.genesara.api.internal.mcp.tools.equipment
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
-import dev.gvart.genesara.world.EquipSlot
 import dev.gvart.genesara.world.EquipmentService
 import dev.gvart.genesara.world.UnequipResult
 import org.springframework.ai.chat.model.ToolContext
@@ -25,30 +24,15 @@ internal class UnequipSlotTool(
         touchActivity(toolContext, activity, "unequip_slot")
         val agent = AgentContextHolder.current()
 
-        val slot = req.slot?.takeIf { it.isNotBlank() }?.let { raw ->
-            runCatching { EquipSlot.valueOf(raw.uppercase()) }.getOrNull()
-                ?: return UnequipSlotResponse(
-                    kind = "rejected",
-                    slot = req.slot,
-                    reason = "bad_request",
-                    detail = "slot '$raw' is not a known slot id",
-                )
-        } ?: return UnequipSlotResponse(
-            kind = "rejected",
-            slot = null,
-            reason = "bad_request",
-            detail = "slot is required",
-        )
-
-        return when (val result = equipment.unequip(agent, slot)) {
+        return when (val result = equipment.unequip(agent, req.slot)) {
             is UnequipResult.Unequipped -> UnequipSlotResponse(
                 kind = "unequipped",
-                slot = slot.name,
-                instanceId = result.instance.instanceId.toString(),
+                slot = req.slot,
+                instanceId = result.instance.instanceId,
             )
             is UnequipResult.SlotEmpty -> UnequipSlotResponse(
                 kind = "empty",
-                slot = slot.name,
+                slot = req.slot,
             )
         }
     }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotToolIo.kt
@@ -2,22 +2,21 @@ package dev.gvart.genesara.api.internal.mcp.tools.equipment
 
 import com.fasterxml.jackson.annotation.JsonClassDescription
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import dev.gvart.genesara.world.EquipSlot
+import java.util.UUID
 
 @JsonClassDescription(
     "Empty an equipment slot, returning the instance to your stash. " +
-        "Returns kind=\"unequipped\" with the freed instance id, kind=\"empty\" if " +
-        "the slot was already empty, or kind=\"rejected\" with reason=\"bad_request\" " +
-        "for a malformed slot id.",
+        "Returns kind=\"unequipped\" with the freed instance id, or kind=\"empty\" if " +
+        "the slot was already empty.",
 )
 data class UnequipSlotRequest(
     @JsonPropertyDescription("Slot id to clear (e.g. MAIN_HAND, HELMET, RING_LEFT).")
-    val slot: String?,
+    val slot: EquipSlot,
 )
 
 data class UnequipSlotResponse(
     val kind: String,
-    val slot: String?,
-    val instanceId: String? = null,
-    val reason: String? = null,
-    val detail: String? = null,
+    val slot: EquipSlot,
+    val instanceId: UUID? = null,
 )

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
@@ -49,22 +49,20 @@ internal class InspectTool(
         val agent = agents.find(agentId) ?: error("Agent not registered: $agentId")
         val depth = inspectDepthFor(agent.attributes.perception)
 
-        val targetType = req.targetType?.lowercase()?.trim()
-        val targetId = req.targetId?.trim()
-        if (targetType.isNullOrBlank() || targetId.isNullOrBlank()) {
-            return errorResponse(depth, InspectError.BAD_TARGET_TYPE, "targetType and targetId are required")
+        val targetId = req.targetId.trim()
+        if (targetId.isEmpty()) {
+            return errorResponse(depth, InspectError.BAD_TARGET_ID, "targetId must not be blank")
         }
 
-        return when (targetType) {
-            "node" -> inspectNode(agentId, targetId, depth)
-            "agent" -> inspectAgent(agentId, targetId, depth)
-            "item" -> inspectItem(agentId, targetId, depth)
-            "building" -> {
+        return when (req.targetType) {
+            InspectTargetType.NODE -> inspectNode(agentId, targetId, depth)
+            InspectTargetType.AGENT -> inspectAgent(agentId, targetId, depth)
+            InspectTargetType.ITEM -> inspectItem(agentId, targetId, depth)
+            InspectTargetType.BUILDING -> {
                 val instanceId = runCatching { UUID.fromString(targetId) }.getOrNull()
                     ?: return errorResponse(depth, InspectError.BAD_TARGET_ID, "building id must be a UUID")
                 inspectBuilding(agentId, instanceId, depth)
             }
-            else -> errorResponse(depth, InspectError.BAD_TARGET_TYPE, "unknown targetType: $targetType")
         }
     }
 

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
@@ -3,6 +3,12 @@ package dev.gvart.genesara.api.internal.mcp.tools.inspect
 import com.fasterxml.jackson.annotation.JsonClassDescription
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
 
+/**
+ * Kind of target a single [InspectRequest] resolves against. Explicit discriminator so a
+ * numeric node id and a UUID agent id can never collide on the wire.
+ */
+enum class InspectTargetType { NODE, AGENT, ITEM, BUILDING }
+
 @JsonClassDescription(
     "Look at a single target (node, agent, item, or building) in detail. " +
         "Visibility-gated: nodes and buildings must be within sight, agents must be in the same node, " +
@@ -11,15 +17,14 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription
 )
 data class InspectRequest(
     @field:JsonPropertyDescription(
-        "Kind of target to inspect. Must be one of: \"node\", \"agent\", \"item\", \"building\". " +
-            "Explicit so a numeric node id and a UUID agent id can never collide.",
+        "Kind of target to inspect. One of NODE, AGENT, ITEM, BUILDING.",
     )
-    val targetType: String?,
+    val targetType: InspectTargetType,
     @field:JsonPropertyDescription(
-        "Target id. For node this is the numeric BIGINT id; for agent and building this is the UUID; " +
-            "for item this is the ItemId string.",
+        "Target id. For NODE this is the numeric BIGINT id; for AGENT and BUILDING this is the UUID; " +
+            "for ITEM this is the ItemId string.",
     )
-    val targetId: String?,
+    val targetId: String,
 )
 
 /**
@@ -43,7 +48,6 @@ data class InspectError(val code: String, val message: String) {
         const val NOT_FOUND = "NOT_FOUND"
         const val NOT_VISIBLE = "NOT_VISIBLE"
         const val NOT_IN_INVENTORY = "NOT_IN_INVENTORY"
-        const val BAD_TARGET_TYPE = "BAD_TARGET_TYPE"
         const val BAD_TARGET_ID = "BAD_TARGET_ID"
     }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
@@ -138,6 +138,24 @@ class AgentEventDispatcherTest {
     }
 
     @Test
+    fun `AttributeMilestoneReached reaches the agent's stream`() {
+        dispatcher.on(
+            AgentEvent.AttributeMilestoneReached(
+                agent = agent,
+                attribute = dev.gvart.genesara.player.Attribute.INTELLIGENCE,
+                milestone = 100,
+                tick = 9,
+            ),
+        )
+
+        val entry = log.since(agent, 0).single()
+        assertEquals("attribute.milestone", entry.type)
+        assertEquals(9L, entry.tick)
+        assertEquals(100, entry.payload.get("milestone").asInt())
+        assertEquals("INTELLIGENCE", entry.payload.get("attribute").asString())
+    }
+
+    @Test
     fun `PassivesApplied fans out one envelope per affected agent`() {
         val a1 = AgentId(UUID.randomUUID())
         val a2 = AgentId(UUID.randomUUID())

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolTest.kt
@@ -50,7 +50,7 @@ class AllocatePointsToolTest {
 
         val response = tool.invoke(AllocatePointsRequest(deltas = mapOf(Attribute.INTELLIGENCE to 99)), toolContext)
 
-        assertEquals("ok", response.kind)
+        assertEquals(AllocatePointsKind.OK, response.kind)
         assertEquals(0, response.remainingUnspent)
         assertEquals(100, response.attributes?.get(Attribute.INTELLIGENCE))
         assertEquals(2, response.crossedMilestones?.size)
@@ -75,54 +75,14 @@ class AllocatePointsToolTest {
     }
 
     @Test
-    fun `sum-zero deltas reject without touching the registry`() {
-        val registry = RecordingRegistry(returns = null)
-
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
-            .invoke(AllocatePointsRequest(mapOf(Attribute.STRENGTH to 0, Attribute.DEXTERITY to 0)), toolContext)
-
-        assertEquals("rejected", response.kind)
-        assertEquals("no_points_requested", response.reason)
-        assertTrue(registry.calls.isEmpty())
-    }
-
-    @Test
-    fun `negative delta is rejected by the tool before the registry is touched`() {
-        val registry = RecordingRegistry(returns = null)
-
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
-            .invoke(AllocatePointsRequest(mapOf(Attribute.STRENGTH to 1, Attribute.LUCK to -1)), toolContext)
-
-        assertEquals("rejected", response.kind)
-        assertEquals("negative_delta", response.reason)
-        assertTrue(registry.calls.isEmpty(), "registry must not be called when a delta is negative")
-    }
-
-    @Test
-    fun `registry-returned NegativeDelta is also surfaced as negative_delta`() {
-        // The tool's pre-check normally short-circuits before the registry sees a
-        // negative delta, so this branch is defensive — pin it so a later refactor
-        // that drops the pre-check still has a working fallback.
+    fun `negative delta from registry maps to NEGATIVE_DELTA reason`() {
         val registry = RecordingRegistry(returns = AllocateAttributesOutcome.NegativeDelta)
 
         val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
             .invoke(AllocatePointsRequest(mapOf(Attribute.STRENGTH to 1)), toolContext)
 
-        assertEquals("rejected", response.kind)
-        assertEquals("negative_delta", response.reason)
-    }
-
-    @Test
-    fun `sum-zero with negative entries reports negative_delta not no_points_requested`() {
-        // {STR: 2, LUCK: -2} sums to zero but contains a negative — the more accurate
-        // rejection is `negative_delta`. Pin the ordering so a future refactor doesn't
-        // shadow it.
-        val registry = RecordingRegistry(returns = null)
-
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
-            .invoke(AllocatePointsRequest(mapOf(Attribute.STRENGTH to 2, Attribute.LUCK to -2)), toolContext)
-
-        assertEquals("negative_delta", response.reason)
+        assertEquals(AllocatePointsKind.REJECTED, response.kind)
+        assertEquals(AllocatePointsRejectionReason.NEGATIVE_DELTA, response.reason)
     }
 
     @Test
@@ -132,22 +92,22 @@ class AllocatePointsToolTest {
         val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
             .invoke(AllocatePointsRequest(mapOf(Attribute.STRENGTH to 5)), toolContext)
 
-        assertEquals("rejected", response.kind)
-        assertEquals("insufficient_points", response.reason)
+        assertEquals(AllocatePointsKind.REJECTED, response.kind)
+        assertEquals(AllocatePointsRejectionReason.INSUFFICIENT_POINTS, response.reason)
         val detail = assertNotNull(response.detail)
         assertTrue("2" in detail)
         assertTrue("5" in detail)
     }
 
     @Test
-    fun `null registry result becomes agent_missing`() {
+    fun `null registry result becomes AGENT_MISSING`() {
         val registry = RecordingRegistry(returns = null)
 
         val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
             .invoke(AllocatePointsRequest(mapOf(Attribute.STRENGTH to 1)), toolContext)
 
-        assertEquals("rejected", response.kind)
-        assertEquals("agent_missing", response.reason)
+        assertEquals(AllocatePointsKind.REJECTED, response.kind)
+        assertEquals(AllocatePointsRejectionReason.AGENT_MISSING, response.reason)
     }
 
     @Test

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolTest.kt
@@ -1,0 +1,194 @@
+package dev.gvart.genesara.api.internal.mcp.tools.attributes
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AllocateAttributesOutcome
+import dev.gvart.genesara.player.Attribute
+import dev.gvart.genesara.player.AttributeMilestoneCrossing
+import dev.gvart.genesara.player.events.AgentEvent
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.context.ApplicationEventPublisher
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class AllocatePointsToolTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val clock = MutableTestClock(Instant.parse("2026-01-01T00:00:00Z"))
+    private val activity = AgentActivityRegistry(clock)
+    private val toolContext = ToolContext(emptyMap())
+    private val tickClock = StubTickClock(currentTick = 42L)
+
+    @BeforeEach fun setUp() = AgentContextHolder.set(agent)
+    @AfterEach fun tearDown() = AgentContextHolder.clear()
+
+    @Test
+    fun `happy path returns ok and publishes one event per crossed milestone`() {
+        val crossings = listOf(
+            AttributeMilestoneCrossing(Attribute.INTELLIGENCE, 50),
+            AttributeMilestoneCrossing(Attribute.INTELLIGENCE, 100),
+        )
+        val newAttrs = AgentAttributes(intelligence = 100)
+        val registry = RecordingRegistry(returns = AllocateAttributesOutcome.Allocated(newAttrs, remainingUnspent = 0, crossedMilestones = crossings))
+        val publisher = RecordingPublisher()
+        val tool = AllocatePointsTool(registry, activity, publisher, tickClock)
+
+        val response = tool.invoke(AllocatePointsRequest(deltas = mapOf(Attribute.INTELLIGENCE to 99)), toolContext)
+
+        assertEquals("ok", response.kind)
+        assertEquals(0, response.remainingUnspent)
+        assertEquals(100, response.attributes?.get(Attribute.INTELLIGENCE))
+        assertEquals(2, response.crossedMilestones?.size)
+
+        val events = publisher.events.filterIsInstance<AgentEvent.AttributeMilestoneReached>()
+        assertEquals(2, events.size)
+        assertTrue(events.all { it.tick == 42L && it.agent == agent && it.attribute == Attribute.INTELLIGENCE })
+        assertEquals(setOf(50, 100), events.map { it.milestone }.toSet())
+    }
+
+    @Test
+    fun `no crossings means no events even on success`() {
+        val registry = RecordingRegistry(
+            returns = AllocateAttributesOutcome.Allocated(AgentAttributes(strength = 4), remainingUnspent = 2, crossedMilestones = emptyList()),
+        )
+        val publisher = RecordingPublisher()
+
+        AllocatePointsTool(registry, activity, publisher, tickClock)
+            .invoke(AllocatePointsRequest(mapOf(Attribute.STRENGTH to 3)), toolContext)
+
+        assertTrue(publisher.events.isEmpty())
+    }
+
+    @Test
+    fun `sum-zero deltas reject without touching the registry`() {
+        val registry = RecordingRegistry(returns = null)
+
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+            .invoke(AllocatePointsRequest(mapOf(Attribute.STRENGTH to 0, Attribute.DEXTERITY to 0)), toolContext)
+
+        assertEquals("rejected", response.kind)
+        assertEquals("no_points_requested", response.reason)
+        assertTrue(registry.calls.isEmpty())
+    }
+
+    @Test
+    fun `negative delta is rejected by the tool before the registry is touched`() {
+        val registry = RecordingRegistry(returns = null)
+
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+            .invoke(AllocatePointsRequest(mapOf(Attribute.STRENGTH to 1, Attribute.LUCK to -1)), toolContext)
+
+        assertEquals("rejected", response.kind)
+        assertEquals("negative_delta", response.reason)
+        assertTrue(registry.calls.isEmpty(), "registry must not be called when a delta is negative")
+    }
+
+    @Test
+    fun `registry-returned NegativeDelta is also surfaced as negative_delta`() {
+        // The tool's pre-check normally short-circuits before the registry sees a
+        // negative delta, so this branch is defensive — pin it so a later refactor
+        // that drops the pre-check still has a working fallback.
+        val registry = RecordingRegistry(returns = AllocateAttributesOutcome.NegativeDelta)
+
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+            .invoke(AllocatePointsRequest(mapOf(Attribute.STRENGTH to 1)), toolContext)
+
+        assertEquals("rejected", response.kind)
+        assertEquals("negative_delta", response.reason)
+    }
+
+    @Test
+    fun `sum-zero with negative entries reports negative_delta not no_points_requested`() {
+        // {STR: 2, LUCK: -2} sums to zero but contains a negative — the more accurate
+        // rejection is `negative_delta`. Pin the ordering so a future refactor doesn't
+        // shadow it.
+        val registry = RecordingRegistry(returns = null)
+
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+            .invoke(AllocatePointsRequest(mapOf(Attribute.STRENGTH to 2, Attribute.LUCK to -2)), toolContext)
+
+        assertEquals("negative_delta", response.reason)
+    }
+
+    @Test
+    fun `insufficient points reports unspent and requested in detail`() {
+        val registry = RecordingRegistry(returns = AllocateAttributesOutcome.InsufficientPoints(unspent = 2, requested = 5L))
+
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+            .invoke(AllocatePointsRequest(mapOf(Attribute.STRENGTH to 5)), toolContext)
+
+        assertEquals("rejected", response.kind)
+        assertEquals("insufficient_points", response.reason)
+        val detail = assertNotNull(response.detail)
+        assertTrue("2" in detail)
+        assertTrue("5" in detail)
+    }
+
+    @Test
+    fun `null registry result becomes agent_missing`() {
+        val registry = RecordingRegistry(returns = null)
+
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+            .invoke(AllocatePointsRequest(mapOf(Attribute.STRENGTH to 1)), toolContext)
+
+        assertEquals("rejected", response.kind)
+        assertEquals("agent_missing", response.reason)
+    }
+
+    @Test
+    fun `touchActivity records the agent on every entry`() {
+        val registry = RecordingRegistry(
+            returns = AllocateAttributesOutcome.Allocated(AgentAttributes(), remainingUnspent = 4, crossedMilestones = emptyList()),
+        )
+
+        AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+            .invoke(AllocatePointsRequest(mapOf(Attribute.STRENGTH to 1)), toolContext)
+
+        assertEquals(clock.instant(), activity.lastActiveAt(agent))
+    }
+
+    private class RecordingRegistry(private val returns: AllocateAttributesOutcome?) : AgentRegistry {
+        val calls = mutableListOf<Pair<AgentId, Map<Attribute, Int>>>()
+        override fun find(id: AgentId): Agent? = null
+        override fun listForOwner(owner: PlayerId): List<Agent> = emptyList()
+        override fun allocateAttributes(
+            agentId: AgentId,
+            deltas: Map<Attribute, Int>,
+        ): AllocateAttributesOutcome? {
+            calls += agentId to deltas
+            return returns
+        }
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+
+    private class StubTickClock(private val currentTick: Long) : TickClock {
+        override fun currentTick(): Long = currentTick
+    }
+
+    private class MutableTestClock(private var now: Instant) : Clock() {
+        override fun instant(): Instant = now
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemToolTest.kt
@@ -40,11 +40,11 @@ class EquipItemToolTest {
         )
         val tool = EquipItemTool(service, activity)
 
-        val res = tool.invoke(EquipItemRequest(instanceId.toString(), "MAIN_HAND"), toolContext)
+        val res = tool.invoke(EquipItemRequest(instanceId, EquipSlot.MAIN_HAND), toolContext)
 
         assertEquals("equipped", res.kind)
-        assertEquals("MAIN_HAND", res.slot)
-        assertEquals(instanceId.toString(), res.instanceId)
+        assertEquals(EquipSlot.MAIN_HAND, res.slot)
+        assertEquals(instanceId, res.instanceId)
         assertEquals(null, res.reason)
     }
 
@@ -55,18 +55,15 @@ class EquipItemToolTest {
         )
         val tool = EquipItemTool(service, activity)
 
-        val res = tool.invoke(EquipItemRequest(UUID.randomUUID().toString(), "OFF_HAND"), toolContext)
+        val res = tool.invoke(EquipItemRequest(UUID.randomUUID(), EquipSlot.OFF_HAND), toolContext)
 
         assertEquals("rejected", res.kind)
         assertEquals("off_hand_blocked_by_two_handed", res.reason)
-        assertEquals("OFF_HAND", res.slot)
+        assertEquals(EquipSlot.OFF_HAND, res.slot)
     }
 
     @Test
     fun `service-supplied detail is passed through verbatim when present`() {
-        // Slice C2: rejections like INSUFFICIENT_ATTRIBUTES carry a pre-formatted
-        // detail naming the failing requirement. The tool must surface that
-        // string rather than overwriting it with its own generic detailFor map.
         val customDetail = "HEAVY_BLADE requires STRENGTH ≥ 12 (you have 5)"
         val service = StubEquipmentService(
             equipResult = EquipResult.Rejected(
@@ -76,49 +73,11 @@ class EquipItemToolTest {
         )
         val tool = EquipItemTool(service, activity)
 
-        val res = tool.invoke(EquipItemRequest(UUID.randomUUID().toString(), "MAIN_HAND"), toolContext)
+        val res = tool.invoke(EquipItemRequest(UUID.randomUUID(), EquipSlot.MAIN_HAND), toolContext)
 
         assertEquals("rejected", res.kind)
         assertEquals("insufficient_attributes", res.reason)
         assertEquals(customDetail, res.detail)
-    }
-
-    @Test
-    fun `bad UUID for instanceId is rejected before the service is touched`() {
-        val service = StubEquipmentService()
-        val tool = EquipItemTool(service, activity)
-
-        val res = tool.invoke(EquipItemRequest("not-a-uuid", "MAIN_HAND"), toolContext)
-
-        assertEquals("rejected", res.kind)
-        assertEquals("bad_request", res.reason)
-        assertEquals(0, service.equipCalls.size)
-    }
-
-    @Test
-    fun `unknown slot string is rejected before the service is touched`() {
-        val service = StubEquipmentService()
-        val tool = EquipItemTool(service, activity)
-
-        val res = tool.invoke(EquipItemRequest(UUID.randomUUID().toString(), "POCKET"), toolContext)
-
-        assertEquals("rejected", res.kind)
-        assertEquals("bad_request", res.reason)
-        assertEquals(0, service.equipCalls.size)
-    }
-
-    @Test
-    fun `slot is normalized to uppercase before lookup`() {
-        val instanceId = UUID.randomUUID()
-        val service = StubEquipmentService(
-            equipResult = EquipResult.Equipped(sampleInstance(instanceId, EquipSlot.HELMET)),
-        )
-        val tool = EquipItemTool(service, activity)
-
-        val res = tool.invoke(EquipItemRequest(instanceId.toString(), "helmet"), toolContext)
-
-        assertEquals("equipped", res.kind)
-        assertEquals(EquipSlot.HELMET, service.equipCalls.single().third)
     }
 
     private fun sampleInstance(id: UUID, slot: EquipSlot) = EquipmentInstance(

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotToolTest.kt
@@ -41,34 +41,22 @@ class UnequipSlotToolTest {
             activity,
         )
 
-        val res = tool.invoke(UnequipSlotRequest("MAIN_HAND"), toolContext)
+        val res = tool.invoke(UnequipSlotRequest(EquipSlot.MAIN_HAND), toolContext)
 
         assertEquals("unequipped", res.kind)
-        assertEquals("MAIN_HAND", res.slot)
-        assertEquals(instanceId.toString(), res.instanceId)
+        assertEquals(EquipSlot.MAIN_HAND, res.slot)
+        assertEquals(instanceId, res.instanceId)
     }
 
     @Test
     fun `empty slot returns kind=empty`() {
         val tool = UnequipSlotTool(StubEquipmentService(unequipResult = UnequipResult.SlotEmpty), activity)
 
-        val res = tool.invoke(UnequipSlotRequest("HELMET"), toolContext)
+        val res = tool.invoke(UnequipSlotRequest(EquipSlot.HELMET), toolContext)
 
         assertEquals("empty", res.kind)
-        assertEquals("HELMET", res.slot)
+        assertEquals(EquipSlot.HELMET, res.slot)
         assertEquals(null, res.instanceId)
-    }
-
-    @Test
-    fun `unknown slot string is rejected with bad_request`() {
-        val service = StubEquipmentService()
-        val tool = UnequipSlotTool(service, activity)
-
-        val res = tool.invoke(UnequipSlotRequest("WRONG"), toolContext)
-
-        assertEquals("rejected", res.kind)
-        assertEquals("bad_request", res.reason)
-        assertEquals(0, service.unequipCalls.size)
     }
 
     private fun sampleInstance(id: UUID, slot: EquipSlot?) = EquipmentInstance(

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
@@ -257,7 +257,8 @@ class InspectBuildingTest {
         override fun listForOwner(owner: PlayerId): List<Agent> = present.filter { it.owner == owner }
     }
 
-    private fun req(targetType: String, targetId: String) = InspectRequest(targetType, targetId)
+    private fun req(targetType: String, targetId: String) =
+        InspectRequest(InspectTargetType.valueOf(targetType.uppercase()), targetId)
 
     private val region = Region(
         id = regionId, worldId = WorldId(1L), sphereIndex = 0,

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
@@ -101,18 +101,11 @@ class InspectToolTest {
     // --- request validation ---
 
     @Test
-    fun `missing targetType returns BAD_TARGET_TYPE`() {
+    fun `blank targetId returns BAD_TARGET_ID`() {
         val tool = tool(perception = 5)
-        val resp = tool.invoke(InspectRequest(targetType = null, targetId = "1"), toolContext)
+        val resp = tool.invoke(InspectRequest(targetType = InspectTargetType.NODE, targetId = "   "), toolContext)
         assertEquals("error", resp.kind)
-        assertEquals(InspectError.BAD_TARGET_TYPE, resp.error?.code)
-    }
-
-    @Test
-    fun `unknown targetType returns BAD_TARGET_TYPE`() {
-        val tool = tool(perception = 5)
-        val resp = tool.invoke(InspectRequest(targetType = "creature", targetId = "1"), toolContext)
-        assertEquals(InspectError.BAD_TARGET_TYPE, resp.error?.code)
+        assertEquals(InspectError.BAD_TARGET_ID, resp.error?.code)
     }
 
     // --- node ---
@@ -343,13 +336,6 @@ class InspectToolTest {
     }
 
     @Test
-    fun `targetType is trimmed and lowercased so quirky inputs still resolve`() {
-        val tool = tool(perception = 5)
-        val resp = tool.invoke(req(" Node ", currentNodeId.value.toString()), toolContext)
-        assertEquals("node", resp.kind)
-    }
-
-    @Test
     fun `inspect item not in inventory returns NOT_IN_INVENTORY`() {
         val tool = tool(perception = 5, inventory = emptyList())
         val resp = tool.invoke(req("item", "WOOD"), toolContext)
@@ -432,7 +418,7 @@ class InspectToolTest {
     }
 
     private fun req(targetType: String, targetId: String) =
-        InspectRequest(targetType = targetType, targetId = targetId)
+        InspectRequest(targetType = InspectTargetType.valueOf(targetType.uppercase()), targetId = targetId)
 
     private fun body(hp: Int, maxHp: Int, maxMana: Int = 0) = BodyView(
         hp = hp, maxHp = maxHp,

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
@@ -30,6 +30,35 @@ interface AgentRegistry {
      */
     fun applyDeathPenalty(agentId: AgentId, xpLossOnDeath: Int): DeathPenaltyOutcome? =
         throw NotImplementedError("applyDeathPenalty not implemented for this AgentRegistry")
+
+    /**
+     * Spend unspent attribute points by adding non-negative [deltas] to the matching
+     * attributes atomically. Validates `unspentAttributePoints >= sum(deltas.values)`,
+     * decrements the pool by the sum, bumps each attribute, and recomputes the
+     * derived `agent_profiles.{maxHp,maxStamina,maxMana}` via [AttributeDerivation].
+     * Current pool values (HP / Stamina / Mana) are NOT auto-restored — leveling
+     * Constitution doesn't heal the agent.
+     *
+     * Returns one of:
+     *  - [AllocateAttributesOutcome.Allocated] — success; carries the post-allocation
+     *    [AgentAttributes], remaining unspent points, and the milestone thresholds
+     *    (50 / 100 / 200) crossed by this allocation.
+     *  - [AllocateAttributesOutcome.NegativeDelta] — at least one delta was < 0.
+     *    No respec / unallocate in v1.
+     *  - [AllocateAttributesOutcome.InsufficientPoints] — sum of deltas exceeds the
+     *    agent's unspent pool.
+     *  - `null` — the agent row was missing (state corruption); caller logs and skips,
+     *    same convention as [applyDeathPenalty].
+     *
+     * Default implementation throws `NotImplementedError` so test stubs can opt in
+     * only when they exercise the allocation path; production [JooqAgentRegistry]
+     * provides the real implementation.
+     */
+    fun allocateAttributes(
+        agentId: AgentId,
+        deltas: Map<Attribute, Int>,
+    ): AllocateAttributesOutcome? =
+        throw NotImplementedError("allocateAttributes not implemented for this AgentRegistry")
 }
 
 /**
@@ -57,3 +86,26 @@ sealed interface AttributePointLoss {
     /** Decremented an allocated attribute by 1 because the unspent pool was empty. */
     data class Allocated(val attribute: Attribute) : AttributePointLoss
 }
+
+/** Result of [AgentRegistry.allocateAttributes]. */
+sealed interface AllocateAttributesOutcome {
+    /** Successful allocation. Carries the post-allocation snapshot for the caller to surface. */
+    data class Allocated(
+        val attributes: AgentAttributes,
+        val remainingUnspent: Int,
+        val crossedMilestones: List<AttributeMilestoneCrossing>,
+    ) : AllocateAttributesOutcome
+
+    /** At least one delta was negative — rejected up-front before the DB round trip. */
+    data object NegativeDelta : AllocateAttributesOutcome
+
+    /**
+     * Sum of deltas exceeded the agent's unspent pool. `requested` is `Long` so the
+     * rejection can faithfully report values that overflow `Int` (e.g. an attacker
+     * sending two near-`Int.MAX_VALUE` deltas).
+     */
+    data class InsufficientPoints(val unspent: Int, val requested: Long) : AllocateAttributesOutcome
+}
+
+/** A single (attribute, milestone) pair crossed by an allocation. */
+data class AttributeMilestoneCrossing(val attribute: Attribute, val milestone: Int)

--- a/player/src/main/kotlin/dev/gvart/genesara/player/events/AgentEvent.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/events/AgentEvent.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.player.events
 
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.SkillId
 import java.util.UUID
 
@@ -35,5 +36,17 @@ sealed interface AgentEvent {
         val slotsFree: Int,
         override val tick: Long,
         val causedBy: UUID,
+    ) : AgentEvent
+
+    /**
+     * Emitted when an [allocate_points] call pushes [attribute] across one of the
+     * milestone thresholds (50, 100, 200). Perk-catalog wiring lands later — this
+     * event only marks the crossing.
+     */
+    data class AttributeMilestoneReached(
+        val agent: AgentId,
+        val attribute: Attribute,
+        val milestone: Int,
+        override val tick: Long,
     ) : AgentEvent
 }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
@@ -10,9 +10,11 @@ import dev.gvart.genesara.player.AgentProfile
 import dev.gvart.genesara.player.AgentProfileRepository
 import dev.gvart.genesara.player.AgentRegistrar
 import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AllocateAttributesOutcome
 import dev.gvart.genesara.player.Attribute
-import dev.gvart.genesara.player.AttributePointLoss
 import dev.gvart.genesara.player.AttributeDerivation
+import dev.gvart.genesara.player.AttributeMilestoneCrossing
+import dev.gvart.genesara.player.AttributePointLoss
 import dev.gvart.genesara.player.DeathPenaltyOutcome
 import dev.gvart.genesara.player.RaceId
 import dev.gvart.genesara.player.internal.jooq.tables.records.AgentsRecord
@@ -122,6 +124,89 @@ internal class JooqAgentRegistry(
             attributes = attrs,
         )
     }
+
+    @Transactional
+    override fun allocateAttributes(
+        agentId: AgentId,
+        deltas: Map<Attribute, Int>,
+    ): AllocateAttributesOutcome? {
+        if (deltas.values.any { it < 0 }) return AllocateAttributesOutcome.NegativeDelta
+
+        val record = lockAgentRow(agentId) ?: return null
+        val unspent = record[AGENTS.UNSPENT_ATTRIBUTE_POINTS]!!
+        // Sum in Long so a malicious caller can't smuggle past the unspent guard with two
+        // big positive ints that wrap around to a negative Int sum.
+        val requestedLong = deltas.values.sumOf { it.toLong() }
+        if (requestedLong > unspent.toLong()) {
+            return AllocateAttributesOutcome.InsufficientPoints(unspent = unspent, requested = requestedLong)
+        }
+        val requested = requestedLong.toInt()
+        if (requested == 0) {
+            return AllocateAttributesOutcome.Allocated(
+                attributes = record.toAttributes(),
+                remainingUnspent = unspent,
+                crossedMilestones = emptyList(),
+            )
+        }
+
+        val oldAttrs = record.toAttributes()
+        val newAttrs = oldAttrs.applyDeltas(deltas)
+        val crossings = detectMilestoneCrossings(oldAttrs, newAttrs, deltas)
+
+        val update = dsl.update(AGENTS).set(AGENTS.UNSPENT_ATTRIBUTE_POINTS, unspent - requested)
+        deltas.forEach { (attr, delta) ->
+            if (delta > 0) update.set(columnFor(attr), attr.valueOn(newAttrs))
+        }
+        update.where(AGENTS.ID.eq(agentId.id)).execute()
+
+        val pools = AttributeDerivation.deriveMaxPools(newAttrs)
+        profiles.save(
+            AgentProfile(
+                id = agentId,
+                maxHp = pools.maxHp,
+                maxStamina = pools.maxStamina,
+                maxMana = pools.maxMana,
+            )
+        )
+
+        return AllocateAttributesOutcome.Allocated(
+            attributes = newAttrs,
+            remainingUnspent = unspent - requested,
+            crossedMilestones = crossings,
+        )
+    }
+
+    private fun detectMilestoneCrossings(
+        old: AgentAttributes,
+        new: AgentAttributes,
+        deltas: Map<Attribute, Int>,
+    ): List<AttributeMilestoneCrossing> = deltas.entries
+        .filter { (_, delta) -> delta > 0 }
+        .flatMap { (attr, _) ->
+            val oldVal = attr.valueOn(old)
+            val newVal = attr.valueOn(new)
+            ATTRIBUTE_MILESTONES
+                .filter { it in (oldVal + 1)..newVal }
+                .map { AttributeMilestoneCrossing(attr, it) }
+        }
+
+    private fun AgentAttributes.applyDeltas(deltas: Map<Attribute, Int>): AgentAttributes = AgentAttributes(
+        strength = strength + (deltas[Attribute.STRENGTH] ?: 0),
+        dexterity = dexterity + (deltas[Attribute.DEXTERITY] ?: 0),
+        constitution = constitution + (deltas[Attribute.CONSTITUTION] ?: 0),
+        perception = perception + (deltas[Attribute.PERCEPTION] ?: 0),
+        intelligence = intelligence + (deltas[Attribute.INTELLIGENCE] ?: 0),
+        luck = luck + (deltas[Attribute.LUCK] ?: 0),
+    )
+
+    private fun AgentsRecord.toAttributes(): AgentAttributes = AgentAttributes(
+        strength = this[AGENTS.STRENGTH]!!,
+        dexterity = this[AGENTS.DEXTERITY]!!,
+        constitution = this[AGENTS.CONSTITUTION]!!,
+        perception = this[AGENTS.PERCEPTION]!!,
+        intelligence = this[AGENTS.INTELLIGENCE]!!,
+        luck = this[AGENTS.LUCK]!!,
+    )
 
     @Transactional
     override fun applyDeathPenalty(agentId: AgentId, xpLossOnDeath: Int): DeathPenaltyOutcome? {
@@ -247,5 +332,6 @@ internal class JooqAgentRegistry(
         const val INITIAL_XP_TO_NEXT = 100
         const val INITIAL_UNSPENT_POINTS = 5
         const val XP_PER_LEVEL = 100
+        val ATTRIBUTE_MILESTONES = listOf(50, 100, 200)
     }
 }

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryAllocateAttributesIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryAllocateAttributesIntegrationTest.kt
@@ -1,0 +1,295 @@
+package dev.gvart.genesara.player.internal.store
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentProfile
+import dev.gvart.genesara.player.AgentProfileRepository
+import dev.gvart.genesara.player.AllocateAttributesOutcome
+import dev.gvart.genesara.player.Attribute
+import dev.gvart.genesara.player.AttributeMilestoneCrossing
+import dev.gvart.genesara.player.AttributeMods
+import dev.gvart.genesara.player.Race
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.player.RaceLookup
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENTS
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENT_PROFILES
+import dev.gvart.genesara.player.internal.race.RaceAssigner
+import dev.gvart.genesara.player.internal.race.RaceDefinitionProperties
+import dev.gvart.genesara.player.internal.race.RandomSource
+import dev.gvart.genesara.player.internal.testsupport.PlayerFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@Testcontainers
+class JooqAgentRegistryAllocateAttributesIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("alloc_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = PlayerFlyway.pooledDataSource(postgres)
+            PlayerFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private val owner = PlayerId(UUID.randomUUID())
+
+    @BeforeEach
+    fun resetTables() {
+        dsl.truncate(AGENT_PROFILES).cascade().execute()
+        dsl.truncate(AGENTS).cascade().execute()
+    }
+
+    @Test
+    fun `single-attribute allocation bumps the column and decrements unspent`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Brawler")
+
+        val outcome = registry.allocateAttributes(agent.id, mapOf(Attribute.STRENGTH to 3))
+
+        val allocated = assertIs<AllocateAttributesOutcome.Allocated>(outcome)
+        assertEquals(4, allocated.attributes.strength)
+        assertEquals(2, allocated.remainingUnspent)
+        assertTrue(allocated.crossedMilestones.isEmpty())
+
+        val row = readAgent(agent.id)
+        assertEquals(4, row[AGENTS.STRENGTH])
+        assertEquals(1, row[AGENTS.DEXTERITY], "untouched attributes stay at default")
+        assertEquals(2, row[AGENTS.UNSPENT_ATTRIBUTE_POINTS])
+    }
+
+    @Test
+    fun `constitution allocation recomputes max_hp and max_stamina via AttributeDerivation`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Tank")
+
+        registry.allocateAttributes(agent.id, mapOf(Attribute.CONSTITUTION to 4))
+
+        val profile = readProfile(agent.id)
+        // CON 5 → maxHp = HP_BASE 50 + 5 × HP_PER_CON 10 = 100.
+        assertEquals(100, profile[AGENT_PROFILES.MAX_HP])
+        // (CON 5 + DEX 1) × STAMINA_PER_PT 5 + STAMINA_BASE 30 = 60.
+        assertEquals(60, profile[AGENT_PROFILES.MAX_STAMINA])
+        // INT unchanged → MANA_PER_INT 5 × 1 = 5.
+        assertEquals(5, profile[AGENT_PROFILES.MAX_MANA])
+    }
+
+    @Test
+    fun `intelligence allocation crossing 50 reports the milestone`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Scholar")
+        seedAttribute(agent.id, AGENTS.INTELLIGENCE, 49)
+        seedUnspent(agent.id, 5)
+
+        val outcome = registry.allocateAttributes(agent.id, mapOf(Attribute.INTELLIGENCE to 2))
+
+        val allocated = assertIs<AllocateAttributesOutcome.Allocated>(outcome)
+        assertEquals(listOf(AttributeMilestoneCrossing(Attribute.INTELLIGENCE, 50)), allocated.crossedMilestones)
+        assertEquals(51, readAgent(agent.id)[AGENTS.INTELLIGENCE])
+    }
+
+    @Test
+    fun `single allocation that spans two milestones reports both in order`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Archmage")
+        seedAttribute(agent.id, AGENTS.INTELLIGENCE, 51)
+        seedUnspent(agent.id, 200)
+
+        val outcome = registry.allocateAttributes(agent.id, mapOf(Attribute.INTELLIGENCE to 151))
+
+        val allocated = assertIs<AllocateAttributesOutcome.Allocated>(outcome)
+        assertEquals(
+            listOf(
+                AttributeMilestoneCrossing(Attribute.INTELLIGENCE, 100),
+                AttributeMilestoneCrossing(Attribute.INTELLIGENCE, 200),
+            ),
+            allocated.crossedMilestones,
+        )
+    }
+
+    @Test
+    fun `multi-attribute allocation updates every column atomically and recomputes pools once`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Hybrid")
+
+        val outcome = registry.allocateAttributes(
+            agent.id,
+            mapOf(
+                Attribute.STRENGTH to 2,
+                Attribute.CONSTITUTION to 3,
+                Attribute.INTELLIGENCE to 0,
+            ),
+        )
+
+        val allocated = assertIs<AllocateAttributesOutcome.Allocated>(outcome)
+        assertEquals(0, allocated.remainingUnspent)
+        assertEquals(3, allocated.attributes.strength)
+        assertEquals(4, allocated.attributes.constitution)
+        assertEquals(1, allocated.attributes.intelligence, "zero delta does not move the value")
+
+        val profile = readProfile(agent.id)
+        // CON 4 → maxHp = 50 + 4 × 10 = 90; (CON 4 + DEX 1) × 5 + 30 = 55.
+        assertEquals(90, profile[AGENT_PROFILES.MAX_HP])
+        assertEquals(55, profile[AGENT_PROFILES.MAX_STAMINA])
+    }
+
+    @Test
+    fun `requested above unspent is rejected and leaves the row untouched`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Greedy")
+
+        val outcome = registry.allocateAttributes(agent.id, mapOf(Attribute.STRENGTH to 6))
+
+        val rejection = assertIs<AllocateAttributesOutcome.InsufficientPoints>(outcome)
+        assertEquals(5, rejection.unspent)
+        assertEquals(6L, rejection.requested)
+
+        val row = readAgent(agent.id)
+        assertEquals(1, row[AGENTS.STRENGTH], "no-op on rejection")
+        assertEquals(5, row[AGENTS.UNSPENT_ATTRIBUTE_POINTS])
+    }
+
+    @Test
+    fun `Int_MAX_VALUE deltas can't smuggle past the unspent guard via overflow`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Overflow")
+
+        val outcome = registry.allocateAttributes(
+            agent.id,
+            mapOf(Attribute.STRENGTH to Int.MAX_VALUE, Attribute.DEXTERITY to 1),
+        )
+
+        val rejection = assertIs<AllocateAttributesOutcome.InsufficientPoints>(outcome)
+        assertEquals(Int.MAX_VALUE.toLong() + 1L, rejection.requested)
+        val row = readAgent(agent.id)
+        assertEquals(1, row[AGENTS.STRENGTH], "no DB mutation despite the overflow attempt")
+    }
+
+    @Test
+    fun `negative delta is rejected before any DB call`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Refunder")
+
+        val outcome = registry.allocateAttributes(
+            agent.id,
+            mapOf(Attribute.STRENGTH to 2, Attribute.LUCK to -1),
+        )
+
+        assertEquals(AllocateAttributesOutcome.NegativeDelta, outcome)
+        val row = readAgent(agent.id)
+        assertEquals(1, row[AGENTS.STRENGTH])
+        assertEquals(5, row[AGENTS.UNSPENT_ATTRIBUTE_POINTS])
+    }
+
+    @Test
+    fun `unregistered agent returns null`() {
+        val registry = registry()
+        assertNull(
+            registry.allocateAttributes(AgentId(UUID.randomUUID()), mapOf(Attribute.STRENGTH to 1)),
+        )
+    }
+
+    @Test
+    fun `empty deltas map is a no-op success`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Idle")
+
+        val outcome = registry.allocateAttributes(agent.id, emptyMap())
+
+        val allocated = assertIs<AllocateAttributesOutcome.Allocated>(outcome)
+        assertEquals(5, allocated.remainingUnspent)
+        assertTrue(allocated.crossedMilestones.isEmpty())
+    }
+
+    private fun seedAttribute(id: AgentId, column: org.jooq.TableField<*, Int?>, value: Int) {
+        @Suppress("UNCHECKED_CAST")
+        dsl.update(AGENTS)
+            .set(column as org.jooq.TableField<org.jooq.Record, Int?>, value)
+            .where(AGENTS.ID.eq(id.id))
+            .execute()
+    }
+
+    private fun seedUnspent(id: AgentId, value: Int) {
+        dsl.update(AGENTS)
+            .set(AGENTS.UNSPENT_ATTRIBUTE_POINTS, value)
+            .where(AGENTS.ID.eq(id.id))
+            .execute()
+    }
+
+    private fun registry(): JooqAgentRegistry {
+        val race = Race(
+            id = RaceId("test_race"),
+            displayName = "Test",
+            weight = 1,
+            attributeMods = AttributeMods.NONE,
+            description = "",
+        )
+        val lookup = SingleRaceLookup(race)
+        val props = RaceDefinitionProperties(defaultId = race.id.value)
+        val assigner = RaceAssigner(lookup, props, FixedRandom)
+        return JooqAgentRegistry(dsl, UpsertingProfileRepository(dsl), assigner)
+    }
+
+    private fun readAgent(id: AgentId) =
+        assertNotNull(dsl.selectFrom(AGENTS).where(AGENTS.ID.eq(id.id)).fetchOne())
+
+    private fun readProfile(id: AgentId) =
+        assertNotNull(dsl.selectFrom(AGENT_PROFILES).where(AGENT_PROFILES.AGENT_ID.eq(id.id)).fetchOne())
+
+    private class SingleRaceLookup(private val race: Race) : RaceLookup {
+        override fun byId(id: RaceId): Race? = if (id == race.id) race else null
+        override fun all(): List<Race> = listOf(race)
+    }
+
+    private object FixedRandom : RandomSource {
+        override fun nextInt(boundExclusive: Int): Int = 0
+    }
+
+    private class UpsertingProfileRepository(private val dsl: DSLContext) : AgentProfileRepository {
+        override fun save(profile: AgentProfile) {
+            dsl.insertInto(AGENT_PROFILES)
+                .set(AGENT_PROFILES.AGENT_ID, profile.id.id)
+                .set(AGENT_PROFILES.MAX_HP, profile.maxHp)
+                .set(AGENT_PROFILES.MAX_STAMINA, profile.maxStamina)
+                .set(AGENT_PROFILES.MAX_MANA, profile.maxMana)
+                .onConflict(AGENT_PROFILES.AGENT_ID)
+                .doUpdate()
+                .set(AGENT_PROFILES.MAX_HP, profile.maxHp)
+                .set(AGENT_PROFILES.MAX_STAMINA, profile.maxStamina)
+                .set(AGENT_PROFILES.MAX_MANA, profile.maxMana)
+                .execute()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Closes #6.** Adds the `allocate_points` MCP tool (sync, no `WorldCommand` — same pattern as `equip_skill`), the `AgentRegistry.allocateAttributes` atomic write path, and `AgentEvent.AttributeMilestoneReached` for crossings of 50 / 100 / 200. Derived `agent_profiles.{maxHp,maxStamina,maxMana}` are recomputed via `AttributeDerivation` on every allocation; current pool values are NOT auto-restored.
- **Side cleanup**: drop `parseXXX` String→typed conversions from MCP tool inputs. `EquipItemTool`, `UnequipSlotTool`, and `InspectTool` now take `UUID` and enum types (`EquipSlot`, new `InspectTargetType`) directly so Jackson validates at the deserialization boundary. Boundary parsers (JWT subject, Redis-stored AgentId, request headers) stay as-is.

### Notable decisions
- `AttributeMilestoneReached` lives on `AgentEvent` (not `WorldEvent` as the issue text said) — the recent commit `822b2b0` moved skill-progression events to `AgentEvent` for the same reason (no `:world` types in the payload).
- Insufficient-points guard sums in `Long` so a malicious caller can't smuggle past it with two near-`Int.MAX_VALUE` deltas that wrap around. `InsufficientPoints.requested` is `Long` so the rejection can faithfully report the overflowing value.
- Empty-deltas short-circuits inside the registry after the row lock — no UPDATE / no profile upsert.
- Tool's pre-checks run negative-delta scan **before** sum-zero so `{STR: 2, LUCK: -2}` reports `negative_delta` rather than `no_points_requested`.

## Test plan

- [x] `./gradlew :player:test :api:test` — unit + integration green.
- [x] `./gradlew test` — full suite green.
- [x] Two passes of `code-quality-reviewer`; second pass clean.
- [x] Registry integration tests cover happy path, multi-attribute, milestone crossings (single + double), insufficient-points (incl. `Int.MAX_VALUE` overflow regression), negative delta, missing agent, empty map, agent_profiles recompute.
- [x] Tool unit tests cover happy path with event publishing, no-crossing path, sum-zero, negative-delta priority, registry-returned `NegativeDelta`, `InsufficientPoints`, `agent_missing`, activity tracking.
- [x] `AgentEventDispatcherTest` covers the new `attribute.milestone` route.
- [ ] Manual MCP smoke (post-merge): register agent → `allocate_points {deltas: {STRENGTH: 3}}` → `get_status` reflects new value + remainingUnspent. Pre-stage `INTELLIGENCE=49`, allocate +1 → event log shows `attribute.milestone` for 50.