### PR TITLE
feat(world,api): typed ResourceItemId enum at terrains.yaml + harvest boundary

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/harvest/HarvestTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/harvest/HarvestTool.kt
@@ -4,7 +4,7 @@ import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
-import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ResourceItemId
 import dev.gvart.genesara.world.WorldCommandGateway
 import dev.gvart.genesara.world.commands.WorldCommand
 import org.springframework.ai.chat.model.ToolContext
@@ -21,21 +21,27 @@ internal class HarvestTool(
 
     @Tool(
         name = "harvest",
-        description = "Extract a resource (wood, berries, herbs, stone, ore, coal, gem, salt, clay, peat, sand, …) " +
-            "from the current node. Queues a Harvest command; the resulting ResourceHarvested event arrives on " +
-            "the agent's event stream once the tick lands. Costs stamina; rejected if the terrain has no deposit " +
-            "of the requested item.",
+        description = "Extract one of the resources currently present at the agent's node. " +
+            "Resource availability is per-node and rolled at world generation — call `look_around` first " +
+            "and pick an itemId from `current.resources`; harvesting an item the node does not stock is " +
+            "rejected with ResourceNotAvailableHere. Queues a Harvest command; the resulting " +
+            "ResourceHarvested event arrives on the agent's event stream once the tick lands. Costs stamina.",
     )
     fun invoke(
-        @ToolParam(required = true, description = "Resource item id to harvest from the current node (e.g. WOOD, BERRY, HERB, STONE, ORE, COAL, GEM, SALT, CLAY).")
-        itemId: String,
+        @ToolParam(
+            required = true,
+            description = "Resource id available at the agent's current node. Read it from " +
+                "`look_around().current.resources` — do not guess. Harvesting an item the node " +
+                "does not stock is rejected with ResourceNotAvailableHere.",
+        )
+        itemId: ResourceItemId,
         toolContext: ToolContext,
     ): HarvestResponse {
         touchActivity(toolContext, activity, "harvest")
         val agent = AgentContextHolder.current()
-        val command = WorldCommand.Harvest(agent = agent, item = ItemId(itemId))
+        val command = WorldCommand.Harvest(agent = agent, item = itemId.toItemId())
         val nextTick = engine.currentTick() + 1
         world.submit(command, appliesAtTick = nextTick)
-        return HarvestResponse.queued(command.commandId, nextTick, itemId)
+        return HarvestResponse.queued(command.commandId, nextTick, itemId.name)
     }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/harvest/HarvestToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/harvest/HarvestToolTest.kt
@@ -6,6 +6,7 @@ import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ResourceItemId
 import dev.gvart.genesara.world.WorldCommandGateway
 import dev.gvart.genesara.world.commands.WorldCommand
 import org.junit.jupiter.api.AfterEach
@@ -37,7 +38,7 @@ class HarvestToolTest {
     fun `queues a Harvest command at the next tick and returns the ack`() {
         val tool = HarvestTool(gateway, tickClock, activity)
 
-        val response = tool.invoke("WOOD", toolContext)
+        val response = tool.invoke(ResourceItemId.WOOD, toolContext)
 
         assertEquals(CommandAckKind.QUEUED, response.kind)
         assertEquals("WOOD", response.itemId)
@@ -54,7 +55,7 @@ class HarvestToolTest {
     fun `accepts a previously-mining-only item — single verb covers every harvest`() {
         val tool = HarvestTool(gateway, tickClock, activity)
 
-        val response = tool.invoke("STONE", toolContext)
+        val response = tool.invoke(ResourceItemId.STONE, toolContext)
 
         assertEquals(CommandAckKind.QUEUED, response.kind)
         assertEquals("STONE", response.itemId)
@@ -68,7 +69,7 @@ class HarvestToolTest {
 
         assertTrue(agent !in activity.staleAgents(clock.instant().minusSeconds(60)))
 
-        tool.invoke("WOOD", toolContext)
+        tool.invoke(ResourceItemId.WOOD, toolContext)
 
         assertTrue(agent in activity.staleAgents(clock.instant().plusSeconds(60)))
     }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/ResourceItemId.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/ResourceItemId.kt
@@ -1,0 +1,36 @@
+package dev.gvart.genesara.world
+
+/**
+ * Subset of [ItemId] covering raw, gatherable resources — the things that appear in
+ * `terrains.yaml` `resource-spawns` and that an agent reaches via `harvest`. Refined
+ * intermediates (IRON_INGOT, CLOTH, BRICK, ...) and equipment ids stay outside the
+ * enum; they're never spawned on terrain and never targeted by `harvest`.
+ *
+ * Used at two boundaries:
+ *  - YAML binding for `ResourceSpawnRuleProperties.item`, so a typo in `terrains.yaml`
+ *    fails the Spring binder at startup.
+ *  - The `harvest` MCP tool's `itemId` parameter, so the JSON Schema lists exactly the
+ *    valid harvest targets up-front.
+ *
+ * Inside the engine everything stays keyed by [ItemId]; convert at the boundary via
+ * [toItemId].
+ */
+enum class ResourceItemId {
+    WOOD,
+    BERRY,
+    HERB,
+    MUSHROOM,
+    FISH,
+    HIDE,
+    FIBER,
+    CLAY,
+    PEAT,
+    SAND,
+    STONE,
+    ORE,
+    COAL,
+    GEM,
+    SALT;
+
+    fun toItemId(): ItemId = ItemId(name)
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -216,6 +216,7 @@ internal class WorldDefinitionBalanceLookup(
 
     override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> =
         props.terrains[terrain]?.resourceSpawns.orEmpty().mapNotNull { rule ->
+            val item = rule.item ?: return@mapNotNull null
             // Tests build properties by hand and may skip the validator; guard against
             // a malformed quantity-range here rather than throwing on read.
             val (lo, hi) = rule.quantityRange.firstOrNull()?.let { lo ->
@@ -223,7 +224,7 @@ internal class WorldDefinitionBalanceLookup(
                 lo to hi
             } ?: return@mapNotNull null
             ResourceSpawnRule(
-                item = ItemId(rule.item),
+                item = item.toItemId(),
                 spawnChance = rule.spawnChance,
                 quantityRange = lo..hi,
             )

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ResourceSpawnRuleProperties.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ResourceSpawnRuleProperties.kt
@@ -1,15 +1,22 @@
 package dev.gvart.genesara.world.internal.balance
 
+import dev.gvart.genesara.world.ResourceItemId
+
 /**
  * YAML binding for one entry under a terrain's `resource-spawns:` list. The Spring
  * Boot binder produces these; [BalanceLookup] converts to the domain
  * [dev.gvart.genesara.world.ResourceSpawnRule].
  *
+ * `item` is typed against the [ResourceItemId] enum so the binder fails fast on a
+ * typo in `terrains.yaml`. The default is null so a partially-built test fixture
+ * (no `resource-spawns:` block at all) still binds; the lookup drops null-item
+ * entries.
+ *
  * `quantityRange` is a `[min, max]` pair encoded as a list because YAML doesn't have a
  * native range type. The validator at startup ensures size == 2 and `min <= max`.
  */
 internal data class ResourceSpawnRuleProperties(
-    val item: String = "",
+    val item: ResourceItemId? = null,
     val spawnChance: Double = 1.0,
     val quantityRange: List<Int> = emptyList(),
 )

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ResourceSpawnsValidator.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ResourceSpawnsValidator.kt
@@ -8,10 +8,15 @@ import org.springframework.stereotype.Component
 /**
  * Cross-validates `terrains.yaml` and `items.yaml` against sibling catalogs at startup.
  * Fails fast on misconfiguration so the runtime hot path stays branch-free. Catches:
- * unknown item ids in spawn rules, malformed quantity ranges, out-of-bounds spawn
- * chances, unknown harvest-skill references (XP grants would silently no-op),
- * unknown combat-skill references (same risk on the attack hook), and unknown
- * required-skills keys (items would be permanently un-equippable).
+ * spawn-rule items missing from `items.yaml` (the enum value exists but no catalog
+ * entry backs it), malformed quantity ranges, out-of-bounds spawn chances, unknown
+ * harvest-skill references (XP grants would silently no-op), unknown combat-skill
+ * references (same risk on the attack hook), and unknown required-skills keys
+ * (items would be permanently un-equippable).
+ *
+ * Typos in the YAML `item:` field itself are caught earlier — the Spring binder
+ * rejects anything not in [dev.gvart.genesara.world.ResourceItemId] before this
+ * validator runs.
  */
 @Component
 internal class ResourceSpawnsValidator(
@@ -43,8 +48,11 @@ internal class ResourceSpawnsValidator(
         val problems = mutableListOf<String>()
         for ((terrain, terrainProps) in world.terrains) {
             for ((index, rule) in terrainProps.resourceSpawns.withIndex()) {
-                if (rule.item !in knownIds) {
-                    problems += "  $terrain[#$index] item='${rule.item}' is not in the catalog"
+                val itemName = rule.item?.name
+                if (itemName == null) {
+                    problems += "  $terrain[#$index] item is missing"
+                } else if (itemName !in knownIds) {
+                    problems += "  $terrain[#$index] item='$itemName' is not in the catalog"
                 }
                 if (rule.quantityRange.size != 2) {
                     problems += "  $terrain[#$index] quantity-range must have exactly 2 elements; got ${rule.quantityRange}"

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/ResourceSpawnsValidatorTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/ResourceSpawnsValidatorTest.kt
@@ -7,6 +7,7 @@ import dev.gvart.genesara.world.Item
 import dev.gvart.genesara.world.ItemCategory
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.ResourceItemId
 import dev.gvart.genesara.world.Terrain
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -23,8 +24,8 @@ class ResourceSpawnsValidatorTest {
                 Terrain.FOREST to TerrainProperties(
                     displayName = "Forest",
                     resourceSpawns = listOf(
-                        ResourceSpawnRuleProperties("WOOD", 0.7, listOf(80, 200)),
-                        ResourceSpawnRuleProperties("BERRY", 0.5, listOf(20, 80)),
+                        ResourceSpawnRuleProperties(ResourceItemId.WOOD, 0.7, listOf(80, 200)),
+                        ResourceSpawnRuleProperties(ResourceItemId.BERRY, 0.5, listOf(20, 80)),
                     ),
                 ),
             ),
@@ -34,12 +35,14 @@ class ResourceSpawnsValidatorTest {
     }
 
     @Test
-    fun `rejects spawn rules referencing unknown items`() {
+    fun `rejects spawn rules whose enum value has no items_yaml entry`() {
+        // The Spring binder rejects typos that don't match a ResourceItemId. This validator
+        // catches the remaining gap: an enum value that wasn't paired with an items.yaml row.
         val world = WorldDefinitionProperties(
             terrains = mapOf(
                 Terrain.FOREST to TerrainProperties(
                     displayName = "Forest",
-                    resourceSpawns = listOf(ResourceSpawnRuleProperties("PHANTOM", 0.5, listOf(10, 20))),
+                    resourceSpawns = listOf(ResourceSpawnRuleProperties(ResourceItemId.HERB, 0.5, listOf(10, 20))),
                 ),
             ),
         )
@@ -47,7 +50,7 @@ class ResourceSpawnsValidatorTest {
         val ex = assertThrows<IllegalArgumentException> {
             ResourceSpawnsValidator(world, items, EmptySkillLookup).validate()
         }
-        assertTrue(ex.message?.contains("PHANTOM") == true, "error must mention the unknown id")
+        assertTrue(ex.message?.contains("HERB") == true, "error must mention the unbacked id")
     }
 
     @Test
@@ -56,7 +59,7 @@ class ResourceSpawnsValidatorTest {
             terrains = mapOf(
                 Terrain.FOREST to TerrainProperties(
                     displayName = "Forest",
-                    resourceSpawns = listOf(ResourceSpawnRuleProperties("WOOD", 0.5, listOf(10))),
+                    resourceSpawns = listOf(ResourceSpawnRuleProperties(ResourceItemId.WOOD, 0.5, listOf(10))),
                 ),
             ),
         )
@@ -72,7 +75,7 @@ class ResourceSpawnsValidatorTest {
             terrains = mapOf(
                 Terrain.FOREST to TerrainProperties(
                     displayName = "Forest",
-                    resourceSpawns = listOf(ResourceSpawnRuleProperties("WOOD", 0.5, listOf(200, 80))),
+                    resourceSpawns = listOf(ResourceSpawnRuleProperties(ResourceItemId.WOOD, 0.5, listOf(200, 80))),
                 ),
             ),
         )
@@ -89,7 +92,7 @@ class ResourceSpawnsValidatorTest {
             terrains = mapOf(
                 Terrain.FOREST to TerrainProperties(
                     displayName = "Forest",
-                    resourceSpawns = listOf(ResourceSpawnRuleProperties("WOOD", 0.5, listOf(-1, 10))),
+                    resourceSpawns = listOf(ResourceSpawnRuleProperties(ResourceItemId.WOOD, 0.5, listOf(-1, 10))),
                 ),
             ),
         )
@@ -145,7 +148,7 @@ class ResourceSpawnsValidatorTest {
             terrains = mapOf(
                 Terrain.FOREST to TerrainProperties(
                     displayName = "Forest",
-                    resourceSpawns = listOf(ResourceSpawnRuleProperties("WOOD", 1.5, listOf(10, 20))),
+                    resourceSpawns = listOf(ResourceSpawnRuleProperties(ResourceItemId.WOOD, 1.5, listOf(10, 20))),
                 ),
             ),
         )

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/WorldDefinitionBalanceLookupTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/WorldDefinitionBalanceLookupTest.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.balance
 
+import dev.gvart.genesara.world.ResourceItemId
 import dev.gvart.genesara.world.Terrain
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -67,8 +68,8 @@ class WorldDefinitionBalanceLookupTest {
                     Terrain.FOREST to TerrainProperties(
                         displayName = "Forest",
                         resourceSpawns = listOf(
-                            ResourceSpawnRuleProperties(item = "WOOD", spawnChance = 0.7, quantityRange = listOf(80, 200)),
-                            ResourceSpawnRuleProperties(item = "BERRY", spawnChance = 0.5, quantityRange = listOf(20, 80)),
+                            ResourceSpawnRuleProperties(item = ResourceItemId.WOOD, spawnChance = 0.7, quantityRange = listOf(80, 200)),
+                            ResourceSpawnRuleProperties(item = ResourceItemId.BERRY, spawnChance = 0.5, quantityRange = listOf(20, 80)),
                         ),
                     ),
                 ),


### PR DESCRIPTION
## Summary
- Adds `ResourceItemId` enum (15 gatherable resources: WOOD..SALT) — a strict subset of the broader string-based `ItemId`.
- Wires the enum at exactly two boundaries:
  - YAML binding — `ResourceSpawnRuleProperties.item: ResourceItemId?` so Spring fails fast on a typo in `terrains.yaml`.
  - MCP harvest tool — `@ToolParam itemId: ResourceItemId` so the published JSON Schema lists valid harvest targets up front.
- Internal flow stays on `ItemId`; conversion happens via `ResourceItemId.toItemId()` at the edge, mirroring the `SkillId`-at-the-edge pattern.
- Validator's "unknown id" check now reports enum values lacking an `items.yaml` row (typos are caught earlier by the binder).

## Test plan
- [x] `./gradlew :world:test :api:test` green
- [x] Adapted `ResourceSpawnsValidatorTest`, `WorldDefinitionBalanceLookupTest`, `HarvestToolTest`
- [ ] Spot-check harvest tool schema in a connected agent client (post-merge)