### PR TITLE
feat(world,player,api): VisionRadius helper for sight computation

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
@@ -8,7 +8,6 @@ import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
-import dev.gvart.genesara.player.ClassPropertiesLookup
 import dev.gvart.genesara.world.BodyView
 import dev.gvart.genesara.world.Building
 import dev.gvart.genesara.world.BuildingDefLookup
@@ -18,6 +17,7 @@ import dev.gvart.genesara.world.ChestContentsStore
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.VisionRadius
 import dev.gvart.genesara.world.WorldQueryGateway
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.annotation.Tool
@@ -28,7 +28,7 @@ import java.util.UUID
 internal class InspectTool(
     private val world: WorldQueryGateway,
     private val agents: AgentRegistry,
-    private val classes: ClassPropertiesLookup,
+    private val vision: VisionRadius,
     private val items: ItemLookup,
     private val activity: AgentActivityTracker,
     private val tick: TickClock,
@@ -105,7 +105,7 @@ internal class InspectTool(
     }
 
     private fun isNodeWithinSight(agent: Agent, currentNodeId: NodeId, nodeId: NodeId): Boolean {
-        val sight = classes.sightRange(agent.classId)
+        val sight = vision.radiusFor(agent, currentNodeId)
         return nodeId in world.nodesWithin(currentNodeId, sight)
     }
 

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
@@ -7,7 +7,6 @@ import dev.gvart.genesara.api.internal.mcp.projection.vitalBand
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
-import dev.gvart.genesara.player.ClassPropertiesLookup
 import dev.gvart.genesara.world.AgentMapMemoryGateway
 import dev.gvart.genesara.world.Building
 import dev.gvart.genesara.world.BuildingsLookup
@@ -16,6 +15,7 @@ import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.NodeMemoryUpdate
 import dev.gvart.genesara.world.NodeResources
 import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.VisionRadius
 import dev.gvart.genesara.world.WorldQueryGateway
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.model.ToolContext
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component
 internal class LookAroundTool(
     private val world: WorldQueryGateway,
     private val agents: AgentRegistry,
-    private val classes: ClassPropertiesLookup,
+    private val vision: VisionRadius,
     private val activity: AgentActivityTracker,
     private val tick: TickClock,
     private val mapMemory: AgentMapMemoryGateway,
@@ -44,11 +44,11 @@ internal class LookAroundTool(
         touchActivity(toolContext, activity, "look_around")
         val agentId = AgentContextHolder.current()
         val agent = agents.find(agentId) ?: error("Agent not registered: $agentId")
-        val sight = classes.sightRange(agent.classId)
 
         val nodeId = world.locationOf(agentId)
             ?: error("Agent has not spawned yet — call `spawn` first")
         val current = world.node(nodeId) ?: error("Current node not found: $nodeId")
+        val sight = vision.radiusFor(agent, nodeId)
         val region = world.region(current.regionId)
             ?: error("Current region not found: ${current.regionId}")
 

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeController.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeController.kt
@@ -6,11 +6,11 @@ import dev.gvart.genesara.api.internal.mcp.tools.lookaround.ResourceView
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentRegistry
-import dev.gvart.genesara.player.ClassPropertiesLookup
 import dev.gvart.genesara.world.Node
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.NodeResources
 import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.VisionRadius
 import dev.gvart.genesara.world.WorldCommandGateway
 import dev.gvart.genesara.world.WorldQueryGateway
 import dev.gvart.genesara.world.commands.WorldCommand
@@ -37,7 +37,7 @@ internal class AgentRuntimeController(
     private val query: WorldQueryGateway,
     private val tick: TickClock,
     private val agents: AgentRegistry,
-    private val classes: ClassPropertiesLookup,
+    private val vision: VisionRadius,
 ) {
 
     data class CommandRequest(@field:Positive val nodeId: Long)
@@ -66,11 +66,11 @@ internal class AgentRuntimeController(
     fun lookAround(@AuthenticationPrincipal agent: Agent): ResponseEntity<LookAroundResponse> {
         val agentRecord = agents.find(agent.id)
             ?: return ResponseEntity.notFound().build()
-        val sight = classes.sightRange(agentRecord.classId)
         val nodeId = query.locationOf(agent.id)
             ?: return ResponseEntity.status(HttpStatus.CONFLICT).build()
         val current = query.node(nodeId)
             ?: return ResponseEntity.notFound().build()
+        val sight = vision.radiusFor(agentRecord, nodeId)
         val region = query.region(current.regionId)
             ?: return ResponseEntity.notFound().build()
         val currentTick = tick.currentTick()

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
@@ -9,7 +9,6 @@ import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
-import dev.gvart.genesara.player.ClassPropertiesLookup
 import dev.gvart.genesara.player.RaceId
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.world.BodyView
@@ -31,6 +30,7 @@ import dev.gvart.genesara.world.NodeResources
 import dev.gvart.genesara.world.Region
 import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.VisionRadius
 import dev.gvart.genesara.world.WorldId
 import dev.gvart.genesara.world.WorldQueryGateway
 import dev.gvart.genesara.world.InventoryView
@@ -234,7 +234,7 @@ class InspectBuildingTest {
         return InspectTool(
             world = world,
             agents = registry(caller(perception)),
-            classes = StubClasses(sight = 1),
+            vision = StubVision(sight = 1),
             items = StubItems,
             activity = activity,
             tick = FixedTickClock(0L),
@@ -266,8 +266,8 @@ class InspectBuildingTest {
         centroid = Vec3(0.0, 0.0, 1.0), faceVertices = emptyList(), neighbors = emptySet(),
     )
 
-    private class StubClasses(private val sight: Int) : ClassPropertiesLookup {
-        override fun sightRange(classId: AgentClass?): Int = sight
+    private class StubVision(private val sight: Int) : VisionRadius {
+        override fun radiusFor(agent: Agent, currentNode: NodeId): Int = sight
     }
 
     private object StubItems : ItemLookup {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
@@ -9,7 +9,6 @@ import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
-import dev.gvart.genesara.player.ClassPropertiesLookup
 import dev.gvart.genesara.player.RaceId
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.BodyView
@@ -27,6 +26,7 @@ import dev.gvart.genesara.world.Region
 import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.Terrain
 import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.VisionRadius
 import dev.gvart.genesara.world.WorldId
 import dev.gvart.genesara.world.WorldQueryGateway
 import org.junit.jupiter.api.AfterEach
@@ -250,7 +250,7 @@ class InspectToolTest {
         val selfTool = InspectTool(
             world = world,
             agents = registry(caller(perception = 10)),
-            classes = StubClasses(sight = 1),
+            vision = StubVision(sight = 1),
             items = StubItems,
             activity = activity,
             tick = FixedTickClock(0L),
@@ -381,7 +381,7 @@ class InspectToolTest {
         return InspectTool(
             world = world,
             agents = registry(caller(perception), targetHumanoid),
-            classes = StubClasses(sight = 1),
+            vision = StubVision(sight = 1),
             items = StubItems,
             activity = activity,
             tick = FixedTickClock(0L),
@@ -397,8 +397,8 @@ class InspectToolTest {
         override fun listForOwner(owner: PlayerId): List<Agent> = present.filter { it.owner == owner }
     }
 
-    private class StubClasses(private val sight: Int) : ClassPropertiesLookup {
-        override fun sightRange(classId: AgentClass?): Int = sight
+    private class StubVision(private val sight: Int) : VisionRadius {
+        override fun radiusFor(agent: Agent, currentNode: NodeId): Int = sight
     }
 
     private object StubItems : ItemLookup {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
@@ -8,7 +8,6 @@ import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
-import dev.gvart.genesara.player.ClassPropertiesLookup
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Climate
 import dev.gvart.genesara.world.Node
@@ -17,6 +16,7 @@ import dev.gvart.genesara.world.Region
 import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.Terrain
 import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.VisionRadius
 import dev.gvart.genesara.world.WorldId
 import dev.gvart.genesara.world.WorldQueryGateway
 import org.junit.jupiter.api.AfterEach
@@ -87,7 +87,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
 
         val response = tool.invoke(LookAroundRequest(), toolContext)
 
@@ -108,7 +108,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
 
         val response = tool.invoke(LookAroundRequest(), toolContext)
 
@@ -128,7 +128,7 @@ class LookAroundToolTest {
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
         val memory = RecordingMapMemory()
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(7L), memory, NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(7L), memory, NoBuildings)
 
         tool.invoke(LookAroundRequest(), toolContext)
 
@@ -157,7 +157,7 @@ class LookAroundToolTest {
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
         val flaky = ThrowingMapMemory()
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), flaky, NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), flaky, NoBuildings)
 
         // Should NOT throw — the read still returns successfully.
         val response = tool.invoke(LookAroundRequest(), toolContext)
@@ -172,7 +172,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
 
         val response = tool.invoke(LookAroundRequest(), toolContext)
 
@@ -189,7 +189,7 @@ class LookAroundToolTest {
         )
         val campfire = activeBuilding(currentNodeId, dev.gvart.genesara.world.BuildingType.CAMPFIRE)
         val buildings = StubBuildingsLookup(byNode = mapOf(currentNodeId to listOf(campfire)))
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), buildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), buildings)
 
         val response = tool.invoke(LookAroundRequest(), toolContext)
 
@@ -213,7 +213,7 @@ class LookAroundToolTest {
         )
         val workbench = activeBuilding(northNodeId, dev.gvart.genesara.world.BuildingType.WORKBENCH)
         val buildings = StubBuildingsLookup(byNode = mapOf(northNodeId to listOf(workbench)))
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), buildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), buildings)
 
         val response = tool.invoke(LookAroundRequest(), toolContext)
 
@@ -238,7 +238,7 @@ class LookAroundToolTest {
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
         val recordingBuildings = RecordingBuildingsLookup()
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), recordingBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), recordingBuildings)
 
         tool.invoke(LookAroundRequest(), toolContext)
 
@@ -309,7 +309,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to unpainted),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
 
         val response = tool.invoke(LookAroundRequest(), toolContext)
 
@@ -325,7 +325,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = emptyMap(),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
 
         assertThrows<IllegalStateException> {
             tool.invoke(LookAroundRequest(), toolContext)
@@ -340,7 +340,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId)),
         )
-        val tool = LookAroundTool(world, EmptyRegistry, classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, EmptyRegistry, vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
 
         assertThrows<IllegalStateException> {
             tool.invoke(LookAroundRequest(), toolContext)
@@ -355,7 +355,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), classes(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
 
         tool.invoke(LookAroundRequest(), toolContext)
 
@@ -367,8 +367,8 @@ class LookAroundToolTest {
         override fun listForOwner(owner: PlayerId): List<Agent> = listOf(agent).filter { it.owner == owner }
     }
 
-    private fun classes(sight: Int) = object : ClassPropertiesLookup {
-        override fun sightRange(classId: AgentClass?): Int = sight
+    private fun vision(sight: Int) = object : VisionRadius {
+        override fun radiusFor(agent: Agent, currentNode: NodeId): Int = sight
     }
 
     private object EmptyRegistry : AgentRegistry {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeControllerTest.kt
@@ -6,7 +6,6 @@ import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
-import dev.gvart.genesara.player.ClassPropertiesLookup
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Climate
 import dev.gvart.genesara.world.Node
@@ -15,6 +14,7 @@ import dev.gvart.genesara.world.Region
 import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.Terrain
 import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.VisionRadius
 import dev.gvart.genesara.world.WorldCommandGateway
 import dev.gvart.genesara.world.WorldId
 import dev.gvart.genesara.world.WorldQueryGateway
@@ -107,7 +107,7 @@ class AgentRuntimeControllerTest {
             query = StubQuery(location = currentNodeId, nodes = mapOf(currentNodeId to current), regions = mapOf(regionId to region)),
             tick = tickClock,
             agents = EmptyRegistry,
-            classes = constantSight(1),
+            vision = constantSight(1),
         )
 
         val response = controller.lookAround(agent)
@@ -140,11 +140,11 @@ class AgentRuntimeControllerTest {
         query = query,
         tick = tickClock,
         agents = SingleAgentRegistry(agent),
-        classes = constantSight(1),
+        vision = constantSight(1),
     )
 
-    private fun constantSight(sight: Int) = object : ClassPropertiesLookup {
-        override fun sightRange(classId: AgentClass?): Int = sight
+    private fun constantSight(sight: Int) = object : VisionRadius {
+        override fun radiusFor(agent: Agent, currentNode: NodeId): Int = sight
     }
 
     private class SingleAgentRegistry(private val agent: Agent) : AgentRegistry {

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentSkillsRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentSkillsRegistry.kt
@@ -36,6 +36,16 @@ interface AgentSkillsRegistry {
     fun snapshot(agent: AgentId): AgentSkillsSnapshot
 
     /**
+     * Single-row read for hot paths that only care about one slotted skill's level
+     * (e.g. the sight-radius helper). Returns 0 when [skill] is not in any of the
+     * agent's slots, regardless of recommendation/XP state. The default implementation
+     * delegates to [snapshot] and is correct but pays the multi-query snapshot cost;
+     * production wiring overrides with a single indexed query.
+     */
+    fun slottedSkillLevel(agent: AgentId, skill: SkillId): Int =
+        snapshot(agent).perSkill[skill]?.takeIf { it.slotIndex != null }?.level ?: 0
+
+    /**
      * Add [delta] XP to the (agent, skill) pair **only if** [skill] is currently
      * in one of the agent's slots. The result discriminates between "skill not
      * slotted, nothing accrued" and "XP accrued, here are the crossed milestone

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentSkillsRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentSkillsRegistry.kt
@@ -61,6 +61,20 @@ internal class JooqAgentSkillsRegistry(
         )
     }
 
+    @Transactional(readOnly = true)
+    override fun slottedSkillLevel(agent: AgentId, skill: SkillId): Int {
+        val xp = dsl.select(AGENT_SKILLS.XP)
+            .from(AGENT_SKILL_SLOTS)
+            .leftJoin(AGENT_SKILLS).on(
+                AGENT_SKILLS.AGENT_ID.eq(AGENT_SKILL_SLOTS.AGENT_ID)
+                    .and(AGENT_SKILLS.SKILL_ID.eq(AGENT_SKILL_SLOTS.SKILL_ID)),
+            )
+            .where(AGENT_SKILL_SLOTS.AGENT_ID.eq(agent.id))
+            .and(AGENT_SKILL_SLOTS.SKILL_ID.eq(skill.value))
+            .fetchOne(AGENT_SKILLS.XP) ?: return 0
+        return levelFromXp(xp)
+    }
+
     private fun readXpBySkill(agent: AgentId): Map<String, Int> =
         dsl.select(AGENT_SKILLS.SKILL_ID, AGENT_SKILLS.XP)
             .from(AGENT_SKILLS)

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentSkillsRegistryIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentSkillsRegistryIntegrationTest.kt
@@ -288,6 +288,28 @@ class JooqAgentSkillsRegistryIntegrationTest {
         assertEquals(0, snap.slotsFilled)
     }
 
+    @Test
+    fun `slottedSkillLevel returns 0 for a skill that is not slotted`() {
+        assertEquals(0, registry.slottedSkillLevel(agent, foraging))
+    }
+
+    @Test
+    fun `slottedSkillLevel returns 0 when the skill is slotted but has no XP yet`() {
+        recommend(foraging)
+        assertNull(registry.setSlot(agent, foraging, slotIndex = 0))
+
+        assertEquals(0, registry.slottedSkillLevel(agent, foraging))
+    }
+
+    @Test
+    fun `slottedSkillLevel reflects accrued XP via the floor formula`() {
+        recommend(foraging)
+        assertNull(registry.setSlot(agent, foraging, slotIndex = 0))
+        assertIs<AddXpResult.Accrued>(registry.addXpIfSlotted(agent, foraging, delta = 75))
+
+        assertEquals(7, registry.slottedSkillLevel(agent, foraging))
+    }
+
     private fun createAgent(level: Int): AgentId {
         val id = AgentId(UUID.randomUUID())
         dsl.insertInto(AGENTS)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/VisionRadius.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/VisionRadius.kt
@@ -1,0 +1,8 @@
+package dev.gvart.genesara.world
+
+import dev.gvart.genesara.player.Agent
+
+/** Per-agent sight radius in node hops; canonical formula in `docs/lore/mechanics-reference.md` §14. */
+interface VisionRadius {
+    fun radiusFor(agent: Agent, currentNode: NodeId): Int
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImpl.kt
@@ -1,0 +1,31 @@
+package dev.gvart.genesara.world.internal.vision
+
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.ClassPropertiesLookup
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.VisionRadius
+import dev.gvart.genesara.world.WorldQueryGateway
+import org.springframework.stereotype.Component
+
+@Component
+internal class VisionRadiusImpl(
+    private val classes: ClassPropertiesLookup,
+    private val skills: AgentSkillsRegistry,
+    private val world: WorldQueryGateway,
+) : VisionRadius {
+
+    override fun radiusFor(agent: Agent, currentNode: NodeId): Int {
+        val base = classes.sightRange(agent.classId)
+        val survivalBonus = skills.slottedSkillLevel(agent.id, SURVIVAL) / SURVIVAL_LEVELS_PER_RING
+        val terrainBonus = if (world.node(currentNode)?.terrain == Terrain.MOUNTAIN) 1 else 0
+        return base + survivalBonus + terrainBonus
+    }
+
+    private companion object {
+        val SURVIVAL = SkillId("SURVIVAL")
+        const val SURVIVAL_LEVELS_PER_RING = 50
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImplTest.kt
@@ -1,0 +1,135 @@
+package dev.gvart.genesara.world.internal.vision
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.ClassPropertiesLookup
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.world.BodyView
+import dev.gvart.genesara.world.InventoryView
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NodeResources
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.WorldQueryGateway
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class VisionRadiusImplTest {
+
+    private val agent = Agent(
+        id = AgentId(UUID.randomUUID()),
+        owner = PlayerId(UUID.randomUUID()),
+        name = "scout",
+        classId = AgentClass.SCOUT,
+    )
+    private val plainsNode = NodeId(1L)
+    private val mountainNode = NodeId(2L)
+
+    @Test
+    fun `base sight only when no skill and not on mountain`() {
+        val helper = helper(base = 3, survivalLevel = 0)
+        assertEquals(3, helper.radiusFor(agent, plainsNode))
+    }
+
+    @Test
+    fun `mountain tile adds plus one`() {
+        val helper = helper(base = 3, survivalLevel = 0)
+        assertEquals(4, helper.radiusFor(agent, mountainNode))
+    }
+
+    @Test
+    fun `slotted Survival level 49 grants no bonus`() {
+        val helper = helper(base = 3, survivalLevel = 49)
+        assertEquals(3, helper.radiusFor(agent, plainsNode))
+    }
+
+    @Test
+    fun `slotted Survival level 50 grants plus one`() {
+        val helper = helper(base = 3, survivalLevel = 50)
+        assertEquals(4, helper.radiusFor(agent, plainsNode))
+    }
+
+    @Test
+    fun `slotted Survival level 99 still grants only plus one`() {
+        val helper = helper(base = 3, survivalLevel = 99)
+        assertEquals(4, helper.radiusFor(agent, plainsNode))
+    }
+
+    @Test
+    fun `slotted Survival level 100 grants plus two`() {
+        val helper = helper(base = 3, survivalLevel = 100)
+        assertEquals(5, helper.radiusFor(agent, plainsNode))
+    }
+
+    @Test
+    fun `slotted Survival level 150 grants plus three`() {
+        val helper = helper(base = 3, survivalLevel = 150)
+        assertEquals(6, helper.radiusFor(agent, plainsNode))
+    }
+
+    @Test
+    fun `mountain plus slotted Survival 150 stack additively`() {
+        val helper = helper(base = 3, survivalLevel = 150)
+        assertEquals(7, helper.radiusFor(agent, mountainNode))
+    }
+
+    @Test
+    fun `unknown current node yields no terrain bonus and does not throw`() {
+        val helper = helper(base = 3, survivalLevel = 0)
+        assertEquals(3, helper.radiusFor(agent, NodeId(999L)))
+    }
+
+    @Test
+    fun `only the SURVIVAL slot is consulted — other slotted skills are ignored`() {
+        val skills = StubSkills(levelsBySkill = mapOf(SkillId("SCOUT") to 150))
+        val helper = VisionRadiusImpl(constantBase(3), skills, stubWorld())
+        assertEquals(3, helper.radiusFor(agent, plainsNode))
+    }
+
+    private fun helper(base: Int, survivalLevel: Int): VisionRadiusImpl {
+        val skills = StubSkills(levelsBySkill = mapOf(SkillId("SURVIVAL") to survivalLevel))
+        return VisionRadiusImpl(constantBase(base), skills, stubWorld())
+    }
+
+    private fun constantBase(base: Int) = object : ClassPropertiesLookup {
+        override fun sightRange(classId: AgentClass?): Int = base
+    }
+
+    private fun stubWorld() = StubWorld(
+        nodes = mapOf(
+            plainsNode to Node(plainsNode, RegionId(1L), q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet()),
+            mountainNode to Node(mountainNode, RegionId(1L), q = 1, r = 0, terrain = Terrain.MOUNTAIN, adjacency = emptySet()),
+        ),
+    )
+
+    private class StubSkills(private val levelsBySkill: Map<SkillId, Int>) : AgentSkillsRegistry {
+        override fun snapshot(agent: AgentId): AgentSkillsSnapshot =
+            AgentSkillsSnapshot(perSkill = emptyMap(), slotCount = 8, slotsFilled = 0)
+        override fun slottedSkillLevel(agent: AgentId, skill: SkillId): Int = levelsBySkill[skill] ?: 0
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int): AddXpResult = AddXpResult.Unslotted
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? = null
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? = null
+    }
+
+    private class StubWorld(private val nodes: Map<NodeId, Node>) : WorldQueryGateway {
+        override fun locationOf(agent: AgentId): NodeId? = null
+        override fun activePositionOf(agent: AgentId): NodeId? = null
+        override fun node(id: NodeId): Node? = nodes[id]
+        override fun region(id: RegionId): Region? = null
+        override fun nodesWithin(origin: NodeId, radius: Int): Set<NodeId> = emptySet()
+        override fun randomSpawnableNode(): NodeId? = null
+        override fun starterNodeFor(race: dev.gvart.genesara.player.RaceId): NodeId? = null
+        override fun bodyOf(agent: AgentId): BodyView? = null
+        override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
+        override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
+    }
+}


### PR DESCRIPTION
Closes #10 (vision *radius* AC). Walls / LOS elevation AC split into #55.

## Summary
- New `VisionRadius` interface + `VisionRadiusImpl` in `:world` composes `classBaseSight + floor(slottedSurvivalLevel/50) + (+1 if mountain)` — canonical formula per `docs/lore/mechanics-reference.md` §14.
- `LookAroundTool`, `InspectTool`, `AgentRuntimeController` swap from `ClassPropertiesLookup` to `VisionRadius` so future addends (watchtowers, Scan ability) extend in one place.
- New `AgentSkillsRegistry.slottedSkillLevel(agent, skill): Int` — single-row indexed read replacing a 4-query `snapshot()` on the read hot path. Default impl falls back to `snapshot()`; jOOQ override does the optimized join.

## Test plan
- [x] `:world:test` — new `VisionRadiusImplTest` (10 cases covering 0/49/50/99/100/150 boundary, unslotted-ignored, mountain stack, unknown node, Survival-only filter).
- [x] `:player:test` — 3 new integration tests on `JooqAgentSkillsRegistry.slottedSkillLevel` (unslotted → 0, slotted with no XP → 0, slotted XP=75 → level 7).
- [x] `:api:test` — existing `LookAround` / `Inspect` / `AgentRuntimeController` tests pass after the dep swap (stub renames only, no behavioral change).
- [x] `:app:test` — Spring wiring resolves the new `VisionRadius` bean.
- [x] `./gradlew test` — full suite green.

## Out of scope (tracked elsewhere)
- Walls / line-of-sight occlusion — #55 (Phase 1 follow-up).
- Watchtower vision contribution — #19 (Phase 2).
- Researcher Scan ability — #36 (Phase 4).
- Cartography map snapshot trading — #37 (Phase 4).