### PR TITLE
feat(player,api): perk selection flow (#63)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -57,6 +57,12 @@ internal class AgentEventDispatcher(
     fun on(event: AgentEvent.AttributeMilestoneReached) = publish(event.agent, "attribute.milestone", event)
 
     @EventListener
+    fun on(event: AgentEvent.PerkChoiceOffered) = publish(event.agent, "perk.offered", event)
+
+    @EventListener
+    fun on(event: AgentEvent.PerkChosen) = publish(event.agent, "perk.chosen", event)
+
+    @EventListener
     fun on(event: WorldEvent.ItemCrafted) = publish(event.agent, "item.crafted", event)
 
     @EventListener

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusTool.kt
@@ -5,8 +5,12 @@ import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentPerksRegistry
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.PerkLookup
+import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillLookup
 import dev.gvart.genesara.world.WorldQueryGateway
 import org.springframework.ai.chat.model.ToolContext
@@ -21,6 +25,8 @@ internal class GetStatusTool(
     private val activity: AgentActivityTracker,
     private val skillsRegistry: AgentSkillsRegistry,
     private val skillCatalog: SkillLookup,
+    private val perksRegistry: AgentPerksRegistry,
+    private val perkCatalog: PerkLookup,
 ) {
 
     @Tool(
@@ -89,11 +95,52 @@ internal class GetStatusTool(
             .filter { (state, _) -> state.slotIndex == null }
             .map { (_, view) -> view }
             .sortedBy { it.id }
+        val chosenPerks = perksRegistry.snapshot(agentId).perks
+            .map {
+                ChosenPerkView(
+                    skillId = it.skill.value,
+                    milestone = it.milestoneLevel,
+                    perkId = it.perkId.value,
+                )
+            }
+            .sortedWith(compareBy({ it.skillId }, { it.milestone }))
         return SkillsView(
             slotCount = snapshot.slotCount,
             slotsFilled = snapshot.slotsFilled,
             slots = slots,
             unslotted = unslotted,
+            chosenPerks = chosenPerks,
+            pendingPerkChoices = pendingPerkChoices(snapshot, chosenPerks),
         )
     }
+
+    /**
+     * Pending = milestones reached on a slotted skill (level >= milestone) for which the
+     * catalog defines perks AND no pick has been recorded yet. Derived state — the perks
+     * table is the single source of truth for "committed", and the catalog for "options".
+     */
+    private fun pendingPerkChoices(
+        snapshot: AgentSkillsSnapshot,
+        chosen: List<ChosenPerkView>,
+    ): List<PendingPerkChoiceView> {
+        val chosenKeys = chosen.map { it.skillId to it.milestone }.toSet()
+        return snapshot.perSkill.values
+            .filter { it.slotIndex != null }
+            .flatMap { state -> pendingForSkill(state.skill, state.level, chosenKeys) }
+            .sortedWith(compareBy({ it.skillId }, { it.milestone }))
+    }
+
+    private fun pendingForSkill(
+        skill: SkillId,
+        level: Int,
+        chosenKeys: Set<Pair<String, Int>>,
+    ): List<PendingPerkChoiceView> = perkCatalog.choicesFor(skill)
+        .filter { it.milestoneLevel <= level && (skill.value to it.milestoneLevel) !in chosenKeys }
+        .map { choice ->
+            PendingPerkChoiceView(
+                skillId = skill.value,
+                milestone = choice.milestoneLevel,
+                options = choice.options.map { it.id.value },
+            )
+        }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolIo.kt
@@ -46,6 +46,10 @@ data class SkillsView(
     val slots: List<SkillSlotView>,
     /** Discovered skills the agent has not placed in a permanent slot yet. */
     val unslotted: List<SkillEntryView>,
+    /** Perks already committed via `select_perk`. Ordered by skill, then milestone. */
+    val chosenPerks: List<ChosenPerkView> = emptyList(),
+    /** Milestones the agent has reached on a slotted skill but not yet committed a pick for. */
+    val pendingPerkChoices: List<PendingPerkChoiceView> = emptyList(),
 )
 
 data class SkillSlotView(
@@ -61,4 +65,16 @@ data class SkillEntryView(
     val xp: Int,
     val level: Int,
     val recommendCount: Int,
+)
+
+data class ChosenPerkView(
+    val skillId: String,
+    val milestone: Int,
+    val perkId: String,
+)
+
+data class PendingPerkChoiceView(
+    val skillId: String,
+    val milestone: Int,
+    val options: List<String>,
 )

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/perks/SelectPerkResponse.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/perks/SelectPerkResponse.kt
@@ -1,0 +1,25 @@
+package dev.gvart.genesara.api.internal.mcp.tools.perks
+
+/**
+ * Response shape for `select_perk`.
+ *
+ * - `kind = "ok"`: the perk is now permanently chosen for (skill, milestone).
+ * - `kind = "rejected"`: the choice was refused; `reason` carries the cause. Possible
+ *   reasons: `unknown_perk`, `perk_mismatch`, `milestone_not_reached`, `already_chosen`.
+ */
+data class SelectPerkResponse(
+    val kind: String,
+    val skillId: String,
+    val milestone: Int,
+    val perkId: String,
+    val reason: String? = null,
+    val detail: String? = null,
+) {
+    companion object {
+        fun ok(skillId: String, milestone: Int, perkId: String) =
+            SelectPerkResponse("ok", skillId, milestone, perkId)
+
+        fun rejected(skillId: String, milestone: Int, perkId: String, reason: String, detail: String? = null) =
+            SelectPerkResponse("rejected", skillId, milestone, perkId, reason, detail)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/perks/SelectPerkTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/perks/SelectPerkTool.kt
@@ -1,0 +1,113 @@
+package dev.gvart.genesara.api.internal.mcp.tools.perks
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentPerksRegistry
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.PerkLookup
+import dev.gvart.genesara.player.RecordPerkResult
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.events.AgentEvent
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.ai.tool.annotation.ToolParam
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+internal class SelectPerkTool(
+    private val perks: PerkLookup,
+    private val agentPerks: AgentPerksRegistry,
+    private val skills: AgentSkillsRegistry,
+    private val tickClock: TickClock,
+    private val publisher: ApplicationEventPublisher,
+    private val activity: AgentActivityTracker,
+) {
+
+    @Tool(
+        name = "select_perk",
+        description = "Permanently commit to one perk from a binary fork offered when a slotted skill " +
+            "crossed a milestone (50/100/150). IRREVERSIBLE — once chosen, the perk stays for the agent's " +
+            "lifetime. Pending offers come from PerkChoiceOffered events and are also surfaced as " +
+            "`pendingPerkChoices` on get_status. Validates: perk exists, perk matches the (skill, milestone) " +
+            "arguments, the agent's slotted skill level reaches the milestone, and no prior pick exists for " +
+            "the same (skill, milestone).",
+    )
+    fun invoke(
+        @ToolParam(required = true, description = "Skill id from the PerkChoiceOffered event (e.g. SWORD).")
+        skillId: String,
+        @ToolParam(required = true, description = "Milestone level: one of 50, 100, 150.")
+        milestone: Int,
+        @ToolParam(required = true, description = "Perk id chosen from the offered options (e.g. SWORD_BLEEDER).")
+        perkId: String,
+        toolContext: ToolContext,
+    ): SelectPerkResponse {
+        touchActivity(toolContext, activity, "select_perk")
+        val agent = AgentContextHolder.current()
+
+        val perk = perks.byId(PerkId(perkId)) ?: return SelectPerkResponse.rejected(
+            skillId = skillId,
+            milestone = milestone,
+            perkId = perkId,
+            reason = "unknown_perk",
+            detail = "Perk id '$perkId' is not in the catalog.",
+        )
+
+        if (perk.skill.value != skillId || perk.milestoneLevel != milestone) {
+            return SelectPerkResponse.rejected(
+                skillId = skillId,
+                milestone = milestone,
+                perkId = perkId,
+                reason = "perk_mismatch",
+                detail = "Perk '$perkId' belongs to ${perk.skill.value}@${perk.milestoneLevel}, " +
+                    "not $skillId@$milestone",
+            )
+        }
+
+        val slottedLevel = skills.slottedSkillLevel(agent, SkillId(skillId))
+        if (slottedLevel < milestone) {
+            return SelectPerkResponse.rejected(
+                skillId = skillId,
+                milestone = milestone,
+                perkId = perkId,
+                reason = "milestone_not_reached",
+                detail = "$skillId is at slotted level $slottedLevel; need >= $milestone to commit " +
+                    "a milestone-$milestone perk (level 0 means the skill is not slotted).",
+            )
+        }
+
+        val tick = tickClock.currentTick()
+        return when (val outcome = agentPerks.recordChoice(agent, perk.id, tick)) {
+            RecordPerkResult.Recorded -> {
+                publisher.publishEvent(
+                    AgentEvent.PerkChosen(
+                        agent = agent,
+                        skill = perk.skill,
+                        milestone = perk.milestoneLevel,
+                        perk = perk.id,
+                        tick = tick,
+                    ),
+                )
+                SelectPerkResponse.ok(skillId, milestone, perkId)
+            }
+            is RecordPerkResult.MilestoneAlreadyChosen -> SelectPerkResponse.rejected(
+                skillId = skillId,
+                milestone = milestone,
+                perkId = perkId,
+                reason = "already_chosen",
+                detail = "Already picked ${outcome.existing.value} for ${outcome.skill.value}@" +
+                    "${outcome.milestoneLevel} (perks are forever).",
+            )
+            is RecordPerkResult.UnknownPerk -> SelectPerkResponse.rejected(
+                skillId = skillId,
+                milestone = milestone,
+                perkId = perkId,
+                reason = "unknown_perk",
+                detail = "Perk id '${outcome.perk.value}' is not in the catalog.",
+            )
+        }
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolTest.kt
@@ -8,11 +8,20 @@ import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentPerk
+import dev.gvart.genesara.player.AgentPerksRegistry
+import dev.gvart.genesara.player.AgentPerksSnapshot
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillState
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.Perk
+import dev.gvart.genesara.player.PerkChoice
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.PerkLookup
 import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.player.RecordPerkResult
 import dev.gvart.genesara.player.Skill
 import dev.gvart.genesara.player.SkillCategory
 import dev.gvart.genesara.player.SkillId
@@ -98,6 +107,8 @@ class GetStatusToolTest {
             activity = activity,
             skillsRegistry = emptySkills,
             skillCatalog = skillCatalog,
+            perksRegistry = StubPerksRegistry(),
+            perkCatalog = StubPerkLookup(),
         )
 
         val res = tool.invoke(toolContext)
@@ -136,6 +147,8 @@ class GetStatusToolTest {
             activity = activity,
             skillsRegistry = emptySkills,
             skillCatalog = skillCatalog,
+            perksRegistry = StubPerksRegistry(),
+            perkCatalog = StubPerkLookup(),
         )
 
         val res = tool.invoke(toolContext)
@@ -152,6 +165,8 @@ class GetStatusToolTest {
             activity = activity,
             skillsRegistry = emptySkills,
             skillCatalog = skillCatalog,
+            perksRegistry = StubPerksRegistry(),
+            perkCatalog = StubPerkLookup(),
         )
 
         val res = tool.invoke(toolContext)
@@ -171,6 +186,8 @@ class GetStatusToolTest {
             activity = activity,
             skillsRegistry = emptySkills,
             skillCatalog = skillCatalog,
+            perksRegistry = StubPerksRegistry(),
+            perkCatalog = StubPerkLookup(),
         )
 
         assertThrows<IllegalStateException> { tool.invoke(toolContext) }
@@ -193,6 +210,8 @@ class GetStatusToolTest {
             activity = activity,
             skillsRegistry = StubSkillsRegistry(snapshot),
             skillCatalog = skillCatalog,
+            perksRegistry = StubPerksRegistry(),
+            perkCatalog = StubPerkLookup(),
         )
 
         val skills = tool.invoke(toolContext).skills
@@ -225,6 +244,8 @@ class GetStatusToolTest {
             activity = activity,
             skillsRegistry = StubSkillsRegistry(snapshot),
             skillCatalog = skillCatalog,
+            perksRegistry = StubPerksRegistry(),
+            perkCatalog = StubPerkLookup(),
         )
 
         val skills = tool.invoke(toolContext).skills
@@ -233,6 +254,198 @@ class GetStatusToolTest {
         assertEquals(emptyList(), skills.slots)
         assertEquals(emptyList(), skills.unslotted)
     }
+
+    @Test
+    fun `chosenPerks lists rows from the perks registry, ordered by skill then milestone`() {
+        val sword = SkillId("SWORD")
+        val bow = SkillId("BOW")
+        val snapshot = AgentSkillsSnapshot(
+            perSkill = mapOf(
+                sword to AgentSkillState(sword, xp = 50, level = 60, slotIndex = 0, recommendCount = 1),
+                bow to AgentSkillState(bow, xp = 50, level = 55, slotIndex = 1, recommendCount = 1),
+            ),
+            slotCount = 8,
+            slotsFilled = 2,
+        )
+        val perksRegistry = StubPerksRegistry(
+            picks = listOf(
+                AgentPerk(skill = sword, milestoneLevel = 50, perkId = PerkId("SWORD_BLEEDER"), chosenAtTick = 1L),
+                AgentPerk(skill = bow, milestoneLevel = 50, perkId = PerkId("BOW_QUICK_DRAW"), chosenAtTick = 2L),
+            ),
+        )
+
+        val tool = GetStatusTool(
+            agents = StubRegistry(agent),
+            world = StubQuery(active = node, body = body),
+            engine = tickClock,
+            activity = activity,
+            skillsRegistry = StubSkillsRegistry(snapshot),
+            skillCatalog = stubSkillLookupForPerks(),
+            perksRegistry = perksRegistry,
+            perkCatalog = StubPerkLookup(),
+        )
+
+        val skills = tool.invoke(toolContext).skills
+
+        assertEquals(
+            listOf(
+                ChosenPerkView("BOW", 50, "BOW_QUICK_DRAW"),
+                ChosenPerkView("SWORD", 50, "SWORD_BLEEDER"),
+            ),
+            skills.chosenPerks,
+        )
+    }
+
+    @Test
+    fun `pendingPerkChoices is derived from slotted skill level minus chosen picks`() {
+        val sword = SkillId("SWORD")
+        val snapshot = AgentSkillsSnapshot(
+            perSkill = mapOf(
+                sword to AgentSkillState(sword, xp = 200, level = 110, slotIndex = 0, recommendCount = 1),
+            ),
+            slotCount = 8,
+            slotsFilled = 1,
+        )
+        val perkCatalog = StubPerkLookup(
+            listOf(
+                stubPerk("SWORD_BLEEDER", sword, 50),
+                stubPerk("SWORD_SHARPEN_EDGE", sword, 50),
+                stubPerk("SWORD_RIPOSTE", sword, 100),
+                stubPerk("SWORD_PARRY", sword, 100),
+            ),
+        )
+        val perksRegistry = StubPerksRegistry(
+            picks = listOf(
+                AgentPerk(skill = sword, milestoneLevel = 50, perkId = PerkId("SWORD_BLEEDER"), chosenAtTick = 1L),
+            ),
+        )
+        val tool = GetStatusTool(
+            agents = StubRegistry(agent),
+            world = StubQuery(active = node, body = body),
+            engine = tickClock,
+            activity = activity,
+            skillsRegistry = StubSkillsRegistry(snapshot),
+            skillCatalog = stubSkillLookupForPerks(),
+            perksRegistry = perksRegistry,
+            perkCatalog = perkCatalog,
+        )
+
+        val skills = tool.invoke(toolContext).skills
+
+        assertEquals(1, skills.pendingPerkChoices.size)
+        val pending = skills.pendingPerkChoices.single()
+        assertEquals("SWORD", pending.skillId)
+        assertEquals(100, pending.milestone)
+        assertEquals(listOf("SWORD_RIPOSTE", "SWORD_PARRY"), pending.options)
+    }
+
+    @Test
+    fun `pendingPerkChoices surfaces every reached milestone with no pick yet, ascending`() {
+        val sword = SkillId("SWORD")
+        val snapshot = AgentSkillsSnapshot(
+            perSkill = mapOf(
+                sword to AgentSkillState(sword, xp = 200, level = 110, slotIndex = 0, recommendCount = 1),
+            ),
+            slotCount = 8,
+            slotsFilled = 1,
+        )
+        val perkCatalog = StubPerkLookup(
+            listOf(
+                stubPerk("SWORD_BLEEDER", sword, 50),
+                stubPerk("SWORD_SHARPEN_EDGE", sword, 50),
+                stubPerk("SWORD_RIPOSTE", sword, 100),
+                stubPerk("SWORD_PARRY", sword, 100),
+            ),
+        )
+        val tool = GetStatusTool(
+            agents = StubRegistry(agent),
+            world = StubQuery(active = node, body = body),
+            engine = tickClock,
+            activity = activity,
+            skillsRegistry = StubSkillsRegistry(snapshot),
+            skillCatalog = stubSkillLookupForPerks(),
+            perksRegistry = StubPerksRegistry(),
+            perkCatalog = perkCatalog,
+        )
+
+        val skills = tool.invoke(toolContext).skills
+
+        assertEquals(
+            listOf(50, 100),
+            skills.pendingPerkChoices.map { it.milestone },
+        )
+        assertEquals(emptyList(), skills.chosenPerks)
+    }
+
+    @Test
+    fun `pendingPerkChoices excludes milestones the slotted skill has not yet reached`() {
+        val sword = SkillId("SWORD")
+        val snapshot = AgentSkillsSnapshot(
+            perSkill = mapOf(
+                sword to AgentSkillState(sword, xp = 30, level = 40, slotIndex = 0, recommendCount = 1),
+            ),
+            slotCount = 8,
+            slotsFilled = 1,
+        )
+        val perkCatalog = StubPerkLookup(listOf(stubPerk("SWORD_BLEEDER", sword, 50)))
+        val tool = GetStatusTool(
+            agents = StubRegistry(agent),
+            world = StubQuery(active = node, body = body),
+            engine = tickClock,
+            activity = activity,
+            skillsRegistry = StubSkillsRegistry(snapshot),
+            skillCatalog = stubSkillLookupForPerks(),
+            perksRegistry = StubPerksRegistry(),
+            perkCatalog = perkCatalog,
+        )
+
+        val skills = tool.invoke(toolContext).skills
+
+        assertEquals(emptyList(), skills.pendingPerkChoices)
+    }
+
+    @Test
+    fun `pendingPerkChoices ignores unslotted skills even when level meets milestone`() {
+        val sword = SkillId("SWORD")
+        val snapshot = AgentSkillsSnapshot(
+            perSkill = mapOf(
+                sword to AgentSkillState(sword, xp = 100, level = 60, slotIndex = null, recommendCount = 1),
+            ),
+            slotCount = 8,
+            slotsFilled = 0,
+        )
+        val perkCatalog = StubPerkLookup(listOf(stubPerk("SWORD_BLEEDER", sword, 50)))
+        val tool = GetStatusTool(
+            agents = StubRegistry(agent),
+            world = StubQuery(active = node, body = body),
+            engine = tickClock,
+            activity = activity,
+            skillsRegistry = StubSkillsRegistry(snapshot),
+            skillCatalog = stubSkillLookupForPerks(),
+            perksRegistry = StubPerksRegistry(),
+            perkCatalog = perkCatalog,
+        )
+
+        val skills = tool.invoke(toolContext).skills
+
+        assertEquals(emptyList(), skills.pendingPerkChoices)
+    }
+
+    private fun stubSkillLookupForPerks() = StubSkillLookup(
+        listOf(
+            Skill(SkillId("SWORD"), "Sword", "blade", SkillCategory.COMBAT),
+            Skill(SkillId("BOW"), "Bow", "ranged", SkillCategory.COMBAT),
+        ),
+    )
+
+    private fun stubPerk(id: String, skill: SkillId, milestone: Int) = Perk(
+        id = PerkId(id),
+        skill = skill,
+        milestoneLevel = milestone,
+        displayName = id,
+        description = id,
+        effect = PerkEffect.PassiveAura(auraKey = id, magnitude = 1.0),
+    )
 
     @Test
     fun `skills view drops skills missing from the catalog`() {
@@ -251,6 +464,8 @@ class GetStatusToolTest {
             activity = activity,
             skillsRegistry = StubSkillsRegistry(snapshot),
             skillCatalog = skillCatalog,
+            perksRegistry = StubPerksRegistry(),
+            perkCatalog = StubPerkLookup(),
         )
 
         val skills = tool.invoke(toolContext).skills
@@ -296,6 +511,27 @@ class GetStatusToolTest {
         private val byId = skills.associateBy { it.id }
         override fun byId(id: SkillId): Skill? = byId[id]
         override fun all(): List<Skill> = skills
+    }
+
+    private class StubPerksRegistry(private val picks: List<AgentPerk> = emptyList()) : AgentPerksRegistry {
+        override fun snapshot(agent: AgentId) = AgentPerksSnapshot(picks)
+        override fun recordChoice(agent: AgentId, perk: PerkId, tick: Long): RecordPerkResult =
+            RecordPerkResult.Recorded
+    }
+
+    private class StubPerkLookup(private val perks: List<Perk> = emptyList()) : PerkLookup {
+        private val byId = perks.associateBy { it.id }
+        override fun byId(id: PerkId): Perk? = byId[id]
+        override fun choicesAt(skill: SkillId, milestoneLevel: Int): PerkChoice? {
+            val opts = perks.filter { it.skill == skill && it.milestoneLevel == milestoneLevel }
+            return if (opts.isEmpty()) null else PerkChoice(skill, milestoneLevel, opts)
+        }
+        override fun choicesFor(skill: SkillId): List<PerkChoice> =
+            perks.filter { it.skill == skill }
+                .groupBy { it.milestoneLevel }
+                .toSortedMap()
+                .map { (level, list) -> PerkChoice(skill, level, list) }
+        override fun all(): List<Perk> = perks
     }
 
     private class StubTickClock(private val currentTick: Long) : TickClock {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/perks/SelectPerkToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/perks/SelectPerkToolTest.kt
@@ -1,0 +1,199 @@
+package dev.gvart.genesara.api.internal.mcp.tools.perks
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentPerksRegistry
+import dev.gvart.genesara.player.AgentPerksSnapshot
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.Perk
+import dev.gvart.genesara.player.PerkChoice
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.PerkLookup
+import dev.gvart.genesara.player.RecordPerkResult
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.player.events.AgentEvent
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.context.ApplicationEventPublisher
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SelectPerkToolTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val sword = SkillId("SWORD")
+    private val bleeder = perk("SWORD_BLEEDER", sword, 50)
+    private val sharpen = perk("SWORD_SHARPEN_EDGE", sword, 50)
+    private val swordRiposte = perk("SWORD_RIPOSTE", sword, 100)
+    private val perks = StubPerkLookup(listOf(bleeder, sharpen, swordRiposte))
+
+    private val clock = MutableTestClock(Instant.parse("2026-01-01T00:00:00Z"))
+    private val activity = AgentActivityRegistry(clock)
+    private val tickClock = StubTickClock(currentTick = 7L)
+    private val toolContext = ToolContext(emptyMap())
+
+    @BeforeEach fun setUp() = AgentContextHolder.set(agent)
+    @AfterEach fun tearDown() = AgentContextHolder.clear()
+
+    @Test
+    fun `records the chosen perk and emits PerkChosen at the current tick`() {
+        val skills = StubSkillsRegistry(slottedLevels = mapOf(sword to 60))
+        val perksRegistry = RecordingPerksRegistry()
+        val publisher = RecordingPublisher()
+        val tool = SelectPerkTool(perks, perksRegistry, skills, tickClock, publisher, activity)
+
+        val response = tool.invoke(skillId = "SWORD", milestone = 50, perkId = "SWORD_BLEEDER", toolContext = toolContext)
+
+        assertEquals("ok", response.kind)
+        assertEquals(Triple(agent, bleeder.id, 7L), perksRegistry.recordCalls.single())
+        val event = publisher.events.filterIsInstance<AgentEvent.PerkChosen>().single()
+        assertEquals(agent, event.agent)
+        assertEquals(sword, event.skill)
+        assertEquals(50, event.milestone)
+        assertEquals(bleeder.id, event.perk)
+        assertEquals(7L, event.tick)
+    }
+
+    @Test
+    fun `rejects an unknown perk before touching the registry`() {
+        val skills = StubSkillsRegistry(slottedLevels = mapOf(sword to 60))
+        val perksRegistry = RecordingPerksRegistry()
+        val publisher = RecordingPublisher()
+        val tool = SelectPerkTool(perks, perksRegistry, skills, tickClock, publisher, activity)
+
+        val response = tool.invoke(skillId = "SWORD", milestone = 50, perkId = "PHANTOM", toolContext = toolContext)
+
+        assertEquals("rejected", response.kind)
+        assertEquals("unknown_perk", response.reason)
+        assertTrue(perksRegistry.recordCalls.isEmpty())
+        assertTrue(publisher.events.isEmpty())
+    }
+
+    @Test
+    fun `rejects when the perk does not match the requested skill or milestone`() {
+        val skills = StubSkillsRegistry(slottedLevels = mapOf(sword to 100))
+        val tool = SelectPerkTool(perks, RecordingPerksRegistry(), skills, tickClock, RecordingPublisher(), activity)
+
+        val mismatchSkill = tool.invoke(skillId = "BOW", milestone = 50, perkId = "SWORD_BLEEDER", toolContext = toolContext)
+        val mismatchMilestone = tool.invoke(skillId = "SWORD", milestone = 100, perkId = "SWORD_BLEEDER", toolContext = toolContext)
+
+        assertEquals("perk_mismatch", mismatchSkill.reason)
+        assertEquals("perk_mismatch", mismatchMilestone.reason)
+    }
+
+    @Test
+    fun `rejects when the agent's slotted skill level has not reached the milestone`() {
+        val skills = StubSkillsRegistry(slottedLevels = mapOf(sword to 49))
+        val perksRegistry = RecordingPerksRegistry()
+        val tool = SelectPerkTool(perks, perksRegistry, skills, tickClock, RecordingPublisher(), activity)
+
+        val response = tool.invoke(skillId = "SWORD", milestone = 50, perkId = "SWORD_BLEEDER", toolContext = toolContext)
+
+        assertEquals("milestone_not_reached", response.reason)
+        assertTrue(response.detail?.contains("49") == true)
+        assertTrue(perksRegistry.recordCalls.isEmpty())
+    }
+
+    @Test
+    fun `rejects when the skill is not slotted at all`() {
+        val skills = StubSkillsRegistry(slottedLevels = emptyMap())
+        val tool = SelectPerkTool(perks, RecordingPerksRegistry(), skills, tickClock, RecordingPublisher(), activity)
+
+        val response = tool.invoke(skillId = "SWORD", milestone = 50, perkId = "SWORD_BLEEDER", toolContext = toolContext)
+
+        assertEquals("milestone_not_reached", response.reason)
+    }
+
+    @Test
+    fun `rejects re-pick at the same milestone naming the existing perk`() {
+        val skills = StubSkillsRegistry(slottedLevels = mapOf(sword to 60))
+        val perksRegistry = RecordingPerksRegistry(
+            recordResult = RecordPerkResult.MilestoneAlreadyChosen(
+                skill = sword,
+                milestoneLevel = 50,
+                existing = sharpen.id,
+            ),
+        )
+        val publisher = RecordingPublisher()
+        val tool = SelectPerkTool(perks, perksRegistry, skills, tickClock, publisher, activity)
+
+        val response = tool.invoke(skillId = "SWORD", milestone = 50, perkId = "SWORD_BLEEDER", toolContext = toolContext)
+
+        assertEquals("already_chosen", response.reason)
+        assertTrue(response.detail?.contains("SWORD_SHARPEN_EDGE") == true)
+        assertTrue(publisher.events.none { it is AgentEvent.PerkChosen })
+    }
+
+    private fun perk(id: String, skill: SkillId, milestone: Int) = Perk(
+        id = PerkId(id),
+        skill = skill,
+        milestoneLevel = milestone,
+        displayName = id,
+        description = id,
+        effect = PerkEffect.PassiveAura(auraKey = id, magnitude = 1.0),
+    )
+
+    private class RecordingPerksRegistry(
+        private val recordResult: RecordPerkResult = RecordPerkResult.Recorded,
+    ) : AgentPerksRegistry {
+        val recordCalls = mutableListOf<Triple<AgentId, PerkId, Long>>()
+        override fun snapshot(agent: AgentId): AgentPerksSnapshot = AgentPerksSnapshot(emptyList())
+        override fun recordChoice(agent: AgentId, perk: PerkId, tick: Long): RecordPerkResult {
+            recordCalls += Triple(agent, perk, tick)
+            return recordResult
+        }
+    }
+
+    private class StubSkillsRegistry(private val slottedLevels: Map<SkillId, Int>) : AgentSkillsRegistry {
+        override fun snapshot(agent: AgentId) = AgentSkillsSnapshot(emptyMap(), 8, 0)
+        override fun slottedSkillLevel(agent: AgentId, skill: SkillId): Int = slottedLevels[skill] ?: 0
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int) = AddXpResult.Unslotted
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? = null
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? = null
+    }
+
+    private class StubPerkLookup(private val perks: List<Perk>) : PerkLookup {
+        private val byId = perks.associateBy { it.id }
+        override fun byId(id: PerkId): Perk? = byId[id]
+        override fun choicesAt(skill: SkillId, milestoneLevel: Int): PerkChoice? {
+            val opts = perks.filter { it.skill == skill && it.milestoneLevel == milestoneLevel }
+            return if (opts.isEmpty()) null else PerkChoice(skill, milestoneLevel, opts)
+        }
+        override fun choicesFor(skill: SkillId): List<PerkChoice> =
+            perks.filter { it.skill == skill }
+                .groupBy { it.milestoneLevel }
+                .toSortedMap()
+                .map { (level, list) -> PerkChoice(skill, level, list) }
+        override fun all(): List<Perk> = perks
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+
+    private class StubTickClock(private val currentTick: Long) : TickClock {
+        override fun currentTick(): Long = currentTick
+    }
+
+    private class MutableTestClock(private var now: Instant) : Clock() {
+        override fun instant(): Instant = now
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+}

--- a/docs/skill-feature-sequence.md
+++ b/docs/skill-feature-sequence.md
@@ -10,12 +10,12 @@
 
 > **HOW TO USE.** When the user says "move on to next step", look here. The next unchecked box is the next slice. When a slice merges, tick the box and update **Current step** below. This file is the single source of truth for roadmap position; per-issue acceptance criteria stay tracked inside each GitHub issue.
 
-**Current step:** ⏭ **Step 1 — #62** (not started)
+**Current step:** ⏭ **Step 3 — effect-type slices** (Steps 1–2 merged)
 
 ### Track A — Phase 1 mechanics + catalog
 
-- [ ] **Step 1** — [#62](https://github.com/Genesara/genesara-engine/issues/62) Skill perks: data shape + canary perk *(foundation; blocks all others)*
-- [ ] **Step 2** — [#63](https://github.com/Genesara/genesara-engine/issues/63) Perk selection flow (events + `select_perk`)
+- [x] **Step 1** — [#62](https://github.com/Genesara/genesara-engine/issues/62) Skill perks: data shape + canary perk *(foundation; blocks all others)*
+- [x] **Step 2** — [#63](https://github.com/Genesara/genesara-engine/issues/63) Perk selection flow (events + `select_perk`)
 - Step 3 — effect-type slices (any order; can be parallelised by independent contributors):
   - [ ] **Step 3a** — [#64](https://github.com/Genesara/genesara-engine/issues/64) TriggeredPassive system *(soft-coordinates with #15 Combat — see "Combat-coupling note" below)*
   - [ ] **Step 3b** — [#65](https://github.com/Genesara/genesara-engine/issues/65) PassiveAura aggregator

--- a/player/src/main/kotlin/dev/gvart/genesara/player/SkillProgression.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/SkillProgression.kt
@@ -31,9 +31,21 @@ interface SkillProgression {
  * Fake-constructor for tests that want a real publishing instance without reaching
  * into [SkillProgressionImpl]'s `internal/` package. Production code receives the
  * Spring-managed [SkillProgressionImpl] bean by interface type.
+ *
+ * [perks] defaults to an empty catalog so reducer tests that don't care about perks
+ * keep their existing call sites; pass a real [PerkLookup] when the test asserts on
+ * `PerkChoiceOffered` emission.
  */
 @Suppress("FunctionName")
 fun SkillProgression(
     skills: AgentSkillsRegistry,
     publisher: ApplicationEventPublisher,
-): SkillProgression = SkillProgressionImpl(skills, publisher)
+    perks: PerkLookup = NoPerks,
+): SkillProgression = SkillProgressionImpl(skills, perks, publisher)
+
+private object NoPerks : PerkLookup {
+    override fun byId(id: PerkId): Perk? = null
+    override fun choicesAt(skill: SkillId, milestoneLevel: Int): PerkChoice? = null
+    override fun choicesFor(skill: SkillId): List<PerkChoice> = emptyList()
+    override fun all(): List<Perk> = emptyList()
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/events/AgentEvent.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/events/AgentEvent.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.player.events
 
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.Attribute
+import dev.gvart.genesara.player.PerkId
 import dev.gvart.genesara.player.SkillId
 import java.util.UUID
 
@@ -11,8 +12,8 @@ sealed interface AgentEvent {
     /**
      * Emitted when an agent's slotted skill XP crosses one of the milestone thresholds
      * (50, 100, 150) as a result of [causedBy]. Only fires for skills currently in a
-     * slot — unslotted skills don't accrue XP. Perk-selection prompts will hang off
-     * this event in a future slice.
+     * slot — unslotted skills don't accrue XP. When the catalog defines perks at the
+     * crossed milestone, a [PerkChoiceOffered] event is published immediately after.
      */
     data class SkillMilestoneReached(
         val agent: AgentId,
@@ -20,6 +21,34 @@ sealed interface AgentEvent {
         val milestone: Int,
         override val tick: Long,
         val causedBy: UUID,
+    ) : AgentEvent
+
+    /**
+     * Emitted right after [SkillMilestoneReached] when the catalog defines perks at
+     * that milestone. Carries the binary fork the agent must commit via `select_perk`.
+     * The offer has no expiry — the agent can defer the pick indefinitely; pending
+     * offers are also surfaced in the `get_status` projection so a missed event can
+     * be recovered on read.
+     */
+    data class PerkChoiceOffered(
+        val agent: AgentId,
+        val skill: SkillId,
+        val milestone: Int,
+        val options: List<PerkId>,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : AgentEvent
+
+    /**
+     * Emitted when an agent commits to a perk via `select_perk`. Choice is forever
+     * (no re-roll) — mirrors the slot-permanence rule for skills.
+     */
+    data class PerkChosen(
+        val agent: AgentId,
+        val skill: SkillId,
+        val milestone: Int,
+        val perk: PerkId,
+        override val tick: Long,
     ) : AgentEvent
 
     /**

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/progression/SkillProgressionImpl.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/progression/SkillProgressionImpl.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.player.internal.progression
 import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.PerkLookup
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.player.events.AgentEvent
@@ -13,6 +14,7 @@ import java.util.UUID
 @Component
 internal class SkillProgressionImpl(
     private val skills: AgentSkillsRegistry,
+    private val perks: PerkLookup,
     private val publisher: ApplicationEventPublisher,
 ) : SkillProgression {
 
@@ -34,6 +36,18 @@ internal class SkillProgressionImpl(
                         causedBy = commandId,
                     ),
                 )
+                perks.choicesAt(skill, milestone)?.let { choice ->
+                    publisher.publishEvent(
+                        AgentEvent.PerkChoiceOffered(
+                            agent = agent,
+                            skill = skill,
+                            milestone = milestone,
+                            options = choice.options.map { it.id },
+                            tick = tick,
+                            causedBy = commandId,
+                        ),
+                    )
+                }
             }
             AddXpResult.Unslotted -> skills.maybeRecommend(agent, skill, tick)?.let { newCount ->
                 val snapshot = skills.snapshot(agent)

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/progression/SkillProgressionImplTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/progression/SkillProgressionImplTest.kt
@@ -5,6 +5,11 @@ import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentSkillState
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.Perk
+import dev.gvart.genesara.player.PerkChoice
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.PerkLookup
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillSlotError
 import dev.gvart.genesara.player.events.AgentEvent
@@ -20,12 +25,18 @@ class SkillProgressionImplTest {
     private val skill = SkillId("LUMBERJACKING")
     private val commandId = UUID.randomUUID()
 
+    private fun progression(
+        skills: AgentSkillsRegistry,
+        publisher: ApplicationEventPublisher,
+        perks: PerkLookup = StubPerkLookup(),
+    ) = SkillProgressionImpl(skills, perks, publisher)
+
     @Test
     fun `slotted skill addXp with no milestone fires no events`() {
         val skills = StubSkillsRegistry().apply { slot(skill) }
         val publisher = RecordingPublisher()
 
-        SkillProgressionImpl(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 7, commandId = commandId)
+        progression(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 7, commandId = commandId)
 
         assertEquals(listOf(skill to 1), skills.xpAddCalls)
         assertTrue(publisher.events.isEmpty())
@@ -39,7 +50,7 @@ class SkillProgressionImplTest {
         }
         val publisher = RecordingPublisher()
 
-        SkillProgressionImpl(skills, publisher).accrueXp(agent, skill, delta = 5, tick = 11, commandId = commandId)
+        progression(skills, publisher).accrueXp(agent, skill, delta = 5, tick = 11, commandId = commandId)
 
         val event = publisher.events.filterIsInstance<AgentEvent.SkillMilestoneReached>().single()
         assertEquals(agent, event.agent)
@@ -58,10 +69,49 @@ class SkillProgressionImplTest {
         }
         val publisher = RecordingPublisher()
 
-        SkillProgressionImpl(skills, publisher).accrueXp(agent, skill, delta = 60, tick = 1, commandId = commandId)
+        progression(skills, publisher).accrueXp(agent, skill, delta = 60, tick = 1, commandId = commandId)
 
         val milestones = publisher.events.filterIsInstance<AgentEvent.SkillMilestoneReached>().map { it.milestone }
         assertEquals(listOf(50, 100), milestones)
+    }
+
+    @Test
+    fun `crossed milestone with catalog perks emits PerkChoiceOffered carrying option ids`() {
+        val sword = SkillId("SWORD")
+        val skills = StubSkillsRegistry().apply {
+            slot(sword)
+            crossedMilestonesOnNextAdd[sword] = listOf(50)
+        }
+        val publisher = RecordingPublisher()
+        val bleeder = stubPerk("SWORD_BLEEDER", sword, 50)
+        val sharpen = stubPerk("SWORD_SHARPEN_EDGE", sword, 50)
+        val perks = StubPerkLookup(listOf(bleeder, sharpen))
+
+        progression(skills, publisher, perks).accrueXp(agent, sword, delta = 5, tick = 9, commandId = commandId)
+
+        val emittedTypes = publisher.events.map { it::class.simpleName }
+        assertEquals(listOf("SkillMilestoneReached", "PerkChoiceOffered"), emittedTypes)
+        val offer = publisher.events.filterIsInstance<AgentEvent.PerkChoiceOffered>().single()
+        assertEquals(agent, offer.agent)
+        assertEquals(sword, offer.skill)
+        assertEquals(50, offer.milestone)
+        assertEquals(listOf(bleeder.id, sharpen.id), offer.options)
+        assertEquals(9L, offer.tick)
+        assertEquals(commandId, offer.causedBy)
+    }
+
+    @Test
+    fun `crossed milestone without catalog perks emits only SkillMilestoneReached`() {
+        val skills = StubSkillsRegistry().apply {
+            slot(skill)
+            crossedMilestonesOnNextAdd[skill] = listOf(50)
+        }
+        val publisher = RecordingPublisher()
+
+        progression(skills, publisher).accrueXp(agent, skill, delta = 5, tick = 7, commandId = commandId)
+
+        assertTrue(publisher.events.none { it is AgentEvent.PerkChoiceOffered })
+        assertEquals(1, publisher.events.filterIsInstance<AgentEvent.SkillMilestoneReached>().size)
     }
 
     @Test
@@ -73,7 +123,7 @@ class SkillProgressionImplTest {
         }
         val publisher = RecordingPublisher()
 
-        SkillProgressionImpl(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 4, commandId = commandId)
+        progression(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 4, commandId = commandId)
 
         val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()
         assertEquals(agent, rec.agent)
@@ -90,7 +140,7 @@ class SkillProgressionImplTest {
         val skills = StubSkillsRegistry()
         val publisher = RecordingPublisher()
 
-        SkillProgressionImpl(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 1, commandId = commandId)
+        progression(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 1, commandId = commandId)
 
         assertTrue(publisher.events.isEmpty())
         assertEquals(listOf(skill to 1L), skills.recommendCalls)
@@ -104,11 +154,20 @@ class SkillProgressionImplTest {
         }
         val publisher = RecordingPublisher()
 
-        SkillProgressionImpl(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 1, commandId = commandId)
+        progression(skills, publisher).accrueXp(agent, skill, delta = 1, tick = 1, commandId = commandId)
 
         assertTrue(publisher.events.none { it is AgentEvent.SkillRecommended })
         assertTrue(skills.recommendCalls.isEmpty())
     }
+
+    private fun stubPerk(id: String, skill: SkillId, milestoneLevel: Int) = Perk(
+        id = PerkId(id),
+        skill = skill,
+        milestoneLevel = milestoneLevel,
+        displayName = id,
+        description = id,
+        effect = PerkEffect.PassiveAura(auraKey = id, magnitude = 1.0),
+    )
 
     private class StubSkillsRegistry : AgentSkillsRegistry {
         private val slottedSkills = mutableSetOf<SkillId>()
@@ -164,5 +223,20 @@ class SkillProgressionImplTest {
         override fun publishEvent(event: Any) {
             events += event
         }
+    }
+
+    private class StubPerkLookup(private val perks: List<Perk> = emptyList()) : PerkLookup {
+        private val byId = perks.associateBy { it.id }
+        override fun byId(id: PerkId): Perk? = byId[id]
+        override fun choicesAt(skill: SkillId, milestoneLevel: Int): PerkChoice? {
+            val opts = perks.filter { it.skill == skill && it.milestoneLevel == milestoneLevel }
+            return if (opts.isEmpty()) null else PerkChoice(skill, milestoneLevel, opts)
+        }
+        override fun choicesFor(skill: SkillId): List<PerkChoice> =
+            perks.filter { it.skill == skill }
+                .groupBy { it.milestoneLevel }
+                .toSortedMap()
+                .map { (level, list) -> PerkChoice(skill, level, list) }
+        override fun all(): List<Perk> = perks
     }
 }


### PR DESCRIPTION
## Summary

Track A Step 2 of the [skill-feature roadmap](docs/skill-feature-sequence.md). Wires the perk selection flow on top of #62's data shape:

- `AgentEvent.PerkChoiceOffered` fires after `SkillMilestoneReached` when the catalog has perks at the crossed milestone; carries the binary fork option ids.
- `AgentEvent.PerkChosen` fires on commit.
- New MCP tool `select_perk(skillId, milestone, perkId)` — sync, IRREVERSIBLE; validates catalog + (skill, milestone) consistency + slotted level + no prior pick.
- `get_status` projection extended with `chosenPerks` and `pendingPerkChoices`.

## Design call: pending = derived state

No `agent_pending_perk_choices` table. Pending = `(slotted level >= milestone) AND (no row in agent_perks for that (skill, milestone))`. Catalog is the source of truth for options; `agent_perks` for committed picks. Cost: ≤ 24 catalog lookups per `get_status` (8 slots × 3 milestones). Benefit: zero sync complexity, no schema churn, can't drift.

## Test plan

- [x] `:player` unit — `SkillProgressionImplTest` covers `PerkChoiceOffered` emission with + without catalog perks, ordering after `SkillMilestoneReached`.
- [x] `:api` unit — `SelectPerkToolTest` covers ok path + every rejection (`unknown_perk`, `perk_mismatch`, `milestone_not_reached` for unslotted + below-threshold, `already_chosen`).
- [x] `:api` unit — `GetStatusToolTest` covers `chosenPerks` ordering and `pendingPerkChoices` derivation (both milestones pending, partial pick, level-not-reached, unslotted).
- [x] `:player` integration — `JooqAgentPerksRegistryIntegrationTest` (existing) covers DB persistence + concurrent re-pick via PK fallback.
- [x] `./gradlew test` — full project including `:app` Spring context boot.

## Out of scope

- Effect-type behavior (Steps 3a–3d).
- Catalog expansion (Step 4).

Closes #63.