### PR TITLE
feat(world,api): MVP attack verb + multi-event reducers + weapon range

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,61 @@
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
 # Genesara Engine
 
 > An open-source MMORPG engine designed to be played entirely by AI agents — a living, persistent world. No human players control characters; every agent is an autonomous program connecting via MCP. The world runs 24/7.

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp
 
 import dev.gvart.genesara.api.internal.mcp.events.EventLogProperties
 import dev.gvart.genesara.api.internal.mcp.presence.PresenceProperties
+import dev.gvart.genesara.api.internal.mcp.tools.attack.AttackTool
 import dev.gvart.genesara.api.internal.mcp.tools.attributes.AllocatePointsTool
 import dev.gvart.genesara.api.internal.mcp.tools.build.BuildTool
 import dev.gvart.genesara.api.internal.mcp.tools.chest.DepositToChestTool
@@ -62,13 +63,14 @@ internal class McpServerConfiguration {
         withdrawFromChest: WithdrawFromChestTool,
         craft: CraftTool,
         pickup: PickupTool,
+        attack: AttackTool,
     ): ToolCallbackProvider =
         MethodToolCallbackProvider.builder()
             .toolObjects(
                 spawn, move, lookAround, unspawn, getStatus, harvest, getInventory,
                 consume, drink, getSkills, equipSkill, allocatePoints, inspect, getMap,
                 equipItem, unequipSlot, getEquipment,
-                setSafeNode, respawn, build, depositToChest, withdrawFromChest, craft, pickup,
+                setSafeNode, respawn, build, depositToChest, withdrawFromChest, craft, pickup, attack,
             )
             .build()
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -69,6 +69,15 @@ internal class AgentEventDispatcher(
         }
     }
 
+    @EventListener
+    fun on(event: WorldEvent.AgentAttacked) {
+        publish(event.attacker, "agent.attacked", event)
+        if (event.attacker != event.target) publish(event.target, "agent.attacked", event)
+    }
+
+    @EventListener
+    fun on(event: WorldEvent.AgentDied) = publish(event.agent, "agent.died", event)
+
     private fun publish(agent: AgentId, type: String, payload: Any) {
         val tick = (payload as? WorldEvent)?.tick
             ?: (payload as? AgentEvent)?.tick

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/CommandAckKind.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/CommandAckKind.kt
@@ -1,0 +1,15 @@
+package dev.gvart.genesara.api.internal.mcp.tools
+
+/**
+ * Discriminator for queue-and-ack tool responses. The MCP `@Tool` returns
+ * synchronously the moment the command is enqueued (before the tick has
+ * resolved it), so the only outcome it can report in-band is "queued".
+ * Reducer-level rejections surface later via `WorldEvent.CommandRejected`
+ * on the agent's event stream, not on this response.
+ *
+ * Tools whose synchronous response itself carries success/failure semantics
+ * (e.g. `equip_item`'s `equipped` / `rejected`, `allocate_points`'
+ * `OK` / `REJECTED`) keep their own enums — they're describing a different
+ * shape (in-band sync outcome, not an enqueue ack).
+ */
+enum class CommandAckKind { QUEUED }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackTool.kt
@@ -1,0 +1,37 @@
+package dev.gvart.genesara.api.internal.mcp.tools.attack
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+internal class AttackTool(
+    private val world: WorldCommandGateway,
+    private val engine: TickClock,
+    private val activity: AgentActivityTracker,
+) {
+
+    @Tool(
+        name = "attack",
+        description = "Attack another agent on your current node. Queues an AttackTarget command; " +
+            "the resulting AgentAttacked event arrives on the agent's event stream once the tick lands. " +
+            "Costs stamina; rejected if the target is not in the world, on a different node, or already dead.",
+    )
+    fun invoke(req: AttackRequest, toolContext: ToolContext): AttackResponse {
+        touchActivity(toolContext, activity, "attack")
+        val agent = AgentContextHolder.current()
+        val target = AgentId(UUID.fromString(req.targetAgentId))
+        val command = WorldCommand.AttackTarget(agent = agent, target = target)
+        val nextTick = engine.currentTick() + 1
+        world.submit(command, appliesAtTick = nextTick)
+        return AttackResponse.queued(command.commandId, nextTick, req.targetAgentId)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackTool.kt
@@ -10,7 +10,6 @@ import dev.gvart.genesara.world.commands.WorldCommand
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.annotation.Tool
 import org.springframework.stereotype.Component
-import java.util.UUID
 
 @Component
 internal class AttackTool(
@@ -21,15 +20,16 @@ internal class AttackTool(
 
     @Tool(
         name = "attack",
-        description = "Attack another agent on your current node. Queues an AttackTarget command; " +
-            "the resulting AgentAttacked event arrives on the agent's event stream once the tick lands. " +
-            "Costs stamina; rejected if the target is not in the world, on a different node, or already dead.",
+        description = "Attack another agent within your weapon's range — same node for melee, " +
+            "adjacent or further nodes for ranged weapons (per the weapon's `range`). Queues an " +
+            "AttackTarget command; the resulting AgentAttacked event arrives on the agent's event " +
+            "stream once the tick lands. Costs stamina; rejected if the target is beyond range, " +
+            "not in the world, or already dead.",
     )
     fun invoke(req: AttackRequest, toolContext: ToolContext): AttackResponse {
         touchActivity(toolContext, activity, "attack")
         val agent = AgentContextHolder.current()
-        val target = AgentId(UUID.fromString(req.targetAgentId))
-        val command = WorldCommand.AttackTarget(agent = agent, target = target)
+        val command = WorldCommand.AttackTarget(agent = agent, target = AgentId(req.targetAgentId))
         val nextTick = engine.currentTick() + 1
         world.submit(command, appliesAtTick = nextTick)
         return AttackResponse.queued(command.commandId, nextTick, req.targetAgentId)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolIo.kt
@@ -5,34 +5,30 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription
 import java.util.UUID
 
 @JsonClassDescription(
-    "Attempt one melee or ranged attack against another agent on the same node. " +
-        "The reducer reads the attacker's MAIN_HAND weapon (or unarmed defaults), rolls dodge then crit, " +
-        "applies damage, spends stamina, and grants weapon-skill XP. The resulting AgentAttacked " +
-        "event arrives on both the attacker's and the target's event streams once the tick lands; if " +
-        "the blow drops the target's HP to zero, an AgentDied event lands at the same tick. Rejected " +
-        "if attacker and target are not on the same node, target is not in the world, target is " +
-        "already dead, attacker is not in the world, or attacker has insufficient stamina.",
+    "Attempt one melee or ranged attack against another agent within the wielded weapon's range " +
+        "(or unarmed reach when no weapon is equipped). The reducer reads the attacker's MAIN_HAND " +
+        "weapon (or unarmed defaults), rolls dodge then crit, applies damage, spends stamina, and " +
+        "grants weapon-skill XP. The resulting AgentAttacked event arrives on both the attacker's " +
+        "and the target's event streams once the tick lands; if the blow drops the target's HP to " +
+        "zero, an AgentDied event lands at the same tick. Rejected if the target is beyond the " +
+        "weapon's range, not in the world, already dead, or if the attacker is not in the world or " +
+        "has insufficient stamina.",
 )
 data class AttackRequest(
-    @JsonPropertyDescription("Target agent id (UUID string).")
-    val targetAgentId: String,
+    @JsonPropertyDescription("Target agent UUID (read it from look_around / inspect).")
+    val targetAgentId: UUID,
 )
 
-/**
- * Response shape for `attack`.
- *
- * - `kind = "queued"`: an AttackTarget command was queued; the result lands on `appliesAtTick`
- *   and shows up via the agent's event stream as an `agent.attacked` notification (and possibly
- *   `agent.died` if the blow killed).
- */
+enum class AttackResponseKind { QUEUED }
+
 data class AttackResponse(
-    val kind: String,
-    val targetAgentId: String,
-    val commandId: UUID? = null,
-    val appliesAtTick: Long? = null,
+    val kind: AttackResponseKind,
+    val targetAgentId: UUID,
+    val commandId: UUID,
+    val appliesAtTick: Long,
 ) {
     companion object {
-        fun queued(commandId: UUID, appliesAtTick: Long, targetAgentId: String) =
-            AttackResponse("queued", targetAgentId, commandId, appliesAtTick)
+        fun queued(commandId: UUID, appliesAtTick: Long, targetAgentId: UUID) =
+            AttackResponse(AttackResponseKind.QUEUED, targetAgentId, commandId, appliesAtTick)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolIo.kt
@@ -1,0 +1,38 @@
+package dev.gvart.genesara.api.internal.mcp.tools.attack
+
+import com.fasterxml.jackson.annotation.JsonClassDescription
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import java.util.UUID
+
+@JsonClassDescription(
+    "Attempt one melee or ranged attack against another agent on the same node. " +
+        "The reducer reads the attacker's MAIN_HAND weapon (or unarmed defaults), rolls dodge then crit, " +
+        "applies damage, spends stamina, and grants weapon-skill XP. The resulting AgentAttacked " +
+        "event arrives on both the attacker's and the target's event streams once the tick lands; if " +
+        "the blow drops the target's HP to zero, an AgentDied event lands at the same tick. Rejected " +
+        "if attacker and target are not on the same node, target is not in the world, target is " +
+        "already dead, attacker is not in the world, or attacker has insufficient stamina.",
+)
+data class AttackRequest(
+    @JsonPropertyDescription("Target agent id (UUID string).")
+    val targetAgentId: String,
+)
+
+/**
+ * Response shape for `attack`.
+ *
+ * - `kind = "queued"`: an AttackTarget command was queued; the result lands on `appliesAtTick`
+ *   and shows up via the agent's event stream as an `agent.attacked` notification (and possibly
+ *   `agent.died` if the blow killed).
+ */
+data class AttackResponse(
+    val kind: String,
+    val targetAgentId: String,
+    val commandId: UUID? = null,
+    val appliesAtTick: Long? = null,
+) {
+    companion object {
+        fun queued(commandId: UUID, appliesAtTick: Long, targetAgentId: String) =
+            AttackResponse("queued", targetAgentId, commandId, appliesAtTick)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolIo.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.attack
 
 import com.fasterxml.jackson.annotation.JsonClassDescription
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import java.util.UUID
 
 @JsonClassDescription(
@@ -19,16 +20,14 @@ data class AttackRequest(
     val targetAgentId: UUID,
 )
 
-enum class AttackResponseKind { QUEUED }
-
 data class AttackResponse(
-    val kind: AttackResponseKind,
+    val kind: CommandAckKind,
     val targetAgentId: UUID,
     val commandId: UUID,
     val appliesAtTick: Long,
 ) {
     companion object {
         fun queued(commandId: UUID, appliesAtTick: Long, targetAgentId: UUID) =
-            AttackResponse(AttackResponseKind.QUEUED, targetAgentId, commandId, appliesAtTick)
+            AttackResponse(CommandAckKind.QUEUED, targetAgentId, commandId, appliesAtTick)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/consume/ConsumeToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/consume/ConsumeToolIo.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.consume
 
 import com.fasterxml.jackson.annotation.JsonClassDescription
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import java.util.UUID
 
 @JsonClassDescription("Consume one unit of a held item to refill a survival gauge. The item must be in the agent's inventory and have a consumable effect.")
@@ -10,20 +11,14 @@ data class ConsumeRequest(
     val itemId: String,
 )
 
-/**
- * Response shape for `consume`.
- *
- * - `kind = "queued"`: a ConsumeItem command was queued; the resulting ItemConsumed
- *   event arrives on the agent's event stream once the tick lands.
- */
 data class ConsumeResponse(
-    val kind: String,
+    val kind: CommandAckKind,
     val itemId: String,
     val commandId: UUID? = null,
     val appliesAtTick: Long? = null,
 ) {
     companion object {
         fun queued(commandId: UUID, appliesAtTick: Long, itemId: String) =
-            ConsumeResponse("queued", itemId, commandId, appliesAtTick)
+            ConsumeResponse(CommandAckKind.QUEUED, itemId, commandId, appliesAtTick)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/drink/DrinkToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/drink/DrinkToolIo.kt
@@ -1,24 +1,19 @@
 package dev.gvart.genesara.api.internal.mcp.tools.drink
 
 import com.fasterxml.jackson.annotation.JsonClassDescription
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import java.util.UUID
 
 @JsonClassDescription("Drink directly from a water-source terrain (coastal, river delta, wetlands, shoreline). Refills THIRST and costs a small amount of stamina. No item required; rejected on terrains without surface water.")
 class DrinkRequest
 
-/**
- * Response shape for `drink`.
- *
- * - `kind = "queued"`: a Drink command was queued; the resulting AgentDrank event arrives
- *   on the agent's event stream once the tick lands.
- */
 data class DrinkResponse(
-    val kind: String,
+    val kind: CommandAckKind,
     val commandId: UUID? = null,
     val appliesAtTick: Long? = null,
 ) {
     companion object {
         fun queued(commandId: UUID, appliesAtTick: Long) =
-            DrinkResponse("queued", commandId, appliesAtTick)
+            DrinkResponse(CommandAckKind.QUEUED, commandId, appliesAtTick)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/harvest/HarvestToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/harvest/HarvestToolIo.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.harvest
 
 import com.fasterxml.jackson.annotation.JsonClassDescription
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import java.util.UUID
 
 @JsonClassDescription(
@@ -16,20 +17,14 @@ data class HarvestRequest(
     val itemId: String,
 )
 
-/**
- * Response shape for `harvest`.
- *
- * - `kind = "queued"`: a Harvest command was queued; the result lands on `appliesAtTick`
- *   and shows up via the agent's event stream as a `resource.harvested` notification.
- */
 data class HarvestResponse(
-    val kind: String,
+    val kind: CommandAckKind,
     val itemId: String,
     val commandId: UUID? = null,
     val appliesAtTick: Long? = null,
 ) {
     companion object {
         fun queued(commandId: UUID, appliesAtTick: Long, itemId: String) =
-            HarvestResponse("queued", itemId, commandId, appliesAtTick)
+            HarvestResponse(CommandAckKind.QUEUED, itemId, commandId, appliesAtTick)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
@@ -181,7 +181,7 @@ internal class InspectTool(
                 regenerating = if (depth != InspectDepth.SHALLOW) item.regenerating else null,
                 rarity = if (depth != InspectDepth.SHALLOW) item.rarity.name else null,
                 maxDurability = if (depth != InspectDepth.SHALLOW) item.maxDurability else null,
-                harvestSkill = if (depth == InspectDepth.EXPERT) item.harvestSkill else null,
+                harvestSkill = if (depth == InspectDepth.EXPERT) item.harvestSkill?.value else null,
             ),
         )
     }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/pickup/PickupToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/pickup/PickupToolIo.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.pickup
 
 import com.fasterxml.jackson.annotation.JsonClassDescription
 import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import java.util.UUID
 
 @JsonClassDescription(
@@ -15,22 +16,14 @@ data class PickupRequest(
     val dropId: String,
 )
 
-/**
- * Response shape for `pickup`.
- *
- * - `kind = QUEUED`: a Pickup command was queued; the result lands on `appliesAtTick`
- *   and shows up via the agent's event stream as an `item.picked-up` notification.
- */
 data class PickupResponse(
-    val kind: PickupResponseKind,
+    val kind: CommandAckKind,
     val dropId: String,
     val commandId: UUID? = null,
     val appliesAtTick: Long? = null,
 ) {
     companion object {
         fun queued(commandId: UUID, appliesAtTick: Long, dropId: String) =
-            PickupResponse(PickupResponseKind.QUEUED, dropId, commandId, appliesAtTick)
+            PickupResponse(CommandAckKind.QUEUED, dropId, commandId, appliesAtTick)
     }
 }
-
-enum class PickupResponseKind { QUEUED }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/respawn/RespawnToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/respawn/RespawnToolIo.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.respawn
 
 import com.fasterxml.jackson.annotation.JsonClassDescription
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import java.util.UUID
 
 @JsonClassDescription(
@@ -11,12 +12,12 @@ import java.util.UUID
 class RespawnRequest
 
 data class RespawnResponse(
-    val kind: String,
+    val kind: CommandAckKind,
     val commandId: UUID? = null,
     val appliesAtTick: Long? = null,
 ) {
     companion object {
         fun queued(commandId: UUID, appliesAtTick: Long) =
-            RespawnResponse("queued", commandId, appliesAtTick)
+            RespawnResponse(CommandAckKind.QUEUED, commandId, appliesAtTick)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/safenode/SetSafeNodeToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/safenode/SetSafeNodeToolIo.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.safenode
 
 import com.fasterxml.jackson.annotation.JsonClassDescription
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import java.util.UUID
 
 @JsonClassDescription(
@@ -10,12 +11,12 @@ import java.util.UUID
 class SetSafeNodeRequest
 
 data class SetSafeNodeResponse(
-    val kind: String,
+    val kind: CommandAckKind,
     val commandId: UUID? = null,
     val appliesAtTick: Long? = null,
 ) {
     companion object {
         fun queued(commandId: UUID, appliesAtTick: Long) =
-            SetSafeNodeResponse("queued", commandId, appliesAtTick)
+            SetSafeNodeResponse(CommandAckKind.QUEUED, commandId, appliesAtTick)
     }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.api.internal.mcp.events
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.DamageType
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.NodeId
@@ -153,6 +154,80 @@ class AgentEventDispatcherTest {
         assertEquals(9L, entry.tick)
         assertEquals(100, entry.payload.get("milestone").asInt())
         assertEquals("INTELLIGENCE", entry.payload.get("attribute").asString())
+    }
+
+    @Test
+    fun `AgentAttacked fans out to both attacker and target streams`() {
+        val attacker = AgentId(UUID.randomUUID())
+        val target = AgentId(UUID.randomUUID())
+        val cmdId = UUID.randomUUID()
+        val event = WorldEvent.AgentAttacked(
+            attacker = attacker,
+            target = target,
+            at = NodeId(1L),
+            damageType = DamageType.SLASH,
+            baseDamage = 10,
+            hpLost = 10,
+            isCrit = false,
+            isDodged = false,
+            targetHpAfter = 40,
+            targetKilled = false,
+            tick = 12,
+            causedBy = cmdId,
+        )
+
+        dispatcher.on(event)
+
+        assertEquals(1, log.since(attacker, 0).size)
+        assertEquals(1, log.since(target, 0).size)
+        assertEquals("agent.attacked", log.since(attacker, 0).single().type)
+        assertEquals("agent.attacked", log.since(target, 0).single().type)
+    }
+
+    @Test
+    fun `AgentAttacked publishes only once when attacker equals target (defensive)`() {
+        // Reducer rejects self-attacks before they reach the dispatcher, but if a future
+        // ability ever fires AgentAttacked with attacker == target, the dispatcher must not
+        // double-publish into the same stream and inflate envelope counts.
+        val cmdId = UUID.randomUUID()
+        val event = WorldEvent.AgentAttacked(
+            attacker = agent,
+            target = agent,
+            at = NodeId(1L),
+            damageType = DamageType.BLUNT,
+            baseDamage = 0,
+            hpLost = 0,
+            isCrit = false,
+            isDodged = false,
+            targetHpAfter = 50,
+            targetKilled = false,
+            tick = 1,
+            causedBy = cmdId,
+        )
+
+        dispatcher.on(event)
+
+        assertEquals(1, log.since(agent, 0).size)
+    }
+
+    @Test
+    fun `AgentDied lands on the dying agent's stream`() {
+        val cmdId = UUID.randomUUID()
+        val event = WorldEvent.AgentDied(
+            agent = agent,
+            at = NodeId(1L),
+            xpLost = 25,
+            deleveled = false,
+            attributePointLost = null,
+            tick = 12,
+            causedBy = cmdId,
+        )
+
+        dispatcher.on(event)
+
+        val entry = log.since(agent, 0).single()
+        assertEquals("agent.died", entry.type)
+        assertEquals(12L, entry.tick)
     }
 
     @Test

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolTest.kt
@@ -36,10 +36,10 @@ class AttackToolTest {
     fun `queues an AttackTarget command at the next tick and returns the ack`() {
         val tool = AttackTool(gateway, tickClock, activity)
 
-        val response = tool.invoke(AttackRequest(targetAgentId = target.id.toString()), toolContext)
+        val response = tool.invoke(AttackRequest(targetAgentId = target.id), toolContext)
 
-        assertEquals("queued", response.kind)
-        assertEquals(target.id.toString(), response.targetAgentId)
+        assertEquals(AttackResponseKind.QUEUED, response.kind)
+        assertEquals(target.id, response.targetAgentId)
         assertEquals(51L, response.appliesAtTick)
         val (cmd, appliesAt) = gateway.submissions.single()
         val attack = assertNotNull(cmd as? WorldCommand.AttackTarget)
@@ -55,7 +55,7 @@ class AttackToolTest {
 
         assertTrue(attacker !in activity.staleAgents(clock.instant().minusSeconds(60)))
 
-        tool.invoke(AttackRequest(targetAgentId = target.id.toString()), toolContext)
+        tool.invoke(AttackRequest(targetAgentId = target.id), toolContext)
 
         assertTrue(attacker in activity.staleAgents(clock.instant().plusSeconds(60)))
     }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolTest.kt
@@ -1,0 +1,79 @@
+package dev.gvart.genesara.api.internal.mcp.tools.attack
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class AttackToolTest {
+
+    private val attacker = AgentId(UUID.randomUUID())
+    private val target = AgentId(UUID.randomUUID())
+    private val clock = MutableTestClock(Instant.parse("2026-01-01T00:00:00Z"))
+    private val activity = AgentActivityRegistry(clock)
+    private val gateway = RecordingGateway()
+    private val tickClock = StubTickClock(currentTick = 50L)
+    private val toolContext = ToolContext(emptyMap())
+
+    @BeforeEach fun setUp() = AgentContextHolder.set(attacker)
+    @AfterEach fun tearDown() = AgentContextHolder.clear()
+
+    @Test
+    fun `queues an AttackTarget command at the next tick and returns the ack`() {
+        val tool = AttackTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(AttackRequest(targetAgentId = target.id.toString()), toolContext)
+
+        assertEquals("queued", response.kind)
+        assertEquals(target.id.toString(), response.targetAgentId)
+        assertEquals(51L, response.appliesAtTick)
+        val (cmd, appliesAt) = gateway.submissions.single()
+        val attack = assertNotNull(cmd as? WorldCommand.AttackTarget)
+        assertEquals(attacker, attack.agent)
+        assertEquals(target, attack.target)
+        assertEquals(51L, appliesAt)
+        assertEquals(attack.commandId, response.commandId)
+    }
+
+    @Test
+    fun `touches activity registry on every successful invocation`() {
+        val tool = AttackTool(gateway, tickClock, activity)
+
+        assertTrue(attacker !in activity.staleAgents(clock.instant().minusSeconds(60)))
+
+        tool.invoke(AttackRequest(targetAgentId = target.id.toString()), toolContext)
+
+        assertTrue(attacker in activity.staleAgents(clock.instant().plusSeconds(60)))
+    }
+
+    private class RecordingGateway : WorldCommandGateway {
+        val submissions = mutableListOf<Pair<WorldCommand, Long>>()
+        override fun submit(command: WorldCommand, appliesAtTick: Long) {
+            submissions += command to appliesAtTick
+        }
+    }
+
+    private class StubTickClock(private val currentTick: Long) : TickClock {
+        override fun currentTick(): Long = currentTick
+    }
+
+    private class MutableTestClock(private var now: Instant) : Clock() {
+        override fun instant(): Instant = now
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolTest.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.attack
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.world.WorldCommandGateway
@@ -38,7 +39,7 @@ class AttackToolTest {
 
         val response = tool.invoke(AttackRequest(targetAgentId = target.id), toolContext)
 
-        assertEquals(AttackResponseKind.QUEUED, response.kind)
+        assertEquals(CommandAckKind.QUEUED, response.kind)
         assertEquals(target.id, response.targetAgentId)
         assertEquals(51L, response.appliesAtTick)
         val (cmd, appliesAt) = gateway.submissions.single()

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/consume/ConsumeToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/consume/ConsumeToolTest.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.consume
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.world.ItemId
@@ -37,7 +38,7 @@ class ConsumeToolTest {
 
         val response = tool.invoke(ConsumeRequest(itemId = "BERRY"), toolContext)
 
-        assertEquals("queued", response.kind)
+        assertEquals(CommandAckKind.QUEUED, response.kind)
         assertEquals("BERRY", response.itemId)
         assertEquals(51L, response.appliesAtTick)
         val (cmd, appliesAt) = gateway.submissions.single()

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/drink/DrinkToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/drink/DrinkToolTest.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.drink
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.world.WorldCommandGateway
@@ -36,7 +37,7 @@ class DrinkToolTest {
 
         val response = tool.invoke(DrinkRequest(), toolContext)
 
-        assertEquals("queued", response.kind)
+        assertEquals(CommandAckKind.QUEUED, response.kind)
         assertEquals(51L, response.appliesAtTick)
         val (cmd, appliesAt) = gateway.submissions.single()
         val drink = assertNotNull(cmd as? WorldCommand.Drink)

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/harvest/HarvestToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/harvest/HarvestToolTest.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.harvest
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.world.ItemId
@@ -38,7 +39,7 @@ class HarvestToolTest {
 
         val response = tool.invoke(HarvestRequest(itemId = "WOOD"), toolContext)
 
-        assertEquals("queued", response.kind)
+        assertEquals(CommandAckKind.QUEUED, response.kind)
         assertEquals("WOOD", response.itemId)
         assertEquals(51L, response.appliesAtTick)
         val (cmd, appliesAt) = gateway.submissions.single()
@@ -55,7 +56,7 @@ class HarvestToolTest {
 
         val response = tool.invoke(HarvestRequest(itemId = "STONE"), toolContext)
 
-        assertEquals("queued", response.kind)
+        assertEquals(CommandAckKind.QUEUED, response.kind)
         assertEquals("STONE", response.itemId)
         val cmd = gateway.submissions.single().first as WorldCommand.Harvest
         assertEquals(ItemId("STONE"), cmd.item)

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
@@ -9,6 +9,7 @@ import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.RaceId
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.BodyView
@@ -410,7 +411,7 @@ class InspectToolTest {
                 category = ItemCategory.RESOURCE,
                 weightPerUnit = 200,
                 maxStack = 99,
-                harvestSkill = "FORESTRY",
+                harvestSkill = SkillId("FORESTRY"),
             ),
         )
         override fun byId(id: ItemId): Item? = catalog[id.value]

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/respawn/RespawnToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/respawn/RespawnToolTest.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.respawn
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.world.WorldCommandGateway
@@ -37,7 +38,7 @@ class RespawnToolTest {
 
         val response = tool.invoke(RespawnRequest(), toolContext)
 
-        assertEquals("queued", response.kind)
+        assertEquals(CommandAckKind.QUEUED, response.kind)
         assertEquals(100L, response.appliesAtTick)
         val (cmd, appliesAt) = gateway.submissions.single()
         val respawn = assertNotNull(cmd as? WorldCommand.Respawn)

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/safenode/SetSafeNodeToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/safenode/SetSafeNodeToolTest.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.safenode
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.world.WorldCommandGateway
@@ -37,7 +38,7 @@ class SetSafeNodeToolTest {
 
         val response = tool.invoke(SetSafeNodeRequest(), toolContext)
 
-        assertEquals("queued", response.kind)
+        assertEquals(CommandAckKind.QUEUED, response.kind)
         assertEquals(51L, response.appliesAtTick)
         val (cmd, appliesAt) = gateway.submissions.single()
         val set = assertNotNull(cmd as? WorldCommand.SetSafeNode)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,11 +59,15 @@ sealed interface WorldEvent  { /* AgentMoved, AgentSpawned, ... */ }
 // 3. State — the thing commands fold over
 data class WorldState(/* nodes, positions, bodies, ... */)
 
-// 4. Reducer — pure (state, command, tick) → Either<Rejection, (state', event)>
-internal fun reduceXxx(state, command, tick): Either<Rejection, Pair<State, Event>>
+// 4. Reducer — pure (state, command, tick) → Either<Rejection, (state', events)>
+internal fun reduceXxx(state, command, tick): Either<Rejection, Pair<State, List<Event>>>
 ```
 
 A reducer has **no Spring, no I/O, no clock**. Trivially unit-testable. Everything stateful (DB, bus, scheduler) is the imperative shell that *calls* reducers.
+
+The reducer return type is `List<WorldEvent>` (not a single event) because some verbs naturally emit more than one fact: an `attack` that lands a killing blow emits `AgentAttacked` AND `AgentDied` in the same tick, and the harvest reducer is wired to emit `NodeResourceDepleted` alongside `ResourceHarvested` once that signal lands. Single-event reducers wrap their event in `listOf(event)` — the cost is one allocation per accept.
+
+Death is a shared seam: per-agent death side-effects (XP penalty, kill-streak drop roll, position removal, event emission) live in `DeathProcessor.applyDeath`. The post-passive death sweep (starvation) calls it with `cause = null`; the attack reducer calls it inline on the killing blow with `cause = AttackCause(commandId, attackerId)` so `AgentDied.causedBy` carries the killing command's id and the attacker's `killStreak` ticks up at the same moment as the death event.
 
 ## The tick loop
 
@@ -191,6 +195,15 @@ See [`persistence.md`](persistence.md) for the patterns: convention plugin, offl
 - **Full JPA** — don't need a managed object graph for this domain.
 - **MapStruct / model-mapper** — Kotlin extension functions are cheaper.
 - **Hexagonal ports/adapters** — the Modulith public package already *is* the port; its `internal/` already *is* the adapter boundary.
+
+## Code style
+
+The architecture above is the *macro* shape; the lines below are the *micro* discipline that keeps modules navigable.
+
+- **Enums (and sealed types) over strings.** Any value with a closed set of variants — resource kinds, building types, rejection reasons, equipment slots, item rarities, command/event discriminators — must be modelled as an `enum class` or `sealed interface`/`sealed class`. Never pass a `String` where an enum would work. Strings cross module boundaries only at the serialization edge (jOOQ codegen, MCP JSON, Flyway migrations); inside the domain everything is typed. If you find yourself writing `when (kind) { "wood" -> ...; "iron" -> ... }`, stop and introduce the enum.
+- **Zero comments by default.** Code, function names, parameter names, and test names carry the meaning. The only survivors are `TODO(<tag>): ...` markers, one-line KDoc on public-API surfaces, and a short *WHY* when an invariant is genuinely non-obvious. No "this block does X" running commentary, no test-setup comments restating literals, no KDoc on private helpers. Re-read every comment in a diff before committing — delete unless it falls into an allowed bucket. Full rules in [`CLAUDE.md`](../CLAUDE.md#code-style-self-explanatory-code).
+- **Clean architecture, applied through the Modulith.** The public package *is* the port; `internal/` *is* the adapter boundary. Reducers stay pure (no Spring, no I/O, no clock); the shell is the only thing that touches the world. Dependencies always point inward — `:api` may import `:world`'s public surface, never the reverse. Do not stack hexagonal ports/adapters on top of this; the Modulith already gives us the layering.
+- **Clean code, applied surgically.** Smallest diff that solves the stated problem. No speculative abstractions, no "while I'm here" refactors, no flexibility that wasn't requested. Match the existing style in the file you're editing even if you'd write it differently. Every changed line must trace to the user's request.
 
 ## Testing strategy
 

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -94,6 +94,8 @@ The resource shape is the **contract**:
 - `payload` — event-specific JSON.
 - `causedBy` — the `commandId` that produced this event, or `null` if it's a world event the agent merely witnessed.
 
+Most events land on a single agent's stream. A few fan out to two: `AgentAttacked` reaches both the attacker and the target so each can correlate by `commandId` (the attacker because they issued the command, the target because they need to know they were hit).
+
 Read parameters:
 
 - `after` — the highest `seq` the agent has already consumed. The resource returns every entry with `seq > after`. Default `0` returns the entire visible window.

--- a/player/src/main/resources/player-definition/skills.yaml
+++ b/player/src/main/resources/player-definition/skills.yaml
@@ -68,6 +68,21 @@ skills:
       description: Active defense with a held shield.
       category: COMBAT
 
+    CLUB:
+      display-name: Cudgel
+      description: One-handed blunt impact weapons (clubs, maces, mauls).
+      category: COMBAT
+
+    SPEAR:
+      display-name: Spearwork
+      description: Reach weapons with a piercing tip — spears, javelins.
+      category: COMBAT
+
+    POLEARM:
+      display-name: Polearm
+      description: Two-handed reach weapons (halberd, glaive, bardiche).
+      category: COMBAT
+
     # ───────────────────────── Crafting (placeholders) ─────────────────────────
 
     CARPENTRY:

--- a/world/src/main/kotlin/dev/gvart/genesara/world/DamageType.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/DamageType.kt
@@ -1,0 +1,15 @@
+package dev.gvart.genesara.world
+
+/**
+ * The five canonical damage taxonomies used by combat resolution. Weapons declare
+ * their primary type via [Item.damageType]; armor pieces will declare per-type
+ * resistances when armor reductions land in a later combat slice. Status-effect
+ * damage (Bleed/Burn/Poison) carries its own type when those land.
+ */
+enum class DamageType {
+    SLASH,
+    PIERCE,
+    BLUNT,
+    ENERGY,
+    MAGICAL,
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/Item.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/Item.kt
@@ -51,7 +51,7 @@ data class Item(
      * for non-harvestable items or for resources that aren't tied to a skill (none
      * today). Cross-validated against the skill catalog at startup.
      */
-    val harvestSkill: String? = null,
+    val harvestSkill: SkillId? = null,
     /**
      * Default rarity for instances of this item. Stackable resources always emit
      * COMMON; equipment items can declare a higher floor here (e.g. an artifact
@@ -100,6 +100,36 @@ data class Item(
      * the rejection.
      */
     val requiredSkills: Map<SkillId, Int> = emptyMap(),
+    /**
+     * Damage taxonomy of an attack performed with this weapon. Null for non-weapon
+     * items and for weapons not yet wired into combat (off-hand torches, shields, etc.).
+     * The attack reducer falls back to [DamageType.BLUNT] when the attacker has nothing
+     * combat-mapped equipped (unarmed).
+     */
+    val damageType: DamageType? = null,
+    /**
+     * Multiplier applied against the attacker's combat stat to compute base damage.
+     * Null for non-weapons. Higher values mean a heavier hit per swing; tier scales
+     * roughly with `weaponPower` (T1 single-hand 6–8, T1 two-hand 9, T2 single-hand 12,
+     * T2 two-hand 14).
+     */
+    val weaponPower: Int? = null,
+    /**
+     * Skill id (from `:player`'s catalog) that an `attack` with this weapon trains.
+     * Mirrors [harvestSkill]'s shape and the `combat-skill` YAML field. Null for
+     * non-weapons or weapons without a designed skill mapping. A null value is the
+     * "no-XP-grant" signal for the attack reducer, parallel to the harvest hook.
+     */
+    val combatSkill: SkillId? = null,
+    /**
+     * Maximum node-distance the weapon can strike across, measured in adjacency
+     * hops. `1` means same-node only (melee — the default for unmapped weapons).
+     * `2` means same-node OR an adjacent node (short-bow reach). `3+` extends
+     * further along the adjacency graph. Null for non-weapons. The attack
+     * reducer rejects with `TargetOutOfRange` when the target sits beyond this
+     * radius.
+     */
+    val range: Int? = null,
 ) {
     init {
         if (twoHanded) {

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
@@ -227,4 +227,32 @@ sealed interface WorldRejection {
         val agent: AgentId,
         val dropId: UUID,
     ) : WorldRejection
+
+    /** Attack target id is the same agent calling the attack — self-strike rejected. */
+    data class CannotAttackSelf(val agent: AgentId) : WorldRejection
+
+    /** Attack target is not currently positioned in the world (never spawned, despawned, or dead and unspawned). */
+    data class TargetNotInWorld(val attacker: AgentId, val target: AgentId) : WorldRejection
+
+    /**
+     * Target sits beyond the wielded weapon's [Item.range] (or the unarmed
+     * fallback range when no weapon is equipped). Carries the weapon's reach
+     * so the agent can decide whether to close the gap or pick a longer-range
+     * weapon — a melee miss against a same-region neighbor reads the same as a
+     * bow shot at three nodes' distance, and that distinction matters.
+     */
+    data class TargetOutOfRange(
+        val attacker: AgentId,
+        val target: AgentId,
+        val attackerAt: NodeId,
+        val targetAt: NodeId,
+        val weaponRange: Int,
+    ) : WorldRejection
+
+    /**
+     * Attack target's body is at HP=0 — already-dead agents await respawn and
+     * cannot be re-attacked. Distinct from [TargetNotInWorld]; this surfaces
+     * only on the rare race where the death sweep hasn't yet removed them.
+     */
+    data class TargetAlreadyDead(val attacker: AgentId, val target: AgentId) : WorldRejection
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
@@ -133,4 +133,19 @@ sealed interface WorldCommand {
         val dropId: UUID,
         override val commandId: UUID = UUID.randomUUID(),
     ) : WorldCommand
+
+    /**
+     * Single melee/ranged attack. The reducer reads the attacker's MAIN_HAND
+     * (or unarmed defaults), rolls dodge then crit, applies the resulting damage
+     * to [target]'s HP, spends stamina on the attacker, and grants weapon-skill
+     * XP. A killing blow flows through [dev.gvart.genesara.world.internal.death.DeathProcessor]
+     * inline so [WorldEvent.AgentDied.causedBy] carries this command's
+     * [commandId]. No `ability` parameter in Slice 1 — abilities + cooldowns
+     * land in a later combat slice.
+     */
+    data class AttackTarget(
+        override val agent: AgentId,
+        val target: AgentId,
+        override val commandId: UUID = UUID.randomUUID(),
+    ) : WorldCommand
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.world.events
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.world.BodyDelta
 import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.DamageType
 import dev.gvart.genesara.world.DroppedItemView
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.ItemId
@@ -84,9 +85,9 @@ sealed interface WorldEvent {
      * fields summarize what the death cost — the agent uses these to know
      * whether they de-leveled or just lost some XP.
      *
-     * `causedBy` is null for starvation deaths in v1 (the sweep isn't a queued
-     * command). When combat ships in Phase 2, the killing-attack reducer will
-     * propagate its `commandId` through to here.
+     * `causedBy` is null for starvation deaths (the sweep isn't a queued
+     * command). For combat deaths the attack reducer routes the killing
+     * command's id through `DeathProcessor` to land here.
      */
     data class AgentDied(
         val agent: AgentId,
@@ -221,9 +222,9 @@ sealed interface WorldEvent {
      * item appeared at their tile — they can call `pickup` with [drop.dropId]
      * if they're standing there.
      *
-     * `causedBy` is null for starvation deaths in v1 (the sweep is not a
-     * queued command). Phase 2 combat will populate it with the killing
-     * attack's commandId, mirroring [AgentDied.causedBy].
+     * `causedBy` is null for starvation deaths (the sweep is not a queued
+     * command). Combat deaths populate it with the killing attack's
+     * commandId, mirroring [AgentDied.causedBy].
      */
     data class ItemDroppedOnGround(
         val at: NodeId,
@@ -238,6 +239,30 @@ sealed interface WorldEvent {
         val agent: AgentId,
         val at: NodeId,
         val drop: DroppedItemView,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : WorldEvent
+
+    /**
+     * Outcome of one [dev.gvart.genesara.world.commands.WorldCommand.AttackTarget].
+     * Always emitted on a successful attack reducer run, including when the target
+     * dodged ([hpLost] = 0). [targetKilled] is a convenience: a paired
+     * [AgentDied] event lands at the same tick when true. Routed to BOTH attacker
+     * and target streams by the dispatcher so each can correlate.
+     */
+    data class AgentAttacked(
+        val attacker: AgentId,
+        val target: AgentId,
+        val at: NodeId,
+        val damageType: DamageType,
+        /** Pre-crit-and-dodge base damage. Useful for clients that want to reason about armor. */
+        val baseDamage: Int,
+        /** Actual HP subtracted from the target. 0 on dodge. */
+        val hpLost: Int,
+        val isCrit: Boolean,
+        val isDodged: Boolean,
+        val targetHpAfter: Int,
+        val targetKilled: Boolean,
         override val tick: Long,
         val causedBy: UUID,
     ) : WorldEvent

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -21,9 +21,11 @@ import dev.gvart.genesara.world.internal.buildings.BuildingsCatalog
 import dev.gvart.genesara.world.internal.buildings.reduceBuild
 import dev.gvart.genesara.world.internal.buildings.reduceDeposit
 import dev.gvart.genesara.world.internal.buildings.reduceWithdraw
+import dev.gvart.genesara.world.internal.combat.reduceAttack
 import dev.gvart.genesara.world.internal.consume.reduceConsume
 import dev.gvart.genesara.world.internal.crafting.RarityRoller
 import dev.gvart.genesara.world.internal.crafting.reduceCraft
+import dev.gvart.genesara.world.internal.death.DeathProcessor
 import dev.gvart.genesara.world.internal.death.SafeNodeResolver
 import dev.gvart.genesara.world.internal.death.reduceRespawn
 import dev.gvart.genesara.world.internal.death.reduceSetSafeNode
@@ -36,6 +38,7 @@ import dev.gvart.genesara.world.internal.spawn.SpawnLocationResolver
 import dev.gvart.genesara.world.internal.spawn.reduceSpawn
 import dev.gvart.genesara.world.internal.spawn.reduceUnspawn
 import dev.gvart.genesara.world.internal.worldstate.WorldState
+import kotlin.random.Random
 
 internal fun reduce(
     state: WorldState,
@@ -58,8 +61,10 @@ internal fun reduce(
     progression: SkillProgression,
     spawnLocationResolver: SpawnLocationResolver,
     groundItems: GroundItemStore,
+    deathProcessor: DeathProcessor,
     tick: Long,
-): Either<WorldRejection, Pair<WorldState, WorldEvent>> = when (command) {
+    rng: Random = Random.Default,
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = when (command) {
     is WorldCommand.SpawnAgent -> reduceSpawn(state, command, profiles, spawnLocationResolver, tick)
     is WorldCommand.MoveAgent -> reduceMove(state, command, balance, buildingsLookup, tick)
     is WorldCommand.UnspawnAgent -> reduceUnspawn(state, command, tick)
@@ -82,4 +87,6 @@ internal fun reduce(
         )
     is WorldCommand.Pickup ->
         reducePickup(state, command, balance, items, agents, equipment, groundItems, tick)
+    is WorldCommand.AttackTarget ->
+        reduceAttack(state, command, balance, items, agents, equipment, progression, deathProcessor, rng, tick)
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemLookupImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemLookupImpl.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component
 
 @Component
 internal class ItemLookupImpl(
-    private val props: ItemDefinitionProperties,
+    props: ItemDefinitionProperties,
 ) : ItemLookup {
 
     private val byId: Map<ItemId, Item> = props.catalog.entries.associate { (key, properties) ->
@@ -32,16 +32,19 @@ internal class ItemLookupImpl(
         regenerating = regenerating,
         regenIntervalTicks = regenIntervalTicks,
         regenAmount = regenAmount,
-        harvestSkill = harvestSkill,
+        harvestSkill = harvestSkill?.let(::SkillId),
         rarity = rarity,
         maxDurability = maxDurability,
         validSlots = validSlots,
         twoHanded = twoHanded,
         requiredAttributes = requiredAttributes,
-        // Convert string keys → typed SkillId once at catalog load. Keeping
-        // the YAML side stringly-typed (matches `harvest-skill: ...`) while
-        // the public `Item` carries `Map<SkillId, Int>` saves an allocation
-        // per equip-time iteration.
+        // Convert string keys → typed SkillId once at catalog load. The YAML
+        // side stays stringly-typed (`harvest-skill: ...`) while the public
+        // `Item` carries SkillId, saving an allocation per equip-time iteration.
         requiredSkills = requiredSkills.mapKeys { (id, _) -> SkillId(id) },
+        damageType = damageType,
+        weaponPower = weaponPower,
+        combatSkill = combatSkill?.let(::SkillId),
+        range = range,
     )
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemProperties.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemProperties.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.world.internal.balance
 
 import dev.gvart.genesara.player.Attribute
+import dev.gvart.genesara.world.DamageType
 import dev.gvart.genesara.world.EquipSlot
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.ItemCategory
@@ -37,6 +38,14 @@ internal data class ItemProperties(
     val requiredAttributes: Map<Attribute, Int> = emptyMap(),
     /** Skill-level floors required to equip; keys are skill ids; empty when none. */
     val requiredSkills: Map<String, Int> = emptyMap(),
+    /** Combat damage taxonomy. Null for non-weapons and weapons not yet combat-wired. */
+    val damageType: DamageType? = null,
+    /** Multiplier against attacker's combat stat to compute base damage. Null for non-weapons. */
+    val weaponPower: Int? = null,
+    /** Skill id trained on a successful attack with this weapon. Null = no-XP weapon. */
+    val combatSkill: String? = null,
+    /** Max node-hop reach of the weapon. 1 = melee (same node). Null = non-weapon. */
+    val range: Int? = null,
 )
 
 internal data class ConsumableEffectProperties(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -1,7 +1,10 @@
 package dev.gvart.genesara.world.internal.balance
 
+import dev.gvart.genesara.player.Attribute
+import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DamageType
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.ResourceSpawnRule
@@ -122,6 +125,64 @@ internal interface BalanceLookup {
      */
     fun dropChanceForKillCount(killCount: Int): Double =
         (killCount * 0.1).coerceIn(0.0, 1.0)
+
+    /** Stamina cost of one [WorldCommand.AttackTarget] invocation. Flat in Slice 1. */
+    fun attackStaminaCost(): Int = 5
+
+    /**
+     * Multiplier applied against the attacker's combat stat when no MAIN_HAND
+     * weapon is equipped. Pairs with [unarmedDamageType] and [unarmedCombatSkill]
+     * to define the bare-hand attack profile.
+     */
+    fun unarmedWeaponPower(): Int = 2
+
+    fun unarmedDamageType(): DamageType = DamageType.BLUNT
+
+    fun unarmedCombatSkill(): SkillId = SkillId("UNARMED")
+
+    /** Reach of an unarmed strike: 1 = same node only. Mirrors the catalog's [Item.range] shape. */
+    fun unarmedRange(): Int = 1
+
+    /**
+     * Crit chance percentage for an attacker with [luck] points of LUCK. Slice 1
+     * uses `clamp(luck, 0, 50)` — roughly 1% per LUCK point, capped at 50% so
+     * even a maxed-out lucky attacker can't auto-crit. Future tuning hook for
+     * skill-bonus interactions.
+     */
+    fun critChancePercent(luck: Int): Int = luck.coerceIn(0, 50)
+
+    /**
+     * Dodge chance percentage for a defender with [dexterity] points of DEX.
+     * Same shape as [critChancePercent]: linear in DEX, capped at 50%. Future
+     * tuning hook for SHIELD-skill bonus when block lands.
+     */
+    fun dodgeChancePercent(dexterity: Int): Int = dexterity.coerceIn(0, 50)
+
+    /** Multiplier on base damage when the crit roll fires. */
+    fun critMultiplier(): Int = 2
+
+    /**
+     * Per-damage-type multiplier on final damage. Flat 1.0 in Slice 1 — armor
+     * resistances and elemental matchups land in later combat slices.
+     */
+    fun damageTypeModifier(type: DamageType): Double = 1.0
+
+    /**
+     * Which attribute scales an attack with [skill]. Slice 1: melee
+     * (SWORD/CLUB/SPEAR/UNARMED) scales with STRENGTH; ranged (BOW) scales with
+     * DEXTERITY. The melee branch is the deliberate default — most future combat
+     * skills will be melee variants — so the `else` is a designed fallthrough,
+     * not a typo guard. Unknown stringly-typed skill ids on item rows are caught
+     * by [dev.gvart.genesara.world.internal.balance.ResourceSpawnsValidator]
+     * before runtime sees them.
+     */
+    fun combatStatFor(skill: SkillId): Attribute = when (skill.value) {
+        "BOW" -> Attribute.DEXTERITY
+        else -> Attribute.STRENGTH
+    }
+
+    /** XP delta granted to the weapon's combat-skill per successful attack. Mirrors craft/build at 1. */
+    fun attackXpDelta(): Int = 1
 }
 
 @Component

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ResourceSpawnsValidator.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ResourceSpawnsValidator.kt
@@ -1,6 +1,5 @@
 package dev.gvart.genesara.world.internal.balance
 
-import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillLookup
 import dev.gvart.genesara.world.ItemLookup
 import jakarta.annotation.PostConstruct
@@ -10,8 +9,9 @@ import org.springframework.stereotype.Component
  * Cross-validates `terrains.yaml` and `items.yaml` against sibling catalogs at startup.
  * Fails fast on misconfiguration so the runtime hot path stays branch-free. Catches:
  * unknown item ids in spawn rules, malformed quantity ranges, out-of-bounds spawn
- * chances, unknown harvest-skill references (XP grants would silently no-op), and
- * unknown required-skills keys (items would be permanently un-equippable).
+ * chances, unknown harvest-skill references (XP grants would silently no-op),
+ * unknown combat-skill references (same risk on the attack hook), and unknown
+ * required-skills keys (items would be permanently un-equippable).
  */
 @Component
 internal class ResourceSpawnsValidator(
@@ -27,6 +27,7 @@ internal class ResourceSpawnsValidator(
 
         problems += spawnRuleProblems(knownIds)
         problems += unknownHarvestSkillProblems()
+        problems += unknownCombatSkillProblems()
         problems += unknownRequiredSkillProblems()
 
         require(problems.isEmpty()) {
@@ -66,9 +67,17 @@ internal class ResourceSpawnsValidator(
 
     private fun unknownHarvestSkillProblems(): List<String> =
         items.all().mapNotNull { item ->
-            val skillId = item.harvestSkill ?: return@mapNotNull null
-            if (skills.byId(SkillId(skillId)) == null) {
-                "  item ${item.id.value} declares harvest-skill='$skillId' which is not in the skill catalog"
+            val skill = item.harvestSkill ?: return@mapNotNull null
+            if (skills.byId(skill) == null) {
+                "  item ${item.id.value} declares harvest-skill='${skill.value}' which is not in the skill catalog"
+            } else null
+        }
+
+    private fun unknownCombatSkillProblems(): List<String> =
+        items.all().mapNotNull { item ->
+            val skill = item.combatSkill ?: return@mapNotNull null
+            if (skills.byId(skill) == null) {
+                "  item ${item.id.value} declares combat-skill='${skill.value}' which is not in the skill catalog"
             } else null
         }
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
@@ -34,7 +34,7 @@ internal fun reduceBuild(
     safeNodes: AgentSafeNodeGateway,
     progression: SkillProgression,
     tick: Long,
-): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
         WorldRejection.NotInWorld(command.agent)
     }
@@ -101,7 +101,7 @@ internal fun reduceBuild(
     val next = state
         .updateBody(command.agent, body.spendStamina(def.staminaPerStep))
         .updateInventory(command.agent, nextInventory)
-    next to event
+    next to listOf(event)
 }
 
 private fun Raise<WorldRejection>.requireMaterials(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/ChestReducers.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/ChestReducers.kt
@@ -27,7 +27,7 @@ internal fun reduceDeposit(
     buildings: BuildingsStore,
     chestContents: ChestContentsStore,
     tick: Long,
-): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     ensure(command.quantity > 0) { WorldRejection.NonPositiveQuantity(command.agent, command.quantity) }
     val agentNode = ensureNotNull(state.positions[command.agent]) {
         WorldRejection.NotInWorld(command.agent)
@@ -63,7 +63,7 @@ internal fun reduceDeposit(
         tick = tick,
         causedBy = command.commandId,
     )
-    next to event
+    next to listOf(event)
 }
 
 internal fun reduceWithdraw(
@@ -72,7 +72,7 @@ internal fun reduceWithdraw(
     buildings: BuildingsStore,
     chestContents: ChestContentsStore,
     tick: Long,
-): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     ensure(command.quantity > 0) { WorldRejection.NonPositiveQuantity(command.agent, command.quantity) }
     val agentNode = ensureNotNull(state.positions[command.agent]) {
         WorldRejection.NotInWorld(command.agent)
@@ -98,7 +98,7 @@ internal fun reduceWithdraw(
         tick = tick,
         causedBy = command.commandId,
     )
-    next to event
+    next to listOf(event)
 }
 
 private fun Raise<WorldRejection>.resolveOwnedActiveChestAtAgentNode(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
@@ -1,0 +1,189 @@
+package dev.gvart.genesara.world.internal.combat
+
+import arrow.core.Either
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import arrow.core.raise.ensureNotNull
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.death.AttackCause
+import dev.gvart.genesara.world.internal.death.DeathProcessor
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import kotlin.random.Random
+
+/**
+ * Reducer for [WorldCommand.AttackTarget]. Slice 1 combat shape:
+ *   damage = attackerStat × weaponPower (armor=0, typeMod=1.0 today)
+ *   dodge first; if dodged, hpLost=0. Else crit; if crit, hpLost = base × critMultiplier.
+ *
+ * RNG is injected so tests can pass a seeded [Random] to pin crit/dodge outcomes.
+ * Production wires `Random.Default` via the same constructor-default pattern as
+ * [dev.gvart.genesara.world.internal.crafting.RarityRoller].
+ *
+ * Killing-blow propagation: when the post-damage HP hits 0, the reducer calls
+ * [DeathProcessor.applyDeath] inline with an [AttackCause] so [WorldEvent.AgentDied]
+ * lands at the same tick with `causedBy = command.commandId` and the attacker's
+ * kill streak ticks up via [WorldState.incrementKillStreak].
+ *
+ * TODO(combat-durability): weapons are not consumed on attack in Slice 1. Land
+ * with the durability slice (separate combat issue).
+ */
+internal fun reduceAttack(
+    state: WorldState,
+    command: WorldCommand.AttackTarget,
+    balance: BalanceLookup,
+    items: ItemLookup,
+    agents: AgentRegistry,
+    equipment: EquipmentInstanceStore,
+    progression: SkillProgression,
+    deathProcessor: DeathProcessor,
+    rng: Random,
+    tick: Long,
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
+    ensure(command.agent != command.target) { WorldRejection.CannotAttackSelf(command.agent) }
+
+    val attackerNode = ensureNotNull(state.positions[command.agent]) {
+        WorldRejection.NotInWorld(command.agent)
+    }
+    val targetNode = ensureNotNull(state.positions[command.target]) {
+        WorldRejection.TargetNotInWorld(command.agent, command.target)
+    }
+
+    val weaponDef = equipment.equippedFor(command.agent)[EquipSlot.MAIN_HAND]
+        ?.let { items.byId(it.itemId) }
+    val weaponProfile = weaponProfileFor(weaponDef, balance)
+
+    ensure(isWithinRange(state, attackerNode, targetNode, weaponProfile.range)) {
+        WorldRejection.TargetOutOfRange(
+            command.agent, command.target, attackerNode, targetNode, weaponProfile.range,
+        )
+    }
+
+    val targetBody = state.bodyOf(command.target)
+        ?: error("Invariant violated: target ${command.target} positioned but has no body")
+    ensure(targetBody.hp > 0) { WorldRejection.TargetAlreadyDead(command.agent, command.target) }
+
+    val attackerBody = state.bodyOf(command.agent)
+        ?: error("Invariant violated: attacker ${command.agent} positioned but has no body")
+    val staminaCost = balance.attackStaminaCost()
+    ensure(attackerBody.stamina >= staminaCost) {
+        WorldRejection.NotEnoughStamina(command.agent, staminaCost, attackerBody.stamina)
+    }
+
+    val attacker = agents.find(command.agent)
+        ?: error("Invariant violated: attacker ${command.agent} positioned but has no registry row")
+    val defender = agents.find(command.target)
+        ?: error("Invariant violated: target ${command.target} positioned but has no registry row")
+
+    val attackerStat = balance.combatStatFor(weaponProfile.combatSkill).valueOn(attacker.attributes)
+    val rawDamage = attackerStat * weaponProfile.weaponPower
+    val typedDamage = (rawDamage * balance.damageTypeModifier(weaponProfile.damageType))
+        .toInt()
+        .coerceAtLeast(0)
+
+    // Dodge rolls FIRST so a successful dodge short-circuits the crit roll. Otherwise a crit
+    // followed by a dodge would burn the RNG cursor on a discarded crit and shift downstream
+    // rolls — keeping order matters for reproducible seeds.
+    val dodgeChance = balance.dodgeChancePercent(defender.attributes.dexterity)
+    val isDodged = rng.nextInt(100) < dodgeChance
+    val (hpLost, isCrit) = if (isDodged) {
+        0 to false
+    } else {
+        val critChance = balance.critChancePercent(attacker.attributes.luck)
+        val crit = rng.nextInt(100) < critChance
+        val landed = if (crit) typedDamage * balance.critMultiplier() else typedDamage
+        landed to crit
+    }
+
+    val nextTargetBody = targetBody.takeDamage(hpLost)
+    val nextAttackerBody = attackerBody.spendStamina(staminaCost)
+    var nextState = state
+        .updateBody(command.target, nextTargetBody)
+        .updateBody(command.agent, nextAttackerBody)
+
+    progression.accrueXp(command.agent, weaponProfile.combatSkill, balance.attackXpDelta(), tick, command.commandId)
+
+    val attackEvent = WorldEvent.AgentAttacked(
+        attacker = command.agent,
+        target = command.target,
+        at = attackerNode,
+        damageType = weaponProfile.damageType,
+        baseDamage = typedDamage,
+        hpLost = hpLost,
+        isCrit = isCrit,
+        isDodged = isDodged,
+        targetHpAfter = nextTargetBody.hp,
+        targetKilled = nextTargetBody.hp == 0,
+        tick = tick,
+        causedBy = command.commandId,
+    )
+
+    val emitted = mutableListOf<WorldEvent>(attackEvent)
+    if (nextTargetBody.hp == 0) {
+        val (afterDeath, deathEvents) = deathProcessor.applyDeath(
+            state = nextState,
+            agentId = command.target,
+            deathNode = targetNode,
+            cause = AttackCause(commandId = command.commandId, attackerId = command.agent),
+            tick = tick,
+            rng = rng,
+        )
+        nextState = afterDeath
+        emitted += deathEvents
+    }
+
+    nextState to emitted.toList()
+}
+
+private data class WeaponProfile(
+    val damageType: DamageType,
+    val weaponPower: Int,
+    val combatSkill: SkillId,
+    val range: Int,
+)
+
+private fun weaponProfileFor(weapon: Item?, balance: BalanceLookup): WeaponProfile {
+    val damageType = weapon?.damageType ?: balance.unarmedDamageType()
+    val weaponPower = weapon?.weaponPower ?: balance.unarmedWeaponPower()
+    val combatSkill = weapon?.combatSkill ?: balance.unarmedCombatSkill()
+    val range = weapon?.range ?: balance.unarmedRange()
+    return WeaponProfile(damageType, weaponPower, combatSkill, range)
+}
+
+/**
+ * BFS over [WorldState.nodes] adjacency, capped at [range] hops, looking for
+ * [target] from [from]. Range 1 = same-node only (no hops). Range 2 = same node
+ * or any direct neighbor. Higher ranges follow the adjacency graph further.
+ * Stops as soon as the target is reachable, so the worst case is one full
+ * `range`-hop expansion of the starting node's neighborhood.
+ */
+private fun isWithinRange(state: WorldState, from: NodeId, target: NodeId, range: Int): Boolean {
+    if (from == target) return true
+    if (range <= 1) return false
+    val visited = mutableSetOf(from)
+    var frontier: Set<NodeId> = setOf(from)
+    repeat(range - 1) {
+        val next = mutableSetOf<NodeId>()
+        for (nodeId in frontier) {
+            val node = state.nodes[nodeId] ?: continue
+            for (neighbor in node.adjacency) {
+                if (neighbor == target) return true
+                if (visited.add(neighbor)) next += neighbor
+            }
+        }
+        if (next.isEmpty()) return false
+        frontier = next
+    }
+    return false
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducer.kt
@@ -28,7 +28,7 @@ internal fun reduceConsume(
     command: WorldCommand.ConsumeItem,
     items: ItemLookup,
     tick: Long,
-): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     ensure(command.agent in state.positions) { WorldRejection.NotInWorld(command.agent) }
 
     val item = ensureNotNull(items.byId(command.item)) { WorldRejection.UnknownItem(command.item) }
@@ -58,5 +58,5 @@ internal fun reduceConsume(
         tick = tick,
         causedBy = command.commandId,
     )
-    next to event
+    next to listOf(event)
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
@@ -48,7 +48,7 @@ internal fun reduceCraft(
     rarityRoller: RarityRoller,
     progression: SkillProgression,
     tick: Long,
-): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
         WorldRejection.NotInWorld(command.agent)
     }
@@ -115,7 +115,7 @@ internal fun reduceCraft(
     val next = state
         .updateBody(command.agent, body.spendStamina(recipe.staminaCost))
         .updateInventory(command.agent, mutation.nextInventory)
-    next to mutation.event
+    next to listOf(mutation.event)
 }
 
 private fun Raise<WorldRejection>.requireMaterials(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/death/DeathProcessor.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/death/DeathProcessor.kt
@@ -1,0 +1,181 @@
+package dev.gvart.genesara.world.internal.death
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AttributePointLoss
+import dev.gvart.genesara.player.DeathPenaltyOutcome
+import dev.gvart.genesara.world.AgentKillStreak
+import dev.gvart.genesara.world.DroppedItemView
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.GroundItemStore
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import org.springframework.stereotype.Component
+import java.util.UUID
+import kotlin.random.Random
+
+/**
+ * Identifies the killing-attack metadata so [DeathProcessor.applyDeath] can
+ * propagate the attack's [commandId] to [WorldEvent.AgentDied.causedBy] (and
+ * any paired [WorldEvent.ItemDroppedOnGround]) and increment the attacker's
+ * kill streak via [WorldState.incrementKillStreak]. Null cause = starvation
+ * death (the post-passive sweep).
+ */
+internal data class AttackCause(
+    val commandId: UUID,
+    val attackerId: AgentId,
+)
+
+/**
+ * Per-agent death side-effects, factored out of [processDeaths] so the attack
+ * reducer can trigger a death inline on a killing blow without duplicating
+ * the penalty / drop / position-removal logic. The sweep continues to call
+ * [applyDeath] with `cause = null` for starvation; combat passes a non-null
+ * [AttackCause] so [WorldEvent.AgentDied.causedBy] carries the killing
+ * commandId and the attacker's kill-streak counter ticks up at the same time.
+ */
+@Component
+internal class DeathProcessor(
+    private val balance: BalanceLookup,
+    private val agents: AgentRegistry,
+    private val equipment: EquipmentInstanceStore,
+    private val groundItems: GroundItemStore,
+) {
+    fun applyDeath(
+        state: WorldState,
+        agentId: AgentId,
+        deathNode: NodeId,
+        cause: AttackCause?,
+        tick: Long,
+        rng: Random,
+    ): Pair<WorldState, List<WorldEvent>> {
+        val outcome = agents.applyDeathPenalty(agentId, balance.xpLossOnDeath())
+            ?: return state.copy(positions = state.positions - agentId) to emptyList()
+
+        val windowTicks = balance.killStreakWindowTicks()
+        val (afterDrop, dropped) = rollDrop(state, agentId, deathNode, windowTicks, tick, rng)
+        val withStreakReset = afterDrop.updateKillStreak(agentId, AgentKillStreak.EMPTY)
+        val withAttackerCredit = if (cause != null) {
+            withStreakReset.incrementKillStreak(cause.attackerId, tick, windowTicks)
+        } else {
+            withStreakReset
+        }
+        val cleared = withAttackerCredit.copy(positions = withAttackerCredit.positions - agentId)
+
+        val events = buildList {
+            add(deathEvent(agentId, deathNode, outcome, tick, dropped, cause?.commandId))
+            if (dropped != null) {
+                add(
+                    WorldEvent.ItemDroppedOnGround(
+                        at = deathNode,
+                        byAgent = agentId,
+                        drop = dropped,
+                        tick = tick,
+                        causedBy = cause?.commandId,
+                    ),
+                )
+            }
+        }
+
+        return cleared to events
+    }
+
+    private fun rollDrop(
+        state: WorldState,
+        agentId: AgentId,
+        deathNode: NodeId,
+        windowTicks: Long,
+        tick: Long,
+        rng: Random,
+    ): Pair<WorldState, DroppedItemView?> {
+        val streak = state.killStreakOf(agentId)
+        val effectiveKills = streak.effectiveKillCount(tick, windowTicks)
+        val dropChance = balance.dropChanceForKillCount(effectiveKills)
+        if (dropChance <= 0.0 || rng.nextDouble() >= dropChance) return state to null
+
+        val pool = buildDropPool(state, agentId)
+        if (pool.isEmpty()) return state to null
+
+        val choice = pool[rng.nextInt(pool.size)]
+        val drop = choice.toDroppedItemView(UUID.randomUUID())
+        groundItems.deposit(deathNode, drop, tick)
+        val nextState = applyDropMutation(state, agentId, choice)
+        return nextState to drop
+    }
+
+    private fun buildDropPool(state: WorldState, agentId: AgentId): List<DropPoolEntry> {
+        val entries = mutableListOf<DropPoolEntry>()
+        state.inventoryOf(agentId).stacks.forEach { (item, quantity) ->
+            entries += DropPoolEntry.Stackable(item, quantity)
+        }
+        equipment.equippedFor(agentId).values.forEach { instance ->
+            entries += DropPoolEntry.Equipment(instance)
+        }
+        return entries
+    }
+
+    private fun applyDropMutation(
+        state: WorldState,
+        agentId: AgentId,
+        choice: DropPoolEntry,
+    ): WorldState = when (choice) {
+        is DropPoolEntry.Stackable -> {
+            val inv = state.inventoryOf(agentId).remove(choice.item, choice.quantity)
+            state.updateInventory(agentId, inv)
+        }
+        is DropPoolEntry.Equipment -> {
+            equipment.delete(choice.instance.instanceId)
+            state
+        }
+    }
+}
+
+private fun deathEvent(
+    agentId: AgentId,
+    deathNode: NodeId,
+    outcome: DeathPenaltyOutcome,
+    tick: Long,
+    droppedItem: DroppedItemView?,
+    causedBy: UUID?,
+): WorldEvent.AgentDied = WorldEvent.AgentDied(
+    agent = agentId,
+    at = deathNode,
+    xpLost = outcome.xpLost,
+    deleveled = outcome.deleveled,
+    attributePointLost = outcome.attributePointLost?.let { loss ->
+        when (loss) {
+            is AttributePointLoss.Unspent -> "UNSPENT"
+            is AttributePointLoss.Allocated -> loss.attribute.name
+        }
+    },
+    tick = tick,
+    causedBy = causedBy,
+    droppedItem = droppedItem,
+)
+
+private sealed interface DropPoolEntry {
+    fun toDroppedItemView(dropId: UUID): DroppedItemView
+
+    data class Stackable(val item: ItemId, val quantity: Int) : DropPoolEntry {
+        override fun toDroppedItemView(dropId: UUID): DroppedItemView =
+            DroppedItemView.Stackable(dropId = dropId, item = item, quantity = quantity)
+    }
+
+    data class Equipment(val instance: EquipmentInstance) : DropPoolEntry {
+        override fun toDroppedItemView(dropId: UUID): DroppedItemView =
+            DroppedItemView.Equipment(
+                dropId = dropId,
+                item = instance.itemId,
+                instanceId = instance.instanceId,
+                rarity = instance.rarity,
+                durabilityCurrent = instance.durabilityCurrent,
+                durabilityMax = instance.durabilityMax,
+                creatorAgentId = instance.creatorAgentId?.id,
+                createdAtTick = instance.createdAtTick,
+            )
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/death/DeathSweep.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/death/DeathSweep.kt
@@ -1,92 +1,53 @@
 package dev.gvart.genesara.world.internal.death
 
 import dev.gvart.genesara.player.AgentId
-import dev.gvart.genesara.player.AgentRegistry
-import dev.gvart.genesara.player.AttributePointLoss
-import dev.gvart.genesara.player.DeathPenaltyOutcome
-import dev.gvart.genesara.world.AgentKillStreak
-import dev.gvart.genesara.world.DroppedItemView
-import dev.gvart.genesara.world.EquipmentInstance
-import dev.gvart.genesara.world.EquipmentInstanceStore
-import dev.gvart.genesara.world.GroundItemStore
-import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.events.WorldEvent
-import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import org.slf4j.LoggerFactory
-import java.util.UUID
 import kotlin.random.Random
 
 private val log = LoggerFactory.getLogger("dev.gvart.genesara.world.internal.death.DeathSweep")
 
 /**
  * Post-passives death sweep. Finds every positioned agent whose body just hit `hp <= 0`
- * (starvation today; combat in Phase 2 will land the same path) and:
- *
- *  1. Applies the canonical death penalty via [AgentRegistry.applyDeathPenalty]
- *     (partial-bar XP loss vs. empty-bar de-level + stat point — the registry decides).
- *  2. Rolls the kill-streak drop hook: if the rolling kill counter is non-zero and
- *     the seeded RNG clears [BalanceLookup.dropChanceForKillCount], one entry from
- *     the agent's drop pool (stackable inventory + currently-equipped instances) is
- *     removed and deposited at the death node via [GroundItemStore]. Other agents
- *     can pick it up later via the `pickup` MCP tool.
- *  3. Resets the dying agent's kill streak so the bonus does not survive death.
- *  4. Removes the agent from `state.positions` so they're "awaiting respawn". The
- *     body persists at HP=0; the agent must call `respawn` to materialize.
- *  5. Emits [WorldEvent.AgentDied] (penalty summary + optional `droppedItem`) and,
- *     if a drop fired, a paired [WorldEvent.ItemDroppedOnGround] so other agents
- *     get a notification independent of the dying agent's own stream.
- *
- * Body restoration happens inside the respawn reducer, not here. The split lets the
- * agent linger at the death state and forces an explicit re-entry rather than auto-
- * spawning them somewhere they didn't choose.
+ * (starvation today; combat-driven hp=0 routes through [DeathProcessor.applyDeath]
+ * inline from the attack reducer) and routes each one through the same
+ * [DeathProcessor] with `cause = null`. The processor handles the penalty + drop
+ * roll + position removal + event emission.
  *
  * Called once per tick from `WorldTickHandler` after passives apply but before the
- * per-command reducers, so a dying agent's queued actions hit `NotInWorld` rather than
- * slipping through one tick of post-mortem play.
+ * per-command reducers, so a dying agent's queued actions hit `NotInWorld` rather
+ * than slipping through one tick of post-mortem play.
  */
 internal fun processDeaths(
     state: WorldState,
-    balance: BalanceLookup,
-    agents: AgentRegistry,
-    equipment: EquipmentInstanceStore,
-    groundItems: GroundItemStore,
+    deathProcessor: DeathProcessor,
     tick: Long,
     rng: Random = Random.Default,
 ): Pair<WorldState, List<WorldEvent>> {
     val dying = collectDying(state)
     if (dying.isEmpty()) return state to emptyList()
 
-    val xpLoss = balance.xpLossOnDeath()
-    val windowTicks = balance.killStreakWindowTicks()
     val events = mutableListOf<WorldEvent>()
     var nextState = state
-    var nextPositions = state.positions
     for ((agentId, deathNode) in dying) {
-        val outcome = agents.applyDeathPenalty(agentId, xpLoss)
-        if (outcome == null) {
+        val (after, deathEvents) = deathProcessor.applyDeath(
+            state = nextState,
+            agentId = agentId,
+            deathNode = deathNode,
+            cause = null,
+            tick = tick,
+            rng = rng,
+        )
+        if (deathEvents.isEmpty()) {
             log.warn("death sweep: positioned agent {} missing from registry — clearing position", agentId.id)
-            nextPositions = nextPositions - agentId
-            continue
         }
-        val (stateAfterDrop, dropped) = rollDrop(nextState, agentId, deathNode, balance, windowTicks, equipment, groundItems, tick, rng)
-        nextState = stateAfterDrop.updateKillStreak(agentId, AgentKillStreak.EMPTY)
-        nextPositions = nextPositions - agentId
-        events += buildDeathEvent(agentId, deathNode, outcome, tick, dropped)
-        if (dropped != null) {
-            events += WorldEvent.ItemDroppedOnGround(
-                at = deathNode,
-                byAgent = agentId,
-                drop = dropped,
-                tick = tick,
-                // TODO(combat): propagate killing-attack commandId once Phase 2 lands.
-                causedBy = null,
-            )
-        }
+        nextState = after
+        events += deathEvents
     }
 
-    return nextState.copy(positions = nextPositions) to events
+    return nextState to events
 }
 
 /**
@@ -101,111 +62,3 @@ private fun collectDying(state: WorldState): List<Pair<AgentId, NodeId>> =
             if (body.hp <= 0) id to nodeId else null
         }
         .sortedBy { it.first.id }
-
-private fun rollDrop(
-    state: WorldState,
-    agentId: AgentId,
-    deathNode: NodeId,
-    balance: BalanceLookup,
-    windowTicks: Long,
-    equipment: EquipmentInstanceStore,
-    groundItems: GroundItemStore,
-    tick: Long,
-    rng: Random,
-): Pair<WorldState, DroppedItemView?> {
-    val streak = state.killStreakOf(agentId)
-    val effectiveKills = streak.effectiveKillCount(tick, windowTicks)
-    val dropChance = balance.dropChanceForKillCount(effectiveKills)
-    if (dropChance <= 0.0 || rng.nextDouble() >= dropChance) return state to null
-
-    val pool = buildDropPool(state, agentId, equipment)
-    if (pool.isEmpty()) return state to null
-
-    val choice = pool[rng.nextInt(pool.size)]
-    val drop = choice.toDroppedItemView(UUID.randomUUID())
-    groundItems.deposit(deathNode, drop, tick)
-    val nextState = applyDropMutation(state, agentId, choice, equipment)
-    return nextState to drop
-}
-
-private fun buildDropPool(
-    state: WorldState,
-    agentId: AgentId,
-    equipment: EquipmentInstanceStore,
-): List<DropPoolEntry> {
-    val entries = mutableListOf<DropPoolEntry>()
-    state.inventoryOf(agentId).stacks.forEach { (item, quantity) ->
-        entries += DropPoolEntry.Stackable(item, quantity)
-    }
-    equipment.equippedFor(agentId).values.forEach { instance ->
-        entries += DropPoolEntry.Equipment(instance)
-    }
-    return entries
-}
-
-/**
- * Removes the chosen drop from its source. Stackable drops zero out the entire
- * stack (one pool entry = one stack); equipment drops delete the instance row
- * since the picker re-INSERTs under the new owner.
- */
-private fun applyDropMutation(
-    state: WorldState,
-    agentId: AgentId,
-    choice: DropPoolEntry,
-    equipment: EquipmentInstanceStore,
-): WorldState = when (choice) {
-    is DropPoolEntry.Stackable -> {
-        val inv = state.inventoryOf(agentId).remove(choice.item, choice.quantity)
-        state.updateInventory(agentId, inv)
-    }
-    is DropPoolEntry.Equipment -> {
-        equipment.delete(choice.instance.instanceId)
-        state
-    }
-}
-
-private sealed interface DropPoolEntry {
-    fun toDroppedItemView(dropId: UUID): DroppedItemView
-
-    data class Stackable(val item: ItemId, val quantity: Int) : DropPoolEntry {
-        override fun toDroppedItemView(dropId: UUID): DroppedItemView =
-            DroppedItemView.Stackable(dropId = dropId, item = item, quantity = quantity)
-    }
-
-    data class Equipment(val instance: EquipmentInstance) : DropPoolEntry {
-        override fun toDroppedItemView(dropId: UUID): DroppedItemView =
-            DroppedItemView.Equipment(
-                dropId = dropId,
-                item = instance.itemId,
-                instanceId = instance.instanceId,
-                rarity = instance.rarity,
-                durabilityCurrent = instance.durabilityCurrent,
-                durabilityMax = instance.durabilityMax,
-                creatorAgentId = instance.creatorAgentId?.id,
-                createdAtTick = instance.createdAtTick,
-            )
-    }
-}
-
-private fun buildDeathEvent(
-    agentId: AgentId,
-    deathNode: NodeId,
-    outcome: DeathPenaltyOutcome,
-    tick: Long,
-    droppedItem: DroppedItemView?,
-): WorldEvent.AgentDied = WorldEvent.AgentDied(
-    agent = agentId,
-    at = deathNode,
-    xpLost = outcome.xpLost,
-    deleveled = outcome.deleveled,
-    attributePointLost = outcome.attributePointLost?.let { loss ->
-        when (loss) {
-            is AttributePointLoss.Unspent -> "UNSPENT"
-            is AttributePointLoss.Allocated -> loss.attribute.name
-        }
-    },
-    tick = tick,
-    // TODO(combat): route the killing-attack's commandId once Phase 2 lands.
-    causedBy = null,
-    droppedItem = droppedItem,
-)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/death/RespawnReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/death/RespawnReducer.kt
@@ -40,7 +40,7 @@ internal fun reduceRespawn(
     safeNodes: AgentSafeNodeGateway,
     resolver: SafeNodeResolver,
     tick: Long,
-): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val profile = ensureNotNull(profiles.find(command.agent)) {
         WorldRejection.UnknownProfile(command.agent)
     }
@@ -65,7 +65,7 @@ internal fun reduceRespawn(
         tick = tick,
         causedBy = command.commandId,
     )
-    next to event
+    next to listOf(event)
 }
 
 private fun resolveLanding(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/death/SetSafeNodeReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/death/SetSafeNodeReducer.kt
@@ -30,7 +30,7 @@ internal fun reduceSetSafeNode(
     command: WorldCommand.SetSafeNode,
     safeNodes: AgentSafeNodeGateway,
     tick: Long,
-): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
         WorldRejection.NotInWorld(command.agent)
     }
@@ -45,5 +45,5 @@ internal fun reduceSetSafeNode(
         tick = tick,
         causedBy = command.commandId,
     )
-    state to event
+    state to listOf(event)
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/drink/DrinkReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/drink/DrinkReducer.kt
@@ -35,7 +35,7 @@ internal fun reduceDrink(
     balance: BalanceLookup,
     buildings: BuildingsLookup,
     tick: Long,
-): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
         WorldRejection.NotInWorld(command.agent)
     }
@@ -67,5 +67,5 @@ internal fun reduceDrink(
         tick = tick,
         causedBy = command.commandId,
     )
-    next to event
+    next to listOf(event)
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
@@ -7,7 +7,6 @@ import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
-import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.ItemId
@@ -41,7 +40,7 @@ internal fun reduceHarvest(
     equipment: EquipmentInstanceStore,
     progression: SkillProgression,
     tick: Long,
-): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
         WorldRejection.NotInWorld(command.agent)
     }
@@ -69,8 +68,8 @@ internal fun reduceHarvest(
     enforceCarryCap(command.agent, agentRecord.attributes.strength, currentGrams, additionalGrams, balance)
 
     resources.decrement(nodeId, command.item, quantity, tick)
-    itemDef.harvestSkill?.let { skillKey ->
-        progression.accrueXp(command.agent, SkillId(skillKey), delta = quantity, tick, command.commandId)
+    itemDef.harvestSkill?.let { skill ->
+        progression.accrueXp(command.agent, skill, delta = quantity, tick, command.commandId)
     }
 
     // TODO(max-stack): reject (StackFull) when adding `quantity` would exceed maxStack.
@@ -88,7 +87,7 @@ internal fun reduceHarvest(
         tick = tick,
         causedBy = command.commandId,
     )
-    next to event
+    next to listOf(event)
 }
 
 /**

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
@@ -18,7 +18,7 @@ internal fun reduceMove(
     balance: BalanceLookup,
     buildings: BuildingsLookup,
     tick: Long,
-): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val from = ensureNotNull(state.positions[command.agent]) {
         WorldRejection.UnknownAgent(command.agent)
     }
@@ -50,7 +50,7 @@ internal fun reduceMove(
         .updateBody(command.agent, body.spendStamina(cost))
     val event = WorldEvent.AgentMoved(command.agent, from, command.to, tick, causedBy = command.commandId)
 
-    next to event
+    next to listOf(event)
 }
 
 private fun hasActiveBuilding(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/pickup/PickupReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/pickup/PickupReducer.kt
@@ -43,7 +43,7 @@ internal fun reducePickup(
     equipment: EquipmentInstanceStore,
     groundItems: GroundItemStore,
     tick: Long,
-): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
         WorldRejection.NotInWorld(command.agent)
     }
@@ -86,7 +86,7 @@ internal fun reducePickup(
         tick = tick,
         causedBy = command.commandId,
     )
-    nextState to event
+    nextState to listOf(event)
 }
 
 private fun applyPickup(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnReducer.kt
@@ -31,7 +31,7 @@ internal fun reduceSpawn(
     profiles: AgentProfileLookup,
     resolver: SpawnLocationResolver,
     tick: Long,
-): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     ensure(command.agent !in state.positions) {
         WorldRejection.AlreadySpawned(command.agent)
     }
@@ -50,5 +50,5 @@ internal fun reduceSpawn(
         .copy(positions = state.positions + (command.agent to target))
         .updateBody(command.agent, body)
     val event = WorldEvent.AgentSpawned(command.agent, target, tick, causedBy = command.commandId)
-    next to event
+    next to listOf(event)
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/spawn/UnspawnReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/spawn/UnspawnReducer.kt
@@ -12,11 +12,11 @@ internal fun reduceUnspawn(
     state: WorldState,
     command: WorldCommand.UnspawnAgent,
     tick: Long,
-): Either<WorldRejection, Pair<WorldState, WorldEvent>> = either {
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val from = ensureNotNull(state.positions[command.agent]) {
         WorldRejection.UnknownAgent(command.agent)
     }
     val next = state.copy(positions = state.positions - command.agent)
     val event = WorldEvent.AgentDespawned(command.agent, from, tick, causedBy = command.commandId)
-    next to event
+    next to listOf(event)
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -17,6 +17,7 @@ import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.buildings.BuildingsCatalog
 import dev.gvart.genesara.world.internal.crafting.RarityRoller
+import dev.gvart.genesara.world.internal.death.DeathProcessor
 import dev.gvart.genesara.world.internal.death.SafeNodeResolver
 import dev.gvart.genesara.world.internal.death.processDeaths
 import dev.gvart.genesara.world.internal.passive.applyPassives
@@ -53,6 +54,7 @@ internal class WorldTickHandler(
     private val progression: SkillProgression,
     private val spawnLocationResolver: SpawnLocationResolver,
     private val groundItems: GroundItemStore,
+    private val deathProcessor: DeathProcessor,
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -73,16 +75,14 @@ internal class WorldTickHandler(
     fun onTick(tick: Tick) {
         val initial = repository.load()
         val (afterPassives, passivesEvent) = applyPassives(initial, balance, tick.number)
-        val (afterDeaths, deathEvents) = processDeaths(
-            afterPassives, balance, agents, equipment, groundItems, tick.number,
-        )
+        val (afterDeaths, deathEvents) = processDeaths(afterPassives, deathProcessor, tick.number)
 
         val commands = queue.drainFor(tick.number)
         val (next, commandEvents) = commands.fold(afterDeaths to emptyList<WorldEvent>()) { (state, acc), command ->
             reduce(
                 state, command, balance, profiles, items, recipes, resources, skills, agents, equipment,
                 safeNodes, safeNodeResolver, buildings, buildingsLookup, buildingsCatalog, chestContents,
-                rarityRoller, progression, spawnLocationResolver, groundItems, tick.number,
+                rarityRoller, progression, spawnLocationResolver, groundItems, deathProcessor, tick.number,
             ).fold(
                 ifLeft = { rejection ->
                     log.info("Rejected {} at tick {}: {}", command, tick.number, rejection)
@@ -95,7 +95,7 @@ internal class WorldTickHandler(
                     )
                     state to (acc + rejectionEvent)
                 },
-                ifRight = { (newState, newEvent) -> newState to (acc + newEvent) },
+                ifRight = { (newState, newEvents) -> newState to (acc + newEvents) },
             )
         }
 

--- a/world/src/main/resources/world-definition/equipment-weapons.yaml
+++ b/world/src/main/resources/world-definition/equipment-weapons.yaml
@@ -15,6 +15,10 @@ items:
       max-durability: 30
       valid-slots: [MAIN_HAND]
       two-handed: false
+      damage-type: BLUNT
+      weapon-power: 6
+      combat-skill: CLUB
+      range: 1
 
     HUNTING_SPEAR:
       display-name: Hunting Spear
@@ -28,6 +32,10 @@ items:
       max-durability: 40
       valid-slots: [MAIN_HAND]
       two-handed: true
+      damage-type: PIERCE
+      weapon-power: 9
+      combat-skill: SPEAR
+      range: 2
 
     WOODEN_BOW:
       display-name: Wooden Bow
@@ -41,6 +49,10 @@ items:
       max-durability: 50
       valid-slots: [MAIN_HAND]
       two-handed: true
+      damage-type: PIERCE
+      weapon-power: 7
+      combat-skill: BOW
+      range: 3
 
     RUSTY_SWORD:
       display-name: Rusty Sword
@@ -54,6 +66,10 @@ items:
       max-durability: 50
       valid-slots: [MAIN_HAND]
       two-handed: false
+      damage-type: SLASH
+      weapon-power: 8
+      combat-skill: SWORD
+      range: 1
 
     WOODEN_SHIELD:
       display-name: Wooden Shield
@@ -107,6 +123,10 @@ items:
       max-durability: 100
       valid-slots: [MAIN_HAND]
       two-handed: false
+      damage-type: SLASH
+      weapon-power: 12
+      combat-skill: SWORD
+      range: 1
 
     IRON_GREATSWORD:
       display-name: Iron Greatsword
@@ -122,6 +142,10 @@ items:
       two-handed: true
       required-attributes:
         STRENGTH: 12
+      damage-type: SLASH
+      weapon-power: 14
+      combat-skill: SWORD
+      range: 1
 
     WAR_HAMMER:
       display-name: War Hammer
@@ -150,6 +174,10 @@ items:
       max-durability: 80
       valid-slots: [MAIN_HAND]
       two-handed: true
+      damage-type: PIERCE
+      weapon-power: 11
+      combat-skill: BOW
+      range: 4
 
     IRON_SHIELD:
       display-name: Iron Shield

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/ResourceSpawnsValidatorTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/ResourceSpawnsValidatorTest.kt
@@ -120,6 +120,26 @@ class ResourceSpawnsValidatorTest {
     }
 
     @Test
+    fun `rejects items declaring a combat-skill that's not in the catalog`() {
+        val itemsWithBadCombat = StubItemLookup(setOf("RUSTY_SWORD"), combatSkillFor = mapOf("RUSTY_SWORD" to "PHANTOM_SKILL"))
+        val knownSkills = StubSkillLookup(setOf("SWORD"))
+
+        val ex = assertThrows<IllegalArgumentException> {
+            ResourceSpawnsValidator(WorldDefinitionProperties(), itemsWithBadCombat, knownSkills).validate()
+        }
+        assertTrue(ex.message?.contains("PHANTOM_SKILL") == true, "error must mention the unknown skill id")
+        assertTrue(ex.message?.contains("combat-skill") == true, "error must explain which field tripped")
+    }
+
+    @Test
+    fun `accepts items declaring a combat-skill that's in the catalog`() {
+        val itemsWithGoodCombat = StubItemLookup(setOf("RUSTY_SWORD"), combatSkillFor = mapOf("RUSTY_SWORD" to "SWORD"))
+        val knownSkills = StubSkillLookup(setOf("SWORD"))
+
+        ResourceSpawnsValidator(WorldDefinitionProperties(), itemsWithGoodCombat, knownSkills).validate()
+    }
+
+    @Test
     fun `rejects spawn-chance outside the unit interval`() {
         val world = WorldDefinitionProperties(
             terrains = mapOf(
@@ -139,6 +159,7 @@ class ResourceSpawnsValidatorTest {
     private class StubItemLookup(
         ids: Set<String>,
         harvestSkillFor: Map<String, String> = emptyMap(),
+        combatSkillFor: Map<String, String> = emptyMap(),
     ) : ItemLookup {
         private val byId = ids.associateWith { id ->
             Item(
@@ -148,7 +169,8 @@ class ResourceSpawnsValidatorTest {
                 category = ItemCategory.RESOURCE,
                 weightPerUnit = 100,
                 maxStack = 100,
-                harvestSkill = harvestSkillFor[id],
+                harvestSkill = harvestSkillFor[id]?.let(::SkillId),
+                combatSkill = combatSkillFor[id]?.let(::SkillId),
             )
         }
         override fun byId(id: ItemId): Item? = byId[id.value]

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
@@ -105,14 +105,14 @@ class BuildReducerTest {
         val skills = StubSkillsRegistry()
         val publisher = RecordingPublisher()
 
-        val (next, event) = assertNotNull(
+        val (next, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
                 catalog, skills, store, safeNodes, SkillProgression(skills, publisher), tick = 7,
             ).getOrNull(),
         )
 
-        val placed = assertIs<WorldEvent.BuildingPlaced>(event)
+        val placed = assertIs<WorldEvent.BuildingPlaced>(events.single())
         assertEquals(BuildingStatus.UNDER_CONSTRUCTION, placed.building.status)
         assertEquals(1, placed.building.progressSteps)
         assertEquals(5, placed.building.totalSteps)
@@ -135,14 +135,14 @@ class BuildReducerTest {
         val skills = StubSkillsRegistry()
         val publisher = RecordingPublisher()
 
-        val (next, event) = assertNotNull(
+        val (next, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
                 catalog, skills, store, safeNodes, SkillProgression(skills, publisher), tick = 9,
             ).getOrNull(),
         )
 
-        val progressed = assertIs<WorldEvent.BuildingProgressed>(event)
+        val progressed = assertIs<WorldEvent.BuildingProgressed>(events.single())
         assertEquals(3, progressed.building.progressSteps)
         assertEquals(BuildingStatus.UNDER_CONSTRUCTION, progressed.building.status)
         assertEquals(9L, progressed.building.lastProgressTick)
@@ -160,14 +160,14 @@ class BuildReducerTest {
         val skills = StubSkillsRegistry()
         val publisher = RecordingPublisher()
 
-        val (_, event) = assertNotNull(
+        val (_, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
                 catalog, skills, store, StubSafeNodes(), SkillProgression(skills, publisher), tick = 11,
             ).getOrNull(),
         )
 
-        val completed = assertIs<WorldEvent.BuildingCompleted>(event)
+        val completed = assertIs<WorldEvent.BuildingCompleted>(events.single())
         assertEquals(BuildingStatus.ACTIVE, completed.building.status)
         assertEquals(5, completed.building.progressSteps)
         assertEquals(0, store.advanced.size)
@@ -294,14 +294,14 @@ class BuildReducerTest {
         val store = StubBuildingsStore(rows = mutableListOf(agentARow))
         val skills = StubSkillsRegistry()
 
-        val (_, event) = assertNotNull(
+        val (_, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agentB, BuildingType.CAMPFIRE),
                 catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 5,
             ).getOrNull(),
         )
 
-        assertIs<WorldEvent.BuildingPlaced>(event)
+        assertIs<WorldEvent.BuildingPlaced>(events.single())
         assertEquals(2, store.rows.size)
         assertEquals(2, store.rows.first { it.builtByAgentId == agent }.progressSteps)
     }
@@ -313,14 +313,14 @@ class BuildReducerTest {
         val store = StubBuildingsStore(rows = mutableListOf(finished))
         val skills = StubSkillsRegistry()
 
-        val (_, event) = assertNotNull(
+        val (_, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
                 catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 12,
             ).getOrNull(),
         )
 
-        assertIs<WorldEvent.BuildingPlaced>(event)
+        assertIs<WorldEvent.BuildingPlaced>(events.single())
         assertEquals(2, store.rows.size)
         assertEquals(0, store.completed.size)
     }
@@ -380,14 +380,14 @@ class BuildReducerTest {
         var lastEvent: WorldEvent? = null
 
         repeat(5) { i ->
-            val (next, event) = assertNotNull(
+            val (next, events) = assertNotNull(
                 reduceBuild(
                     state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
                     catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = (10 + i).toLong(),
                 ).getOrNull(),
             )
             state = next
-            lastEvent = event
+            lastEvent = events.single()
         }
 
         assertIs<WorldEvent.BuildingCompleted>(lastEvent)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/ChestReducersTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/ChestReducersTest.kt
@@ -116,7 +116,7 @@ class ChestReducersTest {
         val store = StubBuildings(c)
         val contents = StubChestContents()
 
-        val (next, event) = assertNotNull(
+        val (next, events) = assertNotNull(
             reduceDeposit(
                 stateAt(), WorldCommand.DepositToChest(agent, c.instanceId, wood, 5),
                 items, catalog, store, contents, tick = 7,
@@ -125,7 +125,7 @@ class ChestReducersTest {
 
         assertEquals(45, next.inventoryOf(agent).quantityOf(wood))
         assertEquals(5, contents.quantityOf(c.instanceId, wood))
-        val deposited = assertIs<WorldEvent.ItemDeposited>(event)
+        val deposited = assertIs<WorldEvent.ItemDeposited>(events.single())
         assertEquals(c.instanceId, deposited.chest)
         assertEquals(wood, deposited.item)
         assertEquals(5, deposited.quantity)
@@ -243,7 +243,7 @@ class ChestReducersTest {
         val store = StubBuildings(c)
         val contents = StubChestContents()
 
-        val (_, event) = assertNotNull(
+        val (_, events) = assertNotNull(
             reduceDeposit(
                 stateAt(inventory = mapOf(wood to 100)),
                 WorldCommand.DepositToChest(agent, c.instanceId, wood, 62),
@@ -251,7 +251,7 @@ class ChestReducersTest {
             ).getOrNull(),
         )
 
-        assertIs<WorldEvent.ItemDeposited>(event)
+        assertIs<WorldEvent.ItemDeposited>(events.single())
         assertEquals(62, contents.quantityOf(c.instanceId, wood))
     }
 
@@ -293,7 +293,7 @@ class ChestReducersTest {
         val store = StubBuildings(c)
         val contents = StubChestContents().also { it.add(c.instanceId, wood, 10) }
 
-        val (next, event) = assertNotNull(
+        val (next, events) = assertNotNull(
             reduceWithdraw(
                 stateAt(inventory = emptyMap()),
                 WorldCommand.WithdrawFromChest(agent, c.instanceId, wood, 4),
@@ -303,7 +303,7 @@ class ChestReducersTest {
 
         assertEquals(4, next.inventoryOf(agent).quantityOf(wood))
         assertEquals(6, contents.quantityOf(c.instanceId, wood))
-        val withdrawn = assertIs<WorldEvent.ItemWithdrawn>(event)
+        val withdrawn = assertIs<WorldEvent.ItemWithdrawn>(events.single())
         assertEquals(c.instanceId, withdrawn.chest)
         assertEquals(wood, withdrawn.item)
         assertEquals(4, withdrawn.quantity)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackKillIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackKillIntegrationTest.kt
@@ -1,0 +1,265 @@
+package dev.gvart.genesara.world.internal.combat
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AgentSkillState
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.DeathPenaltyOutcome
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.DroppedItemView
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.GroundItemStore
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Rarity
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.ResourceSpawnRule
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.death.DeathProcessor
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Cross-call attack flow: two consecutive attack reducer invocations against the
+ * same target, with state threaded from one call into the next. Verifies:
+ *  - Target HP decreases as expected across attacks.
+ *  - The killing blow emits both [WorldEvent.AgentAttacked] AND [WorldEvent.AgentDied]
+ *    in the second call, both carrying the killing command's id as `causedBy`.
+ *  - Attacker's kill-streak counter increments only on the killing blow.
+ *  - SWORD-skill XP accrues on EVERY attack, not just the killing one — so the
+ *    issue #5 recommendation hook fires from the moment combat starts.
+ */
+class AttackKillIntegrationTest {
+
+    private val attacker = AgentId(UUID.randomUUID())
+    private val target = AgentId(UUID.randomUUID())
+    private val regionId = RegionId(1L)
+    private val nodeId = NodeId(1L)
+
+    private val region = Region(
+        id = regionId,
+        worldId = WorldId(1L),
+        sphereIndex = 0,
+        biome = Biome.PLAINS,
+        climate = Climate.OCEANIC,
+        centroid = Vec3(0.0, 0.0, 1.0),
+        faceVertices = emptyList(),
+        neighbors = emptySet(),
+    )
+    private val node = Node(nodeId, regionId, q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())
+    private val rustySword = ItemId("RUSTY_SWORD")
+    private val swordSkill = SkillId("SWORD")
+
+    @Test
+    fun `two-attack kill — second blow emits AgentAttacked + AgentDied with shared causedBy and ticks kill streak`() {
+        val items = StubItemLookup(
+            mapOf(
+                rustySword to Item(
+                    id = rustySword,
+                    displayName = "Rusty Sword",
+                    description = "",
+                    category = ItemCategory.EQUIPMENT,
+                    weightPerUnit = 1500,
+                    maxStack = 1,
+                    damageType = DamageType.SLASH,
+                    weaponPower = 8,
+                    combatSkill = swordSkill,
+                    validSlots = setOf(EquipSlot.MAIN_HAND),
+                ),
+            ),
+        )
+        val agents = StubAgentRegistry(
+            byId = mapOf(
+                attacker to AgentAttributes(strength = 10, luck = 0, dexterity = 0),
+                target to AgentAttributes(strength = 1, luck = 0, dexterity = 0),
+            ),
+            scriptedDeath = mapOf(
+                target to DeathPenaltyOutcome(xpLost = 0, deleveled = false, attributePointLost = null),
+            ),
+        )
+        val equipment = StubEquipmentStore(
+            equippedByAgent = mapOf(
+                attacker to mapOf(
+                    EquipSlot.MAIN_HAND to EquipmentInstance(
+                        instanceId = UUID.randomUUID(),
+                        agentId = attacker,
+                        itemId = rustySword,
+                        rarity = Rarity.COMMON,
+                        durabilityCurrent = 50,
+                        durabilityMax = 50,
+                        creatorAgentId = null,
+                        createdAtTick = 0L,
+                        equippedInSlot = EquipSlot.MAIN_HAND,
+                    ),
+                ),
+            ),
+        )
+        val groundItems = StubGroundItemStore()
+        val balance = combatBalance()
+        val deathProcessor = DeathProcessor(balance, agents, equipment, groundItems)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val progression = SkillProgression(skills, publisher)
+
+        val initial = WorldState(
+            regions = mapOf(regionId to region),
+            nodes = mapOf(nodeId to node),
+            positions = mapOf(attacker to nodeId, target to nodeId),
+            bodies = mapOf(
+                attacker to AgentBody(hp = 100, maxHp = 100, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
+                target to AgentBody(hp = 100, maxHp = 100, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
+            ),
+            inventories = emptyMap(),
+        )
+
+        val firstCommand = WorldCommand.AttackTarget(attacker, target)
+        val (afterFirst, firstEvents) = assertNotNull(
+            reduceAttack(
+                initial, firstCommand, balance, items, agents, equipment, progression,
+                deathProcessor, rng = Random(seed = 1L), tick = 1L,
+            ).getOrNull(),
+        )
+
+        val firstAttacked = assertIs<WorldEvent.AgentAttacked>(firstEvents.single())
+        assertEquals(80, firstAttacked.hpLost)
+        assertEquals(false, firstAttacked.targetKilled)
+        assertEquals(20, afterFirst.bodyOf(target)!!.hp)
+        assertEquals(0, afterFirst.killStreakOf(attacker).killCount, "no kill yet → streak still EMPTY")
+
+        val secondCommand = WorldCommand.AttackTarget(attacker, target)
+        val (afterSecond, secondEvents) = assertNotNull(
+            reduceAttack(
+                afterFirst, secondCommand, balance, items, agents, equipment, progression,
+                deathProcessor, rng = Random(seed = 1L), tick = 2L,
+            ).getOrNull(),
+        )
+
+        assertEquals(2, secondEvents.size, "killing blow emits AgentAttacked + AgentDied")
+        val secondAttacked = assertIs<WorldEvent.AgentAttacked>(secondEvents[0])
+        val died = assertIs<WorldEvent.AgentDied>(secondEvents[1])
+        assertEquals(true, secondAttacked.targetKilled)
+        assertEquals(0, secondAttacked.targetHpAfter)
+        assertEquals(secondCommand.commandId, secondAttacked.causedBy)
+        assertEquals(secondCommand.commandId, died.causedBy, "AgentDied carries the killing attack's commandId")
+        assertTrue(target !in afterSecond.positions, "DeathProcessor removed target from positions")
+        assertEquals(1, afterSecond.killStreakOf(attacker).killCount, "kill streak ticks on the killing blow")
+        assertEquals(2, skills.xpAddCalls.size, "SWORD XP accrued on each attack — issue #5 hook fires from the start")
+        assertEquals(swordSkill to 1, skills.xpAddCalls[0])
+        assertEquals(swordSkill to 1, skills.xpAddCalls[1])
+    }
+
+    private fun combatBalance(): BalanceLookup = object : BalanceLookup {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
+        override fun staminaRegenPerTick(climate: Climate) = 0
+        override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun xpLossOnDeath(): Int = 0
+        override fun killStreakWindowTicks(): Long = 1000L
+        override fun dropChanceForKillCount(killCount: Int): Double = 0.0
+    }
+
+    private class StubItemLookup(private val byId: Map<ItemId, Item>) : ItemLookup {
+        override fun byId(id: ItemId): Item? = byId[id]
+        override fun all(): List<Item> = byId.values.toList()
+    }
+
+    private class StubAgentRegistry(
+        private val byId: Map<AgentId, AgentAttributes>,
+        private val scriptedDeath: Map<AgentId, DeathPenaltyOutcome> = emptyMap(),
+    ) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = byId[id]?.let {
+            Agent(
+                id = id,
+                owner = PlayerId(UUID.randomUUID()),
+                name = "test",
+                attributes = it,
+            )
+        }
+        override fun listForOwner(owner: PlayerId): List<Agent> = error("not used")
+        override fun applyDeathPenalty(agentId: AgentId, xpLossOnDeath: Int): DeathPenaltyOutcome? =
+            scriptedDeath[agentId]
+    }
+
+    private class StubEquipmentStore(
+        private val equippedByAgent: Map<AgentId, Map<EquipSlot, EquipmentInstance>> = emptyMap(),
+    ) : EquipmentInstanceStore {
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> =
+            equippedByAgent[agentId] ?: emptyMap()
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = error("not used")
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? =
+            error("not used")
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = error("not used")
+        override fun delete(instanceId: UUID): Boolean = true
+    }
+
+    private class StubGroundItemStore : GroundItemStore {
+        override fun deposit(node: NodeId, drop: DroppedItemView, droppedAtTick: Long) = Unit
+        override fun atNode(node: NodeId): List<GroundItemView> = error("not used")
+        override fun take(node: NodeId, dropId: UUID): GroundItemView? = error("not used")
+    }
+
+    private class StubSkillsRegistry : AgentSkillsRegistry {
+        val xpAddCalls = mutableListOf<Pair<SkillId, Int>>()
+
+        override fun snapshot(agent: AgentId): AgentSkillsSnapshot =
+            AgentSkillsSnapshot(perSkill = emptyMap(), slotCount = 8, slotsFilled = 0)
+
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int): AddXpResult {
+            xpAddCalls += skill to delta
+            return AddXpResult.Unslotted
+        }
+
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? = null
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? = null
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
@@ -1,0 +1,711 @@
+package dev.gvart.genesara.world.internal.combat
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AgentSkillState
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.Attribute
+import dev.gvart.genesara.player.AttributePointLoss
+import dev.gvart.genesara.player.DeathPenaltyOutcome
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.DroppedItemView
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.GroundItemStore
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Rarity
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.ResourceSpawnRule
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.death.DeathProcessor
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class AttackReducerTest {
+
+    private val attacker = AgentId(UUID.randomUUID())
+    private val target = AgentId(UUID.randomUUID())
+    private val regionId = RegionId(1L)
+    private val nodeAId = NodeId(1L)
+    private val nodeBId = NodeId(2L)
+    private val nodeCId = NodeId(3L)
+
+    private val region = Region(
+        id = regionId,
+        worldId = WorldId(1L),
+        sphereIndex = 0,
+        biome = Biome.PLAINS,
+        climate = Climate.OCEANIC,
+        centroid = Vec3(0.0, 0.0, 1.0),
+        faceVertices = emptyList(),
+        neighbors = emptySet(),
+    )
+    private val nodeA = Node(nodeAId, regionId, q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())
+    private val nodeB = Node(nodeBId, regionId, q = 1, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())
+
+    private val rustySword = ItemId("RUSTY_SWORD")
+    private val woodenBow = ItemId("WOODEN_BOW")
+    private val swordSkill = SkillId("SWORD")
+    private val bowSkill = SkillId("BOW")
+    private val unarmedSkill = SkillId("UNARMED")
+
+    @Test
+    fun `happy path — sword strike with no crit and no dodge, deterministic damage`() {
+        val state = battleState(targetHp = 100)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val deathProcessor = stubDeathProcessor(skills, publisher)
+
+        val (next, events) = assertNotNull(
+            reduceAttack(
+                state, WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
+                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed = 1L), tick = 5,
+            ).getOrNull(),
+        )
+
+        val attacked = assertIs<WorldEvent.AgentAttacked>(events.single())
+        assertEquals(80, attacked.baseDamage)
+        assertEquals(80, attacked.hpLost)
+        assertEquals(false, attacked.isCrit)
+        assertEquals(false, attacked.isDodged)
+        assertEquals(DamageType.SLASH, attacked.damageType)
+        assertEquals(20, attacked.targetHpAfter)
+        assertEquals(false, attacked.targetKilled)
+        assertEquals(20, next.bodyOf(target)!!.hp)
+        assertEquals(45, next.bodyOf(attacker)!!.stamina, "stamina cost 5")
+        assertEquals(listOf(swordSkill to 1), skills.xpAddCalls)
+    }
+
+    @Test
+    fun `unarmed fallback — uses balance defaults and grants UNARMED XP`() {
+        val state = battleState(targetHp = 100)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val deathProcessor = stubDeathProcessor(skills, publisher)
+
+        val (_, events) = assertNotNull(
+            reduceAttack(
+                state, WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithSword(), agents(strength = 5, luck = 0, dex = 0),
+                StubEquipmentStore(),
+                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed = 1L), tick = 1,
+            ).getOrNull(),
+        )
+
+        val attacked = assertIs<WorldEvent.AgentAttacked>(events.single())
+        assertEquals(DamageType.BLUNT, attacked.damageType)
+        assertEquals(10, attacked.hpLost)
+        assertEquals(listOf(unarmedSkill to 1), skills.xpAddCalls)
+    }
+
+    @Test
+    fun `dodge fires when seeded RNG lands in the dodge window`() {
+        val seed = seedThatRolls(target = 49, callIndex = 0)  // first nextInt(100) < 50
+        val state = battleState(targetHp = 100)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val deathProcessor = stubDeathProcessor(skills, publisher)
+
+        val (next, events) = assertNotNull(
+            reduceAttack(
+                state, WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithSword(),
+                agents(strength = 10, luck = 0, dex = 0, targetDex = 99),
+                swordEquipped(),
+                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed), tick = 1,
+            ).getOrNull(),
+        )
+
+        val attacked = assertIs<WorldEvent.AgentAttacked>(events.single())
+        assertEquals(true, attacked.isDodged)
+        assertEquals(false, attacked.isCrit)
+        assertEquals(0, attacked.hpLost)
+        assertEquals(100, next.bodyOf(target)!!.hp, "dodged hits leave the target body untouched")
+        assertEquals(45, next.bodyOf(attacker)!!.stamina, "attacker still pays stamina cost on a miss")
+        assertEquals(listOf(swordSkill to 1), skills.xpAddCalls, "weapon-skill XP accrues even when dodged")
+    }
+
+    @Test
+    fun `crit fires when dodge passes and crit roll lands in the LUCK window`() {
+        val seed = seedThatPassesThenRolls(threshold = 49)  // first call ≥ 50, second call < 50
+        val state = battleState(targetHp = 200)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val deathProcessor = stubDeathProcessor(skills, publisher)
+
+        val (_, events) = assertNotNull(
+            reduceAttack(
+                state, WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithSword(),
+                agents(strength = 10, luck = 99, dex = 0, targetDex = 0),
+                swordEquipped(),
+                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed), tick = 1,
+            ).getOrNull(),
+        )
+
+        val attacked = assertIs<WorldEvent.AgentAttacked>(events.single())
+        assertEquals(false, attacked.isDodged)
+        assertEquals(true, attacked.isCrit)
+        assertEquals(160, attacked.hpLost)
+    }
+
+    @Test
+    fun `weapon with null combat-skill in catalog — falls back to UNARMED skill XP`() {
+        val state = battleState(targetHp = 100)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val deathProcessor = stubDeathProcessor(skills, publisher)
+
+        val (_, events) = assertNotNull(
+            reduceAttack(
+                state, WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithUnmappedWeapon(),
+                agents(strength = 10, luck = 0, dex = 0),
+                unmappedWeaponEquipped(),
+                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed = 1L), tick = 1,
+            ).getOrNull(),
+        )
+
+        val attacked = assertIs<WorldEvent.AgentAttacked>(events.single())
+        assertEquals(DamageType.BLUNT, attacked.damageType, "no damage-type on weapon → unarmed fallback")
+        assertEquals(listOf(unarmedSkill to 1), skills.xpAddCalls)
+    }
+
+    @Test
+    fun `killing blow — emits AgentAttacked and AgentDied with shared causedBy, increments attacker streak`() {
+        val state = battleState(targetHp = 1)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val deathProcessor = stubDeathProcessor(skills, publisher)
+
+        val command = WorldCommand.AttackTarget(attacker, target)
+        val (next, events) = assertNotNull(
+            reduceAttack(
+                state, command,
+                balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0),
+                swordEquipped(),
+                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed = 1L), tick = 7,
+            ).getOrNull(),
+        )
+
+        assertEquals(2, events.size, "AgentAttacked + AgentDied")
+        val attacked = assertIs<WorldEvent.AgentAttacked>(events[0])
+        val died = assertIs<WorldEvent.AgentDied>(events[1])
+        assertEquals(true, attacked.targetKilled)
+        assertEquals(0, attacked.targetHpAfter)
+        assertEquals(command.commandId, attacked.causedBy)
+        assertEquals(command.commandId, died.causedBy)
+        assertTrue(target !in next.positions, "killed target removed from positions by DeathProcessor")
+        assertEquals(1, next.killStreakOf(attacker).killCount, "attacker streak ticked on the kill")
+    }
+
+    @Test
+    fun `zero-base-damage attack still emits AgentAttacked with hpLost=0 — a hit, not a miss`() {
+        val state = battleState(targetHp = 100)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val deathProcessor = stubDeathProcessor(skills, publisher)
+
+        val (next, events) = assertNotNull(
+            reduceAttack(
+                state, WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithSword(),
+                agents(strength = 0, luck = 0, dex = 0),
+                swordEquipped(),
+                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed = 1L), tick = 1,
+            ).getOrNull(),
+        )
+
+        val attacked = assertIs<WorldEvent.AgentAttacked>(events.single())
+        assertEquals(0, attacked.baseDamage)
+        assertEquals(0, attacked.hpLost)
+        assertEquals(false, attacked.isDodged, "STR=0 produces a real hit for 0 damage, not a dodge")
+        assertEquals(false, attacked.isCrit)
+        assertEquals(100, next.bodyOf(target)!!.hp)
+    }
+
+    @Test
+    fun `killing blow with active streak — drop fires and ItemDroppedOnGround inherits the killing commandId`() {
+        val seed = 1L  // any seed — drop chance is 1.0 here so it always clears
+        val state = battleState(targetHp = 1).copy(
+            killStreaks = mapOf(target to dev.gvart.genesara.world.AgentKillStreak(killCount = 5, windowStartTick = 0L)),
+            inventories = mapOf(
+                target to dev.gvart.genesara.world.internal.inventory.AgentInventory(
+                    mapOf(ItemId("WOOD") to 3),
+                ),
+            ),
+        )
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val deathProcessor = DeathProcessor(
+            balance = balanceWithGuaranteedDrop(),
+            agents = StubAgentRegistry(
+                byId = mapOf(target to AgentAttributes()),
+                scriptedDeath = mapOf(
+                    target to DeathPenaltyOutcome(xpLost = 0, deleveled = false, attributePointLost = null),
+                ),
+            ),
+            equipment = StubEquipmentStore(),
+            groundItems = StubGroundItemStore(),
+        )
+
+        val command = WorldCommand.AttackTarget(attacker, target)
+        val (_, events) = assertNotNull(
+            reduceAttack(
+                state, command,
+                balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0),
+                swordEquipped(),
+                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed), tick = 5,
+            ).getOrNull(),
+        )
+
+        assertEquals(3, events.size, "AgentAttacked + AgentDied + ItemDroppedOnGround")
+        val died = assertIs<WorldEvent.AgentDied>(events[1])
+        val dropped = assertIs<WorldEvent.ItemDroppedOnGround>(events[2])
+        assertEquals(command.commandId, died.causedBy)
+        assertEquals(command.commandId, dropped.causedBy, "drop event inherits the killing attack's commandId")
+        assertEquals(target, dropped.byAgent)
+    }
+
+    @Test
+    fun `cannot attack self`() {
+        val state = battleState(targetHp = 100).copy(positions = mapOf(attacker to nodeAId))
+        val result = reduceAttack(
+            state, WorldCommand.AttackTarget(attacker, attacker),
+            balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
+            SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
+            rng = Random(seed = 1L), tick = 1,
+        )
+        assertEquals(WorldRejection.CannotAttackSelf(attacker), result.leftOrNull())
+    }
+
+    @Test
+    fun `attacker not in world`() {
+        val state = battleState(targetHp = 100).copy(positions = mapOf(target to nodeAId))
+        val result = reduceAttack(
+            state, WorldCommand.AttackTarget(attacker, target),
+            balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
+            SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
+            rng = Random(seed = 1L), tick = 1,
+        )
+        assertEquals(WorldRejection.NotInWorld(attacker), result.leftOrNull())
+    }
+
+    @Test
+    fun `target not in world`() {
+        val state = battleState(targetHp = 100).copy(positions = mapOf(attacker to nodeAId))
+        val result = reduceAttack(
+            state, WorldCommand.AttackTarget(attacker, target),
+            balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
+            SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
+            rng = Random(seed = 1L), tick = 1,
+        )
+        assertEquals(WorldRejection.TargetNotInWorld(attacker, target), result.leftOrNull())
+    }
+
+    @Test
+    fun `melee weapon (range=1) rejects target on a different node`() {
+        val state = battleState(targetHp = 100).copy(positions = mapOf(attacker to nodeAId, target to nodeBId))
+        val result = reduceAttack(
+            state, WorldCommand.AttackTarget(attacker, target),
+            balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
+            SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
+            rng = Random(seed = 1L), tick = 1,
+        )
+        assertEquals(
+            WorldRejection.TargetOutOfRange(attacker, target, nodeAId, nodeBId, weaponRange = 1),
+            result.leftOrNull(),
+        )
+    }
+
+    @Test
+    fun `ranged weapon (range=2) hits target on an adjacent node`() {
+        val state = battleStateAdjacentNodes(targetHp = 100)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val deathProcessor = stubDeathProcessor(skills, publisher)
+
+        val (next, events) = assertNotNull(
+            reduceAttack(
+                state, WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithBow(), agents(strength = 0, luck = 0, dex = 10), bowEquipped(),
+                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed = 1L), tick = 1,
+            ).getOrNull(),
+        )
+
+        val attacked = assertIs<WorldEvent.AgentAttacked>(events.single())
+        assertEquals(DamageType.PIERCE, attacked.damageType)
+        assertEquals(false, attacked.isDodged)
+        assertEquals(70, attacked.hpLost)
+        assertEquals(SkillId("BOW") to 1, skills.xpAddCalls.single())
+        assertEquals(30, next.bodyOf(target)!!.hp)
+    }
+
+    @Test
+    fun `ranged weapon (range=2) still rejects a target two hops away`() {
+        val state = battleStateAdjacentNodes(targetHp = 100)
+            .copy(positions = mapOf(attacker to nodeAId, target to nodeCId))
+        val result = reduceAttack(
+            state, WorldCommand.AttackTarget(attacker, target),
+            balance(), itemsWithBow(), agents(strength = 10, luck = 0, dex = 0), bowEquipped(),
+            SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
+            rng = Random(seed = 1L), tick = 1,
+        )
+        assertEquals(
+            WorldRejection.TargetOutOfRange(attacker, target, nodeAId, nodeCId, weaponRange = 2),
+            result.leftOrNull(),
+        )
+    }
+
+    @Test
+    fun `target already at HP=0`() {
+        val state = battleState(targetHp = 0)
+        val result = reduceAttack(
+            state, WorldCommand.AttackTarget(attacker, target),
+            balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
+            SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
+            rng = Random(seed = 1L), tick = 1,
+        )
+        assertEquals(WorldRejection.TargetAlreadyDead(attacker, target), result.leftOrNull())
+    }
+
+    @Test
+    fun `attacker has insufficient stamina`() {
+        val state = battleState(targetHp = 100, attackerStamina = 3)
+        val result = reduceAttack(
+            state, WorldCommand.AttackTarget(attacker, target),
+            balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
+            SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
+            rng = Random(seed = 1L), tick = 1,
+        )
+        assertEquals(
+            WorldRejection.NotEnoughStamina(attacker, required = 5, available = 3),
+            result.leftOrNull(),
+        )
+    }
+
+    private fun battleState(targetHp: Int, attackerStamina: Int = 50): WorldState = WorldState(
+        regions = mapOf(regionId to region),
+        nodes = mapOf(nodeAId to nodeA, nodeBId to nodeB),
+        positions = mapOf(attacker to nodeAId, target to nodeAId),
+        bodies = mapOf(
+            attacker to AgentBody(hp = 100, maxHp = 100, stamina = attackerStamina, maxStamina = 50, mana = 0, maxMana = 0),
+            target to AgentBody(hp = targetHp, maxHp = 100, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
+        ),
+        inventories = emptyMap(),
+    )
+
+    private fun battleStateAdjacentNodes(targetHp: Int): WorldState {
+        // A — B — C: attacker on A, target on B (adjacent → range 2 reaches), C is two hops out.
+        val a = Node(nodeAId, regionId, q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = setOf(nodeBId))
+        val b = Node(nodeBId, regionId, q = 1, r = 0, terrain = Terrain.PLAINS, adjacency = setOf(nodeAId, nodeCId))
+        val c = Node(nodeCId, regionId, q = 2, r = 0, terrain = Terrain.PLAINS, adjacency = setOf(nodeBId))
+        return WorldState(
+            regions = mapOf(regionId to region),
+            nodes = mapOf(nodeAId to a, nodeBId to b, nodeCId to c),
+            positions = mapOf(attacker to nodeAId, target to nodeBId),
+            bodies = mapOf(
+                attacker to AgentBody(hp = 100, maxHp = 100, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
+                target to AgentBody(hp = targetHp, maxHp = 100, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
+            ),
+            inventories = emptyMap(),
+        )
+    }
+
+    private fun balanceWithGuaranteedDrop(): BalanceLookup = object : BalanceLookup {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
+        override fun staminaRegenPerTick(climate: Climate) = 0
+        override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun xpLossOnDeath(): Int = 0
+        override fun killStreakWindowTicks(): Long = 1000L
+        override fun dropChanceForKillCount(killCount: Int): Double = 1.0
+    }
+
+    private fun balance(): BalanceLookup = object : BalanceLookup {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
+        override fun staminaRegenPerTick(climate: Climate) = 0
+        override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun xpLossOnDeath(): Int = 0
+        override fun killStreakWindowTicks(): Long = 1000L
+        override fun dropChanceForKillCount(killCount: Int): Double = 0.0
+    }
+
+    private fun itemsWithSword(): ItemLookup = StubItemLookup(
+        mapOf(
+            rustySword to Item(
+                id = rustySword,
+                displayName = "Rusty Sword",
+                description = "",
+                category = ItemCategory.EQUIPMENT,
+                weightPerUnit = 1500,
+                maxStack = 1,
+                damageType = DamageType.SLASH,
+                weaponPower = 8,
+                combatSkill = swordSkill,
+                validSlots = setOf(EquipSlot.MAIN_HAND),
+            ),
+        ),
+    )
+
+    private fun itemsWithBow(): ItemLookup = StubItemLookup(
+        mapOf(
+            woodenBow to Item(
+                id = woodenBow,
+                displayName = "Wooden Bow",
+                description = "",
+                category = ItemCategory.EQUIPMENT,
+                weightPerUnit = 1500,
+                maxStack = 1,
+                damageType = DamageType.PIERCE,
+                weaponPower = 7,
+                combatSkill = bowSkill,
+                range = 2,
+                validSlots = setOf(EquipSlot.MAIN_HAND),
+                twoHanded = true,
+            ),
+        ),
+    )
+
+    private fun bowEquipped(): EquipmentInstanceStore = StubEquipmentStore(
+        equippedByAgent = mapOf(
+            attacker to mapOf(
+                EquipSlot.MAIN_HAND to EquipmentInstance(
+                    instanceId = UUID.randomUUID(),
+                    agentId = attacker,
+                    itemId = woodenBow,
+                    rarity = Rarity.COMMON,
+                    durabilityCurrent = 50,
+                    durabilityMax = 50,
+                    creatorAgentId = null,
+                    createdAtTick = 0L,
+                    equippedInSlot = EquipSlot.MAIN_HAND,
+                ),
+            ),
+        ),
+    )
+
+    private fun itemsWithUnmappedWeapon(): ItemLookup = StubItemLookup(
+        mapOf(
+            ItemId("CRUDE_STICK") to Item(
+                id = ItemId("CRUDE_STICK"),
+                displayName = "Crude Stick",
+                description = "",
+                category = ItemCategory.EQUIPMENT,
+                weightPerUnit = 100,
+                maxStack = 1,
+                validSlots = setOf(EquipSlot.MAIN_HAND),
+            ),
+        ),
+    )
+
+    private fun swordEquipped(): EquipmentInstanceStore = StubEquipmentStore(
+        equippedByAgent = mapOf(
+            attacker to mapOf(
+                EquipSlot.MAIN_HAND to EquipmentInstance(
+                    instanceId = UUID.randomUUID(),
+                    agentId = attacker,
+                    itemId = rustySword,
+                    rarity = Rarity.COMMON,
+                    durabilityCurrent = 50,
+                    durabilityMax = 50,
+                    creatorAgentId = null,
+                    createdAtTick = 0L,
+                    equippedInSlot = EquipSlot.MAIN_HAND,
+                ),
+            ),
+        ),
+    )
+
+    private fun unmappedWeaponEquipped(): EquipmentInstanceStore = StubEquipmentStore(
+        equippedByAgent = mapOf(
+            attacker to mapOf(
+                EquipSlot.MAIN_HAND to EquipmentInstance(
+                    instanceId = UUID.randomUUID(),
+                    agentId = attacker,
+                    itemId = ItemId("CRUDE_STICK"),
+                    rarity = Rarity.COMMON,
+                    durabilityCurrent = 10,
+                    durabilityMax = 10,
+                    creatorAgentId = null,
+                    createdAtTick = 0L,
+                    equippedInSlot = EquipSlot.MAIN_HAND,
+                ),
+            ),
+        ),
+    )
+
+    private fun agents(strength: Int, luck: Int, dex: Int, targetDex: Int = 0): AgentRegistry =
+        StubAgentRegistry(
+            byId = mapOf(
+                attacker to AgentAttributes(strength = strength, luck = luck, dexterity = dex),
+                target to AgentAttributes(dexterity = targetDex),
+            ),
+        )
+
+    private fun stubDeathProcessor(
+        skills: AgentSkillsRegistry,
+        publisher: ApplicationEventPublisher,
+    ): DeathProcessor = DeathProcessor(
+        balance = balance(),
+        agents = StubAgentRegistry(
+            byId = mapOf(target to AgentAttributes(strength = 1)),
+            scriptedDeath = mapOf(target to DeathPenaltyOutcome(xpLost = 0, deleveled = false, attributePointLost = null)),
+        ),
+        equipment = StubEquipmentStore(),
+        groundItems = StubGroundItemStore(),
+    )
+
+    private fun seedThatRolls(target: Int, callIndex: Int): Long {
+        for (s in 0L..10_000L) {
+            val rng = Random(s)
+            repeat(callIndex) { rng.nextInt(100) }
+            if (rng.nextInt(100) < target) return s
+        }
+        error("could not find a seed where call #$callIndex rolls < $target")
+    }
+
+    private fun seedThatPassesThenRolls(threshold: Int): Long {
+        for (s in 0L..10_000L) {
+            val rng = Random(s)
+            val first = rng.nextInt(100)
+            val second = rng.nextInt(100)
+            if (first >= 50 && second < threshold) return s
+        }
+        error("could not find a seed that skips dodge and lands a crit")
+    }
+
+    private class StubItemLookup(private val byId: Map<ItemId, Item>) : ItemLookup {
+        override fun byId(id: ItemId): Item? = byId[id]
+        override fun all(): List<Item> = byId.values.toList()
+    }
+
+    private class StubAgentRegistry(
+        private val byId: Map<AgentId, AgentAttributes>,
+        private val scriptedDeath: Map<AgentId, DeathPenaltyOutcome> = emptyMap(),
+    ) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = byId[id]?.let {
+            Agent(
+                id = id,
+                owner = PlayerId(UUID.randomUUID()),
+                name = "test",
+                attributes = it,
+            )
+        }
+        override fun listForOwner(owner: PlayerId): List<Agent> = error("not used")
+        override fun applyDeathPenalty(agentId: AgentId, xpLossOnDeath: Int): DeathPenaltyOutcome? =
+            scriptedDeath[agentId]
+    }
+
+    private class StubEquipmentStore(
+        private val equippedByAgent: Map<AgentId, Map<EquipSlot, EquipmentInstance>> = emptyMap(),
+    ) : EquipmentInstanceStore {
+        val deletedInstanceIds: MutableList<UUID> = mutableListOf()
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> =
+            equippedByAgent[agentId] ?: emptyMap()
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = error("not used")
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? =
+            error("not used")
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = error("not used")
+        override fun delete(instanceId: UUID): Boolean {
+            deletedInstanceIds += instanceId
+            return true
+        }
+    }
+
+    private class StubGroundItemStore : GroundItemStore {
+        override fun deposit(node: NodeId, drop: DroppedItemView, droppedAtTick: Long) = Unit
+        override fun atNode(node: NodeId): List<GroundItemView> = error("not used")
+        override fun take(node: NodeId, dropId: UUID): GroundItemView? = error("not used")
+    }
+
+    private class StubSkillsRegistry : AgentSkillsRegistry {
+        val xpAddCalls = mutableListOf<Pair<SkillId, Int>>()
+        val recommendCalls = mutableListOf<Pair<SkillId, Long>>()
+
+        override fun snapshot(agent: AgentId): AgentSkillsSnapshot =
+            AgentSkillsSnapshot(perSkill = emptyMap(), slotCount = 8, slotsFilled = 0)
+
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int): AddXpResult {
+            xpAddCalls += skill to delta
+            return AddXpResult.Unslotted
+        }
+
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? {
+            recommendCalls += skill to tick
+            return null
+        }
+
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? = null
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducerTest.kt
@@ -80,7 +80,8 @@ class ConsumeReducerTest {
 
         val result = reduceConsume(state, command, items, tick = 7)
 
-        val (next, event) = assertNotNull(result.getOrNull())
+        val (next, events) = assertNotNull(result.getOrNull())
+        val event = events.single()
         // Gauge clamped at max — agent had 90/100, refill 20 → 100, actual refilled = 10.
         assertEquals(100, next.bodyOf(agent)!!.hunger)
         assertEquals(1, next.inventoryOf(agent).quantityOf(berry))

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
@@ -146,7 +146,7 @@ class CraftReducerTest {
         val store = StubEquipmentStore()
         val publisher = RecordingPublisher()
 
-        val (next, event) = assertNotNull(
+        val (next, events) = assertNotNull(
             reduceCraft(
                 state,
                 WorldCommand.CraftItem(agent, ironSwordRecipe.id),
@@ -163,7 +163,7 @@ class CraftReducerTest {
             ).getOrNull(),
         )
 
-        val crafted = assertIs<WorldEvent.ItemCrafted>(event)
+        val crafted = assertIs<WorldEvent.ItemCrafted>(events.single())
         assertEquals(ironSword, crafted.output)
         assertEquals(Rarity.UNCOMMON, crafted.rarity)
         assertNotNull(crafted.instanceId)
@@ -189,7 +189,7 @@ class CraftReducerTest {
         val skills = StubSkillsRegistry().apply { slot(alchemy, level = 1) }
         val store = StubEquipmentStore()
 
-        val (next, event) = assertNotNull(
+        val (next, events) = assertNotNull(
             reduceCraft(
                 state,
                 WorldCommand.CraftItem(agent, healingSalveRecipe.id),
@@ -206,7 +206,7 @@ class CraftReducerTest {
             ).getOrNull(),
         )
 
-        val crafted = assertIs<WorldEvent.ItemCrafted>(event)
+        val crafted = assertIs<WorldEvent.ItemCrafted>(events.single())
         assertEquals(healingSalve, crafted.output)
         assertNull(crafted.instanceId)
         assertNull(crafted.rarity)
@@ -419,7 +419,7 @@ class CraftReducerTest {
         buildings: BuildingsLookup = StubBuildingsLookup(
             stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_METAL, BuildingCategoryHint.CRAFTING_STATION_POTION)),
         ),
-    ): Either<WorldRejection, Pair<WorldState, WorldEvent>> = reduceCraft(
+    ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = reduceCraft(
         state,
         command,
         stubBalance(),

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/DeathSweepTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/DeathSweepTest.kt
@@ -68,7 +68,7 @@ class DeathSweepTest {
         val equipment = StubEquipmentStore()
         val groundItems = StubGroundItemStore()
 
-        val (next, events) = processDeaths(state, balance(), agents, equipment, groundItems, tick = 1)
+        val (next, events) = processDeaths(state, DeathProcessor(balance(), agents, equipment, groundItems), tick =1)
 
         assertEquals(state, next)
         assertEquals(emptyList(), events)
@@ -90,7 +90,7 @@ class DeathSweepTest {
         val equipment = StubEquipmentStore()
         val groundItems = StubGroundItemStore()
 
-        val (next, events) = processDeaths(state, balance(), agents, equipment, groundItems, tick = 7)
+        val (next, events) = processDeaths(state, DeathProcessor(balance(), agents, equipment, groundItems), tick =7)
 
         assertTrue(agentId !in next.positions, "agent removed from positions on death")
         assertEquals(0, next.bodyOf(agentId)?.hp)
@@ -120,7 +120,7 @@ class DeathSweepTest {
             ),
         )
 
-        val (_, events) = processDeaths(state, balance(), agents, StubEquipmentStore(), StubGroundItemStore(), tick = 1)
+        val (_, events) = processDeaths(state, DeathProcessor(balance(), agents, StubEquipmentStore(), StubGroundItemStore()), tick =1)
 
         val died = assertIs<WorldEvent.AgentDied>(events.single())
         assertEquals("UNSPENT", died.attributePointLost)
@@ -141,7 +141,7 @@ class DeathSweepTest {
             ),
         )
 
-        val (_, events) = processDeaths(state, balance(), agents, StubEquipmentStore(), StubGroundItemStore(), tick = 1)
+        val (_, events) = processDeaths(state, DeathProcessor(balance(), agents, StubEquipmentStore(), StubGroundItemStore()), tick =1)
 
         val died = assertIs<WorldEvent.AgentDied>(events.single())
         assertEquals("STRENGTH", died.attributePointLost)
@@ -165,7 +165,7 @@ class DeathSweepTest {
             ),
         )
 
-        val (next, events) = processDeaths(state, balance(), agents, StubEquipmentStore(), StubGroundItemStore(), tick = 1)
+        val (next, events) = processDeaths(state, DeathProcessor(balance(), agents, StubEquipmentStore(), StubGroundItemStore()), tick =1)
 
         assertEquals(emptyMap(), next.positions)
         val deaths = events.filterIsInstance<WorldEvent.AgentDied>()
@@ -178,7 +178,7 @@ class DeathSweepTest {
         val state = stateWith(agentId, hp = 0, atNode = nodeAId)
         val agents = StubRegistry(returnNull = true)
 
-        val (next, events) = processDeaths(state, balance(), agents, StubEquipmentStore(), StubGroundItemStore(), tick = 1)
+        val (next, events) = processDeaths(state, DeathProcessor(balance(), agents, StubEquipmentStore(), StubGroundItemStore()), tick =1)
 
         assertTrue(agentId !in next.positions, "position cleared so the same row doesn't loop forever")
         assertEquals(emptyList(), events, "no AgentDied event for an agent we couldn't penalize")
@@ -196,7 +196,7 @@ class DeathSweepTest {
         )
         val agents = StubRegistry()
 
-        val (next, events) = processDeaths(state, balance(), agents, StubEquipmentStore(), StubGroundItemStore(), tick = 1)
+        val (next, events) = processDeaths(state, DeathProcessor(balance(), agents, StubEquipmentStore(), StubGroundItemStore()), tick =1)
 
         assertEquals(state, next)
         assertEquals(emptyList(), events)
@@ -217,7 +217,8 @@ class DeathSweepTest {
         val rng = Random(seed = 42)
 
         val (next, events) = processDeaths(
-            state, balance(), agents, StubEquipmentStore(), groundItems,
+            state,
+            DeathProcessor(balance(), agents, StubEquipmentStore(), groundItems),
             tick = 100L, rng = rng,
         )
 
@@ -248,7 +249,8 @@ class DeathSweepTest {
         val groundItems = StubGroundItemStore()
 
         val (next, events) = processDeaths(
-            state, balance(), agents, StubEquipmentStore(), groundItems,
+            state,
+            DeathProcessor(balance(), agents, StubEquipmentStore(), groundItems),
             tick = 5_000L, rng = Random(seed = 1),
         )
 
@@ -280,7 +282,8 @@ class DeathSweepTest {
         val groundItems = StubGroundItemStore()
 
         val (_, events) = processDeaths(
-            state, balance(), agents, equipment, groundItems,
+            state,
+            DeathProcessor(balance(), agents, equipment, groundItems),
             tick = 100L, rng = Random(seed = 7),
         )
 
@@ -303,7 +306,8 @@ class DeathSweepTest {
         val groundItems = StubGroundItemStore()
 
         val (next, events) = processDeaths(
-            state, balance(), agents, StubEquipmentStore(), groundItems,
+            state,
+            DeathProcessor(balance(), agents, StubEquipmentStore(), groundItems),
             tick = 50L, rng = Random(seed = 1),
         )
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/RespawnReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/RespawnReducerTest.kt
@@ -56,7 +56,8 @@ class RespawnReducerTest {
 
         val result = reduceRespawn(state, WorldCommand.Respawn(agent), profiles, RecordingGateway(), resolver, tick = 5)
 
-        val (next, event) = assertIs<Either.Right<Pair<WorldState, WorldEvent>>>(result).value
+        val (next, events) = assertIs<Either.Right<Pair<WorldState, List<WorldEvent>>>>(result).value
+        val event = events.single()
         assertEquals(checkpointNodeId, next.positions[agent])
         val body = assertNotNull(next.bodyOf(agent))
         assertEquals(100, body.hp, "HP should be fully restored")
@@ -74,7 +75,8 @@ class RespawnReducerTest {
 
         val result = reduceRespawn(state, WorldCommand.Respawn(agent), profiles, RecordingGateway(), resolver, tick = 5)
 
-        val (_, event) = assertIs<Either.Right<Pair<WorldState, WorldEvent>>>(result).value
+        val (_, events) = assertIs<Either.Right<Pair<WorldState, List<WorldEvent>>>>(result).value
+        val event = events.single()
         val respawned = assertIs<WorldEvent.AgentRespawned>(event)
         assertEquals(starterNodeId, respawned.at)
         assertEquals(false, respawned.fromCheckpoint)
@@ -156,7 +158,8 @@ class RespawnReducerTest {
 
         val result = reduceRespawn(state, WorldCommand.Respawn(agent), profiles, gateway, resolver, tick = 5)
 
-        val (next, event) = assertIs<Either.Right<Pair<WorldState, WorldEvent>>>(result).value
+        val (next, events) = assertIs<Either.Right<Pair<WorldState, List<WorldEvent>>>>(result).value
+        val event = events.single()
         val respawned = assertIs<WorldEvent.AgentRespawned>(event)
         assertEquals(starterNodeId, respawned.at)
         assertEquals(false, respawned.fromCheckpoint)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/SetSafeNodeReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/SetSafeNodeReducerTest.kt
@@ -46,7 +46,8 @@ class SetSafeNodeReducerTest {
 
         val result = reduceSetSafeNode(state, WorldCommand.SetSafeNode(agent), gateway, tick = 7)
 
-        val (next, event) = assertIs<arrow.core.Either.Right<Pair<WorldState, WorldEvent>>>(result).value
+        val (next, events) = assertIs<arrow.core.Either.Right<Pair<WorldState, List<WorldEvent>>>>(result).value
+        val event = events.single()
         assertEquals(state, next)  // state unchanged — gateway carries the side-effect
         val set = assertIs<WorldEvent.SafeNodeSet>(event)
         assertEquals(agent, set.agent)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/StarvationDeathRespawnIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/death/StarvationDeathRespawnIntegrationTest.kt
@@ -99,7 +99,9 @@ class StarvationDeathRespawnIntegrationTest {
 
         // Sweep observes HP=0 and removes from positions.
         val (afterDeaths, deathEvents) = processDeaths(
-            afterPassives, balance, agents, NoOpEquipmentStore(), NoOpGroundItemStore(), tick = 1L,
+            afterPassives,
+            DeathProcessor(balance, agents, NoOpEquipmentStore(), NoOpGroundItemStore()),
+            tick = 1L,
         )
         val died = assertIs<WorldEvent.AgentDied>(deathEvents.single())
         assertEquals(agent, died.agent)
@@ -123,8 +125,8 @@ class StarvationDeathRespawnIntegrationTest {
             resolver,
             tick = 2L,
         )
-        val (afterRespawn, respawnEvent) = assertIs<arrow.core.Either.Right<Pair<WorldState, WorldEvent>>>(respawnResult).value
-        val respawned = assertIs<WorldEvent.AgentRespawned>(respawnEvent)
+        val (afterRespawn, respawnEvents) = assertIs<arrow.core.Either.Right<Pair<WorldState, List<WorldEvent>>>>(respawnResult).value
+        val respawned = assertIs<WorldEvent.AgentRespawned>(respawnEvents.single())
         assertEquals(checkpointId, respawned.at)
         assertEquals(true, respawned.fromCheckpoint)
         assertEquals(checkpointId, afterRespawn.positions[agent])
@@ -149,7 +151,9 @@ class StarvationDeathRespawnIntegrationTest {
         )
 
         val (next, events) = processDeaths(
-            state, balance(), agents, NoOpEquipmentStore(), NoOpGroundItemStore(), tick = 5L,
+            state,
+            DeathProcessor(balance(), agents, NoOpEquipmentStore(), NoOpGroundItemStore()),
+            tick = 5L,
         )
 
         assertEquals(state, next)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/drink/DrinkReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/drink/DrinkReducerTest.kt
@@ -80,7 +80,8 @@ class DrinkReducerTest {
 
         val result = reduceDrink(state, command, balance, NoBuildings, tick = 9)
 
-        val (next, event) = assertNotNull(result.getOrNull())
+        val (next, events) = assertNotNull(result.getOrNull())
+        val event = events.single()
         val nextBody = next.bodyOf(agent)!!
         assertEquals(75, nextBody.thirst)
         assertEquals(29, nextBody.stamina)
@@ -128,7 +129,8 @@ class DrinkReducerTest {
 
         val result = reduceDrink(state, WorldCommand.Drink(agent), balance, NoBuildings, tick = 3)
 
-        val (next, event) = assertNotNull(result.getOrNull())
+        val (next, events) = assertNotNull(result.getOrNull())
+        val event = events.single()
         assertEquals(100, next.bodyOf(agent)!!.thirst)
         assertEquals(29, next.bodyOf(agent)!!.stamina)
         val drank = assertIs<WorldEvent.AgentDrank>(event)
@@ -141,7 +143,8 @@ class DrinkReducerTest {
 
         val result = reduceDrink(state, WorldCommand.Drink(agent), balance, NoBuildings, tick = 4)
 
-        val (next, event) = assertNotNull(result.getOrNull())
+        val (next, events) = assertNotNull(result.getOrNull())
+        val event = events.single()
         assertEquals(100, next.bodyOf(agent)!!.thirst)
         val drank = assertIs<WorldEvent.AgentDrank>(event)
         assertEquals(10, drank.refilled)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
@@ -109,7 +109,8 @@ class HarvestReducerTest {
             state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
         )
 
-        val (next, event) = assertNotNull(result.getOrNull())
+        val (next, events) = assertNotNull(result.getOrNull())
+        val event = events.single()
         assertEquals(1, next.inventoryOf(agent).quantityOf(wood))
         assertEquals(25, next.bodyOf(agent)!!.stamina)
         assertEquals(99, store.quantity(wood))
@@ -134,7 +135,8 @@ class HarvestReducerTest {
             state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), tick = 1,
         )
 
-        val (next, event) = assertNotNull(result.getOrNull())
+        val (next, events) = assertNotNull(result.getOrNull())
+        val event = events.single()
         assertEquals(1, next.inventoryOf(agent).quantityOf(stone))
         assertEquals(49, store.quantity(stone))
         assertIs<WorldEvent.ResourceHarvested>(event)
@@ -156,7 +158,7 @@ class HarvestReducerTest {
                     category = ItemCategory.RESOURCE,
                     weightPerUnit = 100,
                     maxStack = 100,
-                    harvestSkill = "MINING",
+                    harvestSkill = mining,
                     regenerating = true,
                     regenIntervalTicks = 100,
                     regenAmount = 1,
@@ -291,7 +293,8 @@ class HarvestReducerTest {
             store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
         )
 
-        val (next, event) = assertNotNull(result.getOrNull())
+        val (next, events) = assertNotNull(result.getOrNull())
+        val event = events.single()
         assertEquals(1, next.inventoryOf(agent).quantityOf(wood))
         assertEquals(0, store.quantity(wood))
         val harvested = assertIs<WorldEvent.ResourceHarvested>(event)
@@ -503,7 +506,7 @@ class HarvestReducerTest {
         category = ItemCategory.RESOURCE,
         weightPerUnit = 100,
         maxStack = 100,
-        harvestSkill = harvestSkill,
+        harvestSkill = harvestSkill?.let(::SkillId),
     )
 
     private class StubItemLookup(private val byId: Map<ItemId, Item>) : ItemLookup {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
@@ -65,12 +65,12 @@ class MovementReducerTest {
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
-            ifRight = { (next, event) ->
+            ifRight = { (next, events) ->
                 assertEquals(b, next.positions[agent])
                 assertEquals(9, next.bodyOf(agent)!!.stamina)
                 assertEquals(
                     WorldEvent.AgentMoved(agent, a, b, tick = 1, causedBy = command.commandId),
-                    event,
+                    events.single(),
                 )
             },
         )

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/pickup/PickupReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/pickup/PickupReducerTest.kt
@@ -108,7 +108,8 @@ class PickupReducerTest {
             StubEquipmentStore(), groundItems, tick = 9L,
         )
 
-        val (next, event) = assertNotNull(result.getOrNull())
+        val (next, events) = assertNotNull(result.getOrNull())
+        val event = events.single()
         assertEquals(7, next.inventoryOf(agent).quantityOf(wood))
         val pickedUp = assertIs<WorldEvent.ItemPickedUp>(event)
         assertEquals(agent, pickedUp.agent)
@@ -190,7 +191,8 @@ class PickupReducerTest {
             StubItemLookup(), StubAgentRegistry(strength = 100), equipment, groundItems, tick = 9L,
         )
 
-        val (_, event) = assertNotNull(result.getOrNull())
+        val (_, events) = assertNotNull(result.getOrNull())
+        val event = events.single()
         assertIs<WorldEvent.ItemPickedUp>(event)
         val inserted = assertNotNull(equipment.inserted, "pickup must re-INSERT the instance under the new owner")
         assertEquals(originalInstanceId, inserted.instanceId, "instance id is preserved across drop+pickup")

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnReducerTest.kt
@@ -58,7 +58,7 @@ class SpawnReducerTest {
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
-            ifRight = { (next, event) ->
+            ifRight = { (next, events) ->
                 assertEquals(home, next.positions[agent])
                 val body = assertNotNull(next.bodyOf(agent))
                 assertEquals(100, body.hp)
@@ -67,7 +67,7 @@ class SpawnReducerTest {
                 assertEquals(50, body.maxStamina)
                 assertEquals(
                     WorldEvent.AgentSpawned(agent, home, tick = 1, causedBy = command.commandId),
-                    event,
+                    events.single(),
                 )
             },
         )

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/UnspawnReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/UnspawnReducerTest.kt
@@ -52,11 +52,11 @@ class UnspawnReducerTest {
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
-            ifRight = { (next, event) ->
+            ifRight = { (next, events) ->
                 assertNull(next.positions[agent])
                 assertEquals(
                     WorldEvent.AgentDespawned(agent, home, tick = 7, causedBy = command.commandId),
-                    event,
+                    events.single(),
                 )
             },
         )

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -21,6 +21,7 @@ import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.death.DeathProcessor
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import dev.gvart.genesara.world.internal.worldstate.WorldStateRepository
 import org.junit.jupiter.api.Test
@@ -89,7 +90,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 7)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -111,7 +112,7 @@ class WorldTickHandlerTest {
 
         val cmd = WorldCommand.MoveAgent(agent, ghostId)
         queue.submit(cmd, appliesAtTick = 1)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
 
         handler.onTick(Tick(1, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -147,7 +148,7 @@ class WorldTickHandlerTest {
             override fun sleepRegenPerOfflineTick(): Int = 0
             override fun isTraversable(terrain: Terrain): Boolean = true
         }
-        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore)
+        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
 
         handler.onTick(Tick(2, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -163,7 +164,7 @@ class WorldTickHandlerTest {
         val queue = CommandQueue()
         val publisher = RecordingPublisher()
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 99)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 


### PR DESCRIPTION
## Summary

Phase 2 Combat Slice 1 (#15) — the first reducer that produces hostile HP loss, plus the architecture seams it needs. Also ticks the "attack extends the recommendation hook" checkbox on #5.

- **`attack` MCP tool + `AttackReducer`** with deterministic damage (`attackerStat × weaponPower`) and stochastic crit (LUCK%) / dodge (DEX%), capped at 50%.
- **Killing-blow propagation**: `DeathProcessor` extracted from `DeathSweep`. Combat triggers the same per-agent death path inline (penalty + drop roll + position removal + attacker kill-streak increment), so `AgentDied.causedBy` carries the killing command's id and `AgentAttacked` + `AgentDied` (+ `ItemDroppedOnGround` if a drop fires) land in the same tick.
- **Multi-event reducer return**: every reducer now returns `Pair<WorldState, List<WorldEvent>>` (mechanical refactor across 12 reducer files + their tests). This unblocks future verbs that need to emit ≥2 events.
- **Weapon range**: new `Item.range` field. Melee = 1 (same node). Ranged weapons (BOW, COMPOSITE_BOW) reach 3–4 nodes via depth-limited BFS over node adjacency. New `TargetOutOfRange` rejection (replaces `TargetNotInSameNode`) carries the weapon's range so the agent can decide between closing the gap and switching weapons.
- **Typed skill ids**: `Item.harvestSkill` and `Item.combatSkill` are now `SkillId?` (was `String?`); YAML strings are wrapped once at catalog load.
- **Catalog wiring**: T1/T2 weapons get `damage-type` / `weapon-power` / `combat-skill` / `range`. New skill placeholders in `skills.yaml`: `CLUB`, `SPEAR`, `POLEARM`.
- **Event dispatch**: `AgentAttacked` fans out to both attacker and target streams; `AgentDied` is now dispatched (previously undispatched).

## Out of scope (later combat slices)

Status effects (Bleed/Burn/Stun/Poison) + tick passive. Active abilities + tick-based cooldowns. SHIELD-skill XP grants. Armor damage reduction. Damage-type modifiers (typeMod = 1.0 today). Weapon durability on attack. PvP zone enforcement / outlaw state.

## Test plan

- [x] `./gradlew build` green across all modules
- [x] `AttackReducerTest` (16 cases: happy path, unarmed fallback, crit, dodge, killing blow, killing-blow-with-drop, zero-damage hit, weapon-without-skill, melee-rejects-different-node, ranged-hits-adjacent, ranged-rejects-two-hops, 5 rejection paths)
- [x] `AttackKillIntegrationTest` (cross-call kill scenario: 2 attacks, streak ticks on the killing blow only, SWORD XP accrues on every attack)
- [x] `AttackToolTest` (queue-and-ack + presence touch)
- [x] `AgentEventDispatcherTest` extended (3 cases: AgentAttacked fans to both, no double-publish on self-attack, AgentDied dispatched)
- [x] `ResourceSpawnsValidatorTest` extended (combat-skill rejection + acceptance)
- [x] `DeathSweepTest` + `StarvationDeathRespawnIntegrationTest` rerouted through `DeathProcessor`, all assertions stay green
- [x] Manual MCP verification: spawn two agents → craft + equip RUSTY_SWORD → `attack` → observe `AgentAttacked` on both streams + `SkillRecommended` for SWORD on attacker stream → continue until kill → observe `AgentDied(causedBy)` on target stream