### PR TITLE
feat(player): perk data shape + SWORD canary perks (#62)

### DIFF
--- a/docs/skill-feature-sequence.md
+++ b/docs/skill-feature-sequence.md
@@ -1,0 +1,209 @@
+# Skill Feature — Implementation Sequence
+
+> Roadmap for the **Skills + Perks + Abilities + Classes** expansion. All issues tagged [`skill-feature`](https://github.com/Genesara/genesara-engine/labels/skill-feature). This document is the canonical sequencing source — issue bodies link back here.
+
+**Designed:** 2026-05-08 (grilling session) · **Status:** Ready for implementation
+
+---
+
+## Progress tracker
+
+> **HOW TO USE.** When the user says "move on to next step", look here. The next unchecked box is the next slice. When a slice merges, tick the box and update **Current step** below. This file is the single source of truth for roadmap position; per-issue acceptance criteria stay tracked inside each GitHub issue.
+
+**Current step:** ⏭ **Step 1 — #62** (not started)
+
+### Track A — Phase 1 mechanics + catalog
+
+- [ ] **Step 1** — [#62](https://github.com/Genesara/genesara-engine/issues/62) Skill perks: data shape + canary perk *(foundation; blocks all others)*
+- [ ] **Step 2** — [#63](https://github.com/Genesara/genesara-engine/issues/63) Perk selection flow (events + `select_perk`)
+- Step 3 — effect-type slices (any order; can be parallelised by independent contributors):
+  - [ ] **Step 3a** — [#64](https://github.com/Genesara/genesara-engine/issues/64) TriggeredPassive system *(soft-coordinates with #15 Combat — see "Combat-coupling note" below)*
+  - [ ] **Step 3b** — [#65](https://github.com/Genesara/genesara-engine/issues/65) PassiveAura aggregator
+  - [ ] **Step 3c** — [#66](https://github.com/Genesara/genesara-engine/issues/66) Per-level scaling + Modifier perk
+  - [ ] **Step 3d** — [#67](https://github.com/Genesara/genesara-engine/issues/67) Active ability system + `use_ability` *(soft-coordinates with #15 Combat)*
+- [ ] **Step 4** — [#68](https://github.com/Genesara/genesara-engine/issues/68) Skill+perk catalog v1 *(blocked by all of step 3)*
+
+### Track B — Phase 4 class system
+
+- [ ] **Step 5** — [#31](https://github.com/Genesara/genesara-engine/issues/31) Behavior tracker *(can run in parallel with step 3d / #67; if #31 lands first, hook `use_ability` when #67 adds it)*
+- [ ] **Step 6** — [#32](https://github.com/Genesara/genesara-engine/issues/32) Class catalog + `AgentClass` surgery *(blocked by step 5 + step 4)*
+- [ ] **Step 7** — [#33](https://github.com/Genesara/genesara-engine/issues/33) Level-10 event + `select_class`
+- [ ] **Step 8** — [#34](https://github.com/Genesara/genesara-engine/issues/34) Class evolution L50 + `select_evolution` *(L100 stays deferred — partial-close on this checkbox)*
+
+### Cross-issue ticks (apply when the parent step lands)
+
+- [ ] When #67 (step 3d) merges → tick `use_ability` row in [#5](https://github.com/Genesara/genesara-engine/issues/5); add comment to [#35](https://github.com/Genesara/genesara-engine/issues/35) noting Mana's broadened consumer base.
+- [ ] When #68 (step 4) merges → tick the rows in [#5](https://github.com/Genesara/genesara-engine/issues/5) for every new skill that maps to a verb (HUNTING, TRAPS, new combat skills, new craft skills, TRACKING, FIRECRAFT).
+- [ ] When #34 (step 8) merges → coordinate naming with [#38](https://github.com/Genesara/genesara-engine/issues/38) for the TECHNICIAN ↔ Drone-Operator overlap.
+
+### Combat-coupling note
+
+Steps 3a (#64) and 3d (#67) have hooks into `AttackReducer`, which is the deliverable of [#15 Phase 2 Combat](https://github.com/Genesara/genesara-engine/issues/15).
+
+- If #15 has **already merged** when we reach step 3a/3d: full scope, all 9 triggers + all active ability effects.
+- If #15 has **not merged** yet: scope step 3a to non-combat triggers (`OnHarvestComplete/CraftComplete/BuildComplete/OnLowHp`) and step 3d to non-combat actives (`Self/HealSelf/TeleportNodes`); leave combat triggers / `ScaleNextAttack` for a follow-up tick when #15 lands.
+
+---
+
+## What we're building
+
+A complete progression layer on top of the existing skill module:
+
+1. **51-skill catalog** (up from 17) across 10 categories — gathering, crafting, combat, athletics, survival, knowledge, stealth, social, animal, class-locked.
+2. **Perk system** — every skill has 3 milestone perk choices (at levels 50/100/150); each milestone is a binary fork (1-of-2 perks); each perk carries one of 4 effect types.
+3. **4 perk effect types** —
+   - **`ActiveAbility`** — agent calls `use_ability(...)`, pays HP/Stamina/Mana, ability resolves at next tick, goes on cooldown.
+   - **`PassiveAura`** — always-on flat bonus while skill slotted.
+   - **`TriggeredPassive`** — fires automatically on one of 9 trigger events (OnHit, OnKill, OnLowHp, OnHarvest, etc.); has internal CD.
+   - **`Modifier`** — multiplies the per-level passive scaling rate.
+4. **Per-level passive scaling** — every skill declares a `levelEffect: { type, perLevelPct }`; ~+50–75% of primary output by L150, uncapped past 150.
+5. **8 base classes** + **24 evolution branches** at L50 — `SOLDIER, SCOUT, HUNTER, ARTISAN, ENGINEER, MEDIC, MERCHANT, RESEARCHER`. Low-magic; near-real-world professions. PSIONICS / MAGE / CLERIC dropped from v1.
+6. **Behavior tracker** — 8-axis `ActionCategory` enum drives the level-10 class choice and L50 evolution.
+
+---
+
+## Design decisions (grilled and locked)
+
+| # | Decision | Detail |
+|---|---|---|
+| 1 | Skill model | **Model C**: passive scaling + perks at milestones (no baseline actives). Existing verbs (`attack`, `harvest`, `craft`, `build`) are the unconditional action layer. |
+| 2 | Active abilities | **All from perks** — no skill grants an active at L1. |
+| 3 | Per-level scaling | Per-skill custom YAML; bounded `ScalingEffect` enum; slotted-only; ~+50–75% at L150; uncapped past 150. |
+| 4 | Perk cardinality | **1 of 2** per milestone. Static (same options for everyone at the same skill+milestone). |
+| 5 | Perk effect taxonomy | Closed sealed union: `ActiveAbility | PassiveAura | TriggeredPassive | Modifier`. |
+| 6 | Perk discoverability | **Hidden until milestone fires.** Mirror of class-system hidden-until-event. Past picks visible to the agent only. |
+| 7 | TriggeredPassive triggers | Closed set of **9**: `OnHitTaken/Dealt/Crit/Kill/LowHp/Dodge`, `OnHarvestComplete/CraftComplete/BuildComplete`. |
+| 8 | TriggeredPassive effects | Closed set of **7**: `GrantSelfBuff, HealSelf, DealBonusDamage, ApplyStatusToTarget, TeleportNodes, RefundResource, GrantBonusItem`. |
+| 9 | Multi-trigger stacking | All matching triggers fire (no first-match-wins). Each perk has its own internal CD. |
+| 10 | ActiveAbility cost | Single resource per ability: `HP | STAMINA | MANA`. Stamina default; Mana for RESEARCHER/MEDIC focus actives (3–5 perks); HP for berserker actives (5–10 perks). |
+| 11 | ActiveAbility target | Closed: `Self | SingleAgent (same node) | AreaSelfNode`. Same-node only for v1. |
+| 12 | ActiveAbility verb | **Single generic** `use_ability(abilityId, target?)` MCP tool. Not per-ability tools. |
+| 13 | Cost timing | Paid at cast; not refunded on miss/dodge. Resolution at tick N+1. |
+| 14 | Hard restrictions | **One total**: RESEARCHER cannot wield auto-firearms. Everything else is soft modifiers. |
+| 15 | Soft XP modifier | 3-tier per class: 1.5x primary / 1.0x neutral / **0.5x default off-build**. ~10–15 explicit overrides per class. |
+| 16 | Damage modifiers | Per class: `Map<DamageType, Float>`, default 1.0. |
+| 17 | Behavior fingerprint | 8 axes: `COMBAT, GATHER, CRAFT, BUILD, SOCIAL, EXPLORE, MEDICAL, TRADE`. |
+| 18 | Class roster (8) | `SOLDIER, SCOUT, HUNTER, ARTISAN, ENGINEER, MEDIC, MERCHANT, RESEARCHER`. |
+| 19 | Class drops | `WARRIOR (→SOLDIER), MAGE, CLERIC, FARMER, COMMANDER, RANGER`. |
+| 20 | Evolution branches | 3 per class at L50 (24 total). L100 deferred. |
+| 21 | PSIONICS | Dropped from v1 catalog (low-magic). Re-add when psionic class lands. |
+
+---
+
+## Issue map
+
+### New issues — Phase 1 mechanics + catalog (created 2026-05-08)
+
+| # | Issue | Phase | Blocks |
+|---|---|---|---|
+| [#62](https://github.com/Genesara/genesara-engine/issues/62) | Skill perks: data shape + canary perk | Foundation | All others |
+| [#63](https://github.com/Genesara/genesara-engine/issues/63) | Perk selection flow (events + `select_perk`) | Foundation | #64–#68 |
+| [#64](https://github.com/Genesara/genesara-engine/issues/64) | TriggeredPassive system (9 triggers, 7 effects) | Effect layer | #68 |
+| [#65](https://github.com/Genesara/genesara-engine/issues/65) | PassiveAura aggregator | Effect layer | #68 |
+| [#66](https://github.com/Genesara/genesara-engine/issues/66) | Per-level passive scaling + Modifier perk | Effect layer | #68 |
+| [#67](https://github.com/Genesara/genesara-engine/issues/67) | Active ability system + `use_ability` tool | Effect layer | #68 |
+| [#68](https://github.com/Genesara/genesara-engine/issues/68) | Skill+perk catalog v1 (51 skills, ~300 perks) | Content | — |
+
+### Existing issues — Phase 4 class system (tagged `skill-feature` 2026-05-08)
+
+| # | Issue | Status |
+|---|---|---|
+| [#31](https://github.com/Genesara/genesara-engine/issues/31) | Behavior tracker | Updated with 8-axis `ActionCategory` decision |
+| [#32](https://github.com/Genesara/genesara-engine/issues/32) | Class catalog | Updated with 8-class roster + restrictions + 24 branches |
+| [#33](https://github.com/Genesara/genesara-engine/issues/33) | Level-10 event | No design change — confirmed |
+| [#34](https://github.com/Genesara/genesara-engine/issues/34) | Class evolution | Updated with 24-branch table; **L100 deferred** |
+
+### Existing issues — touched but not closed
+
+| # | Issue | Touch |
+|---|---|---|
+| [#5](https://github.com/Genesara/genesara-engine/issues/5) | Skills recommendation-hook coverage | New verbs (`use_ability`, `select_perk`) and new skills (HUNTING, TRAPS, etc.) extend its rolling tracker. Tick rows as #67/#68 land. |
+| [#15](https://github.com/Genesara/genesara-engine/issues/15) | Phase 2 Combat | `AttackReducer` is the host for 5 of the 9 TriggeredPassive trigger hooks (#64) and ScaleNextAttack actives (#67). Coordinate sequencing — see Implementation order below. |
+| [#35](https://github.com/Genesara/genesara-engine/issues/35) | Psionics | Body needs an update note when #67 lands: Mana now consumed by RESEARCHER/MEDIC actives, not exclusively psionic. **Do not close** — psionics itself is still deferred. |
+| [#36](https://github.com/Genesara/genesara-engine/issues/36) | Scanning (Researcher) | SCANNING formalised as the only class-locked skill in v1 (#68 + #32). |
+| [#38](https://github.com/Genesara/genesara-engine/issues/38) | Drones (class-locked) | Converges with `ENGINEER → TECHNICIAN` evolution branch (#34). Coordinate naming. |
+
+---
+
+## Implementation order
+
+### Track A — Phase 1 mechanics + catalog
+
+```
+#62 ─┬─► #63 ─┬─► #64 ─┐
+     │       ├─► #65 ─┤
+     │       ├─► #66 ─┤── #68
+     │       └─► #67 ─┘
+```
+
+**Strict order:**
+
+1. **#62 — Perks: data shape + canary** (foundation; nothing works without this).
+2. **#63 — Perk selection flow** (depends on #62; needed before any effect type can be tested end-to-end).
+3. **#64–#67** — four effect-type slices, can run in parallel by independent contributors. Each must:
+   - Implement its effect type.
+   - Ship a canary perk on SWORD using that effect type.
+   - Pass integration tests through the canary.
+4. **#68 — Catalog v1** (depends on all of #64–#67; this is where the bulk YAML lands).
+
+**Sequencing constraint with Phase 2 Combat (#15):**
+- If #15 has not shipped when we start #64, scope #64 to non-combat triggers only (`OnHarvestComplete/CraftComplete/BuildComplete/OnLowHp`) and add a follow-up to wire combat triggers when `AttackReducer` lands.
+- Same constraint on #67's combat-impacting actives. Non-combat actives (Self-buff, HealSelf, TeleportNodes) can ship sooner; `ScaleNextAttack` and any direct-damage active needs Combat.
+
+### Track B — Phase 4 class system
+
+```
+#31 ──► #32 ──► #33 ──► #34 (L50 only; L100 deferred)
+```
+
+**Strict order:**
+
+5. **#31 — Behavior tracker** — needs the 8-axis enum and per-action-reducer counter bumps. Must hook into `use_ability` (from #67) before #67 ships, so order: **#67 → #31** (the COMBAT counter uses the ability fire-points). If #31 ships first, hook the new verb when it lands.
+6. **#32 — Class catalog** — `AgentClass` enum surgery (drop 5, rename 1, add 4) + `classes.yaml` expansion + `ClassLookup` + soft-modifier reads + the single hard restriction. Depends on #31 (`behaviorFingerprint` axes) and on **#68** (eligibleSkills reference final skill IDs).
+7. **#33 — Level-10 event** — depends on #31 + #32. Mostly a thin orchestrator over those.
+8. **#34 — Class evolution L50** — mirror of #33 with sliding-window read. Depends on #33. **L100 stays deferred.**
+
+### Cross-track integration
+
+- **#67 must add an entry to #5** (`use_ability` extends the recommendation hook for skill XP).
+- **#68 must tick rows in #5** for every new skill added.
+- **#67 must post a comment on #35** noting Mana's broadened consumer base; do not close.
+- **#34's TRAPPER branch depends on TRAPS skill from #68** — tick the dependency when #68 lands.
+- **#32's TECHNICIAN branch overlaps #38** — coordinate naming/skills.
+
+---
+
+## Test posture per slice
+
+Every slice follows `feedback_implementation_workflow.md`:
+
+1. Implement.
+2. Unit + integration tests in the same slice (Testcontainers Postgres for DB-backed work).
+3. Invoke `code-quality-reviewer` agent on the changed surface.
+4. Iterate until tests green and review surfaces nothing material.
+5. **Ask before committing.** Branch + PR (see `feedback_branch_and_pr.md`); never commit straight to main.
+6. After merge: tick the matching checkbox in the GitHub issue, plus any cross-issue ticks called out in this doc.
+
+---
+
+## Out of scope
+
+- **PSIONICS** skill and psionic class — deferred until / unless a future "magic" expansion lands.
+- **L100 class evolution** — design when L50 lands and behavior is observable.
+- **Multi-resource costs** on a single ability — single resource per ability for v1.
+- **Multi-node ranged abilities** — same-node only for v1.
+- **Channeling / charge-up actives** — future expansion.
+- **Ability XP independent of parent skill** — abilities don't level; their effects are fixed per perk.
+- **Perk re-rolling** — choices are forever (mirrors class no-respec rule).
+- **Perk preview** — perks hidden until milestone fires (mirrors class system).
+- **Hybrid / multi-class** — explicitly forbidden by spec §4.
+
+---
+
+## Spec cross-references
+
+- [`docs/lore/mechanics-reference.md` §3 Skills](lore/mechanics-reference.md#3-skills) — milestone model
+- [`docs/lore/mechanics-reference.md` §4 Classes](lore/mechanics-reference.md#4-classes) — class system
+- [`docs/lore/mechanics-reference.md` §9 Combat Resolution](lore/mechanics-reference.md#9-combat-resolution) — damage formula
+- [`docs/lore/mechanics-reference.md` §10 Abilities](lore/mechanics-reference.md#10-abilities-active-vs-passive) — active vs passive
+- [`docs/ROADMAP.md`](ROADMAP.md) — phase narrative

--- a/player/build.gradle.kts
+++ b/player/build.gradle.kts
@@ -19,5 +19,5 @@ dependencies {
 
 jooqModule {
     migrationsSubdir.set("player")
-    tableIncludes.set("agents|agent_profiles|agent_skills|agent_skill_slots|agent_skill_recommendations")
+    tableIncludes.set("agents|agent_profiles|agent_skills|agent_skill_slots|agent_skill_recommendations|agent_perks")
 }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentPerksRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentPerksRegistry.kt
@@ -1,0 +1,34 @@
+package dev.gvart.genesara.player
+
+/**
+ * Read + write surface for per-agent perk choices.
+ *
+ * Choices are forever (no `clearChoice`); one perk per (agent, skill, milestone) is
+ * enforced by the DB PK and surfaced as a typed rejection via [RecordPerkResult].
+ */
+interface AgentPerksRegistry {
+
+    fun snapshot(agent: AgentId): AgentPerksSnapshot
+
+    /** Skill + milestone are derived from the catalog entry, so callers cannot mismatch them. */
+    fun recordChoice(agent: AgentId, perk: PerkId, tick: Long): RecordPerkResult
+}
+
+data class AgentPerksSnapshot(val perks: List<AgentPerk>)
+
+data class AgentPerk(
+    val skill: SkillId,
+    val milestoneLevel: Int,
+    val perkId: PerkId,
+    val chosenAtTick: Long,
+)
+
+sealed interface RecordPerkResult {
+    data object Recorded : RecordPerkResult
+    data class UnknownPerk(val perk: PerkId) : RecordPerkResult
+    data class MilestoneAlreadyChosen(
+        val skill: SkillId,
+        val milestoneLevel: Int,
+        val existing: PerkId,
+    ) : RecordPerkResult
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/Perk.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/Perk.kt
@@ -1,0 +1,18 @@
+package dev.gvart.genesara.player
+
+/** One concrete perk a skill offers at a given milestone. */
+data class Perk(
+    val id: PerkId,
+    val skill: SkillId,
+    val milestoneLevel: Int,
+    val displayName: String,
+    val description: String,
+    val effect: PerkEffect,
+)
+
+/** Binary fork (always exactly two [options]; [PerksValidator] enforces the count). */
+data class PerkChoice(
+    val skill: SkillId,
+    val milestoneLevel: Int,
+    val options: List<Perk>,
+)

--- a/player/src/main/kotlin/dev/gvart/genesara/player/PerkEffect.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/PerkEffect.kt
@@ -1,0 +1,56 @@
+package dev.gvart.genesara.player
+
+/** Closed union of perk effect kinds — see `docs/skill-feature-sequence.md` decisions §5/§7/§8/§10/§11. */
+sealed interface PerkEffect {
+
+    data class ActiveAbility(
+        val abilityId: String,
+        val costResource: AbilityCostResource,
+        val costAmount: Int,
+        val target: AbilityTarget,
+        val cooldownTicks: Int,
+    ) : PerkEffect
+
+    data class PassiveAura(
+        val auraKey: String,
+        val magnitude: Double,
+    ) : PerkEffect
+
+    data class TriggeredPassive(
+        val trigger: TriggeredPassiveTrigger,
+        val effectKind: TriggeredPassiveEffectKind,
+        val params: Map<String, String>,
+        val internalCooldownTicks: Int,
+    ) : PerkEffect
+
+    data class Modifier(
+        val target: String,
+        val multiplier: Double,
+    ) : PerkEffect
+}
+
+enum class AbilityCostResource { HP, STAMINA, MANA }
+
+enum class AbilityTarget { SELF, SINGLE_AGENT, AREA_SELF_NODE }
+
+enum class TriggeredPassiveTrigger {
+    ON_HIT_TAKEN,
+    ON_HIT_DEALT,
+    ON_CRIT,
+    ON_KILL,
+    ON_LOW_HP,
+    ON_DODGE,
+    ON_HARVEST_COMPLETE,
+    ON_CRAFT_COMPLETE,
+    ON_BUILD_COMPLETE,
+}
+
+enum class TriggeredPassiveEffectKind {
+    GRANT_SELF_BUFF,
+    HEAL_SELF,
+    DEAL_BONUS_DAMAGE,
+    APPLY_STATUS_TO_TARGET,
+    TELEPORT_NODES,
+    REFUND_RESOURCE,
+    GRANT_BONUS_ITEM,
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/PerkId.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/PerkId.kt
@@ -1,0 +1,8 @@
+package dev.gvart.genesara.player
+
+@JvmInline
+value class PerkId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "PerkId must not be blank" }
+    }
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/PerkLookup.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/PerkLookup.kt
@@ -1,0 +1,14 @@
+package dev.gvart.genesara.player
+
+/** Catalog-level read surface — backed by `player-definition/skills.yaml` milestone blocks. */
+interface PerkLookup {
+
+    fun byId(id: PerkId): Perk?
+
+    fun choicesAt(skill: SkillId, milestoneLevel: Int): PerkChoice?
+
+    /** Forks for [skill], ordered by milestone level ascending. */
+    fun choicesFor(skill: SkillId): List<PerkChoice>
+
+    fun all(): List<Perk>
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/PerkLookupImpl.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/PerkLookupImpl.kt
@@ -1,0 +1,86 @@
+package dev.gvart.genesara.player.internal.balance
+
+import dev.gvart.genesara.player.Perk
+import dev.gvart.genesara.player.PerkChoice
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.PerkLookup
+import dev.gvart.genesara.player.SkillId
+import org.springframework.stereotype.Component
+
+@Component
+internal class PerkLookupImpl(
+    private val props: SkillDefinitionProperties,
+) : PerkLookup {
+
+    private val byId: Map<PerkId, Perk>
+    private val choicesBySkill: Map<SkillId, List<PerkChoice>>
+
+    init {
+        val problems = PerksValidator.collectProblems(props)
+        require(problems.isEmpty()) {
+            buildString {
+                append("Perk catalog failed validation:\n")
+                problems.forEach { appendLine("  - $it") }
+            }
+        }
+        val flatPerks = mutableListOf<Perk>()
+        val perSkill = mutableMapOf<SkillId, MutableList<PerkChoice>>()
+        for ((skillKey, skillProps) in props.catalog) {
+            val skill = SkillId(skillKey)
+            val sortedMilestones = skillProps.milestones.entries
+                .map { (levelKey, perks) -> levelKey.toInt() to perks }
+                .sortedBy { it.first }
+            for ((level, perks) in sortedMilestones) {
+                val options = perks.map { it.toPerk(skill, level) }
+                flatPerks += options
+                perSkill.getOrPut(skill) { mutableListOf() } += PerkChoice(skill, level, options)
+            }
+        }
+        byId = flatPerks.associateBy { it.id }
+        choicesBySkill = perSkill.mapValues { (_, list) -> list.toList() }
+    }
+
+    override fun byId(id: PerkId): Perk? = byId[id]
+
+    override fun choicesAt(skill: SkillId, milestoneLevel: Int): PerkChoice? =
+        choicesBySkill[skill]?.firstOrNull { it.milestoneLevel == milestoneLevel }
+
+    override fun choicesFor(skill: SkillId): List<PerkChoice> = choicesBySkill[skill].orEmpty()
+
+    override fun all(): List<Perk> = byId.values.toList()
+
+    private fun PerkProperties.toPerk(skill: SkillId, milestoneLevel: Int): Perk = Perk(
+        id = PerkId(id),
+        skill = skill,
+        milestoneLevel = milestoneLevel,
+        displayName = displayName,
+        description = description,
+        effect = effect.toEffect(),
+    )
+
+    private fun PerkEffectProperties.toEffect(): PerkEffect = when (type) {
+        PerkEffectType.ACTIVE_ABILITY -> PerkEffect.ActiveAbility(
+            abilityId = abilityId!!,
+            costResource = costResource!!,
+            costAmount = costAmount!!,
+            target = abilityTarget!!,
+            cooldownTicks = cooldownTicks!!,
+        )
+        PerkEffectType.PASSIVE_AURA -> PerkEffect.PassiveAura(
+            auraKey = auraKey!!,
+            magnitude = auraMagnitude!!,
+        )
+        PerkEffectType.TRIGGERED_PASSIVE -> PerkEffect.TriggeredPassive(
+            trigger = trigger!!,
+            effectKind = effectKind!!,
+            params = params,
+            internalCooldownTicks = internalCooldownTicks!!,
+        )
+        PerkEffectType.MODIFIER -> PerkEffect.Modifier(
+            target = modifierTarget!!,
+            multiplier = multiplier!!,
+        )
+        null -> error("perk effect type is null — PerksValidator should have rejected this at startup")
+    }
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/PerksValidator.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/PerksValidator.kt
@@ -1,0 +1,100 @@
+package dev.gvart.genesara.player.internal.balance
+
+/**
+ * Catalog-shape sanity check, called from [PerkLookupImpl]'s init before any `!!`
+ * translation runs. Aggregates every problem so a malformed catalog surfaces as a
+ * single readable message rather than a cascade of NPEs.
+ */
+internal object PerksValidator {
+
+    private val LEGAL_MILESTONES = setOf(50, 100, 150)
+    private const val PERKS_PER_MILESTONE = 2
+
+    fun collectProblems(props: SkillDefinitionProperties): List<String> {
+        val problems = mutableListOf<String>()
+        val perkIdLocations = mutableMapOf<String, MutableList<String>>()
+
+        for ((skillKey, skillProps) in props.catalog) {
+            if (skillProps.milestones.isEmpty()) continue
+            for ((rawLevel, perks) in skillProps.milestones) {
+                val location = "$skillKey @ milestone $rawLevel"
+                val level = rawLevel.toIntOrNull()
+                if (level == null) {
+                    problems += "$location: milestone key '$rawLevel' is not an integer"
+                    continue
+                }
+                if (level !in LEGAL_MILESTONES) {
+                    problems += "$location: milestone level must be one of $LEGAL_MILESTONES"
+                }
+                if (perks.size != PERKS_PER_MILESTONE) {
+                    problems += "$location: expected exactly $PERKS_PER_MILESTONE perks (1-of-2 fork), got ${perks.size}"
+                }
+                perks.forEachIndexed { idx, perk ->
+                    validatePerk(perk, "$location[$idx]", problems)
+                    if (perk.id.isNotBlank()) {
+                        perkIdLocations.getOrPut(perk.id) { mutableListOf() } += "$skillKey/$rawLevel#$idx"
+                    }
+                }
+            }
+        }
+
+        perkIdLocations
+            .filterValues { it.size > 1 }
+            .forEach { (id, locations) ->
+                problems += "perk id '$id' is declared in multiple places: ${locations.joinToString(", ")}"
+            }
+
+        return problems
+    }
+
+    private fun validatePerk(perk: PerkProperties, location: String, problems: MutableList<String>) {
+        if (perk.id.isBlank()) problems += "$location: perk id is blank"
+        if (perk.displayName.isBlank()) problems += "$location: missing display-name"
+        if (perk.description.isBlank()) problems += "$location: missing description"
+        validateEffect(perk.effect, location, problems)
+    }
+
+    private fun validateEffect(
+        effect: PerkEffectProperties,
+        location: String,
+        problems: MutableList<String>,
+    ) {
+        when (effect.type) {
+            null -> problems += "$location: effect.type is required"
+            PerkEffectType.ACTIVE_ABILITY -> {
+                requireField(effect.abilityId, "$location.effect.ability-id", problems)
+                requireField(effect.costResource, "$location.effect.cost-resource", problems)
+                requireField(effect.costAmount, "$location.effect.cost-amount", problems)
+                requireField(effect.abilityTarget, "$location.effect.ability-target", problems)
+                requireField(effect.cooldownTicks, "$location.effect.cooldown-ticks", problems)
+                if (effect.costAmount != null && effect.costAmount < 0) {
+                    problems += "$location.effect.cost-amount: must be >= 0"
+                }
+                if (effect.cooldownTicks != null && effect.cooldownTicks < 0) {
+                    problems += "$location.effect.cooldown-ticks: must be >= 0"
+                }
+            }
+            PerkEffectType.PASSIVE_AURA -> {
+                requireField(effect.auraKey, "$location.effect.aura-key", problems)
+                requireField(effect.auraMagnitude, "$location.effect.aura-magnitude", problems)
+            }
+            PerkEffectType.TRIGGERED_PASSIVE -> {
+                requireField(effect.trigger, "$location.effect.trigger", problems)
+                requireField(effect.effectKind, "$location.effect.effect-kind", problems)
+                requireField(effect.internalCooldownTicks, "$location.effect.internal-cooldown-ticks", problems)
+                if (effect.internalCooldownTicks != null && effect.internalCooldownTicks < 0) {
+                    problems += "$location.effect.internal-cooldown-ticks: must be >= 0"
+                }
+            }
+            PerkEffectType.MODIFIER -> {
+                requireField(effect.modifierTarget, "$location.effect.modifier-target", problems)
+                requireField(effect.multiplier, "$location.effect.multiplier", problems)
+            }
+        }
+    }
+
+    private fun requireField(value: Any?, label: String, problems: MutableList<String>) {
+        if (value == null) problems += "$label is required"
+        if (value is String && value.isBlank()) problems += "$label is blank"
+    }
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/SkillProperties.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/SkillProperties.kt
@@ -1,9 +1,55 @@
 package dev.gvart.genesara.player.internal.balance
 
+import dev.gvart.genesara.player.AbilityCostResource
+import dev.gvart.genesara.player.AbilityTarget
 import dev.gvart.genesara.player.SkillCategory
+import dev.gvart.genesara.player.TriggeredPassiveEffectKind
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
 
 internal data class SkillProperties(
     val displayName: String = "",
     val description: String = "",
     val category: SkillCategory = SkillCategory.SURVIVAL,
+    /**
+     * YAML keys are strings ("50", "100", "150"); converted to Int milestone levels in
+     * [SkillLookupImpl] / [PerkLookupImpl]. The validator enforces the legal level set.
+     */
+    val milestones: Map<String, List<PerkProperties>> = emptyMap(),
 )
+
+internal data class PerkProperties(
+    val id: String = "",
+    val displayName: String = "",
+    val description: String = "",
+    val effect: PerkEffectProperties = PerkEffectProperties(),
+)
+
+/**
+ * Flat union — the YAML carries one [type] discriminator and the fields the validator
+ * requires for that type. Translation to the sealed [dev.gvart.genesara.player.PerkEffect]
+ * happens in [PerkLookupImpl]; the validator rejects mismatched / missing fields before
+ * a translation is ever attempted.
+ */
+internal data class PerkEffectProperties(
+    val type: PerkEffectType? = null,
+    val abilityId: String? = null,
+    val costResource: AbilityCostResource? = null,
+    val costAmount: Int? = null,
+    val abilityTarget: AbilityTarget? = null,
+    val cooldownTicks: Int? = null,
+    val auraKey: String? = null,
+    val auraMagnitude: Double? = null,
+    val trigger: TriggeredPassiveTrigger? = null,
+    val effectKind: TriggeredPassiveEffectKind? = null,
+    val params: Map<String, String> = emptyMap(),
+    val internalCooldownTicks: Int? = null,
+    val modifierTarget: String? = null,
+    val multiplier: Double? = null,
+)
+
+internal enum class PerkEffectType {
+    ACTIVE_ABILITY,
+    PASSIVE_AURA,
+    TRIGGERED_PASSIVE,
+    MODIFIER,
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentPerksRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentPerksRegistry.kt
@@ -1,0 +1,88 @@
+package dev.gvart.genesara.player.internal.store
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentPerk
+import dev.gvart.genesara.player.AgentPerksRegistry
+import dev.gvart.genesara.player.AgentPerksSnapshot
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.PerkLookup
+import dev.gvart.genesara.player.RecordPerkResult
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENT_PERKS
+import org.jooq.DSLContext
+import org.springframework.dao.DuplicateKeyException
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+internal class JooqAgentPerksRegistry(
+    private val dsl: DSLContext,
+    private val perks: PerkLookup,
+) : AgentPerksRegistry {
+
+    @Transactional(readOnly = true)
+    override fun snapshot(agent: AgentId): AgentPerksSnapshot {
+        val rows = dsl.select(
+            AGENT_PERKS.SKILL_ID,
+            AGENT_PERKS.MILESTONE_LEVEL,
+            AGENT_PERKS.PERK_ID,
+            AGENT_PERKS.CHOSEN_AT_TICK,
+        )
+            .from(AGENT_PERKS)
+            .where(AGENT_PERKS.AGENT_ID.eq(agent.id))
+            .orderBy(AGENT_PERKS.SKILL_ID.asc(), AGENT_PERKS.MILESTONE_LEVEL.asc())
+            .fetch()
+            .map { row ->
+                AgentPerk(
+                    skill = SkillId(row[AGENT_PERKS.SKILL_ID]!!),
+                    milestoneLevel = row[AGENT_PERKS.MILESTONE_LEVEL]!!,
+                    perkId = PerkId(row[AGENT_PERKS.PERK_ID]!!),
+                    chosenAtTick = row[AGENT_PERKS.CHOSEN_AT_TICK]!!,
+                )
+            }
+        return AgentPerksSnapshot(rows)
+    }
+
+    @Transactional
+    override fun recordChoice(agent: AgentId, perk: PerkId, tick: Long): RecordPerkResult {
+        val catalog = perks.byId(perk) ?: return RecordPerkResult.UnknownPerk(perk)
+        readExistingPick(agent, catalog.skill, catalog.milestoneLevel)?.let { existing ->
+            return RecordPerkResult.MilestoneAlreadyChosen(catalog.skill, catalog.milestoneLevel, existing)
+        }
+        return insertTranslatingRace(agent, catalog.skill, catalog.milestoneLevel, perk, tick)
+    }
+
+    /** PK race fallback: typed rejection rather than a 500 if the pre-check is bypassed. */
+    private fun insertTranslatingRace(
+        agent: AgentId,
+        skill: SkillId,
+        milestoneLevel: Int,
+        perk: PerkId,
+        tick: Long,
+    ): RecordPerkResult = try {
+        dsl.insertInto(AGENT_PERKS)
+            .set(AGENT_PERKS.AGENT_ID, agent.id)
+            .set(AGENT_PERKS.SKILL_ID, skill.value)
+            .set(AGENT_PERKS.MILESTONE_LEVEL, milestoneLevel)
+            .set(AGENT_PERKS.PERK_ID, perk.value)
+            .set(AGENT_PERKS.CHOSEN_AT_TICK, tick)
+            .execute()
+        RecordPerkResult.Recorded
+    } catch (_: DuplicateKeyException) {
+        val existing = readExistingPick(agent, skill, milestoneLevel)
+            ?: throw IllegalStateException(
+                "DB reports duplicate (agent=${agent.id}, skill=${skill.value}, " +
+                    "milestone=$milestoneLevel) but no row was readable",
+            )
+        RecordPerkResult.MilestoneAlreadyChosen(skill, milestoneLevel, existing)
+    }
+
+    private fun readExistingPick(agent: AgentId, skill: SkillId, milestoneLevel: Int): PerkId? =
+        dsl.select(AGENT_PERKS.PERK_ID)
+            .from(AGENT_PERKS)
+            .where(AGENT_PERKS.AGENT_ID.eq(agent.id))
+            .and(AGENT_PERKS.SKILL_ID.eq(skill.value))
+            .and(AGENT_PERKS.MILESTONE_LEVEL.eq(milestoneLevel))
+            .fetchOne(AGENT_PERKS.PERK_ID)
+            ?.let { PerkId(it) }
+}

--- a/player/src/main/resources/db/migration/player/V205__agent_perks.sql
+++ b/player/src/main/resources/db/migration/player/V205__agent_perks.sql
@@ -1,0 +1,16 @@
+-- Per-agent perk choices. Each row records the binary fork an agent picked at a given
+-- skill+milestone (50/100/150). Choices are forever — no UPDATE / DELETE pathway.
+--
+-- Primary key (agent, skill, milestone_level) enforces the one-pick-per-milestone
+-- invariant; the application surfaces a typed rejection on attempted re-pick.
+-- skill_id mirrors the VARCHAR(32) shape used in agent_skills for cross-table parity.
+CREATE TABLE agent_perks (
+    agent_id        UUID        NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    skill_id        VARCHAR(32) NOT NULL,
+    milestone_level INT         NOT NULL CHECK (milestone_level IN (50, 100, 150)),
+    perk_id         VARCHAR(64) NOT NULL,
+    chosen_at_tick  BIGINT      NOT NULL,
+    PRIMARY KEY (agent_id, skill_id, milestone_level)
+);
+
+CREATE INDEX idx_agent_perks_agent_skill ON agent_perks (agent_id, skill_id);

--- a/player/src/main/resources/player-definition/skills.yaml
+++ b/player/src/main/resources/player-definition/skills.yaml
@@ -52,6 +52,28 @@ skills:
       display-name: Swordsmanship
       description: One-handed slashing weapons.
       category: COMBAT
+      milestones:
+        "50":
+          - id: SWORD_BLEEDER
+            display-name: Bleeder
+            description: >-
+              A successful sword strike applies the Bleed status to the target.
+            effect:
+              type: TRIGGERED_PASSIVE
+              trigger: ON_HIT_DEALT
+              effect-kind: APPLY_STATUS_TO_TARGET
+              params:
+                status: BLEED
+                duration-ticks: "10"
+              internal-cooldown-ticks: 8
+          - id: SWORD_SHARPEN_EDGE
+            display-name: Sharpen Edge
+            description: >-
+              Permanent +5 flat slash damage while a sword is wielded.
+            effect:
+              type: PASSIVE_AURA
+              aura-key: SLASH_DAMAGE_FLAT
+              aura-magnitude: 5.0
 
     BOW:
       display-name: Archery

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/PerkLookupImplTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/PerkLookupImplTest.kt
@@ -1,0 +1,139 @@
+package dev.gvart.genesara.player.internal.balance
+
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.SkillCategory
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.TriggeredPassiveEffectKind
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class PerkLookupImplTest {
+
+    @Test
+    fun `byId returns a Perk with effect translated to the matching sealed variant`() {
+        val lookup = PerkLookupImpl(swordCatalog())
+
+        val bleeder = assertNotNull(lookup.byId(PerkId("SWORD_BLEEDER")))
+        assertEquals(SkillId("SWORD"), bleeder.skill)
+        assertEquals(50, bleeder.milestoneLevel)
+        val triggered = assertIs<PerkEffect.TriggeredPassive>(bleeder.effect)
+        assertEquals(TriggeredPassiveTrigger.ON_HIT_DEALT, triggered.trigger)
+        assertEquals(TriggeredPassiveEffectKind.APPLY_STATUS_TO_TARGET, triggered.effectKind)
+        assertEquals("BLEED", triggered.params["status"])
+        assertEquals(8, triggered.internalCooldownTicks)
+
+        val sharpen = assertNotNull(lookup.byId(PerkId("SWORD_SHARPEN_EDGE")))
+        val aura = assertIs<PerkEffect.PassiveAura>(sharpen.effect)
+        assertEquals("SLASH_DAMAGE_FLAT", aura.auraKey)
+        assertEquals(5.0, aura.magnitude)
+    }
+
+    @Test
+    fun `byId returns null for unknown perk`() {
+        assertNull(PerkLookupImpl(swordCatalog()).byId(PerkId("PHANTOM")))
+    }
+
+    @Test
+    fun `choicesAt returns the binary fork at the requested milestone`() {
+        val lookup = PerkLookupImpl(swordCatalog())
+        val choice = assertNotNull(lookup.choicesAt(SkillId("SWORD"), 50))
+        assertEquals(SkillId("SWORD"), choice.skill)
+        assertEquals(50, choice.milestoneLevel)
+        val ids = choice.options.map { it.id.value }.toSet()
+        assertEquals(setOf("SWORD_BLEEDER", "SWORD_SHARPEN_EDGE"), ids)
+    }
+
+    @Test
+    fun `choicesAt returns null for a milestone with no declared fork`() {
+        assertNull(PerkLookupImpl(swordCatalog()).choicesAt(SkillId("SWORD"), 100))
+    }
+
+    @Test
+    fun `choicesFor returns every declared fork for the skill, ordered by level`() {
+        val props = SkillDefinitionProperties(
+            catalog = mapOf(
+                "SWORD" to SkillProperties(
+                    displayName = "Sword",
+                    description = "blade",
+                    category = SkillCategory.COMBAT,
+                    milestones = mapOf(
+                        "150" to listOf(passiveAuraPerk("S150_A"), passiveAuraPerk("S150_B")),
+                        "50" to listOf(passiveAuraPerk("S50_A"), passiveAuraPerk("S50_B")),
+                    ),
+                ),
+            ),
+        )
+        val lookup = PerkLookupImpl(props)
+        val choices = lookup.choicesFor(SkillId("SWORD"))
+        assertEquals(listOf(50, 150), choices.map { it.milestoneLevel })
+    }
+
+    @Test
+    fun `init runs validation and throws on a bad catalog`() {
+        val props = SkillDefinitionProperties(
+            catalog = mapOf(
+                "SWORD" to SkillProperties(
+                    displayName = "Sword",
+                    description = "blade",
+                    category = SkillCategory.COMBAT,
+                    milestones = mapOf("50" to listOf(passiveAuraPerk("ONLY_ONE"))),
+                ),
+            ),
+        )
+        val ex = assertThrows<IllegalArgumentException> { PerkLookupImpl(props) }
+        assertEquals(true, ex.message?.contains("Perk catalog failed validation"))
+    }
+
+    private fun swordCatalog() = SkillDefinitionProperties(
+        catalog = mapOf(
+            "SWORD" to SkillProperties(
+                displayName = "Sword",
+                description = "blade",
+                category = SkillCategory.COMBAT,
+                milestones = mapOf(
+                    "50" to listOf(
+                        PerkProperties(
+                            id = "SWORD_BLEEDER",
+                            displayName = "Bleeder",
+                            description = "Apply Bleed on hit.",
+                            effect = PerkEffectProperties(
+                                type = PerkEffectType.TRIGGERED_PASSIVE,
+                                trigger = TriggeredPassiveTrigger.ON_HIT_DEALT,
+                                effectKind = TriggeredPassiveEffectKind.APPLY_STATUS_TO_TARGET,
+                                params = mapOf("status" to "BLEED", "duration-ticks" to "10"),
+                                internalCooldownTicks = 8,
+                            ),
+                        ),
+                        PerkProperties(
+                            id = "SWORD_SHARPEN_EDGE",
+                            displayName = "Sharpen Edge",
+                            description = "Permanent +5 flat slash damage.",
+                            effect = PerkEffectProperties(
+                                type = PerkEffectType.PASSIVE_AURA,
+                                auraKey = "SLASH_DAMAGE_FLAT",
+                                auraMagnitude = 5.0,
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    private fun passiveAuraPerk(id: String) = PerkProperties(
+        id = id,
+        displayName = id,
+        description = id,
+        effect = PerkEffectProperties(
+            type = PerkEffectType.PASSIVE_AURA,
+            auraKey = "K",
+            auraMagnitude = 1.0,
+        ),
+    )
+}

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/PerksValidatorTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/PerksValidatorTest.kt
@@ -1,0 +1,237 @@
+package dev.gvart.genesara.player.internal.balance
+
+import dev.gvart.genesara.player.AbilityCostResource
+import dev.gvart.genesara.player.AbilityTarget
+import dev.gvart.genesara.player.SkillCategory
+import dev.gvart.genesara.player.TriggeredPassiveEffectKind
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PerksValidatorTest {
+
+    @Test
+    fun `accepts a well-formed catalog with no perks`() {
+        val props = SkillDefinitionProperties(
+            catalog = mapOf("FORAGING" to skill()),
+        )
+        assertEquals(emptyList(), PerksValidator.collectProblems(props))
+    }
+
+    @Test
+    fun `accepts a well-formed milestone fork`() {
+        val props = SkillDefinitionProperties(
+            catalog = mapOf(
+                "SWORD" to skill(
+                    milestones = mapOf(
+                        "50" to listOf(
+                            triggeredPassivePerk("SWORD_BLEEDER"),
+                            passiveAuraPerk("SWORD_SHARPEN_EDGE"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        assertEquals(emptyList(), PerksValidator.collectProblems(props))
+    }
+
+    @Test
+    fun `rejects a milestone with one perk — must be a 1-of-2 fork`() {
+        val props = SkillDefinitionProperties(
+            catalog = mapOf(
+                "SWORD" to skill(
+                    milestones = mapOf("50" to listOf(passiveAuraPerk("SOLO"))),
+                ),
+            ),
+        )
+        val problems = PerksValidator.collectProblems(props)
+        assertTrue(problems.any { it.contains("expected exactly 2 perks") }, problems.toString())
+    }
+
+    @Test
+    fun `rejects an illegal milestone level`() {
+        val props = SkillDefinitionProperties(
+            catalog = mapOf(
+                "SWORD" to skill(
+                    milestones = mapOf(
+                        "75" to listOf(
+                            passiveAuraPerk("SWORD_A"),
+                            passiveAuraPerk("SWORD_B"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val problems = PerksValidator.collectProblems(props)
+        assertTrue(problems.any { it.contains("milestone level must be one of") }, problems.toString())
+    }
+
+    @Test
+    fun `rejects a non-numeric milestone key`() {
+        val props = SkillDefinitionProperties(
+            catalog = mapOf(
+                "SWORD" to skill(
+                    milestones = mapOf(
+                        "fifty" to listOf(passiveAuraPerk("A"), passiveAuraPerk("B")),
+                    ),
+                ),
+            ),
+        )
+        val problems = PerksValidator.collectProblems(props)
+        assertTrue(problems.any { it.contains("not an integer") }, problems.toString())
+    }
+
+    @Test
+    fun `rejects perk-id collisions across skills`() {
+        val props = SkillDefinitionProperties(
+            catalog = mapOf(
+                "SWORD" to skill(
+                    milestones = mapOf(
+                        "50" to listOf(passiveAuraPerk("DUPLICATE"), passiveAuraPerk("UNIQUE_A")),
+                    ),
+                ),
+                "BOW" to skill(
+                    milestones = mapOf(
+                        "50" to listOf(passiveAuraPerk("DUPLICATE"), passiveAuraPerk("UNIQUE_B")),
+                    ),
+                ),
+            ),
+        )
+        val problems = PerksValidator.collectProblems(props)
+        assertTrue(
+            problems.any { it.contains("DUPLICATE") && it.contains("declared in multiple places") },
+            problems.toString(),
+        )
+    }
+
+    @Test
+    fun `rejects an active-ability perk missing required fields`() {
+        val props = SkillDefinitionProperties(
+            catalog = mapOf(
+                "SWORD" to skill(
+                    milestones = mapOf(
+                        "50" to listOf(
+                            PerkProperties(
+                                id = "BAD_ACTIVE",
+                                displayName = "Bad",
+                                description = "Bad",
+                                effect = PerkEffectProperties(type = PerkEffectType.ACTIVE_ABILITY),
+                            ),
+                            passiveAuraPerk("OK"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val problems = PerksValidator.collectProblems(props)
+        assertTrue(problems.any { it.contains("ability-id is required") }, problems.toString())
+        assertTrue(problems.any { it.contains("cost-resource is required") }, problems.toString())
+    }
+
+    @Test
+    fun `rejects a perk with a missing effect type`() {
+        val props = SkillDefinitionProperties(
+            catalog = mapOf(
+                "SWORD" to skill(
+                    milestones = mapOf(
+                        "50" to listOf(
+                            PerkProperties(
+                                id = "NO_TYPE",
+                                displayName = "X",
+                                description = "X",
+                                effect = PerkEffectProperties(),
+                            ),
+                            passiveAuraPerk("OK"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val problems = PerksValidator.collectProblems(props)
+        assertTrue(problems.any { it.contains("effect.type is required") }, problems.toString())
+    }
+
+    @Test
+    fun `rejects a perk with blank id, display-name, description`() {
+        val props = SkillDefinitionProperties(
+            catalog = mapOf(
+                "SWORD" to skill(
+                    milestones = mapOf(
+                        "50" to listOf(
+                            PerkProperties(effect = passiveAuraEffect()),
+                            passiveAuraPerk("OK"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val problems = PerksValidator.collectProblems(props)
+        assertTrue(problems.any { it.contains("perk id is blank") }, problems.toString())
+        assertTrue(problems.any { it.contains("missing display-name") }, problems.toString())
+        assertTrue(problems.any { it.contains("missing description") }, problems.toString())
+    }
+
+    @Test
+    fun `valid active-ability perk parses without problems`() {
+        val props = SkillDefinitionProperties(
+            catalog = mapOf(
+                "SWORD" to skill(
+                    milestones = mapOf(
+                        "50" to listOf(activeAbilityPerk("SWORD_LUNGE"), passiveAuraPerk("PARTNER")),
+                    ),
+                ),
+            ),
+        )
+        assertEquals(emptyList(), PerksValidator.collectProblems(props))
+    }
+
+    private fun skill(
+        milestones: Map<String, List<PerkProperties>> = emptyMap(),
+    ) = SkillProperties(
+        displayName = "stub",
+        description = "stub",
+        category = SkillCategory.COMBAT,
+        milestones = milestones,
+    )
+
+    private fun passiveAuraEffect() = PerkEffectProperties(
+        type = PerkEffectType.PASSIVE_AURA,
+        auraKey = "STUB",
+        auraMagnitude = 1.0,
+    )
+
+    private fun passiveAuraPerk(id: String) = PerkProperties(
+        id = id,
+        displayName = id,
+        description = id,
+        effect = passiveAuraEffect(),
+    )
+
+    private fun triggeredPassivePerk(id: String) = PerkProperties(
+        id = id,
+        displayName = id,
+        description = id,
+        effect = PerkEffectProperties(
+            type = PerkEffectType.TRIGGERED_PASSIVE,
+            trigger = TriggeredPassiveTrigger.ON_HIT_DEALT,
+            effectKind = TriggeredPassiveEffectKind.APPLY_STATUS_TO_TARGET,
+            params = mapOf("status" to "BLEED"),
+            internalCooldownTicks = 8,
+        ),
+    )
+
+    private fun activeAbilityPerk(id: String) = PerkProperties(
+        id = id,
+        displayName = id,
+        description = id,
+        effect = PerkEffectProperties(
+            type = PerkEffectType.ACTIVE_ABILITY,
+            abilityId = "stub_ability",
+            costResource = AbilityCostResource.STAMINA,
+            costAmount = 10,
+            abilityTarget = AbilityTarget.SELF,
+            cooldownTicks = 30,
+        ),
+    )
+}

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentPerksRegistryIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentPerksRegistryIntegrationTest.kt
@@ -1,0 +1,212 @@
+package dev.gvart.genesara.player.internal.store
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.Perk
+import dev.gvart.genesara.player.PerkChoice
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.PerkLookup
+import dev.gvart.genesara.player.RecordPerkResult
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENTS
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENT_PERKS
+import dev.gvart.genesara.player.internal.testsupport.PlayerFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+@Testcontainers
+class JooqAgentPerksRegistryIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("player_perks_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = PlayerFlyway.pooledDataSource(postgres)
+            PlayerFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private val sword = SkillId("SWORD")
+    private val bleeder = stubPerk(
+        id = "SWORD_BLEEDER",
+        skill = sword,
+        milestoneLevel = 50,
+        effect = PerkEffect.TriggeredPassive(
+            trigger = dev.gvart.genesara.player.TriggeredPassiveTrigger.ON_HIT_DEALT,
+            effectKind = dev.gvart.genesara.player.TriggeredPassiveEffectKind.APPLY_STATUS_TO_TARGET,
+            params = mapOf("status" to "BLEED"),
+            internalCooldownTicks = 8,
+        ),
+    )
+    private val sharpen = stubPerk(
+        id = "SWORD_SHARPEN_EDGE",
+        skill = sword,
+        milestoneLevel = 50,
+        effect = PerkEffect.PassiveAura(auraKey = "SLASH_DAMAGE_FLAT", magnitude = 5.0),
+    )
+    private val perks = StubPerkLookup(listOf(bleeder, sharpen))
+
+    private lateinit var registry: JooqAgentPerksRegistry
+    private var agent: AgentId = AgentId(UUID.randomUUID())
+
+    @BeforeEach
+    fun resetTables() {
+        dsl.truncate(AGENT_PERKS).cascade().execute()
+        dsl.truncate(AGENTS).cascade().execute()
+        agent = createAgent()
+        registry = JooqAgentPerksRegistry(dsl, perks)
+    }
+
+    @Test
+    fun `recordChoice writes a row and snapshot reads it back`() {
+        val result = registry.recordChoice(agent, bleeder.id, tick = 42L)
+        assertEquals(RecordPerkResult.Recorded, result)
+
+        val snap = registry.snapshot(agent)
+        assertEquals(1, snap.perks.size)
+        val pick = snap.perks.single()
+        assertEquals(sword, pick.skill)
+        assertEquals(50, pick.milestoneLevel)
+        assertEquals(bleeder.id, pick.perkId)
+        assertEquals(42L, pick.chosenAtTick)
+    }
+
+    @Test
+    fun `recordChoice rejects an unknown perk`() {
+        val result = registry.recordChoice(agent, PerkId("PHANTOM"), tick = 0L)
+        val unknown = assertIs<RecordPerkResult.UnknownPerk>(result)
+        assertEquals(PerkId("PHANTOM"), unknown.perk)
+
+        val rowCount = dsl.fetchCount(AGENT_PERKS)
+        assertEquals(0, rowCount, "rejected pick must not write a row")
+    }
+
+    @Test
+    fun `recordChoice rejects re-pick at the same milestone, naming the existing pick`() {
+        assertEquals(RecordPerkResult.Recorded, registry.recordChoice(agent, bleeder.id, tick = 1L))
+
+        val second = registry.recordChoice(agent, sharpen.id, tick = 2L)
+        val already = assertIs<RecordPerkResult.MilestoneAlreadyChosen>(second)
+        assertEquals(sword, already.skill)
+        assertEquals(50, already.milestoneLevel)
+        assertEquals(bleeder.id, already.existing)
+
+        val pick = registry.snapshot(agent).perks.single()
+        assertEquals(bleeder.id, pick.perkId)
+        assertEquals(1L, pick.chosenAtTick)
+    }
+
+    @Test
+    fun `snapshot is empty for a fresh agent`() {
+        assertEquals(emptyList(), registry.snapshot(agent).perks)
+    }
+
+    @Test
+    fun `snapshot orders rows by skill ascending then milestone ascending`() {
+        val bowQuickDraw = stubPerk(
+            id = "BOW_QUICK_DRAW",
+            skill = SkillId("BOW"),
+            milestoneLevel = 50,
+            effect = PerkEffect.PassiveAura(auraKey = "DRAW_SPEED", magnitude = 0.1),
+        )
+        val swordHundredA = stubPerk(
+            id = "SWORD_RIPOSTE",
+            skill = SkillId("SWORD"),
+            milestoneLevel = 100,
+            effect = PerkEffect.PassiveAura(auraKey = "RIPOSTE", magnitude = 1.0),
+        )
+        val multiSkillRegistry = JooqAgentPerksRegistry(
+            dsl,
+            StubPerkLookup(listOf(bleeder, sharpen, bowQuickDraw, swordHundredA)),
+        )
+
+        multiSkillRegistry.recordChoice(agent, swordHundredA.id, tick = 3L)
+        multiSkillRegistry.recordChoice(agent, bleeder.id, tick = 2L)
+        multiSkillRegistry.recordChoice(agent, bowQuickDraw.id, tick = 1L)
+
+        val snap = multiSkillRegistry.snapshot(agent)
+        assertEquals(
+            listOf(
+                SkillId("BOW") to 50,
+                SkillId("SWORD") to 50,
+                SkillId("SWORD") to 100,
+            ),
+            snap.perks.map { it.skill to it.milestoneLevel },
+        )
+    }
+
+    private fun createAgent(): AgentId {
+        val id = AgentId(UUID.randomUUID())
+        dsl.insertInto(AGENTS)
+            .set(AGENTS.ID, id.id)
+            .set(AGENTS.OWNER_ID, UUID.randomUUID())
+            .set(AGENTS.NAME, "test-${id.id.toString().take(6)}")
+            .set(AGENTS.RACE_ID, "human_commoner")
+            .set(AGENTS.LEVEL, 1)
+            .set(AGENTS.XP_CURRENT, 0)
+            .set(AGENTS.XP_TO_NEXT, 100)
+            .set(AGENTS.UNSPENT_ATTRIBUTE_POINTS, 5)
+            .set(AGENTS.STRENGTH, 5)
+            .set(AGENTS.DEXTERITY, 5)
+            .set(AGENTS.CONSTITUTION, 5)
+            .set(AGENTS.PERCEPTION, 5)
+            .set(AGENTS.INTELLIGENCE, 5)
+            .set(AGENTS.LUCK, 5)
+            .execute()
+        return id
+    }
+
+    private fun stubPerk(id: String, skill: SkillId, milestoneLevel: Int, effect: PerkEffect) = Perk(
+        id = PerkId(id),
+        skill = skill,
+        milestoneLevel = milestoneLevel,
+        displayName = id,
+        description = id,
+        effect = effect,
+    )
+
+    private class StubPerkLookup(private val perks: List<Perk>) : PerkLookup {
+        private val byId = perks.associateBy { it.id }
+        override fun byId(id: PerkId): Perk? = byId[id]
+        override fun choicesAt(skill: SkillId, milestoneLevel: Int): PerkChoice? {
+            val opts = perks.filter { it.skill == skill && it.milestoneLevel == milestoneLevel }
+            return if (opts.isEmpty()) null else PerkChoice(skill, milestoneLevel, opts)
+        }
+        override fun choicesFor(skill: SkillId): List<PerkChoice> =
+            perks.filter { it.skill == skill }
+                .groupBy { it.milestoneLevel }
+                .toSortedMap()
+                .map { (level, list) -> PerkChoice(skill, level, list) }
+        override fun all(): List<Perk> = perks
+    }
+}


### PR DESCRIPTION
Step 1 of the skill-feature sequence (`docs/skill-feature-sequence.md`). Foundation slice — every other Phase-1 skill-feature slice depends on this substrate.

Closes #62.

## Summary
- Public API in `:player`: `Perk`, `PerkChoice`, sealed `PerkEffect` (ActiveAbility | PassiveAura | TriggeredPassive | Modifier), `AgentPerksRegistry` + `RecordPerkResult`. Closed enums lock the 9 triggers / 7 effect kinds / cost resources / targets per spec decisions §5/§7/§8/§10/§11.
- YAML schema: `skills.milestones { 50|100|150 -> [perkA, perkB] }`. Validator rejects illegal levels, wrong fork cardinality, missing effect fields, and perk-id collisions across skills.
- Persistence: `agent_perks` table (Flyway `V205`) with PK `(agent_id, skill_id, milestone_level)`, CHECK on legal levels, FK CASCADE, covering index. `JooqAgentPerksRegistry` does pre-check + duplicate-key fallback for a typed `MilestoneAlreadyChosen` rejection on race.
- Canary perks at SWORD-50: **Bleeder** (TriggeredPassive → ApplyStatusToTarget BLEED) and **Sharpen Edge** (PassiveAura SLASH_DAMAGE_FLAT +5). Effects are stubbed; runtime lands in slices #64 / #65.

## Test plan
- [x] `./gradlew :player:test` — 99 tests, all green (validator unit, lookup unit, registry Testcontainers integration).
- [x] `./gradlew :app:test` — Spring boot context loads with the canary perks parsed from `skills.yaml`, so the YAML → validator → lookup data path is end-to-end verified.
- [x] `./gradlew test` — full project suite green.
- [x] `code-quality-reviewer` agent pass on the diff; in-fix findings applied.