### PR TITLE
feat(world,api): kill-streak item drop on death + ground items + pickup tool

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
@@ -19,6 +19,7 @@ import dev.gvart.genesara.api.internal.mcp.tools.inspect.InspectTool
 import dev.gvart.genesara.api.internal.mcp.tools.inventory.GetInventoryTool
 import dev.gvart.genesara.api.internal.mcp.tools.lookaround.LookAroundTool
 import dev.gvart.genesara.api.internal.mcp.tools.move.MoveTool
+import dev.gvart.genesara.api.internal.mcp.tools.pickup.PickupTool
 import dev.gvart.genesara.api.internal.mcp.tools.respawn.RespawnTool
 import dev.gvart.genesara.api.internal.mcp.tools.safenode.SetSafeNodeTool
 import dev.gvart.genesara.api.internal.mcp.tools.skills.EquipSkillTool
@@ -60,13 +61,14 @@ internal class McpServerConfiguration {
         depositToChest: DepositToChestTool,
         withdrawFromChest: WithdrawFromChestTool,
         craft: CraftTool,
+        pickup: PickupTool,
     ): ToolCallbackProvider =
         MethodToolCallbackProvider.builder()
             .toolObjects(
                 spawn, move, lookAround, unspawn, getStatus, harvest, getInventory,
                 consume, drink, getSkills, equipSkill, allocatePoints, inspect, getMap,
                 equipItem, unequipSlot, getEquipment,
-                setSafeNode, respawn, build, depositToChest, withdrawFromChest, craft,
+                setSafeNode, respawn, build, depositToChest, withdrawFromChest, craft, pickup,
             )
             .build()
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
@@ -10,6 +10,7 @@ import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.world.AgentMapMemoryGateway
 import dev.gvart.genesara.world.Building
 import dev.gvart.genesara.world.BuildingsLookup
+import dev.gvart.genesara.world.DroppedItemView
 import dev.gvart.genesara.world.Node
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.NodeMemoryUpdate
@@ -17,6 +18,7 @@ import dev.gvart.genesara.world.NodeResources
 import dev.gvart.genesara.world.Region
 import dev.gvart.genesara.world.VisionRadius
 import dev.gvart.genesara.world.WorldQueryGateway
+import dev.gvart.genesara.world.GroundItemView as DomainGroundItemView
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.annotation.Tool
@@ -54,6 +56,7 @@ internal class LookAroundTool(
 
         val currentTick = tick.currentTick()
         val currentResources = world.resourcesAt(current.id, currentTick)
+        val currentGroundItems = world.groundItemsAt(current.id)
         val adjacent = adjacentVisibleNodes(nodeId, sight, currentTick)
 
         // Single round-trip for every visible node's buildings — never call `byNode` in a loop.
@@ -71,6 +74,7 @@ internal class LookAroundTool(
                     initialQuantity = it.initialQuantity,
                 )
             },
+            groundItems = currentGroundItems.map { it.toView() },
             adjacent = adjacent.map { (n, r, res) ->
                 n.toView(r, res, buildingsByNode[n.id].orEmpty(), fogOfWar = true)
             },
@@ -137,6 +141,27 @@ private fun Node.toView(
         .sortedBy { it.instanceId }
         .map { it.toSummary(fogOfWar) },
 )
+
+private fun DomainGroundItemView.toView(): GroundItemView = when (val payload = drop) {
+    is DroppedItemView.Stackable -> GroundItemView(
+        dropId = payload.dropId.toString(),
+        itemId = payload.item.value,
+        droppedAtTick = droppedAtTick,
+        kind = "STACKABLE",
+        quantity = payload.quantity,
+    )
+    is DroppedItemView.Equipment -> GroundItemView(
+        dropId = payload.dropId.toString(),
+        itemId = payload.item.value,
+        droppedAtTick = droppedAtTick,
+        kind = "EQUIPMENT",
+        rarity = payload.rarity.name,
+        durabilityCurrent = payload.durabilityCurrent,
+        durabilityMax = payload.durabilityMax,
+        creatorAgentId = payload.creatorAgentId?.toString(),
+        createdAtTick = payload.createdAtTick,
+    )
+}
 
 private fun Building.toSummary(fogOfWar: Boolean): BuildingSummaryView =
     if (fogOfWar) {

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
@@ -147,15 +147,15 @@ private fun DomainGroundItemView.toView(): GroundItemView = when (val payload = 
         dropId = payload.dropId.toString(),
         itemId = payload.item.value,
         droppedAtTick = droppedAtTick,
-        kind = "STACKABLE",
+        kind = GroundItemKind.STACKABLE,
         quantity = payload.quantity,
     )
     is DroppedItemView.Equipment -> GroundItemView(
         dropId = payload.dropId.toString(),
         itemId = payload.item.value,
         droppedAtTick = droppedAtTick,
-        kind = "EQUIPMENT",
-        rarity = payload.rarity.name,
+        kind = GroundItemKind.EQUIPMENT,
+        rarity = payload.rarity,
         durabilityCurrent = payload.durabilityCurrent,
         durabilityMax = payload.durabilityMax,
         creatorAgentId = payload.creatorAgentId?.toString(),

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolIo.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.lookaround
 
 import com.fasterxml.jackson.annotation.JsonClassDescription
+import dev.gvart.genesara.world.Rarity
 
 @JsonClassDescription("Return the agent's current node and the visible adjacent nodes within its sight range. The current node also includes per-resource quantities; adjacent nodes show only resource ids (no counts) as a fog-of-war approximation.")
 class LookAroundRequest
@@ -58,14 +59,16 @@ data class GroundItemView(
     val dropId: String,
     val itemId: String,
     val droppedAtTick: Long,
-    val kind: String,
+    val kind: GroundItemKind,
     val quantity: Int? = null,
-    val rarity: String? = null,
+    val rarity: Rarity? = null,
     val durabilityCurrent: Int? = null,
     val durabilityMax: Int? = null,
     val creatorAgentId: String? = null,
     val createdAtTick: Long? = null,
 )
+
+enum class GroundItemKind { STACKABLE, EQUIPMENT }
 
 /**
  * Per-building summary returned by `look_around`. On the agent's current node every field is

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolIo.kt
@@ -8,6 +8,13 @@ class LookAroundRequest
 data class LookAroundResponse(
     val currentNode: NodeView,
     val currentResources: List<ResourceView>,
+    /**
+     * Drops sitting on the agent's current tile, ready to be picked up via the
+     * `pickup` MCP tool. Empty when nothing has been dropped here. Adjacent
+     * nodes intentionally do not surface ground items (fog-of-war parity with
+     * adjacent resources).
+     */
+    val groundItems: List<GroundItemView> = emptyList(),
     val adjacent: List<NodeView>,
 )
 
@@ -38,6 +45,26 @@ data class ResourceView(
     val itemId: String,
     val quantity: Int,
     val initialQuantity: Int,
+)
+
+/**
+ * One ground item visible at the agent's current node. [dropId] is the handle
+ * the agent passes to the `pickup` MCP tool. [kind] discriminates between
+ * stackable and equipment payloads — stackable rows populate [quantity];
+ * equipment rows populate [rarity], [durabilityCurrent], [durabilityMax],
+ * [creatorAgentId], and [createdAtTick].
+ */
+data class GroundItemView(
+    val dropId: String,
+    val itemId: String,
+    val droppedAtTick: Long,
+    val kind: String,
+    val quantity: Int? = null,
+    val rarity: String? = null,
+    val durabilityCurrent: Int? = null,
+    val durabilityMax: Int? = null,
+    val creatorAgentId: String? = null,
+    val createdAtTick: Long? = null,
 )
 
 /**

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/pickup/PickupTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/pickup/PickupTool.kt
@@ -1,0 +1,37 @@
+package dev.gvart.genesara.api.internal.mcp.tools.pickup
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+internal class PickupTool(
+    private val world: WorldCommandGateway,
+    private val engine: TickClock,
+    private val activity: AgentActivityTracker,
+) {
+
+    @Tool(
+        name = "pickup",
+        description = "Take a ground item off the agent's current node. The dropId comes from the " +
+            "ground items list returned by `look_around`. Atomic with concurrent pickups — the first " +
+            "agent on the same tick wins; later callers receive a GroundItemNoLongerAvailable rejection. " +
+            "Stackable drops land in inventory; equipment drops land in the equipment store unequipped " +
+            "(call `equip` separately to slot them).",
+    )
+    fun invoke(req: PickupRequest, toolContext: ToolContext): PickupResponse {
+        touchActivity(toolContext, activity, "pickup")
+        val agent = AgentContextHolder.current()
+        val command = WorldCommand.Pickup(agent = agent, dropId = UUID.fromString(req.dropId))
+        val nextTick = engine.currentTick() + 1
+        world.submit(command, appliesAtTick = nextTick)
+        return PickupResponse.queued(command.commandId, nextTick, req.dropId)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/pickup/PickupToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/pickup/PickupToolIo.kt
@@ -1,0 +1,34 @@
+package dev.gvart.genesara.api.internal.mcp.tools.pickup
+
+import com.fasterxml.jackson.annotation.JsonClassDescription
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import java.util.UUID
+
+@JsonClassDescription(
+    "Take a ground item off the agent's current node. The dropId comes from the ground " +
+        "items list in the `look_around` response. The agent must be standing on the node " +
+        "where the drop sits. Concurrent pickups on the same tick are atomic — only the first " +
+        "caller wins; the second receives a GroundItemNoLongerAvailable rejection.",
+)
+data class PickupRequest(
+    @JsonPropertyDescription("Drop id (UUID) from look_around's groundItems entry.")
+    val dropId: String,
+)
+
+/**
+ * Response shape for `pickup`.
+ *
+ * - `kind = "queued"`: a Pickup command was queued; the result lands on `appliesAtTick`
+ *   and shows up via the agent's event stream as an `item.picked-up` notification.
+ */
+data class PickupResponse(
+    val kind: String,
+    val dropId: String,
+    val commandId: UUID? = null,
+    val appliesAtTick: Long? = null,
+) {
+    companion object {
+        fun queued(commandId: UUID, appliesAtTick: Long, dropId: String) =
+            PickupResponse("queued", dropId, commandId, appliesAtTick)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/pickup/PickupToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/pickup/PickupToolIo.kt
@@ -18,17 +18,19 @@ data class PickupRequest(
 /**
  * Response shape for `pickup`.
  *
- * - `kind = "queued"`: a Pickup command was queued; the result lands on `appliesAtTick`
+ * - `kind = QUEUED`: a Pickup command was queued; the result lands on `appliesAtTick`
  *   and shows up via the agent's event stream as an `item.picked-up` notification.
  */
 data class PickupResponse(
-    val kind: String,
+    val kind: PickupResponseKind,
     val dropId: String,
     val commandId: UUID? = null,
     val appliesAtTick: Long? = null,
 ) {
     companion object {
         fun queued(commandId: UUID, appliesAtTick: Long, dropId: String) =
-            PickupResponse("queued", dropId, commandId, appliesAtTick)
+            PickupResponse(PickupResponseKind.QUEUED, dropId, commandId, appliesAtTick)
     }
 }
+
+enum class PickupResponseKind { QUEUED }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/presence/PresenceReaperTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/presence/PresenceReaperTest.kt
@@ -90,6 +90,7 @@ class PresenceReaperTest {
             dev.gvart.genesara.world.InventoryView(emptyList())
         override fun resourcesAt(nodeId: NodeId, tick: Long): dev.gvart.genesara.world.NodeResources =
             dev.gvart.genesara.world.NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
     }
 
     private class StubTickClock(private val currentTick: Long) : TickClock {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolTest.kt
@@ -165,6 +165,7 @@ class GetStatusToolTest {
             dev.gvart.genesara.world.InventoryView(emptyList())
         override fun resourcesAt(nodeId: NodeId, tick: Long): dev.gvart.genesara.world.NodeResources =
             dev.gvart.genesara.world.NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
     }
 
     private class StubTickClock(private val currentTick: Long) : TickClock {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
@@ -291,6 +291,7 @@ class InspectBuildingTest {
         override fun bodyOf(agent: AgentId): BodyView? = null
         override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
     }
 
     private class StubBuildings(private val rows: List<Building>) : BuildingsLookup {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
@@ -452,6 +452,7 @@ class InspectToolTest {
         override fun bodyOf(agent: AgentId): BodyView? = if (agent == otherAgentId) body else null
         override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(inventory)
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
     }
 
     private class MutableTestClock(private var now: Instant) : Clock() {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inventory/GetInventoryToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inventory/GetInventoryToolTest.kt
@@ -130,6 +130,7 @@ class GetInventoryToolTest {
         override fun inventoryOf(agent: AgentId): InventoryView = inventory
         override fun resourcesAt(nodeId: NodeId, tick: Long): dev.gvart.genesara.world.NodeResources =
             dev.gvart.genesara.world.NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
     }
 
     private class MutableTestClock(private var now: Instant) : Clock() {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
@@ -395,6 +395,7 @@ class LookAroundToolTest {
             dev.gvart.genesara.world.InventoryView(emptyList())
         override fun resourcesAt(nodeId: NodeId, tick: Long): dev.gvart.genesara.world.NodeResources =
             dev.gvart.genesara.world.NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
     }
 
     private class MutableTestClock(private var now: Instant) : Clock() {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/AgentManagementControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/AgentManagementControllerTest.kt
@@ -160,6 +160,7 @@ class AgentManagementControllerTest {
         override fun starterNodeFor(race: RaceId): NodeId? = null
         override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
     }
 
     private class StubActivity(private val rows: Map<AgentId, Instant>) : AgentActivityTracker {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeControllerTest.kt
@@ -186,5 +186,6 @@ class AgentRuntimeControllerTest {
             dev.gvart.genesara.world.InventoryView(emptyList())
         override fun resourcesAt(nodeId: NodeId, tick: Long): dev.gvart.genesara.world.NodeResources =
             dev.gvart.genesara.world.NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
     }
 }

--- a/world/build.gradle.kts
+++ b/world/build.gradle.kts
@@ -23,5 +23,5 @@ dependencies {
 
 jooqModule {
     migrationsSubdir.set("world")
-    tableIncludes.set("worlds|regions|region_neighbors|nodes|node_adjacency|agent_positions|agent_bodies|starter_nodes|agent_inventory|non_renewable_resources|agent_node_memory|agent_equipment_instances|agent_safe_nodes|node_buildings|building_chest_inventory")
+    tableIncludes.set("worlds|regions|region_neighbors|nodes|node_adjacency|agent_positions|agent_bodies|starter_nodes|agent_inventory|non_renewable_resources|agent_node_memory|agent_equipment_instances|agent_safe_nodes|node_buildings|building_chest_inventory|agent_kill_streaks")
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/AgentKillStreak.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/AgentKillStreak.kt
@@ -1,0 +1,31 @@
+package dev.gvart.genesara.world
+
+/**
+ * Per-agent rolling kill counter that drives the death-sweep drop chance.
+ * Persisted in `agent_kill_streaks`; loaded into `WorldState.killStreaks`.
+ *
+ * Window semantics: a kill at tick `t` is "in the window" when
+ * `t - windowStartTick < windowTicks`. The combat reducer (Phase 2) calls
+ * [WorldState.incrementKillStreak] which encapsulates the reset rule so
+ * callers do not branch on the window themselves.
+ */
+data class AgentKillStreak(
+    val killCount: Int,
+    val windowStartTick: Long,
+) {
+    init {
+        require(killCount >= 0) { "killCount ($killCount) must be non-negative" }
+    }
+
+    /**
+     * The kill count the death sweep should treat as live at [currentTick].
+     * Returns 0 when the window has expired so the drop-chance formula sees
+     * a fresh streak rather than stale credit.
+     */
+    fun effectiveKillCount(currentTick: Long, windowTicks: Long): Int =
+        if (currentTick - windowStartTick < windowTicks) killCount else 0
+
+    companion object {
+        val EMPTY: AgentKillStreak = AgentKillStreak(killCount = 0, windowStartTick = 0L)
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/DroppedItemView.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/DroppedItemView.kt
@@ -1,0 +1,52 @@
+package dev.gvart.genesara.world
+
+import java.util.UUID
+
+/**
+ * What the death sweep dropped on a given death. Carried inline on the
+ * resulting `WorldEvent.AgentDied` so the dying agent learns what they lost
+ * without a follow-up read, and on `WorldEvent.ItemDroppedOnGround` so other
+ * agents can pick it up via the `pickup` MCP tool.
+ *
+ * Pickup uses [dropId] as the handle — also the field name in the Redis
+ * Hash backing the [GroundItemStore].
+ */
+sealed interface DroppedItemView {
+    val dropId: UUID
+    val item: ItemId
+
+    /** A unit dropped from the agent's stackable inventory. */
+    data class Stackable(
+        override val dropId: UUID,
+        override val item: ItemId,
+        val quantity: Int,
+    ) : DroppedItemView {
+        init {
+            require(quantity > 0) { "quantity ($quantity) must be positive" }
+        }
+    }
+
+    /**
+     * An equipment instance that was equipped at the moment of death and is
+     * now on the ground. The original [instanceId] is preserved so pickup
+     * can re-INSERT the row under the new owner without losing the rarity /
+     * durability / signature.
+     */
+    data class Equipment(
+        override val dropId: UUID,
+        override val item: ItemId,
+        val instanceId: UUID,
+        val rarity: Rarity,
+        val durabilityCurrent: Int,
+        val durabilityMax: Int,
+        val creatorAgentId: UUID?,
+        val createdAtTick: Long,
+    ) : DroppedItemView {
+        init {
+            require(durabilityMax > 0) { "durabilityMax ($durabilityMax) must be positive" }
+            require(durabilityCurrent in 0..durabilityMax) {
+                "durabilityCurrent ($durabilityCurrent) must be in 0..durabilityMax ($durabilityMax)"
+            }
+        }
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/GroundItemStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/GroundItemStore.kt
@@ -1,0 +1,31 @@
+package dev.gvart.genesara.world
+
+import java.util.UUID
+
+/**
+ * Per-node ground-item storage. The death sweep deposits drops here; the
+ * `pickup` reducer takes them. Concurrent pickup is resolved by [take]
+ * being atomic — only the first caller for a given `(node, dropId)` wins.
+ *
+ * Redis-only and intentionally ephemeral — a Redis flush or container restart
+ * vanishes every in-flight drop, which is acceptable for v1.
+ */
+interface GroundItemStore {
+
+    /**
+     * Persist [drop] at [node], dropped on tick [droppedAtTick]. Idempotent on
+     * `drop.dropId`: re-depositing the same drop id is a logic error and the
+     * store throws. The death sweep generates a fresh UUID per drop.
+     */
+    fun deposit(node: NodeId, drop: DroppedItemView, droppedAtTick: Long)
+
+    /** Snapshot of every drop currently sitting at [node]. Empty if nothing dropped. */
+    fun atNode(node: NodeId): List<GroundItemView>
+
+    /**
+     * Atomic take. Returns the drop and removes it from both Redis and Postgres.
+     * Returns null when no drop with [dropId] exists at [node] — covers both
+     * "wrong node" and "already taken by another agent on the same tick".
+     */
+    fun take(node: NodeId, dropId: UUID): GroundItemView?
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/GroundItemView.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/GroundItemView.kt
@@ -1,0 +1,12 @@
+package dev.gvart.genesara.world
+
+/**
+ * A drop currently sitting on the ground at [nodeId], waiting to be picked up.
+ * Returned by `WorldQueryGateway.groundItemsAt` and surfaced through the
+ * `look_around` MCP tool. The handle agents use to pick it up is `drop.dropId`.
+ */
+data class GroundItemView(
+    val nodeId: NodeId,
+    val droppedAtTick: Long,
+    val drop: DroppedItemView,
+)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldQueryGateway.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldQueryGateway.kt
@@ -58,4 +58,11 @@ interface WorldQueryGateway {
      * reducer path, not this gateway.
      */
     fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources
+
+    /**
+     * Drops currently sitting at [nodeId]. Empty when nothing has been dropped or
+     * everything has been picked up. The `pickup` MCP tool calls
+     * [GroundItemStore.take] via the reducer path; this gateway is read-only.
+     */
+    fun groundItemsAt(nodeId: NodeId): List<GroundItemView>
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
@@ -210,4 +210,20 @@ sealed interface WorldRejection {
         val incoming: Int,
         val maxStack: Int,
     ) : WorldRejection
+
+    /**
+     * Pickup target dropId is not at the agent's node. Two underlying causes
+     * collapse to this single rejection:
+     *
+     *  - The dropId never existed on this node (agent submitted a stale id).
+     *  - Another agent on the same tick raced to the same drop and won the
+     *    atomic [GroundItemStore.take]; the second caller sees null.
+     *
+     * The agent's strategic response is the same in both cases: re-read the
+     * node via `look_around` and pick a different drop.
+     */
+    data class GroundItemNoLongerAvailable(
+        val agent: AgentId,
+        val dropId: java.util.UUID,
+    ) : WorldRejection
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.world
 
 import dev.gvart.genesara.player.AgentId
+import java.util.UUID
 
 sealed interface WorldRejection {
     data class UnknownAgent(val agent: AgentId) : WorldRejection
@@ -224,6 +225,6 @@ sealed interface WorldRejection {
      */
     data class GroundItemNoLongerAvailable(
         val agent: AgentId,
-        val dropId: java.util.UUID,
+        val dropId: UUID,
     ) : WorldRejection
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
@@ -119,4 +119,18 @@ sealed interface WorldCommand {
         val recipe: RecipeId,
         override val commandId: UUID = UUID.randomUUID(),
     ) : WorldCommand
+
+    /**
+     * Take a ground item identified by [dropId] off the agent's current node.
+     * Atomic with concurrent pickups — only the first agent on the same tick
+     * succeeds; subsequent ones get [WorldRejection.GroundItemNoLongerAvailable].
+     * Stackable drops land in the agent's inventory; equipment drops land in
+     * the equipment store unequipped (slot null) — the agent must call `equip`
+     * separately to slot them.
+     */
+    data class Pickup(
+        override val agent: AgentId,
+        val dropId: UUID,
+        override val commandId: UUID = UUID.randomUUID(),
+    ) : WorldCommand
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.world.events
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.world.BodyDelta
 import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.DroppedItemView
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.NodeId
@@ -104,6 +105,14 @@ sealed interface WorldEvent {
         val attributePointLost: String?,
         override val tick: Long,
         val causedBy: UUID?,
+        /**
+         * Set when the kill-streak drop-chance roll fired and the dying agent
+         * had something to drop. Null when no drop happened (no streak, the
+         * roll failed, or the pool was empty). The same drop shows up at the
+         * death node on a paired [ItemDroppedOnGround] so other agents can
+         * see and pick it up.
+         */
+        val droppedItem: DroppedItemView? = null,
     ) : WorldEvent
 
     /**
@@ -202,6 +211,33 @@ sealed interface WorldEvent {
         val agent: AgentId,
         val kind: String,
         val rejection: WorldRejection,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : WorldEvent
+
+    /**
+     * Fired alongside [AgentDied] when the kill-streak drop hook produced a
+     * drop. Lets agents who weren't the dying one notice that a new ground
+     * item appeared at their tile — they can call `pickup` with [drop.dropId]
+     * if they're standing there.
+     *
+     * `causedBy` is null for starvation deaths in v1 (the sweep is not a
+     * queued command). Phase 2 combat will populate it with the killing
+     * attack's commandId, mirroring [AgentDied.causedBy].
+     */
+    data class ItemDroppedOnGround(
+        val at: NodeId,
+        val byAgent: AgentId,
+        val drop: DroppedItemView,
+        override val tick: Long,
+        val causedBy: UUID?,
+    ) : WorldEvent
+
+    /** Fired by the pickup reducer when an agent successfully takes a ground item. */
+    data class ItemPickedUp(
+        val agent: AgentId,
+        val at: NodeId,
+        val drop: DroppedItemView,
         override val tick: Long,
         val causedBy: UUID,
     ) : WorldEvent

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -10,6 +10,7 @@ import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.BuildingsStore
 import dev.gvart.genesara.world.ChestContentsStore
 import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.GroundItemStore
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.RecipeLookup
 import dev.gvart.genesara.world.WorldRejection
@@ -29,6 +30,7 @@ import dev.gvart.genesara.world.internal.death.reduceSetSafeNode
 import dev.gvart.genesara.world.internal.drink.reduceDrink
 import dev.gvart.genesara.world.internal.harvest.reduceHarvest
 import dev.gvart.genesara.world.internal.movement.reduceMove
+import dev.gvart.genesara.world.internal.pickup.reducePickup
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.spawn.SpawnLocationResolver
 import dev.gvart.genesara.world.internal.spawn.reduceSpawn
@@ -55,6 +57,7 @@ internal fun reduce(
     rarityRoller: RarityRoller,
     progression: SkillProgression,
     spawnLocationResolver: SpawnLocationResolver,
+    groundItems: GroundItemStore,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = when (command) {
     is WorldCommand.SpawnAgent -> reduceSpawn(state, command, profiles, spawnLocationResolver, tick)
@@ -77,4 +80,6 @@ internal fun reduce(
             state, command, balance, items, recipes, equipment, buildingsLookup,
             skills, agents, rarityRoller, progression, tick,
         )
+    is WorldCommand.Pickup ->
+        reducePickup(state, command, balance, items, agents, equipment, groundItems, tick)
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -105,6 +105,23 @@ internal interface BalanceLookup {
      * the cost. The reducer floors the result at 1 so movement always costs something.
      */
     fun roadStaminaMultiplier(): Double = 1.0
+
+    /**
+     * Length of the kill-streak rolling window in ticks. A kill outside the window
+     * (i.e. `currentTick - windowStartTick >= windowTicks`) starts a fresh streak
+     * via `WorldState.incrementKillStreak`, and the death sweep treats an expired
+     * window as zero kills via `AgentKillStreak.effectiveKillCount`.
+     */
+    fun killStreakWindowTicks(): Long = 1000L
+
+    /**
+     * Probability in `[0.0, 1.0]` that the death sweep drops an item from the
+     * dying agent's pool, given their effective kill count over the streak
+     * window. Default ramps linearly: `0.1` per kill, plateauing at `1.0`
+     * after 10 kills. Production may override via `WorldDefinitionBalanceLookup`.
+     */
+    fun dropChanceForKillCount(killCount: Int): Double =
+        (killCount * 0.1).coerceIn(0.0, 1.0)
 }
 
 @Component

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/death/DeathSweep.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/death/DeathSweep.kt
@@ -4,11 +4,19 @@ import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AttributePointLoss
 import dev.gvart.genesara.player.DeathPenaltyOutcome
+import dev.gvart.genesara.world.AgentKillStreak
+import dev.gvart.genesara.world.DroppedItemView
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.GroundItemStore
+import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import org.slf4j.LoggerFactory
+import java.util.UUID
+import kotlin.random.Random
 
 private val log = LoggerFactory.getLogger("dev.gvart.genesara.world.internal.death.DeathSweep")
 
@@ -18,10 +26,17 @@ private val log = LoggerFactory.getLogger("dev.gvart.genesara.world.internal.dea
  *
  *  1. Applies the canonical death penalty via [AgentRegistry.applyDeathPenalty]
  *     (partial-bar XP loss vs. empty-bar de-level + stat point — the registry decides).
- *  2. Removes the agent from `state.positions` so they're "awaiting respawn". The body
- *     persists at HP=0; the agent must call `respawn` to materialize.
- *  3. Emits [WorldEvent.AgentDied] carrying the penalty summary so the agent learns
- *     what their death cost without a follow-up read.
+ *  2. Rolls the kill-streak drop hook: if the rolling kill counter is non-zero and
+ *     the seeded RNG clears [BalanceLookup.dropChanceForKillCount], one entry from
+ *     the agent's drop pool (stackable inventory + currently-equipped instances) is
+ *     removed and deposited at the death node via [GroundItemStore]. Other agents
+ *     can pick it up later via the `pickup` MCP tool.
+ *  3. Resets the dying agent's kill streak so the bonus does not survive death.
+ *  4. Removes the agent from `state.positions` so they're "awaiting respawn". The
+ *     body persists at HP=0; the agent must call `respawn` to materialize.
+ *  5. Emits [WorldEvent.AgentDied] (penalty summary + optional `droppedItem`) and,
+ *     if a drop fired, a paired [WorldEvent.ItemDroppedOnGround] so other agents
+ *     get a notification independent of the dying agent's own stream.
  *
  * Body restoration happens inside the respawn reducer, not here. The split lets the
  * agent linger at the death state and forces an explicit re-entry rather than auto-
@@ -35,13 +50,18 @@ internal fun processDeaths(
     state: WorldState,
     balance: BalanceLookup,
     agents: AgentRegistry,
+    equipment: EquipmentInstanceStore,
+    groundItems: GroundItemStore,
     tick: Long,
-): Pair<WorldState, List<WorldEvent.AgentDied>> {
+    rng: Random = Random.Default,
+): Pair<WorldState, List<WorldEvent>> {
     val dying = collectDying(state)
     if (dying.isEmpty()) return state to emptyList()
 
     val xpLoss = balance.xpLossOnDeath()
-    val events = mutableListOf<WorldEvent.AgentDied>()
+    val windowTicks = balance.killStreakWindowTicks()
+    val events = mutableListOf<WorldEvent>()
+    var nextState = state
     var nextPositions = state.positions
     for ((agentId, deathNode) in dying) {
         val outcome = agents.applyDeathPenalty(agentId, xpLoss)
@@ -50,11 +70,23 @@ internal fun processDeaths(
             nextPositions = nextPositions - agentId
             continue
         }
+        val (stateAfterDrop, dropped) = rollDrop(nextState, agentId, deathNode, balance, windowTicks, equipment, groundItems, tick, rng)
+        nextState = stateAfterDrop.updateKillStreak(agentId, AgentKillStreak.EMPTY)
         nextPositions = nextPositions - agentId
-        events += buildDeathEvent(agentId, deathNode, outcome, tick)
+        events += buildDeathEvent(agentId, deathNode, outcome, tick, dropped)
+        if (dropped != null) {
+            events += WorldEvent.ItemDroppedOnGround(
+                at = deathNode,
+                byAgent = agentId,
+                drop = dropped,
+                tick = tick,
+                // TODO(combat): propagate killing-attack commandId once Phase 2 lands.
+                causedBy = null,
+            )
+        }
     }
 
-    return state.copy(positions = nextPositions) to events
+    return nextState.copy(positions = nextPositions) to events
 }
 
 /**
@@ -70,11 +102,103 @@ private fun collectDying(state: WorldState): List<Pair<AgentId, NodeId>> =
         }
         .sortedBy { it.first.id }
 
+private fun rollDrop(
+    state: WorldState,
+    agentId: AgentId,
+    deathNode: NodeId,
+    balance: BalanceLookup,
+    windowTicks: Long,
+    equipment: EquipmentInstanceStore,
+    groundItems: GroundItemStore,
+    tick: Long,
+    rng: Random,
+): Pair<WorldState, DroppedItemView?> {
+    val streak = state.killStreakOf(agentId)
+    val effectiveKills = streak.effectiveKillCount(tick, windowTicks)
+    val dropChance = balance.dropChanceForKillCount(effectiveKills)
+    if (dropChance <= 0.0 || rng.nextDouble() >= dropChance) return state to null
+
+    val pool = buildDropPool(state, agentId, equipment)
+    if (pool.isEmpty()) return state to null
+
+    val choice = pool[rng.nextInt(pool.size)]
+    val drop = choice.toDroppedItemView(UUID.randomUUID())
+    // Deposit first: if Redis is unreachable, the HSETNX throws and we bail
+    // before deleting the equipment instance, so a failed deposit never
+    // pre-burns the source. Equipment-instance delete is in-tx; if it throws
+    // after a successful deposit, the tick rolls back any DB changes and the
+    // Redis row is the only remnant — accepted v1 drift (Redis is ephemeral
+    // by design).
+    groundItems.deposit(deathNode, drop, tick)
+    val nextState = applyDropMutation(state, agentId, choice, equipment)
+    return nextState to drop
+}
+
+private fun buildDropPool(
+    state: WorldState,
+    agentId: AgentId,
+    equipment: EquipmentInstanceStore,
+): List<DropPoolEntry> {
+    val entries = mutableListOf<DropPoolEntry>()
+    state.inventoryOf(agentId).stacks.forEach { (item, quantity) ->
+        entries += DropPoolEntry.Stackable(item, quantity)
+    }
+    equipment.equippedFor(agentId).values.forEach { instance ->
+        entries += DropPoolEntry.Equipment(instance)
+    }
+    return entries
+}
+
+/**
+ * Removes the chosen drop from its source. Stackable drops zero out the entire
+ * stack (one pool entry = one stack); equipment drops delete the instance row
+ * since the picker re-INSERTs under the new owner.
+ */
+private fun applyDropMutation(
+    state: WorldState,
+    agentId: AgentId,
+    choice: DropPoolEntry,
+    equipment: EquipmentInstanceStore,
+): WorldState = when (choice) {
+    is DropPoolEntry.Stackable -> {
+        val inv = state.inventoryOf(agentId).remove(choice.item, choice.quantity)
+        state.updateInventory(agentId, inv)
+    }
+    is DropPoolEntry.Equipment -> {
+        equipment.delete(choice.instance.instanceId)
+        state
+    }
+}
+
+private sealed interface DropPoolEntry {
+    fun toDroppedItemView(dropId: UUID): DroppedItemView
+
+    data class Stackable(val item: ItemId, val quantity: Int) : DropPoolEntry {
+        override fun toDroppedItemView(dropId: UUID): DroppedItemView =
+            DroppedItemView.Stackable(dropId = dropId, item = item, quantity = quantity)
+    }
+
+    data class Equipment(val instance: EquipmentInstance) : DropPoolEntry {
+        override fun toDroppedItemView(dropId: UUID): DroppedItemView =
+            DroppedItemView.Equipment(
+                dropId = dropId,
+                item = instance.itemId,
+                instanceId = instance.instanceId,
+                rarity = instance.rarity,
+                durabilityCurrent = instance.durabilityCurrent,
+                durabilityMax = instance.durabilityMax,
+                creatorAgentId = instance.creatorAgentId?.id,
+                createdAtTick = instance.createdAtTick,
+            )
+    }
+}
+
 private fun buildDeathEvent(
     agentId: AgentId,
     deathNode: NodeId,
     outcome: DeathPenaltyOutcome,
     tick: Long,
+    droppedItem: DroppedItemView?,
 ): WorldEvent.AgentDied = WorldEvent.AgentDied(
     agent = agentId,
     at = deathNode,
@@ -89,4 +213,5 @@ private fun buildDeathEvent(
     tick = tick,
     // TODO(combat): route the killing-attack's commandId once Phase 2 lands.
     causedBy = null,
+    droppedItem = droppedItem,
 )

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/death/DeathSweep.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/death/DeathSweep.kt
@@ -123,12 +123,6 @@ private fun rollDrop(
 
     val choice = pool[rng.nextInt(pool.size)]
     val drop = choice.toDroppedItemView(UUID.randomUUID())
-    // Deposit first: if Redis is unreachable, the HSETNX throws and we bail
-    // before deleting the equipment instance, so a failed deposit never
-    // pre-burns the source. Equipment-instance delete is in-tx; if it throws
-    // after a successful deposit, the tick rolls back any DB changes and the
-    // Redis row is the only remnant — accepted v1 drift (Redis is ephemeral
-    // by design).
     groundItems.deposit(deathNode, drop, tick)
     val nextState = applyDropMutation(state, agentId, choice, equipment)
     return nextState to drop

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/grounditems/RedisGroundItemStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/grounditems/RedisGroundItemStore.kt
@@ -1,0 +1,148 @@
+package dev.gvart.genesara.world.internal.grounditems
+
+import dev.gvart.genesara.world.DroppedItemView
+import dev.gvart.genesara.world.GroundItemStore
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Rarity
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.core.script.DefaultRedisScript
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+import java.util.UUID
+
+/**
+ * Redis-only [GroundItemStore]. Drops live in a per-node Hash:
+ *
+ * ```
+ * Key:   world:groundItems:{nodeId}
+ * Hash:  {dropId}  →  JSON payload (kind, item, quantity OR equipment metadata,
+ *                     droppedAtTick)
+ * ```
+ *
+ * **Atomicity.** [take] uses a Lua `HGET` + `HDEL` so two agents racing to pick
+ * up the same drop on the same tick don't both succeed — only the first caller
+ * gets the payload, the second sees null.
+ *
+ * **Persistence.** No durable backing. A Redis flush or container restart
+ * vanishes every in-flight drop — that's intentional: ground items are
+ * ephemeral by design.
+ */
+@Component
+internal class RedisGroundItemStore(
+    private val redis: StringRedisTemplate,
+    private val mapper: ObjectMapper,
+) : GroundItemStore {
+
+    private val hash get() = redis.opsForHash<String, String>()
+
+    override fun deposit(node: NodeId, drop: DroppedItemView, droppedAtTick: Long) {
+        val payload = mapper.writeValueAsString(drop.toRecord(droppedAtTick))
+        check(hash.putIfAbsent(nodeKey(node), drop.dropId.toString(), payload)) {
+            "ground item ${drop.dropId} already exists at node ${node.value}"
+        }
+    }
+
+    override fun atNode(node: NodeId): List<GroundItemView> {
+        val raw = hash.entries(nodeKey(node))
+        if (raw.isEmpty()) return emptyList()
+        return raw.entries.map { (_, payload) -> mapper.readValue(payload, GroundItemRecord::class.java).toView(node) }
+    }
+
+    override fun take(node: NodeId, dropId: UUID): GroundItemView? {
+        val payload = redis.execute(
+            TAKE_SCRIPT,
+            listOf(nodeKey(node)),
+            dropId.toString(),
+        ) ?: return null
+        return mapper.readValue(payload, GroundItemRecord::class.java).toView(node)
+    }
+
+    private fun nodeKey(node: NodeId) = "world:groundItems:${node.value}"
+
+    private fun DroppedItemView.toRecord(droppedAtTick: Long): GroundItemRecord = when (this) {
+        is DroppedItemView.Stackable -> GroundItemRecord(
+            dropId = dropId.toString(),
+            droppedAtTick = droppedAtTick,
+            kind = KIND_STACKABLE,
+            item = item.value,
+            quantity = quantity,
+        )
+        is DroppedItemView.Equipment -> GroundItemRecord(
+            dropId = dropId.toString(),
+            droppedAtTick = droppedAtTick,
+            kind = KIND_EQUIPMENT,
+            item = item.value,
+            equipmentInstanceId = instanceId.toString(),
+            equipmentRarity = rarity.name,
+            equipmentDurabilityCurrent = durabilityCurrent,
+            equipmentDurabilityMax = durabilityMax,
+            equipmentCreatorAgentId = creatorAgentId?.toString(),
+            equipmentCreatedAtTick = createdAtTick,
+        )
+    }
+
+    private fun GroundItemRecord.toView(node: NodeId): GroundItemView {
+        val drop: DroppedItemView = when (kind) {
+            KIND_STACKABLE -> DroppedItemView.Stackable(
+                dropId = UUID.fromString(dropId),
+                item = ItemId(item),
+                quantity = checkNotNull(quantity) { "STACKABLE record missing quantity" },
+            )
+            KIND_EQUIPMENT -> DroppedItemView.Equipment(
+                dropId = UUID.fromString(dropId),
+                item = ItemId(item),
+                instanceId = UUID.fromString(checkNotNull(equipmentInstanceId)),
+                rarity = Rarity.valueOf(checkNotNull(equipmentRarity)),
+                durabilityCurrent = checkNotNull(equipmentDurabilityCurrent),
+                durabilityMax = checkNotNull(equipmentDurabilityMax),
+                creatorAgentId = equipmentCreatorAgentId?.let(UUID::fromString),
+                createdAtTick = checkNotNull(equipmentCreatedAtTick),
+            )
+            else -> error("unknown ground item kind: $kind")
+        }
+        return GroundItemView(nodeId = node, droppedAtTick = droppedAtTick, drop = drop)
+    }
+
+    /**
+     * Flat record used as the Redis Hash field value (JSON-encoded). One shape
+     * for both stackable and equipment drops; the [kind] discriminator selects
+     * which optional columns are populated.
+     */
+    private data class GroundItemRecord(
+        val dropId: String = "",
+        val droppedAtTick: Long = 0L,
+        val kind: String = "",
+        val item: String = "",
+        val quantity: Int? = null,
+        val equipmentInstanceId: String? = null,
+        val equipmentRarity: String? = null,
+        val equipmentDurabilityCurrent: Int? = null,
+        val equipmentDurabilityMax: Int? = null,
+        val equipmentCreatorAgentId: String? = null,
+        val equipmentCreatedAtTick: Long? = null,
+    )
+
+    private companion object {
+        private const val KIND_STACKABLE = "STACKABLE"
+        private const val KIND_EQUIPMENT = "EQUIPMENT"
+
+        /**
+         * Atomic check-and-take. Returns the JSON payload as a bulk string, or
+         * Lua nil if no field exists (Spring maps the latter to Java null).
+         *
+         *   KEYS[1] = node hash key
+         *   ARGV[1] = drop id field name
+         */
+        private val TAKE_SCRIPT = DefaultRedisScript<String>(
+            """
+            local v = redis.call('HGET', KEYS[1], ARGV[1])
+            if not v then return nil end
+            redis.call('HDEL', KEYS[1], ARGV[1])
+            return v
+            """.trimIndent(),
+            String::class.java,
+        )
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/pickup/PickupReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/pickup/PickupReducer.kt
@@ -1,0 +1,118 @@
+package dev.gvart.genesara.world.internal.pickup
+
+import arrow.core.Either
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import arrow.core.raise.ensureNotNull
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.world.DroppedItemView
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.GroundItemStore
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.inventory.enforceCarryCap
+import dev.gvart.genesara.world.internal.inventory.equippedGrams
+import dev.gvart.genesara.world.internal.inventory.totalGrams
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+
+/**
+ * Reducer for [WorldCommand.Pickup]. Reads the candidate drop from
+ * [GroundItemStore] before [GroundItemStore.take] so a stackable pickup that
+ * would over-encumber the agent rejects without leaving the drop in limbo.
+ *
+ * The peek + take split has a small TOCTOU window: another agent's pickup may
+ * win the atomic [GroundItemStore.take] between the carry-cap check and our
+ * own take call. That second-place caller gets [WorldRejection.GroundItemNoLongerAvailable]
+ * — the same rejection a stale dropId produces — which matches the
+ * `harvest`-style "deposit gone" framing. Equipment drops skip the carry-cap
+ * check (no body-grams accounting yet for unequipped instances; the equip
+ * reducer enforces fit when the agent later slots them).
+ */
+internal fun reducePickup(
+    state: WorldState,
+    command: WorldCommand.Pickup,
+    balance: BalanceLookup,
+    items: ItemLookup,
+    agents: AgentRegistry,
+    equipment: EquipmentInstanceStore,
+    groundItems: GroundItemStore,
+    tick: Long,
+): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+    val nodeId = ensureNotNull(state.positions[command.agent]) {
+        WorldRejection.NotInWorld(command.agent)
+    }
+
+    val candidate: GroundItemView = groundItems.atNode(nodeId)
+        .firstOrNull { it.drop.dropId == command.dropId }
+        ?: raise(WorldRejection.GroundItemNoLongerAvailable(command.agent, command.dropId))
+
+    if (candidate.drop is DroppedItemView.Stackable) {
+        val stack = candidate.drop
+        val itemDef = ensureNotNull(items.byId(stack.item)) {
+            WorldRejection.UnknownItem(stack.item)
+        }
+        val currentInStack = state.inventoryOf(command.agent).quantityOf(stack.item)
+        ensure(currentInStack + stack.quantity <= itemDef.maxStack) {
+            WorldRejection.StackFull(
+                agent = command.agent,
+                item = stack.item,
+                current = currentInStack,
+                incoming = stack.quantity,
+                maxStack = itemDef.maxStack,
+            )
+        }
+        val agentRecord = agents.find(command.agent)
+            ?: error("Invariant violated: agent ${command.agent} has a position but no registry row")
+        val currentGrams = state.inventoryOf(command.agent).totalGrams(items) +
+            equippedGrams(equipment.equippedFor(command.agent), items)
+        val additionalGrams = stack.quantity * itemDef.weightPerUnit
+        enforceCarryCap(command.agent, agentRecord.attributes.strength, currentGrams, additionalGrams, balance)
+    }
+
+    val taken = groundItems.take(nodeId, command.dropId)
+        ?: raise(WorldRejection.GroundItemNoLongerAvailable(command.agent, command.dropId))
+
+    val nextState = applyPickup(state, command.agent, taken.drop, equipment)
+    val event = WorldEvent.ItemPickedUp(
+        agent = command.agent,
+        at = nodeId,
+        drop = taken.drop,
+        tick = tick,
+        causedBy = command.commandId,
+    )
+    nextState to event
+}
+
+private fun applyPickup(
+    state: WorldState,
+    agent: AgentId,
+    drop: DroppedItemView,
+    equipment: EquipmentInstanceStore,
+): WorldState = when (drop) {
+    is DroppedItemView.Stackable -> state.updateInventory(
+        agent,
+        state.inventoryOf(agent).add(drop.item, drop.quantity),
+    )
+    is DroppedItemView.Equipment -> {
+        equipment.insert(
+            EquipmentInstance(
+                instanceId = drop.instanceId,
+                agentId = agent,
+                itemId = drop.item,
+                rarity = drop.rarity,
+                durabilityCurrent = drop.durabilityCurrent,
+                durabilityMax = drop.durabilityMax,
+                creatorAgentId = drop.creatorAgentId?.let(::AgentId),
+                createdAtTick = drop.createdAtTick,
+                equippedInSlot = null,
+            ),
+        )
+        state
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -10,6 +10,7 @@ import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.BuildingsStore
 import dev.gvart.genesara.world.ChestContentsStore
 import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.GroundItemStore
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.RecipeLookup
 import dev.gvart.genesara.world.events.WorldEvent
@@ -51,6 +52,7 @@ internal class WorldTickHandler(
     private val rarityRoller: RarityRoller,
     private val progression: SkillProgression,
     private val spawnLocationResolver: SpawnLocationResolver,
+    private val groundItems: GroundItemStore,
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -71,14 +73,16 @@ internal class WorldTickHandler(
     fun onTick(tick: Tick) {
         val initial = repository.load()
         val (afterPassives, passivesEvent) = applyPassives(initial, balance, tick.number)
-        val (afterDeaths, deathEvents) = processDeaths(afterPassives, balance, agents, tick.number)
+        val (afterDeaths, deathEvents) = processDeaths(
+            afterPassives, balance, agents, equipment, groundItems, tick.number,
+        )
 
         val commands = queue.drainFor(tick.number)
         val (next, commandEvents) = commands.fold(afterDeaths to emptyList<WorldEvent>()) { (state, acc), command ->
             reduce(
                 state, command, balance, profiles, items, recipes, resources, skills, agents, equipment,
                 safeNodes, safeNodeResolver, buildings, buildingsLookup, buildingsCatalog, chestContents,
-                rarityRoller, progression, spawnLocationResolver, tick.number,
+                rarityRoller, progression, spawnLocationResolver, groundItems, tick.number,
             ).fold(
                 ifLeft = { rejection ->
                     log.info("Rejected {} at tick {}: {}", command, tick.number, rejection)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/worldstate/JooqWorldStateRepository.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/worldstate/JooqWorldStateRepository.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.world.internal.worldstate
 import tools.jackson.core.type.TypeReference
 import tools.jackson.databind.ObjectMapper
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.AgentKillStreak
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Climate
 import dev.gvart.genesara.world.Node
@@ -17,6 +18,7 @@ import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.inventory.AgentInventory
 import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_BODIES
 import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_INVENTORY
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_KILL_STREAKS
 import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_POSITIONS
 import dev.gvart.genesara.world.internal.jooq.tables.references.NODES
 import dev.gvart.genesara.world.internal.jooq.tables.references.NODE_ADJACENCY
@@ -45,6 +47,7 @@ internal class JooqWorldStateRepository(
         positions = loadActivePositions(),
         bodies = loadBodies(),
         inventories = loadInventories(),
+        killStreaks = loadKillStreaks(),
     )
 
     /**
@@ -77,6 +80,7 @@ internal class JooqWorldStateRepository(
         state.positions.forEach { (agent, node) -> upsertActivePosition(agent, node) }
         state.bodies.forEach { (agent, body) -> upsertBody(agent, body) }
         state.inventories.forEach { (agent, inventory) -> saveInventory(agent, inventory) }
+        state.killStreaks.forEach { (agent, streak) -> saveKillStreak(agent, streak) }
     }
 
     private fun loadActivePositions(): Map<AgentId, NodeId> =
@@ -203,6 +207,45 @@ internal class JooqWorldStateRepository(
                 .set(AGENT_INVENTORY.QUANTITY, qty)
                 .execute()
         }
+    }
+
+    private fun loadKillStreaks(): Map<AgentId, AgentKillStreak> =
+        dsl.select(
+            AGENT_KILL_STREAKS.AGENT_ID,
+            AGENT_KILL_STREAKS.KILL_COUNT,
+            AGENT_KILL_STREAKS.WINDOW_START_TICK,
+        )
+            .from(AGENT_KILL_STREAKS)
+            .fetch {
+                AgentId(it[AGENT_KILL_STREAKS.AGENT_ID]!!) to AgentKillStreak(
+                    killCount = it[AGENT_KILL_STREAKS.KILL_COUNT]!!,
+                    windowStartTick = it[AGENT_KILL_STREAKS.WINDOW_START_TICK]!!,
+                )
+            }
+            .toMap()
+
+    /**
+     * `AgentKillStreak.EMPTY` is the absence of a streak — delete the row rather
+     * than persist a (0, 0) sentinel. The next read reconstructs `EMPTY` via
+     * `WorldState.killStreakOf` so deleted vs (0, 0) is observationally identical
+     * but the table stays compact.
+     */
+    private fun saveKillStreak(agent: AgentId, streak: AgentKillStreak) {
+        if (streak == AgentKillStreak.EMPTY) {
+            dsl.deleteFrom(AGENT_KILL_STREAKS)
+                .where(AGENT_KILL_STREAKS.AGENT_ID.eq(agent.id))
+                .execute()
+            return
+        }
+        dsl.insertInto(AGENT_KILL_STREAKS)
+            .set(AGENT_KILL_STREAKS.AGENT_ID, agent.id)
+            .set(AGENT_KILL_STREAKS.KILL_COUNT, streak.killCount)
+            .set(AGENT_KILL_STREAKS.WINDOW_START_TICK, streak.windowStartTick)
+            .onConflict(AGENT_KILL_STREAKS.AGENT_ID)
+            .doUpdate()
+            .set(AGENT_KILL_STREAKS.KILL_COUNT, streak.killCount)
+            .set(AGENT_KILL_STREAKS.WINDOW_START_TICK, streak.windowStartTick)
+            .execute()
     }
 }
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldState.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldState.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.world.internal.worldstate
 
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.AgentKillStreak
 import dev.gvart.genesara.world.Node
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.Region
@@ -14,6 +15,7 @@ internal data class WorldState(
     val positions: Map<AgentId, NodeId>,
     val bodies: Map<AgentId, AgentBody>,
     val inventories: Map<AgentId, AgentInventory>,
+    val killStreaks: Map<AgentId, AgentKillStreak> = emptyMap(),
 ) {
 
     fun isAdjacent(from: NodeId, to: NodeId): Boolean =
@@ -35,6 +37,36 @@ internal data class WorldState(
     fun updateInventory(agent: AgentId, inventory: AgentInventory): WorldState =
         copy(inventories = inventories + (agent to inventory))
 
+    fun killStreakOf(agent: AgentId): AgentKillStreak =
+        killStreaks[agent] ?: AgentKillStreak.EMPTY
+
+    fun updateKillStreak(agent: AgentId, streak: AgentKillStreak): WorldState =
+        copy(killStreaks = killStreaks + (agent to streak))
+
+    /**
+     * Public-API surface for the Phase 2 combat reducer. Encapsulates the
+     * rolling-window reset: a kill outside the active window starts a fresh
+     * streak; a kill inside the window adds 1.
+     *
+     * `AgentKillStreak.EMPTY` is the explicit "no prior streak" sentinel, not a
+     * live (0, 0) streak — the first kill always anchors the window to
+     * [currentTick]. Without this, the very first kills at low ticks
+     * (currentTick < windowTicks) would inherit `windowStartTick = 0L` from the
+     * sentinel and silently expire earlier than the documented "1000 ticks
+     * since your last kill" semantic.
+     */
+    fun incrementKillStreak(agent: AgentId, currentTick: Long, windowTicks: Long): WorldState {
+        val current = killStreakOf(agent)
+        val noPriorStreak = current == AgentKillStreak.EMPTY
+        val windowExpired = currentTick - current.windowStartTick >= windowTicks
+        val next = if (noPriorStreak || windowExpired) {
+            AgentKillStreak(killCount = 1, windowStartTick = currentTick)
+        } else {
+            current.copy(killCount = current.killCount + 1)
+        }
+        return updateKillStreak(agent, next)
+    }
+
     companion object {
         val EMPTY = WorldState(
             regions = emptyMap(),
@@ -42,6 +74,7 @@ internal data class WorldState(
             positions = emptyMap(),
             bodies = emptyMap(),
             inventories = emptyMap(),
+            killStreaks = emptyMap(),
         )
     }
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGateway.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGateway.kt
@@ -3,6 +3,8 @@ package dev.gvart.genesara.world.internal.worldstate
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.RaceId
 import dev.gvart.genesara.world.BodyView
+import dev.gvart.genesara.world.GroundItemStore
+import dev.gvart.genesara.world.GroundItemView
 import dev.gvart.genesara.world.InventoryEntry
 import dev.gvart.genesara.world.InventoryView
 import dev.gvart.genesara.world.ItemId
@@ -30,6 +32,7 @@ internal class WorldStateQueryGateway(
     private val starterNodes: StarterNodeLookup,
     private val resources: NodeResourceStore,
     private val balance: BalanceLookup,
+    private val groundItems: GroundItemStore,
 ) : WorldQueryGateway {
 
     override fun locationOf(agent: AgentId): NodeId? =
@@ -122,4 +125,7 @@ internal class WorldStateQueryGateway(
 
     override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources =
         resources.read(nodeId, tick)
+
+    override fun groundItemsAt(nodeId: NodeId): List<GroundItemView> =
+        groundItems.atNode(nodeId)
 }

--- a/world/src/main/resources/db/migration/world/V14__agent_kill_streaks.sql
+++ b/world/src/main/resources/db/migration/world/V14__agent_kill_streaks.sql
@@ -1,0 +1,24 @@
+-- Phase 1 death-system slice (kill-streak item drop): per-agent rolling kill
+-- counter. Read by the death sweep when computing drop chance, written by the
+-- combat reducer (Phase 2) on every successful kill.
+--
+-- Rolling-window semantics: when a kill arrives outside the configured window
+-- (`BalanceLookup.killStreakWindowTicks`), the counter resets to 1 and
+-- window_start_tick advances to the kill's tick. The death sweep treats a
+-- counter whose window has expired as zero — `AgentKillStreak.effectiveKillCount`
+-- enforces the same rule on read.
+--
+-- One row per agent (PK on agent_id) — counters overwrite, so an agent always
+-- has at most one active streak. Resets on death (the death sweep zeroes the
+-- streak so the bonus does not persist across deaths).
+--
+-- agent_id has no cross-module FK to player.agents (matches the pattern in
+-- agent_positions / agent_bodies / agent_safe_nodes / agent_equipment_instances).
+-- TODO(phase-5): wire explicit cleanup on permadeath when that lands.
+CREATE TABLE agent_kill_streaks
+(
+    agent_id          UUID    NOT NULL,
+    kill_count        INT     NOT NULL CHECK (kill_count >= 0),
+    window_start_tick BIGINT  NOT NULL,
+    PRIMARY KEY (agent_id)
+);

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/DeathSweepTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/DeathSweepTest.kt
@@ -7,12 +7,20 @@ import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.AttributePointLoss
 import dev.gvart.genesara.player.DeathPenaltyOutcome
+import dev.gvart.genesara.world.AgentKillStreak
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DroppedItemView
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.Gauge
+import dev.gvart.genesara.world.GroundItemStore
+import dev.gvart.genesara.world.GroundItemView
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.Node
 import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Rarity
 import dev.gvart.genesara.world.Region
 import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.ResourceSpawnRule
@@ -22,10 +30,15 @@ import dev.gvart.genesara.world.WorldId
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.inventory.AgentInventory
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import org.junit.jupiter.api.Test
 import java.util.UUID
+import kotlin.random.Random
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class DeathSweepTest {
@@ -51,9 +64,11 @@ class DeathSweepTest {
     fun `no agents at HP=0 — sweep is a no-op`() {
         val agentId = AgentId(UUID.randomUUID())
         val state = stateWith(agentId, hp = 50, atNode = nodeAId)
-        val agents = StubRegistry()  // poison: applyDeathPenalty would throw
+        val agents = StubRegistry()
+        val equipment = StubEquipmentStore()
+        val groundItems = StubGroundItemStore()
 
-        val (next, events) = processDeaths(state, balance(), agents, tick = 1)
+        val (next, events) = processDeaths(state, balance(), agents, equipment, groundItems, tick = 1)
 
         assertEquals(state, next)
         assertEquals(emptyList(), events)
@@ -72,14 +87,14 @@ class DeathSweepTest {
                 ),
             ),
         )
+        val equipment = StubEquipmentStore()
+        val groundItems = StubGroundItemStore()
 
-        val (next, events) = processDeaths(state, balance(), agents, tick = 7)
+        val (next, events) = processDeaths(state, balance(), agents, equipment, groundItems, tick = 7)
 
         assertTrue(agentId !in next.positions, "agent removed from positions on death")
-        // Body persists at HP=0 — the respawn reducer restores it.
         assertEquals(0, next.bodyOf(agentId)?.hp)
-        assertEquals(1, events.size)
-        val died = events.single()
+        val died = assertIs<WorldEvent.AgentDied>(events.single())
         assertEquals(agentId, died.agent)
         assertEquals(nodeAId, died.at)
         assertEquals(25, died.xpLost)
@@ -87,6 +102,8 @@ class DeathSweepTest {
         assertEquals(null, died.attributePointLost)
         assertEquals(7L, died.tick)
         assertEquals(null, died.causedBy, "starvation deaths have no causing command")
+        assertNull(died.droppedItem, "no streak → no drop")
+        assertEquals(emptyList(), groundItems.deposits, "no streak → ground item store untouched")
     }
 
     @Test
@@ -103,10 +120,11 @@ class DeathSweepTest {
             ),
         )
 
-        val (_, events) = processDeaths(state, balance(), agents, tick = 1)
+        val (_, events) = processDeaths(state, balance(), agents, StubEquipmentStore(), StubGroundItemStore(), tick = 1)
 
-        assertEquals("UNSPENT", events.single().attributePointLost)
-        assertEquals(true, events.single().deleveled)
+        val died = assertIs<WorldEvent.AgentDied>(events.single())
+        assertEquals("UNSPENT", died.attributePointLost)
+        assertEquals(true, died.deleveled)
     }
 
     @Test
@@ -123,14 +141,14 @@ class DeathSweepTest {
             ),
         )
 
-        val (_, events) = processDeaths(state, balance(), agents, tick = 1)
+        val (_, events) = processDeaths(state, balance(), agents, StubEquipmentStore(), StubGroundItemStore(), tick = 1)
 
-        assertEquals("STRENGTH", events.single().attributePointLost)
+        val died = assertIs<WorldEvent.AgentDied>(events.single())
+        assertEquals("STRENGTH", died.attributePointLost)
     }
 
     @Test
     fun `multiple agents dying at the same tick are sorted by agent id`() {
-        // Determinism matters for replay logs and event-stream consumers.
         val firstId = AgentId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
         val secondId = AgentId(UUID.fromString("00000000-0000-0000-0000-000000000002"))
         val state = WorldState(
@@ -147,11 +165,11 @@ class DeathSweepTest {
             ),
         )
 
-        val (next, events) = processDeaths(state, balance(), agents, tick = 1)
+        val (next, events) = processDeaths(state, balance(), agents, StubEquipmentStore(), StubGroundItemStore(), tick = 1)
 
         assertEquals(emptyMap(), next.positions)
-        assertEquals(2, events.size)
-        assertEquals(listOf(firstId, secondId), events.map { it.agent })
+        val deaths = events.filterIsInstance<WorldEvent.AgentDied>()
+        assertEquals(listOf(firstId, secondId), deaths.map { it.agent })
     }
 
     @Test
@@ -160,7 +178,7 @@ class DeathSweepTest {
         val state = stateWith(agentId, hp = 0, atNode = nodeAId)
         val agents = StubRegistry(returnNull = true)
 
-        val (next, events) = processDeaths(state, balance(), agents, tick = 1)
+        val (next, events) = processDeaths(state, balance(), agents, StubEquipmentStore(), StubGroundItemStore(), tick = 1)
 
         assertTrue(agentId !in next.positions, "position cleared so the same row doesn't loop forever")
         assertEquals(emptyList(), events, "no AgentDied event for an agent we couldn't penalize")
@@ -168,23 +186,131 @@ class DeathSweepTest {
 
     @Test
     fun `unpositioned agent at HP=0 is not swept (already dead, awaiting respawn)`() {
-        // Idempotency: an agent who already died on a prior tick (and hasn't
-        // respawned yet) is unpositioned. The sweep must skip them — otherwise
-        // they'd re-trigger death every tick and rack up infinite penalties.
         val agentId = AgentId(UUID.randomUUID())
         val state = WorldState(
             regions = mapOf(regionId to region),
             nodes = mapOf(nodeAId to nodeA),
-            positions = emptyMap(),  // unpositioned = already dead
+            positions = emptyMap(),
             bodies = mapOf(agentId to bodyAt(0)),
             inventories = emptyMap(),
         )
-        val agents = StubRegistry()  // poison: must not be called
+        val agents = StubRegistry()
 
-        val (next, events) = processDeaths(state, balance(), agents, tick = 1)
+        val (next, events) = processDeaths(state, balance(), agents, StubEquipmentStore(), StubGroundItemStore(), tick = 1)
 
         assertEquals(state, next)
         assertEquals(emptyList(), events)
+    }
+
+    @Test
+    fun `kill-streak triggers stackable drop and emits paired ground-item event`() {
+        val agentId = AgentId(UUID.fromString("00000000-0000-0000-0000-000000000010"))
+        val wood = ItemId("WOOD")
+        val state = stateWith(agentId, hp = 0, atNode = nodeAId).copy(
+            inventories = mapOf(agentId to AgentInventory(mapOf(wood to 50))),
+            killStreaks = mapOf(agentId to AgentKillStreak(killCount = 10, windowStartTick = 0L)),
+        )
+        val agents = StubRegistry(scripted(agentId, xpLost = 25))
+        val groundItems = StubGroundItemStore()
+        // Seeded RNG: at killCount=10, dropChance=1.0, so the first nextDouble always
+        // clears it. Pool has one entry (the WOOD stack), so nextInt(1) = 0 picks it.
+        val rng = Random(seed = 42)
+
+        val (next, events) = processDeaths(
+            state, balance(), agents, StubEquipmentStore(), groundItems,
+            tick = 100L, rng = rng,
+        )
+
+        val died = assertIs<WorldEvent.AgentDied>(events.first())
+        val droppedOnGround = assertIs<WorldEvent.ItemDroppedOnGround>(events[1])
+        val drop = assertIs<DroppedItemView.Stackable>(died.droppedItem)
+        assertEquals(wood, drop.item)
+        assertEquals(50, drop.quantity, "whole stack drops on a successful roll")
+        assertEquals(drop.dropId, droppedOnGround.drop.dropId, "AgentDied + ItemDroppedOnGround share dropId")
+        assertEquals(nodeAId, droppedOnGround.at)
+        assertEquals(agentId, droppedOnGround.byAgent)
+        assertEquals(1, groundItems.deposits.size)
+        assertEquals(nodeAId, groundItems.deposits.single().first)
+        assertEquals(0, next.inventoryOf(agentId).quantityOf(wood), "stack removed from inventory")
+        assertEquals(AgentKillStreak.EMPTY, next.killStreakOf(agentId), "streak resets after death")
+    }
+
+    @Test
+    fun `kill-streak window expired — drop does not fire`() {
+        val agentId = AgentId(UUID.randomUUID())
+        val wood = ItemId("WOOD")
+        // killCount=10 but windowStartTick=0 and current tick > windowTicks (1000).
+        val state = stateWith(agentId, hp = 0, atNode = nodeAId).copy(
+            inventories = mapOf(agentId to AgentInventory(mapOf(wood to 5))),
+            killStreaks = mapOf(agentId to AgentKillStreak(killCount = 10, windowStartTick = 0L)),
+        )
+        val agents = StubRegistry(scripted(agentId, xpLost = 25))
+        val groundItems = StubGroundItemStore()
+
+        val (next, events) = processDeaths(
+            state, balance(), agents, StubEquipmentStore(), groundItems,
+            tick = 5_000L, rng = Random(seed = 1),
+        )
+
+        val died = assertIs<WorldEvent.AgentDied>(events.single())
+        assertNull(died.droppedItem, "expired window → effective kills 0 → no drop")
+        assertEquals(emptyList(), groundItems.deposits)
+        assertEquals(5, next.inventoryOf(agentId).quantityOf(wood), "inventory untouched")
+    }
+
+    @Test
+    fun `equipment-only agent drops an equipment instance and the store deletes it`() {
+        val agentId = AgentId(UUID.randomUUID())
+        val instance = EquipmentInstance(
+            instanceId = UUID.fromString("00000000-0000-0000-0000-0000000000aa"),
+            agentId = agentId,
+            itemId = ItemId("IRON_SWORD"),
+            rarity = Rarity.RARE,
+            durabilityCurrent = 80,
+            durabilityMax = 100,
+            creatorAgentId = null,
+            createdAtTick = 5L,
+            equippedInSlot = EquipSlot.MAIN_HAND,
+        )
+        val state = stateWith(agentId, hp = 0, atNode = nodeAId).copy(
+            killStreaks = mapOf(agentId to AgentKillStreak(killCount = 10, windowStartTick = 0L)),
+        )
+        val agents = StubRegistry(scripted(agentId, xpLost = 25))
+        val equipment = StubEquipmentStore(equippedByAgent = mapOf(agentId to mapOf(EquipSlot.MAIN_HAND to instance)))
+        val groundItems = StubGroundItemStore()
+
+        val (_, events) = processDeaths(
+            state, balance(), agents, equipment, groundItems,
+            tick = 100L, rng = Random(seed = 7),
+        )
+
+        val died = assertIs<WorldEvent.AgentDied>(events.first())
+        val drop = assertIs<DroppedItemView.Equipment>(died.droppedItem)
+        assertEquals(instance.instanceId, drop.instanceId)
+        assertEquals(Rarity.RARE, drop.rarity)
+        assertEquals(80, drop.durabilityCurrent)
+        assertEquals(100, drop.durabilityMax)
+        assertEquals(listOf(instance.instanceId), equipment.deletedInstanceIds, "equipment store deleted the instance")
+    }
+
+    @Test
+    fun `empty inventory and no equipment — drop roll succeeds but no event added`() {
+        val agentId = AgentId(UUID.randomUUID())
+        val state = stateWith(agentId, hp = 0, atNode = nodeAId).copy(
+            killStreaks = mapOf(agentId to AgentKillStreak(killCount = 10, windowStartTick = 0L)),
+        )
+        val agents = StubRegistry(scripted(agentId, xpLost = 25))
+        val groundItems = StubGroundItemStore()
+
+        val (next, events) = processDeaths(
+            state, balance(), agents, StubEquipmentStore(), groundItems,
+            tick = 50L, rng = Random(seed = 1),
+        )
+
+        val died = assertIs<WorldEvent.AgentDied>(events.single())
+        assertNull(died.droppedItem, "roll succeeded but pool empty → graceful no-drop")
+        assertEquals(emptyList(), groundItems.deposits)
+        assertEquals(AgentKillStreak.EMPTY, next.killStreakOf(agentId), "streak still resets on death even when no drop")
     }
 
     private fun stateWith(agentId: AgentId, hp: Int, atNode: NodeId): WorldState = WorldState(
@@ -199,6 +325,10 @@ class DeathSweepTest {
         hp = hp, maxHp = 100,
         stamina = 0, maxStamina = 100,
         mana = 0, maxMana = 0,
+    )
+
+    private fun scripted(agentId: AgentId, xpLost: Int): Map<AgentId, DeathPenaltyOutcome> = mapOf(
+        agentId to DeathPenaltyOutcome(xpLost = xpLost, deleveled = false, attributePointLost = null),
     )
 
     private fun balance(xpLoss: Int = 25): BalanceLookup = object : BalanceLookup {
@@ -216,13 +346,10 @@ class DeathSweepTest {
         override fun sleepRegenPerOfflineTick(): Int = 0
         override fun isTraversable(terrain: Terrain): Boolean = true
         override fun xpLossOnDeath(): Int = xpLoss
+        override fun killStreakWindowTicks(): Long = 1000L
+        override fun dropChanceForKillCount(killCount: Int): Double = (killCount * 0.1).coerceIn(0.0, 1.0)
     }
 
-    /**
-     * Stub registry. Default behavior throws to surface accidental calls; pass
-     * a [scriptedOutcomes] map (or [returnNull] = true) to script the death
-     * sweep's `applyDeathPenalty` interaction.
-     */
     private class StubRegistry(
         private val scriptedOutcomes: Map<AgentId, DeathPenaltyOutcome> = emptyMap(),
         private val returnNull: Boolean = false,
@@ -235,5 +362,35 @@ class DeathSweepTest {
             return scriptedOutcomes[agentId]
                 ?: error("no scripted outcome for $agentId — test setup mismatch")
         }
+    }
+
+    private class StubEquipmentStore(
+        private val equippedByAgent: Map<AgentId, Map<EquipSlot, EquipmentInstance>> = emptyMap(),
+    ) : EquipmentInstanceStore {
+        val deletedInstanceIds: MutableList<UUID> = mutableListOf()
+
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = error("not used")
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> =
+            equippedByAgent[agentId] ?: emptyMap()
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? =
+            error("not used")
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = error("not used")
+        override fun delete(instanceId: UUID): Boolean {
+            deletedInstanceIds += instanceId
+            return true
+        }
+    }
+
+    private class StubGroundItemStore : GroundItemStore {
+        val deposits: MutableList<Pair<NodeId, DroppedItemView>> = mutableListOf()
+
+        override fun deposit(node: NodeId, drop: DroppedItemView, droppedAtTick: Long) {
+            deposits += node to drop
+        }
+        override fun atNode(node: NodeId): List<GroundItemView> = error("not used")
+        override fun take(node: NodeId, dropId: UUID): GroundItemView? = error("not used")
     }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/StarvationDeathRespawnIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/StarvationDeathRespawnIntegrationTest.kt
@@ -5,7 +5,13 @@ import dev.gvart.genesara.player.AttributePointLoss
 import dev.gvart.genesara.player.DeathPenaltyOutcome
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DroppedItemView
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.Gauge
+import dev.gvart.genesara.world.GroundItemStore
+import dev.gvart.genesara.world.GroundItemView
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.Node
 import dev.gvart.genesara.world.NodeId
@@ -92,7 +98,9 @@ class StarvationDeathRespawnIntegrationTest {
         assertTrue(agent in afterPassives.positions, "still positioned just before sweep")
 
         // Sweep observes HP=0 and removes from positions.
-        val (afterDeaths, deathEvents) = processDeaths(afterPassives, balance, agents, tick = 1L)
+        val (afterDeaths, deathEvents) = processDeaths(
+            afterPassives, balance, agents, NoOpEquipmentStore(), NoOpGroundItemStore(), tick = 1L,
+        )
         val died = assertIs<WorldEvent.AgentDied>(deathEvents.single())
         assertEquals(agent, died.agent)
         assertEquals(nodeId, died.at)
@@ -140,7 +148,9 @@ class StarvationDeathRespawnIntegrationTest {
             inventories = emptyMap(),
         )
 
-        val (next, events) = processDeaths(state, balance(), agents, tick = 5L)
+        val (next, events) = processDeaths(
+            state, balance(), agents, NoOpEquipmentStore(), NoOpGroundItemStore(), tick = 5L,
+        )
 
         assertEquals(state, next)
         assertEquals(emptyList(), events)
@@ -208,5 +218,23 @@ class StarvationDeathRespawnIntegrationTest {
 
     private class FixedProfileLookup(private val profile: AgentProfile) : AgentProfileLookup {
         override fun find(id: AgentId): AgentProfile? = if (id == profile.id) profile else null
+    }
+
+    private class NoOpEquipmentStore : EquipmentInstanceStore {
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = error("not used")
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> = emptyMap()
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? =
+            error("not used")
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = error("not used")
+        override fun delete(instanceId: UUID): Boolean = error("not used")
+    }
+
+    private class NoOpGroundItemStore : GroundItemStore {
+        override fun deposit(node: NodeId, drop: DroppedItemView, droppedAtTick: Long) = error("not used")
+        override fun atNode(node: NodeId): List<GroundItemView> = error("not used")
+        override fun take(node: NodeId, dropId: UUID): GroundItemView? = error("not used")
     }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/editor/JooqWorldEditingGatewayCreateWorldIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/editor/JooqWorldEditingGatewayCreateWorldIntegrationTest.kt
@@ -201,6 +201,7 @@ class JooqWorldEditingGatewayCreateWorldIntegrationTest {
             starterNodes = NoOpStarterNodes,
             resources = NoOpResourceStore,
             balance = OceanIsImpassable,
+            groundItems = dev.gvart.genesara.world.internal.testsupport.NoOpGroundItemStore,
         )
 
         // 50 samples — chance of picking only PLAINS by luck if the filter were broken

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/grounditems/RedisGroundItemStoreIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/grounditems/RedisGroundItemStoreIntegrationTest.kt
@@ -1,0 +1,155 @@
+package dev.gvart.genesara.world.internal.grounditems
+
+import dev.gvart.genesara.world.DroppedItemView
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Rarity
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Exercises [RedisGroundItemStore] against a real Redis. Pins the Lua atomic
+ * `take` (only the first racer wins), the JSON codec round-trip for both
+ * stackable and equipment drops, and the empty-node read.
+ */
+@Testcontainers
+class RedisGroundItemStoreIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val redis: GenericContainer<*> =
+            GenericContainer(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379)
+    }
+
+    private val nodeA = NodeId(1L)
+    private val nodeB = NodeId(2L)
+
+    private lateinit var connectionFactory: LettuceConnectionFactory
+    private lateinit var template: StringRedisTemplate
+    private lateinit var store: RedisGroundItemStore
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+
+    @BeforeEach
+    fun setUp() {
+        connectionFactory = LettuceConnectionFactory(redis.host, redis.firstMappedPort).apply {
+            afterPropertiesSet()
+        }
+        template = StringRedisTemplate(connectionFactory)
+        template.connectionFactory!!.connection.serverCommands().flushDb()
+        store = RedisGroundItemStore(template, mapper)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        connectionFactory.destroy()
+    }
+
+    @Test
+    fun `stackable deposit + atNode round-trips`() {
+        val drop = stackable(item = ItemId("WOOD"), quantity = 50)
+
+        store.deposit(nodeA, drop, droppedAtTick = 100L)
+
+        val view = store.atNode(nodeA).single()
+        assertEquals(nodeA, view.nodeId)
+        assertEquals(100L, view.droppedAtTick)
+        val payload = view.drop as DroppedItemView.Stackable
+        assertEquals(drop.dropId, payload.dropId)
+        assertEquals(50, payload.quantity)
+    }
+
+    @Test
+    fun `equipment deposit preserves rarity, durability, creator, and createdAtTick`() {
+        val instanceId = UUID.randomUUID()
+        val creator = UUID.randomUUID()
+        val drop = DroppedItemView.Equipment(
+            dropId = UUID.randomUUID(),
+            item = ItemId("IRON_SWORD"),
+            instanceId = instanceId,
+            rarity = Rarity.LEGENDARY,
+            durabilityCurrent = 80,
+            durabilityMax = 100,
+            creatorAgentId = creator,
+            createdAtTick = 5L,
+        )
+
+        store.deposit(nodeA, drop, droppedAtTick = 10L)
+
+        val payload = store.atNode(nodeA).single().drop as DroppedItemView.Equipment
+        assertEquals(instanceId, payload.instanceId)
+        assertEquals(Rarity.LEGENDARY, payload.rarity)
+        assertEquals(80, payload.durabilityCurrent)
+        assertEquals(100, payload.durabilityMax)
+        assertEquals(creator, payload.creatorAgentId)
+        assertEquals(5L, payload.createdAtTick)
+    }
+
+    @Test
+    fun `take returns the drop and removes it from Redis`() {
+        val drop = stackable(item = ItemId("STONE"), quantity = 3)
+        store.deposit(nodeA, drop, droppedAtTick = 1L)
+
+        val taken = assertNotNull(store.take(nodeA, drop.dropId))
+
+        assertEquals(drop.dropId, taken.drop.dropId)
+        assertEquals(emptyList(), store.atNode(nodeA), "Redis hash should be empty after take")
+    }
+
+    @Test
+    fun `take returns null when dropId not on the requested node`() {
+        val drop = stackable(item = ItemId("WOOD"), quantity = 1)
+        store.deposit(nodeA, drop, droppedAtTick = 1L)
+
+        // Same dropId, wrong node — atomic take returns null.
+        assertNull(store.take(nodeB, drop.dropId))
+        // And the original drop is untouched on nodeA.
+        assertEquals(1, store.atNode(nodeA).size)
+    }
+
+    @Test
+    fun `concurrent take — second caller receives null`() {
+        val drop = stackable(item = ItemId("WOOD"), quantity = 1)
+        store.deposit(nodeA, drop, droppedAtTick = 1L)
+
+        val firstWinner = assertNotNull(store.take(nodeA, drop.dropId))
+        val secondLoser = store.take(nodeA, drop.dropId)
+
+        assertEquals(drop.dropId, firstWinner.drop.dropId)
+        assertNull(secondLoser, "Lua HGET+HDEL atomic — second caller sees nothing")
+    }
+
+    @Test
+    fun `multiple drops at the same node are all returned by atNode`() {
+        val a = stackable(item = ItemId("WOOD"), quantity = 1)
+        val b = stackable(item = ItemId("STONE"), quantity = 2)
+        store.deposit(nodeA, a, droppedAtTick = 1L)
+        store.deposit(nodeA, b, droppedAtTick = 2L)
+
+        val list = store.atNode(nodeA).sortedBy { (it.drop as DroppedItemView.Stackable).item.value }
+        assertEquals(2, list.size)
+        assertEquals(ItemId("STONE"), (list[0].drop as DroppedItemView.Stackable).item)
+        assertEquals(ItemId("WOOD"), (list[1].drop as DroppedItemView.Stackable).item)
+    }
+
+    @Test
+    fun `atNode returns empty list when no drops at the node`() {
+        assertEquals(emptyList(), store.atNode(nodeA))
+    }
+
+    private fun stackable(item: ItemId, quantity: Int): DroppedItemView.Stackable =
+        DroppedItemView.Stackable(dropId = UUID.randomUUID(), item = item, quantity = quantity)
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/pickup/PickupReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/pickup/PickupReducerTest.kt
@@ -1,0 +1,335 @@
+package dev.gvart.genesara.world.internal.pickup
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DroppedItemView
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.Gauge
+import dev.gvart.genesara.world.GroundItemStore
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Rarity
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.ResourceSpawnRule
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.inventory.AgentInventory
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PickupReducerTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val regionId = RegionId(1L)
+    private val nodeId = NodeId(1L)
+    private val otherNodeId = NodeId(2L)
+    private val wood = ItemId("WOOD")
+
+    private val region = Region(
+        id = regionId,
+        worldId = WorldId(1L),
+        sphereIndex = 0,
+        biome = Biome.PLAINS,
+        climate = Climate.CONTINENTAL,
+        centroid = Vec3(0.0, 0.0, 1.0),
+        faceVertices = emptyList(),
+        neighbors = emptySet(),
+    )
+    private val node = Node(nodeId, regionId, q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())
+
+    @Test
+    fun `agent not positioned — rejects with NotInWorld`() {
+        val state = stateWith(positioned = false)
+        val command = WorldCommand.Pickup(agent, dropId = UUID.randomUUID())
+        val groundItems = StubGroundItemStore()
+
+        val result = reducePickup(
+            state, command, balance(), StubItemLookup(), StubAgentRegistry(),
+            StubEquipmentStore(), groundItems, tick = 1L,
+        )
+
+        assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
+        assertEquals(emptyList(), groundItems.taken)
+    }
+
+    @Test
+    fun `dropId not at the agent's node — rejects with GroundItemNoLongerAvailable`() {
+        val state = stateWith()
+        val staleId = UUID.randomUUID()
+        val groundItems = StubGroundItemStore(atNode = mapOf(otherNodeId to listOf(stackableDrop(staleId, wood, 5))))
+
+        val result = reducePickup(
+            state, WorldCommand.Pickup(agent, dropId = staleId), balance(),
+            StubItemLookup(woodWeight = 100), StubAgentRegistry(strength = 100),
+            StubEquipmentStore(), groundItems, tick = 1L,
+        )
+
+        assertEquals(WorldRejection.GroundItemNoLongerAvailable(agent, staleId), result.leftOrNull())
+        assertEquals(emptyList(), groundItems.taken, "no take call when atNode lookup misses")
+    }
+
+    @Test
+    fun `stackable pickup — inventory grows, drop is taken, ItemPickedUp event emitted`() {
+        val dropId = UUID.fromString("00000000-0000-0000-0000-0000000000ee")
+        val state = stateWith()
+        val groundItems = StubGroundItemStore(
+            atNode = mapOf(nodeId to listOf(stackableDrop(dropId, wood, 7))),
+            takeable = mapOf((nodeId to dropId) to stackableView(dropId, wood, 7)),
+        )
+
+        val result = reducePickup(
+            state, WorldCommand.Pickup(agent, dropId), balance(),
+            StubItemLookup(woodWeight = 100), StubAgentRegistry(strength = 100),
+            StubEquipmentStore(), groundItems, tick = 9L,
+        )
+
+        val (next, event) = assertNotNull(result.getOrNull())
+        assertEquals(7, next.inventoryOf(agent).quantityOf(wood))
+        val pickedUp = assertIs<WorldEvent.ItemPickedUp>(event)
+        assertEquals(agent, pickedUp.agent)
+        assertEquals(nodeId, pickedUp.at)
+        val drop = assertIs<DroppedItemView.Stackable>(pickedUp.drop)
+        assertEquals(wood, drop.item)
+        assertEquals(7, drop.quantity)
+        assertEquals(listOf(nodeId to dropId), groundItems.taken)
+    }
+
+    @Test
+    fun `stackable pickup that would exceed maxStack — rejects with StackFull`() {
+        // 99 WOOD already + dropped 5 → would land at 104, breaching maxStack=100.
+        val dropId = UUID.randomUUID()
+        val state = stateWith().copy(
+            inventories = mapOf(agent to AgentInventory(mapOf(wood to 99))),
+        )
+        val groundItems = StubGroundItemStore(
+            atNode = mapOf(nodeId to listOf(stackableDrop(dropId, wood, 5))),
+        )
+
+        val result = reducePickup(
+            state, WorldCommand.Pickup(agent, dropId), balance(),
+            StubItemLookup(woodWeight = 1), StubAgentRegistry(strength = 100_000),
+            StubEquipmentStore(), groundItems, tick = 1L,
+        )
+
+        assertEquals(
+            WorldRejection.StackFull(agent, wood, current = 99, incoming = 5, maxStack = 100),
+            result.leftOrNull(),
+        )
+        assertEquals(emptyList(), groundItems.taken, "rejection happens BEFORE take so drop stays available")
+    }
+
+    @Test
+    fun `stackable pickup over carry cap — rejects, drop is not taken`() {
+        val dropId = UUID.randomUUID()
+        // 50 wood × 100g = 5000g ; strength 1 × 100g/str = 100g capacity.
+        val state = stateWith()
+        val groundItems = StubGroundItemStore(
+            atNode = mapOf(nodeId to listOf(stackableDrop(dropId, wood, 50))),
+        )
+
+        val result = reducePickup(
+            state, WorldCommand.Pickup(agent, dropId),
+            balance(carryGramsPerStrengthPoint = 100),
+            StubItemLookup(woodWeight = 100), StubAgentRegistry(strength = 1),
+            StubEquipmentStore(), groundItems, tick = 1L,
+        )
+
+        assertIs<WorldRejection.OverEncumbered>(result.leftOrNull())
+        assertEquals(emptyList(), groundItems.taken, "rejection happens BEFORE take so drop stays available")
+    }
+
+    @Test
+    fun `equipment pickup — instance re-INSERTed under new owner with slot null`() {
+        val dropId = UUID.fromString("00000000-0000-0000-0000-0000000000bb")
+        val originalInstanceId = UUID.fromString("00000000-0000-0000-0000-0000000000cc")
+        val drop = DroppedItemView.Equipment(
+            dropId = dropId,
+            item = ItemId("IRON_SWORD"),
+            instanceId = originalInstanceId,
+            rarity = Rarity.RARE,
+            durabilityCurrent = 80,
+            durabilityMax = 100,
+            creatorAgentId = null,
+            createdAtTick = 5L,
+        )
+        val state = stateWith()
+        val view = GroundItemView(nodeId = nodeId, droppedAtTick = 5L, drop = drop)
+        val groundItems = StubGroundItemStore(
+            atNode = mapOf(nodeId to listOf(view)),
+            takeable = mapOf((nodeId to dropId) to view),
+        )
+        val equipment = StubEquipmentStore()
+
+        val result = reducePickup(
+            state, WorldCommand.Pickup(agent, dropId), balance(),
+            StubItemLookup(), StubAgentRegistry(strength = 100), equipment, groundItems, tick = 9L,
+        )
+
+        val (_, event) = assertNotNull(result.getOrNull())
+        assertIs<WorldEvent.ItemPickedUp>(event)
+        val inserted = assertNotNull(equipment.inserted, "pickup must re-INSERT the instance under the new owner")
+        assertEquals(originalInstanceId, inserted.instanceId, "instance id is preserved across drop+pickup")
+        assertEquals(agent, inserted.agentId)
+        assertEquals(Rarity.RARE, inserted.rarity)
+        assertEquals(80, inserted.durabilityCurrent)
+        assertNull(inserted.equippedInSlot, "picked-up equipment lands unequipped — agent must call equip separately")
+    }
+
+    @Test
+    fun `take race lost — second-place agent receives GroundItemNoLongerAvailable`() {
+        // Simulates: atNode shows the drop, but between our check and our take call
+        // another agent's pickup stole it. take returns null, reducer rejects.
+        val dropId = UUID.randomUUID()
+        val state = stateWith()
+        val groundItems = StubGroundItemStore(
+            atNode = mapOf(nodeId to listOf(stackableDrop(dropId, wood, 5))),
+            takeable = emptyMap(), // take always returns null — race lost
+        )
+
+        val result = reducePickup(
+            state, WorldCommand.Pickup(agent, dropId), balance(),
+            StubItemLookup(woodWeight = 100), StubAgentRegistry(strength = 100),
+            StubEquipmentStore(), groundItems, tick = 1L,
+        )
+
+        assertEquals(WorldRejection.GroundItemNoLongerAvailable(agent, dropId), result.leftOrNull())
+        assertEquals(listOf(nodeId to dropId), groundItems.taken, "take was attempted, returned null")
+    }
+
+    @Test
+    fun `stackable drop with unknown item — rejects with UnknownItem`() {
+        val dropId = UUID.randomUUID()
+        val unknown = ItemId("MYSTERY")
+        val state = stateWith()
+        val groundItems = StubGroundItemStore(
+            atNode = mapOf(nodeId to listOf(stackableDrop(dropId, unknown, 1))),
+        )
+
+        val result = reducePickup(
+            state, WorldCommand.Pickup(agent, dropId), balance(),
+            StubItemLookup(), StubAgentRegistry(strength = 100),
+            StubEquipmentStore(), groundItems, tick = 1L,
+        )
+
+        assertEquals(WorldRejection.UnknownItem(unknown), result.leftOrNull())
+        assertEquals(emptyList(), groundItems.taken)
+    }
+
+    private fun stateWith(positioned: Boolean = true): WorldState = WorldState(
+        regions = mapOf(regionId to region),
+        nodes = mapOf(nodeId to node),
+        positions = if (positioned) mapOf(agent to nodeId) else emptyMap(),
+        bodies = mapOf(agent to AgentBody(hp = 50, maxHp = 50, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0)),
+        inventories = mapOf(agent to AgentInventory.EMPTY),
+    )
+
+    private fun stackableDrop(dropId: UUID, item: ItemId, quantity: Int): GroundItemView =
+        GroundItemView(
+            nodeId = nodeId,
+            droppedAtTick = 1L,
+            drop = DroppedItemView.Stackable(dropId = dropId, item = item, quantity = quantity),
+        )
+
+    private fun stackableView(dropId: UUID, item: ItemId, quantity: Int): GroundItemView =
+        stackableDrop(dropId, item, quantity)
+
+    private fun balance(
+        carryGramsPerStrengthPoint: Int = 5_000,
+    ): BalanceLookup = object : BalanceLookup {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
+        override fun staminaRegenPerTick(climate: Climate) = 0
+        override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun carryGramsPerStrengthPoint(): Int = carryGramsPerStrengthPoint
+    }
+
+    private inner class StubItemLookup(woodWeight: Int = 100) : ItemLookup {
+        private val byId = mapOf(
+            wood to Item(
+                id = wood,
+                displayName = "Wood",
+                description = "",
+                category = ItemCategory.RESOURCE,
+                weightPerUnit = woodWeight,
+                maxStack = 100,
+            ),
+        )
+        override fun byId(id: ItemId): Item? = byId[id]
+        override fun all(): List<Item> = byId.values.toList()
+    }
+
+    private inner class StubAgentRegistry(private val strength: Int = 100) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = if (id == agent) {
+            Agent(id = id, owner = PlayerId(UUID.randomUUID()), name = "test", attributes = AgentAttributes(strength = strength))
+        } else {
+            null
+        }
+        override fun listForOwner(owner: PlayerId): List<Agent> = error("not used")
+        override fun applyDeathPenalty(agentId: AgentId, xpLossOnDeath: Int) = error("not used")
+    }
+
+    private class StubEquipmentStore : EquipmentInstanceStore {
+        var inserted: EquipmentInstance? = null
+            private set
+
+        override fun insert(instance: EquipmentInstance) {
+            inserted = instance
+        }
+        override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = error("not used")
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> = emptyMap()
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? =
+            error("not used")
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = error("not used")
+        override fun delete(instanceId: UUID): Boolean = error("not used")
+    }
+
+    private class StubGroundItemStore(
+        private val atNode: Map<NodeId, List<GroundItemView>> = emptyMap(),
+        private val takeable: Map<Pair<NodeId, UUID>, GroundItemView> = emptyMap(),
+    ) : GroundItemStore {
+        val taken: MutableList<Pair<NodeId, UUID>> = mutableListOf()
+
+        override fun deposit(node: NodeId, drop: DroppedItemView, droppedAtTick: Long) = error("not used")
+        override fun atNode(node: NodeId): List<GroundItemView> = atNode[node] ?: emptyList()
+        override fun take(node: NodeId, dropId: UUID): GroundItemView? {
+            taken += node to dropId
+            return takeable[node to dropId]
+        }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnLocationResolverTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnLocationResolverTest.kt
@@ -105,5 +105,6 @@ class SpawnLocationResolverTest {
         override fun bodyOf(agent: AgentId): BodyView? = null
         override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
     }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/NoOpGroundItemStore.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/NoOpGroundItemStore.kt
@@ -1,0 +1,19 @@
+package dev.gvart.genesara.world.internal.testsupport
+
+import dev.gvart.genesara.world.DroppedItemView
+import dev.gvart.genesara.world.GroundItemStore
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.NodeId
+import java.util.UUID
+
+/**
+ * No-op [GroundItemStore] for integration tests that need a `WorldStateQueryGateway`
+ * or `WorldTickHandler` but don't exercise the drop / pickup flow. Returns empty
+ * for reads; throws on writes so accidental traffic surfaces loudly.
+ */
+internal object NoOpGroundItemStore : GroundItemStore {
+    override fun deposit(node: NodeId, drop: DroppedItemView, droppedAtTick: Long) =
+        error("NoOpGroundItemStore: deposit should not be called in this test")
+    override fun atNode(node: NodeId): List<GroundItemView> = emptyList()
+    override fun take(node: NodeId, dropId: UUID): GroundItemView? = null
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -89,7 +89,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 7)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore)
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -111,7 +111,7 @@ class WorldTickHandlerTest {
 
         val cmd = WorldCommand.MoveAgent(agent, ghostId)
         queue.submit(cmd, appliesAtTick = 1)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore)
 
         handler.onTick(Tick(1, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -147,7 +147,7 @@ class WorldTickHandlerTest {
             override fun sleepRegenPerOfflineTick(): Int = 0
             override fun isTraversable(terrain: Terrain): Boolean = true
         }
-        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver)
+        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore)
 
         handler.onTick(Tick(2, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -163,7 +163,7 @@ class WorldTickHandlerTest {
         val queue = CommandQueue()
         val publisher = RecordingPublisher()
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 99)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore)
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -318,4 +318,14 @@ class WorldTickHandlerTest {
 
     private val NoopRarityRoller: dev.gvart.genesara.world.internal.crafting.RarityRoller =
         dev.gvart.genesara.world.internal.crafting.RarityRoller(kotlin.random.Random(0))
+
+    private object NoopGroundItemStore : dev.gvart.genesara.world.GroundItemStore {
+        override fun deposit(
+            node: NodeId,
+            drop: dev.gvart.genesara.world.DroppedItemView,
+            droppedAtTick: Long,
+        ) = error("not used")
+        override fun atNode(node: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
+        override fun take(node: NodeId, dropId: java.util.UUID): dev.gvart.genesara.world.GroundItemView? = null
+    }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImplTest.kt
@@ -131,5 +131,6 @@ class VisionRadiusImplTest {
         override fun bodyOf(agent: AgentId): BodyView? = null
         override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
     }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/JooqAgentKillStreakIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/JooqAgentKillStreakIntegrationTest.kt
@@ -1,0 +1,117 @@
+package dev.gvart.genesara.world.internal.worldstate
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.AgentKillStreak
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_BODIES
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_INVENTORY
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_KILL_STREAKS
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_POSITIONS
+import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Integration test for kill-streak load/save on [JooqWorldStateRepository]. Verifies
+ * the round-trip: a non-empty `AgentKillStreak` saved via the repository reloads via
+ * `WorldState.killStreaks`, and a streak reset to `EMPTY` deletes the row rather than
+ * persisting a (0, 0) sentinel.
+ */
+@Testcontainers
+class JooqAgentKillStreakIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("world_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = WorldFlyway.pooledDataSource(postgres)
+            WorldFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private lateinit var repository: JooqWorldStateRepository
+
+    @BeforeEach
+    fun resetState() {
+        dsl.truncate(AGENT_KILL_STREAKS).cascade().execute()
+        dsl.truncate(AGENT_INVENTORY).cascade().execute()
+        dsl.truncate(AGENT_BODIES).cascade().execute()
+        dsl.truncate(AGENT_POSITIONS).cascade().execute()
+        val staticConfig = WorldStaticConfig(dsl, JsonMapper.builder().addModule(kotlinModule()).build())
+        repository = JooqWorldStateRepository(dsl, staticConfig)
+        repository.init()
+    }
+
+    @Test
+    fun `non-empty streak round-trips through save and load`() {
+        val agent = AgentId(UUID.randomUUID())
+        val state = WorldState.EMPTY.copy(
+            killStreaks = mapOf(agent to AgentKillStreak(killCount = 7, windowStartTick = 100L)),
+        )
+
+        repository.save(state)
+        val reloaded = repository.load()
+
+        assertEquals(
+            AgentKillStreak(killCount = 7, windowStartTick = 100L),
+            reloaded.killStreaks[agent],
+        )
+    }
+
+    @Test
+    fun `EMPTY streak deletes the row instead of persisting zero sentinels`() {
+        val agent = AgentId(UUID.randomUUID())
+        repository.save(
+            WorldState.EMPTY.copy(killStreaks = mapOf(agent to AgentKillStreak(5, windowStartTick = 50L))),
+        )
+
+        repository.save(WorldState.EMPTY.copy(killStreaks = mapOf(agent to AgentKillStreak.EMPTY)))
+
+        val reloaded = repository.load().killStreaks
+        assertNull(reloaded[agent], "EMPTY streak should clear the row")
+    }
+
+    @Test
+    fun `existing streak update overwrites kill_count and window_start_tick`() {
+        val agent = AgentId(UUID.randomUUID())
+        repository.save(
+            WorldState.EMPTY.copy(killStreaks = mapOf(agent to AgentKillStreak(3, windowStartTick = 10L))),
+        )
+        repository.save(
+            WorldState.EMPTY.copy(killStreaks = mapOf(agent to AgentKillStreak(8, windowStartTick = 200L))),
+        )
+
+        val reloaded = repository.load().killStreaks[agent]
+        assertEquals(AgentKillStreak(killCount = 8, windowStartTick = 200L), reloaded)
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateIncrementKillStreakTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateIncrementKillStreakTest.kt
@@ -1,0 +1,72 @@
+package dev.gvart.genesara.world.internal.worldstate
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.AgentKillStreak
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+
+/**
+ * Pins the rolling-window contract for the public-API surface combat (Phase 2)
+ * will plug into. The first kill always anchors the window to the kill tick;
+ * subsequent kills inside the window add 1; a kill outside the window starts a
+ * fresh streak.
+ */
+class WorldStateIncrementKillStreakTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val state = WorldState.EMPTY
+
+    @Test
+    fun `first kill at low tick anchors windowStartTick to the kill tick`() {
+        // Regression for the EMPTY-sentinel edge case: with a default
+        // (killCount=0, windowStartTick=0L) and a low currentTick, the naive
+        // "currentTick - 0 < windowTicks" branch would run the within-window
+        // path and produce (1, 0L) instead of (1, currentTick). The streak
+        // would then expire as soon as currentTick crosses windowTicks rather
+        // than 1000 ticks after the first kill.
+        val next = state.incrementKillStreak(agent, currentTick = 500L, windowTicks = 1000L)
+
+        assertEquals(
+            AgentKillStreak(killCount = 1, windowStartTick = 500L),
+            next.killStreakOf(agent),
+        )
+    }
+
+    @Test
+    fun `second kill inside window adds 1 and keeps windowStartTick`() {
+        val first = state.incrementKillStreak(agent, currentTick = 500L, windowTicks = 1000L)
+
+        val second = first.incrementKillStreak(agent, currentTick = 999L, windowTicks = 1000L)
+
+        assertEquals(
+            AgentKillStreak(killCount = 2, windowStartTick = 500L),
+            second.killStreakOf(agent),
+        )
+    }
+
+    @Test
+    fun `kill at the window boundary expires the prior streak and re-anchors`() {
+        val first = state.incrementKillStreak(agent, currentTick = 500L, windowTicks = 1000L)
+
+        // currentTick - windowStartTick = 1500 - 500 = 1000 >= windowTicks → expired.
+        val second = first.incrementKillStreak(agent, currentTick = 1500L, windowTicks = 1000L)
+
+        assertEquals(
+            AgentKillStreak(killCount = 1, windowStartTick = 1500L),
+            second.killStreakOf(agent),
+        )
+    }
+
+    @Test
+    fun `kill far outside window resets the streak`() {
+        val first = state.incrementKillStreak(agent, currentTick = 100L, windowTicks = 1000L)
+
+        val second = first.incrementKillStreak(agent, currentTick = 5000L, windowTicks = 1000L)
+
+        assertEquals(
+            AgentKillStreak(killCount = 1, windowStartTick = 5000L),
+            second.killStreakOf(agent),
+        )
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayBodyViewIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayBodyViewIntegrationTest.kt
@@ -73,6 +73,7 @@ class WorldStateQueryGatewayBodyViewIntegrationTest {
             starterNodes = NoOpStarterNodes(),
             resources = EmptyResourceStore,
             balance = AlwaysTraversableBalance,
+            groundItems = dev.gvart.genesara.world.internal.testsupport.NoOpGroundItemStore,
         )
     }
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayInventoryIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayInventoryIntegrationTest.kt
@@ -71,6 +71,7 @@ class WorldStateQueryGatewayInventoryIntegrationTest {
             starterNodes = NoOpStarterNodes(),
             resources = EmptyResourceStore,
             balance = AlwaysTraversableBalance,
+            groundItems = dev.gvart.genesara.world.internal.testsupport.NoOpGroundItemStore,
         )
     }
 


### PR DESCRIPTION
Closes #7.

## Summary

- **Kill-streak counter** (`agent_kill_streaks`, V14) — per-agent rolling counter with public `WorldState.incrementKillStreak` for the future combat reducer; encapsulates the window-reset rule.
- **Drop hook in `processDeaths`** — seeded `Random` rolls `dropChance = min(1, killCount × 0.1)`, picks uniform-random from the agent's pool (stackable inventory entries + currently-equipped instances), deposits at the death node, resets the streak.
- **Ground items** in a Redis Hash (`world:groundItems:{nodeId}`), atomic Lua `HGET`+`HDEL` on `take`, intentionally ephemeral (flush vanishes drops by design — no Postgres mirror).
- **`look_around` extension** — current node response now carries `groundItems`; adjacent nodes intentionally omit them (fog-of-war parity).
- **`pickup` MCP tool + `PickupReducer`** — guards carry-cap and `StackFull`; race-loss collapses with stale-id into `GroundItemNoLongerAvailable`.
- **Events** — `AgentDied` extended with `droppedItem`; new `ItemDroppedOnGround` (paired with `AgentDied`) and `ItemPickedUp` (from the pickup reducer).

User-pinned tuning placeholders surfaced through `BalanceLookup` (`killStreakWindowTicks = 1000`, linear `0.1` per kill drop chance). To be retuned with combat balance pass.

## Caveats

- The kill counter has **no production incrementer** until combat (#15) lands. Substrate ships ahead so the attack reducer is a one-line add.
- Drop pool weighting is uniform-by-pool-entry — a 100-stack equals one equipment instance probability-wise. Flagged for the combat balance pass.
- Ground items are Redis-only. A Redis flush vanishes in-flight drops; this is the intended v1 behavior.

## Issue acceptance

- [x] Kill-streak counter
- [x] Drop-chance roll in `processDeaths`
- [x] Item picked from inventory (extended to equipment instances per design call)
- [x] Drop event (`AgentDied.droppedItem` + `ItemDroppedOnGround`)
- [x] No 9-death permadeath counter (already honored by Slice D)

## Test plan

- [x] Unit: `DeathSweepTest` (drop fires/doesn't fire, equipment vs stackable, streak reset, empty-pool fallback, multi-agent ordering)
- [x] Unit: `PickupReducerTest` (NotInWorld, GroundItemNoLongerAvailable, StackFull, OverEncumbered, equipment re-INSERT, race-loss)
- [x] Unit: `WorldStateIncrementKillStreakTest` (rolling-window contract, EMPTY-sentinel low-tick edge case)
- [x] Integration: `JooqAgentKillStreakIntegrationTest` — Postgres round-trip + EMPTY-deletes-row
- [x] Integration: `RedisGroundItemStoreIntegrationTest` — Testcontainers Redis, deposit/atNode/take, atomic concurrent take, equipment metadata round-trip
- [x] Integration: `StarvationDeathRespawnIntegrationTest` updated to compile + still green
- [x] `./gradlew :world:test :api:test` — all green