### PR TITLE
feat(player,world): per-level skill scaling + Modifier perk (#66)

### DIFF
--- a/player/src/main/kotlin/dev/gvart/genesara/player/LevelScalingAggregator.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/LevelScalingAggregator.kt
@@ -1,0 +1,18 @@
+package dev.gvart.genesara.player
+
+/**
+ * Sum of `level × perLevelPct` across slotted skills, multiplied per-skill by chosen
+ * [PerkEffect.Modifier] perks targeting the same effect. Reducers apply the result as
+ * `(1.0 + bonus)` against a base value — `0.25` means +25%.
+ */
+interface LevelScalingAggregator {
+
+    fun bonusFor(agent: AgentId, effect: ScalingEffect): Double
+
+    companion object {
+        /** No-op aggregator for reducer tests that don't exercise scaling. */
+        val NoScaling: LevelScalingAggregator = object : LevelScalingAggregator {
+            override fun bonusFor(agent: AgentId, effect: ScalingEffect): Double = 0.0
+        }
+    }
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/PerkEffect.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/PerkEffect.kt
@@ -23,8 +23,14 @@ sealed interface PerkEffect {
         val internalCooldownTicks: Int,
     ) : PerkEffect
 
+    /**
+     * Multiplier applied per-skill to the [LevelEffect] scaling rate. Scopes to the
+     * skill that owns the perk: a Modifier perk on SWORD only multiplies SWORD's own
+     * `level × perLevelPct` contribution, not contributions from other slotted skills
+     * that scale the same [ScalingEffect].
+     */
     data class Modifier(
-        val target: String,
+        val target: ScalingEffect,
         val multiplier: Double,
     ) : PerkEffect
 }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/ScalingEffect.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/ScalingEffect.kt
@@ -1,0 +1,25 @@
+package dev.gvart.genesara.player
+
+/**
+ * Closed enum of per-level passive scaling outputs. Pinned in
+ * `docs/skill-feature-sequence.md` (issue #66) — adding a value implies a new
+ * reducer hook.
+ */
+enum class ScalingEffect {
+    SLASH_DAMAGE_BONUS,
+    PIERCE_DAMAGE_BONUS,
+    BLUNT_DAMAGE_BONUS,
+    ENERGY_DAMAGE_BONUS,
+    BLOCK_CHANCE,
+    DODGE_CHANCE,
+    CRIT_CHANCE,
+    HARVEST_YIELD_BONUS,
+    CRAFT_QUALITY_BONUS,
+    MOVEMENT_SPEED,
+    STAMINA_REGEN,
+    MAX_CARRY_WEIGHT,
+    STEALTH_DETECTION_REDUCTION,
+    NPC_PERSUASION_BONUS,
+    MOUNT_TAMING_BONUS,
+    SCAN_RANGE_BONUS,
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/Skill.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/Skill.kt
@@ -12,4 +12,12 @@ data class Skill(
     val displayName: String,
     val description: String,
     val category: SkillCategory,
+    /** Null when the skill declares no passive scaling rule. */
+    val levelEffect: LevelEffect? = null,
+)
+
+/** `perLevelPct` is a fractional bonus per level (0.005 = +0.5%/level). */
+data class LevelEffect(
+    val type: ScalingEffect,
+    val perLevelPct: Double,
 )

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/SkillLookupImpl.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/SkillLookupImpl.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.player.internal.balance
 
+import dev.gvart.genesara.player.LevelEffect
 import dev.gvart.genesara.player.Skill
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillLookup
@@ -24,5 +25,7 @@ internal class SkillLookupImpl(
         displayName = displayName,
         description = description,
         category = category,
+        levelEffect = levelEffect?.takeIf { it.type != null && it.perLevelPct != null }
+            ?.let { LevelEffect(type = it.type!!, perLevelPct = it.perLevelPct!!) },
     )
 }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/SkillProperties.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/SkillProperties.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.player.internal.balance
 
 import dev.gvart.genesara.player.AbilityCostResource
 import dev.gvart.genesara.player.AbilityTarget
+import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillCategory
 import dev.gvart.genesara.player.TriggeredPassiveEffectKind
 import dev.gvart.genesara.player.TriggeredPassiveTrigger
@@ -10,11 +11,17 @@ internal data class SkillProperties(
     val displayName: String = "",
     val description: String = "",
     val category: SkillCategory = SkillCategory.SURVIVAL,
+    val levelEffect: LevelEffectProperties? = null,
     /**
      * YAML keys are strings ("50", "100", "150"); converted to Int milestone levels in
      * [SkillLookupImpl] / [PerkLookupImpl]. The validator enforces the legal level set.
      */
     val milestones: Map<String, List<PerkProperties>> = emptyMap(),
+)
+
+internal data class LevelEffectProperties(
+    val type: ScalingEffect? = null,
+    val perLevelPct: Double? = null,
 )
 
 internal data class PerkProperties(
@@ -43,7 +50,7 @@ internal data class PerkEffectProperties(
     val effectKind: TriggeredPassiveEffectKind? = null,
     val params: Map<String, String> = emptyMap(),
     val internalCooldownTicks: Int? = null,
-    val modifierTarget: String? = null,
+    val modifierTarget: ScalingEffect? = null,
     val multiplier: Double? = null,
 )
 

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/SkillsValidator.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/SkillsValidator.kt
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component
 @Component
 internal class SkillsValidator(
     private val lookup: SkillLookup,
+    private val props: SkillDefinitionProperties,
 ) {
 
     @PostConstruct
@@ -22,12 +23,27 @@ internal class SkillsValidator(
             "Skill catalog is empty — every gather would silently no-op. Check that " +
                 "player-definition/skills.yaml is on the classpath and parsed."
         }
-        val problems = all.mapNotNull { skill ->
-            when {
-                skill.displayName.isBlank() -> skill.id.value to "missing display-name"
-                skill.description.isBlank() -> skill.id.value to "missing description"
-                else -> null
+        val problems = all.flatMap { skill ->
+            buildList {
+                if (skill.displayName.isBlank()) add(skill.id.value to "missing display-name")
+                if (skill.description.isBlank()) add(skill.id.value to "missing description")
+                skill.levelEffect?.let { effect ->
+                    if (effect.perLevelPct <= 0.0) {
+                        add(skill.id.value to "level-effect.per-level-pct must be > 0 (got ${effect.perLevelPct})")
+                    }
+                }
             }
+        } + props.catalog.flatMap { (key, properties) ->
+            properties.levelEffect?.let { raw ->
+                buildList {
+                    if (raw.type == null) add(key to "level-effect.type missing")
+                    if (raw.perLevelPct == null) {
+                        add(key to "level-effect.per-level-pct missing")
+                    } else if (raw.perLevelPct <= 0.0) {
+                        add(key to "level-effect.per-level-pct must be > 0 (got ${raw.perLevelPct})")
+                    }
+                }
+            }.orEmpty()
         }
         require(problems.isEmpty()) {
             buildString {

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/scaling/LevelScalingAggregatorImpl.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/scaling/LevelScalingAggregatorImpl.kt
@@ -1,0 +1,50 @@
+package dev.gvart.genesara.player.internal.scaling
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentPerksRegistry
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.LevelScalingAggregator
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkLookup
+import dev.gvart.genesara.player.ScalingEffect
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillLookup
+import org.springframework.stereotype.Component
+
+@Component
+internal class LevelScalingAggregatorImpl(
+    private val skills: SkillLookup,
+    private val perks: PerkLookup,
+    private val skillsRegistry: AgentSkillsRegistry,
+    private val perksRegistry: AgentPerksRegistry,
+) : LevelScalingAggregator {
+
+    override fun bonusFor(agent: AgentId, effect: ScalingEffect): Double {
+        val skillsSnapshot = skillsRegistry.snapshot(agent)
+        val slotted = skillsSnapshot.perSkill.values.filter { it.slotIndex != null }
+        if (slotted.isEmpty()) return 0.0
+
+        val modifierBySkill = chosenModifiersFor(agent, effect)
+        return slotted.sumOf { state ->
+            val skill = skills.byId(state.skill) ?: return@sumOf 0.0
+            val levelEffect = skill.levelEffect ?: return@sumOf 0.0
+            if (levelEffect.type != effect) return@sumOf 0.0
+            val base = state.level * levelEffect.perLevelPct
+            val multiplier = modifierBySkill[state.skill] ?: 1.0
+            base * multiplier
+        }
+    }
+
+    private fun chosenModifiersFor(agent: AgentId, effect: ScalingEffect): Map<SkillId, Double> {
+        val chosen = perksRegistry.snapshot(agent).perks
+        if (chosen.isEmpty()) return emptyMap()
+        val byOwningSkill = mutableMapOf<SkillId, Double>()
+        for (chosenPerk in chosen) {
+            val perk = perks.byId(chosenPerk.perkId) ?: continue
+            val modifier = perk.effect as? PerkEffect.Modifier ?: continue
+            if (modifier.target != effect) continue
+            byOwningSkill.merge(perk.skill, modifier.multiplier, Double::times)
+        }
+        return byOwningSkill
+    }
+}

--- a/player/src/main/resources/player-definition/skills.yaml
+++ b/player/src/main/resources/player-definition/skills.yaml
@@ -52,6 +52,9 @@ skills:
       display-name: Swordsmanship
       description: One-handed slashing weapons.
       category: COMBAT
+      level-effect:
+        type: SLASH_DAMAGE_BONUS
+        per-level-pct: 0.005
       milestones:
         "50":
           - id: SWORD_BLEEDER
@@ -74,6 +77,24 @@ skills:
               type: PASSIVE_AURA
               aura-key: SLASH_DAMAGE_FLAT
               aura-magnitude: 5.0
+        "150":
+          - id: SWORD_DOUBLED_EDGE
+            display-name: Doubled Edge
+            description: >-
+              Doubles the slash damage scaling rate from sword level — every level
+              counts twice for SLASH_DAMAGE_BONUS.
+            effect:
+              type: MODIFIER
+              modifier-target: SLASH_DAMAGE_BONUS
+              multiplier: 2.0
+          - id: SWORD_PRECISION
+            display-name: Precision
+            description: >-
+              Permanent +10 flat slash damage while a sword is wielded.
+            effect:
+              type: PASSIVE_AURA
+              aura-key: SLASH_DAMAGE_FLAT
+              aura-magnitude: 10.0
 
     BOW:
       display-name: Archery

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/SkillsValidatorTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/SkillsValidatorTest.kt
@@ -1,5 +1,7 @@
 package dev.gvart.genesara.player.internal.balance
 
+import dev.gvart.genesara.player.LevelEffect
+import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.Skill
 import dev.gvart.genesara.player.SkillCategory
 import dev.gvart.genesara.player.SkillId
@@ -18,7 +20,7 @@ class SkillsValidatorTest {
                 Skill(SkillId("MINING"), "Mining", "rock breaking", SkillCategory.GATHERING),
             ),
         )
-        SkillsValidator(lookup).validate()
+        SkillsValidator(lookup, emptyProps()).validate()
     }
 
     @Test
@@ -26,7 +28,7 @@ class SkillsValidatorTest {
         val lookup = StubLookup(
             listOf(Skill(SkillId("FORAGING"), "", "non-empty", SkillCategory.GATHERING)),
         )
-        val ex = assertThrows<IllegalArgumentException> { SkillsValidator(lookup).validate() }
+        val ex = assertThrows<IllegalArgumentException> { SkillsValidator(lookup, emptyProps()).validate() }
         assertTrue(ex.message?.contains("FORAGING") == true)
         assertTrue(ex.message?.contains("display-name") == true)
     }
@@ -36,19 +38,55 @@ class SkillsValidatorTest {
         val lookup = StubLookup(
             listOf(Skill(SkillId("MINING"), "Mining", "", SkillCategory.GATHERING)),
         )
-        val ex = assertThrows<IllegalArgumentException> { SkillsValidator(lookup).validate() }
+        val ex = assertThrows<IllegalArgumentException> { SkillsValidator(lookup, emptyProps()).validate() }
         assertTrue(ex.message?.contains("MINING") == true)
         assertTrue(ex.message?.contains("description") == true)
     }
 
     @Test
     fun `rejects an empty catalog so misconfiguration fails fast at startup`() {
-        // An empty catalog would silently no-op every gather XP grant — fail fast.
         val ex = assertThrows<IllegalArgumentException> {
-            SkillsValidator(StubLookup(emptyList())).validate()
+            SkillsValidator(StubLookup(emptyList()), emptyProps()).validate()
         }
         assertTrue(ex.message?.contains("empty") == true)
     }
+
+    @Test
+    fun `rejects a level-effect with non-positive per-level pct`() {
+        val lookup = StubLookup(
+            listOf(
+                Skill(
+                    SkillId("SWORD"), "Swords", "blades", SkillCategory.COMBAT,
+                    levelEffect = LevelEffect(ScalingEffect.SLASH_DAMAGE_BONUS, perLevelPct = 0.0),
+                ),
+            ),
+        )
+        val ex = assertThrows<IllegalArgumentException> { SkillsValidator(lookup, emptyProps()).validate() }
+        assertTrue(ex.message?.contains("SWORD") == true)
+        assertTrue(ex.message?.contains("per-level-pct") == true)
+    }
+
+    @Test
+    fun `rejects a level-effect block with type set but per-level-pct missing`() {
+        val lookup = StubLookup(
+            listOf(Skill(SkillId("SWORD"), "Swords", "blades", SkillCategory.COMBAT)),
+        )
+        val props = SkillDefinitionProperties(
+            catalog = mapOf(
+                "SWORD" to SkillProperties(
+                    displayName = "Swords",
+                    description = "blades",
+                    category = SkillCategory.COMBAT,
+                    levelEffect = LevelEffectProperties(type = ScalingEffect.SLASH_DAMAGE_BONUS, perLevelPct = null),
+                ),
+            ),
+        )
+        val ex = assertThrows<IllegalArgumentException> { SkillsValidator(lookup, props).validate() }
+        assertTrue(ex.message?.contains("SWORD") == true)
+        assertTrue(ex.message?.contains("per-level-pct") == true)
+    }
+
+    private fun emptyProps(): SkillDefinitionProperties = SkillDefinitionProperties(catalog = emptyMap())
 
     private class StubLookup(private val skills: List<Skill>) : SkillLookup {
         private val byId = skills.associateBy { it.id }

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/scaling/LevelScalingAggregatorImplTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/scaling/LevelScalingAggregatorImplTest.kt
@@ -1,0 +1,281 @@
+package dev.gvart.genesara.player.internal.scaling
+
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentPerk
+import dev.gvart.genesara.player.AgentPerksRegistry
+import dev.gvart.genesara.player.AgentPerksSnapshot
+import dev.gvart.genesara.player.AgentSkillState
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.LevelEffect
+import dev.gvart.genesara.player.Perk
+import dev.gvart.genesara.player.PerkChoice
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.PerkLookup
+import dev.gvart.genesara.player.RecordPerkResult
+import dev.gvart.genesara.player.ScalingEffect
+import dev.gvart.genesara.player.Skill
+import dev.gvart.genesara.player.SkillCategory
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillLookup
+import dev.gvart.genesara.player.SkillSlotError
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class LevelScalingAggregatorImplTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val sword = SkillId("SWORD")
+    private val club = SkillId("CLUB")
+    private val swordDoubledEdge = PerkId("SWORD_DOUBLED_EDGE")
+
+    @Test
+    fun `returns 0 when agent has no slotted skills`() {
+        val agg = aggregator(skills = catalogWithSwordScaling(), perks = emptyList(), slottedSkills = emptyMap(), chosenPerks = emptyList())
+        assertEquals(0.0, agg.bonusFor(agent, ScalingEffect.SLASH_DAMAGE_BONUS))
+    }
+
+    @Test
+    fun `returns 0 when slotted skill has no level-effect`() {
+        val agg = aggregator(
+            skills = listOf(plainSwordSkill()),
+            perks = emptyList(),
+            slottedSkills = mapOf(sword to 100),
+            chosenPerks = emptyList(),
+        )
+        assertEquals(0.0, agg.bonusFor(agent, ScalingEffect.SLASH_DAMAGE_BONUS))
+    }
+
+    @Test
+    fun `returns 0 when slotted skill scales a different effect`() {
+        val agg = aggregator(
+            skills = catalogWithSwordScaling(),
+            perks = emptyList(),
+            slottedSkills = mapOf(sword to 50),
+            chosenPerks = emptyList(),
+        )
+        assertEquals(0.0, agg.bonusFor(agent, ScalingEffect.PIERCE_DAMAGE_BONUS))
+    }
+
+    @Test
+    fun `scales linearly with level — L1 to L150 unmodified`() {
+        listOf(1 to 0.005, 50 to 0.25, 100 to 0.50, 150 to 0.75).forEach { (level, expected) ->
+            val agg = aggregator(
+                skills = catalogWithSwordScaling(),
+                perks = emptyList(),
+                slottedSkills = mapOf(sword to level),
+                chosenPerks = emptyList(),
+            )
+            assertEquals(expected, agg.bonusFor(agent, ScalingEffect.SLASH_DAMAGE_BONUS), absoluteTolerance = 1e-9)
+        }
+    }
+
+    @Test
+    fun `scales beyond L150 — uncapped per spec section 3`() {
+        val agg = aggregator(
+            skills = catalogWithSwordScaling(),
+            perks = emptyList(),
+            slottedSkills = mapOf(sword to 200),
+            chosenPerks = emptyList(),
+        )
+        assertEquals(1.0, agg.bonusFor(agent, ScalingEffect.SLASH_DAMAGE_BONUS), absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `Modifier perk on the same skill multiplies that skill's contribution`() {
+        val agg = aggregator(
+            skills = catalogWithSwordScaling(),
+            perks = listOf(doubledEdgePerk()),
+            slottedSkills = mapOf(sword to 150),
+            chosenPerks = listOf(swordDoubledEdge),
+        )
+        assertEquals(1.5, agg.bonusFor(agent, ScalingEffect.SLASH_DAMAGE_BONUS), absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `Modifier on a different skill does not affect this skill's contribution`() {
+        val clubModifier = perk(
+            id = "CLUB_DOUBLED_BLOW",
+            skill = club,
+            milestone = 150,
+            effect = PerkEffect.Modifier(target = ScalingEffect.SLASH_DAMAGE_BONUS, multiplier = 2.0),
+        )
+        val agg = aggregator(
+            skills = listOf(swordWithSlashScaling(), plainClubSkill()),
+            perks = listOf(clubModifier),
+            slottedSkills = mapOf(sword to 150, club to 150),
+            chosenPerks = listOf(PerkId("CLUB_DOUBLED_BLOW")),
+        )
+        assertEquals(0.75, agg.bonusFor(agent, ScalingEffect.SLASH_DAMAGE_BONUS), absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `multiple slotted skills sum their contributions for the same effect`() {
+        val agg = aggregator(
+            skills = listOf(swordWithSlashScaling(), clubWithSlashScaling()),
+            perks = emptyList(),
+            slottedSkills = mapOf(sword to 100, club to 50),
+            chosenPerks = emptyList(),
+        )
+        assertEquals(0.50 + 0.25, agg.bonusFor(agent, ScalingEffect.SLASH_DAMAGE_BONUS), absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `two Modifier perks on the same skill targeting the same effect compose multiplicatively`() {
+        val secondModifier = perk(
+            id = "SWORD_HONED_EDGE",
+            skill = sword,
+            milestone = 100,
+            effect = PerkEffect.Modifier(target = ScalingEffect.SLASH_DAMAGE_BONUS, multiplier = 1.5),
+        )
+        val agg = aggregator(
+            skills = catalogWithSwordScaling(),
+            perks = listOf(doubledEdgePerk(), secondModifier),
+            slottedSkills = mapOf(sword to 100),
+            chosenPerks = listOf(swordDoubledEdge, PerkId("SWORD_HONED_EDGE")),
+        )
+        // base = 100 × 0.005 = 0.5; modifiers compose: 0.5 × 2.0 × 1.5 = 1.5
+        assertEquals(1.5, agg.bonusFor(agent, ScalingEffect.SLASH_DAMAGE_BONUS), absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `Modifier on the same skill targeting a different effect does not apply`() {
+        val blockModifier = perk(
+            id = "SWORD_GUARD",
+            skill = sword,
+            milestone = 100,
+            effect = PerkEffect.Modifier(target = ScalingEffect.BLOCK_CHANCE, multiplier = 3.0),
+        )
+        val agg = aggregator(
+            skills = catalogWithSwordScaling(),
+            perks = listOf(blockModifier),
+            slottedSkills = mapOf(sword to 100),
+            chosenPerks = listOf(PerkId("SWORD_GUARD")),
+        )
+        // SWORD scales SLASH; the BLOCK_CHANCE modifier must not multiply it.
+        assertEquals(0.50, agg.bonusFor(agent, ScalingEffect.SLASH_DAMAGE_BONUS), absoluteTolerance = 1e-9)
+    }
+
+    @Test
+    fun `non-Modifier perks like PassiveAura are ignored by the scaling aggregator`() {
+        val auraPerk = perk(
+            id = "SWORD_SHARPEN_EDGE",
+            skill = sword,
+            milestone = 50,
+            effect = PerkEffect.PassiveAura(auraKey = "SLASH_DAMAGE_FLAT", magnitude = 5.0),
+        )
+        val agg = aggregator(
+            skills = catalogWithSwordScaling(),
+            perks = listOf(auraPerk),
+            slottedSkills = mapOf(sword to 100),
+            chosenPerks = listOf(PerkId("SWORD_SHARPEN_EDGE")),
+        )
+        assertEquals(0.50, agg.bonusFor(agent, ScalingEffect.SLASH_DAMAGE_BONUS), absoluteTolerance = 1e-9)
+    }
+
+    private fun aggregator(
+        skills: List<Skill>,
+        perks: List<Perk>,
+        slottedSkills: Map<SkillId, Int>,
+        chosenPerks: List<PerkId>,
+    ) = LevelScalingAggregatorImpl(
+        skills = StubSkillLookup(skills),
+        perks = StubPerkLookup(perks),
+        skillsRegistry = StubSkillsRegistry(slottedSkills),
+        perksRegistry = StubPerksRegistry(chosenPerks),
+    )
+
+    private fun catalogWithSwordScaling(): List<Skill> = listOf(swordWithSlashScaling())
+
+    private fun swordWithSlashScaling() = Skill(
+        id = sword,
+        displayName = "Sword",
+        description = "blade",
+        category = SkillCategory.COMBAT,
+        levelEffect = LevelEffect(ScalingEffect.SLASH_DAMAGE_BONUS, perLevelPct = 0.005),
+    )
+
+    private fun clubWithSlashScaling() = Skill(
+        id = club,
+        displayName = "Club",
+        description = "blunt",
+        category = SkillCategory.COMBAT,
+        levelEffect = LevelEffect(ScalingEffect.SLASH_DAMAGE_BONUS, perLevelPct = 0.005),
+    )
+
+    private fun plainSwordSkill() = Skill(sword, "Sword", "blade", SkillCategory.COMBAT, levelEffect = null)
+
+    private fun plainClubSkill() = Skill(club, "Club", "blunt", SkillCategory.COMBAT, levelEffect = null)
+
+    private fun doubledEdgePerk() = perk(
+        id = swordDoubledEdge.value,
+        skill = sword,
+        milestone = 150,
+        effect = PerkEffect.Modifier(target = ScalingEffect.SLASH_DAMAGE_BONUS, multiplier = 2.0),
+    )
+
+    private fun perk(id: String, skill: SkillId, milestone: Int, effect: PerkEffect): Perk = Perk(
+        id = PerkId(id),
+        skill = skill,
+        milestoneLevel = milestone,
+        displayName = id,
+        description = id,
+        effect = effect,
+    )
+
+    private class StubSkillLookup(private val skills: List<Skill>) : SkillLookup {
+        private val byId = skills.associateBy { it.id }
+        override fun byId(id: SkillId): Skill? = byId[id]
+        override fun all(): List<Skill> = skills
+    }
+
+    private class StubPerkLookup(private val perks: List<Perk>) : PerkLookup {
+        private val byId = perks.associateBy { it.id }
+        override fun byId(id: PerkId): Perk? = byId[id]
+        override fun choicesAt(skill: SkillId, milestoneLevel: Int): PerkChoice? = null
+        override fun choicesFor(skill: SkillId): List<PerkChoice> = emptyList()
+        override fun all(): List<Perk> = perks
+    }
+
+    private inner class StubSkillsRegistry(private val slotted: Map<SkillId, Int>) : AgentSkillsRegistry {
+        override fun snapshot(agent: AgentId): AgentSkillsSnapshot = AgentSkillsSnapshot(
+            perSkill = slotted.entries.mapIndexed { idx, (skill, level) ->
+                skill to AgentSkillState(
+                    skill = skill,
+                    xp = 0,
+                    level = level,
+                    slotIndex = idx,
+                    recommendCount = 0,
+                )
+            }.toMap(),
+            slotCount = slotted.size,
+            slotsFilled = slotted.size,
+        )
+
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int): AddXpResult =
+            AddXpResult.Unslotted
+
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? = null
+
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? = null
+    }
+
+    private inner class StubPerksRegistry(private val chosen: List<PerkId>) : AgentPerksRegistry {
+        override fun snapshot(agent: AgentId): AgentPerksSnapshot = AgentPerksSnapshot(
+            perks = chosen.map { id ->
+                AgentPerk(
+                    skill = SkillId("ANY"),
+                    milestoneLevel = 0,
+                    perkId = id,
+                    chosenAtTick = 0,
+                )
+            },
+        )
+
+        override fun recordChoice(agent: AgentId, perk: PerkId, tick: Long): RecordPerkResult =
+            RecordPerkResult.Recorded
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
@@ -255,7 +255,11 @@ sealed interface WorldEvent {
         val target: AgentId,
         val at: NodeId,
         val damageType: DamageType,
-        /** Pre-crit-and-dodge base damage. Useful for clients that want to reason about armor. */
+        /**
+         * Damage after attacker scaling but before crit, dodge, and armor mitigation:
+         * `weaponPower × stat × damageTypeMod × (1 + skill scaling bonus)`. Armor will
+         * subtract from this in a future combat slice.
+         */
         val baseDamage: Int,
         /** Actual HP subtracted from the target. 0 on dodge. */
         val hpLost: Int,

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import dev.gvart.genesara.player.AgentProfileLookup
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.BuildingsLookup
@@ -59,6 +60,7 @@ internal fun reduce(
     chestContents: ChestContentsStore,
     rarityRoller: RarityRoller,
     progression: SkillProgression,
+    scaling: LevelScalingAggregator,
     spawnLocationResolver: SpawnLocationResolver,
     groundItems: GroundItemStore,
     deathProcessor: DeathProcessor,
@@ -66,10 +68,10 @@ internal fun reduce(
     rng: Random = Random.Default,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = when (command) {
     is WorldCommand.SpawnAgent -> reduceSpawn(state, command, profiles, spawnLocationResolver, tick)
-    is WorldCommand.MoveAgent -> reduceMove(state, command, balance, buildingsLookup, tick)
+    is WorldCommand.MoveAgent -> reduceMove(state, command, balance, buildingsLookup, scaling, tick)
     is WorldCommand.UnspawnAgent -> reduceUnspawn(state, command, tick)
     is WorldCommand.Harvest ->
-        reduceHarvest(state, command, balance, items, resources, agents, equipment, progression, tick)
+        reduceHarvest(state, command, balance, items, resources, agents, equipment, progression, scaling, tick)
     is WorldCommand.ConsumeItem -> reduceConsume(state, command, items, tick)
     is WorldCommand.Drink -> reduceDrink(state, command, balance, buildingsLookup, tick)
     is WorldCommand.SetSafeNode -> reduceSetSafeNode(state, command, safeNodes, tick)
@@ -83,10 +85,13 @@ internal fun reduce(
     is WorldCommand.CraftItem ->
         reduceCraft(
             state, command, balance, items, recipes, equipment, buildingsLookup,
-            skills, agents, rarityRoller, progression, tick,
+            skills, agents, rarityRoller, progression, scaling, tick,
         )
     is WorldCommand.Pickup ->
         reducePickup(state, command, balance, items, agents, equipment, groundItems, tick)
     is WorldCommand.AttackTarget ->
-        reduceAttack(state, command, balance, items, agents, equipment, progression, deathProcessor, rng, tick)
+        reduceAttack(
+            state, command, balance, items, agents, equipment, progression, scaling,
+            deathProcessor, rng, tick,
+        )
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
@@ -5,6 +5,8 @@ import arrow.core.raise.either
 import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.LevelScalingAggregator
+import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.DamageType
@@ -47,6 +49,7 @@ internal fun reduceAttack(
     agents: AgentRegistry,
     equipment: EquipmentInstanceStore,
     progression: SkillProgression,
+    scaling: LevelScalingAggregator,
     deathProcessor: DeathProcessor,
     rng: Random,
     tick: Long,
@@ -91,6 +94,9 @@ internal fun reduceAttack(
     val typedDamage = (rawDamage * balance.damageTypeModifier(weaponProfile.damageType))
         .toInt()
         .coerceAtLeast(0)
+    val damageScaling = scalingEffectFor(weaponProfile.damageType)
+        ?.let { scaling.bonusFor(command.agent, it) } ?: 0.0
+    val scaledDamage = (typedDamage * (1.0 + damageScaling)).toInt().coerceAtLeast(0)
 
     // Dodge rolls FIRST so a successful dodge short-circuits the crit roll. Otherwise a crit
     // followed by a dodge would burn the RNG cursor on a discarded crit and shift downstream
@@ -102,7 +108,7 @@ internal fun reduceAttack(
     } else {
         val critChance = balance.critChancePercent(attacker.attributes.luck)
         val crit = rng.nextInt(100) < critChance
-        val landed = if (crit) typedDamage * balance.critMultiplier() else typedDamage
+        val landed = if (crit) scaledDamage * balance.critMultiplier() else scaledDamage
         landed to crit
     }
 
@@ -119,7 +125,7 @@ internal fun reduceAttack(
         target = command.target,
         at = attackerNode,
         damageType = weaponProfile.damageType,
-        baseDamage = typedDamage,
+        baseDamage = scaledDamage,
         hpLost = hpLost,
         isCrit = isCrit,
         isDodged = isDodged,
@@ -152,6 +158,20 @@ private data class WeaponProfile(
     val combatSkill: SkillId,
     val range: Int,
 )
+
+/**
+ * Damage types unmapped here (e.g. [DamageType.MAGICAL]) have no corresponding
+ * scaling effect in the v1 enum (`docs/skill-feature-sequence.md` issue #66 pin) —
+ * a magical attack scales only by armor/resists and gets no per-level skill bonus
+ * until a magic-class slice extends the enum.
+ */
+private fun scalingEffectFor(type: DamageType): ScalingEffect? = when (type) {
+    DamageType.SLASH -> ScalingEffect.SLASH_DAMAGE_BONUS
+    DamageType.PIERCE -> ScalingEffect.PIERCE_DAMAGE_BONUS
+    DamageType.BLUNT -> ScalingEffect.BLUNT_DAMAGE_BONUS
+    DamageType.ENERGY -> ScalingEffect.ENERGY_DAMAGE_BONUS
+    DamageType.MAGICAL -> null
+}
 
 private fun weaponProfileFor(weapon: Item?, balance: BalanceLookup): WeaponProfile {
     val damageType = weapon?.damageType ?: balance.unarmedDamageType()

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
@@ -8,6 +8,8 @@ import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.LevelScalingAggregator
+import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.EquipmentInstance
@@ -47,6 +49,7 @@ internal fun reduceCraft(
     agents: AgentRegistry,
     rarityRoller: RarityRoller,
     progression: SkillProgression,
+    scaling: LevelScalingAggregator,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
@@ -93,12 +96,15 @@ internal fun reduceCraft(
         WorldRejection.UnknownItem(recipe.output.item)
     }
 
+    val qualityBonus = scaling.bonusFor(command.agent, ScalingEffect.CRAFT_QUALITY_BONUS)
+    val effectiveSkillLevel = (skillLevel * (1.0 + qualityBonus)).toInt().coerceAtLeast(skillLevel)
+
     val mutation = produceOutput(
         command = command,
         recipe = recipe,
         outputItem = outputItem,
         inventory = inventory,
-        skillLevel = skillLevel,
+        skillLevel = effectiveSkillLevel,
         agents = agents,
         equipment = equipment,
         balance = balance,

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
@@ -7,6 +7,8 @@ import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.LevelScalingAggregator
+import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.ItemId
@@ -39,6 +41,7 @@ internal fun reduceHarvest(
     agents: AgentRegistry,
     equipment: EquipmentInstanceStore,
     progression: SkillProgression,
+    scaling: LevelScalingAggregator,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
@@ -58,7 +61,10 @@ internal fun reduceHarvest(
         WorldRejection.NotEnoughStamina(command.agent, cost, body.stamina)
     }
 
-    val quantity = balance.harvestYield(command.item).coerceAtMost(cell.quantity)
+    val yieldBonus = scaling.bonusFor(command.agent, ScalingEffect.HARVEST_YIELD_BONUS)
+    val baseYield = balance.harvestYield(command.item)
+    val scaledYield = (baseYield * (1.0 + yieldBonus)).toInt().coerceAtLeast(baseYield)
+    val quantity = scaledYield.coerceAtMost(cell.quantity)
 
     val agentRecord = agents.find(command.agent)
         ?: error("Invariant violated: agent ${command.agent} has a position but no registry row")

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
@@ -4,6 +4,8 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
+import dev.gvart.genesara.player.LevelScalingAggregator
+import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.world.BuildingCategoryHint
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.WorldRejection
@@ -17,6 +19,7 @@ internal fun reduceMove(
     command: WorldCommand.MoveAgent,
     balance: BalanceLookup,
     buildings: BuildingsLookup,
+    scaling: LevelScalingAggregator,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val from = ensureNotNull(state.positions[command.agent]) {
@@ -41,7 +44,9 @@ internal fun reduceMove(
     val baseCost = balance.moveStaminaCost(biome, climate, toNode.terrain)
     val onRoad = hasActiveBuilding(buildings, from, BuildingCategoryHint.INFRASTRUCTURE_ROAD)
     // Floor at 1 so road-hopping still costs stamina.
-    val cost = if (onRoad) (baseCost * balance.roadStaminaMultiplier()).toInt().coerceAtLeast(1) else baseCost
+    val roadAdjusted = if (onRoad) (baseCost * balance.roadStaminaMultiplier()).toInt().coerceAtLeast(1) else baseCost
+    val speedBonus = scaling.bonusFor(command.agent, ScalingEffect.MOVEMENT_SPEED)
+    val cost = (roadAdjusted / (1.0 + speedBonus)).toInt().coerceAtLeast(1)
     ensure(body.stamina >= cost) {
         WorldRejection.NotEnoughStamina(command.agent, cost, body.stamina)
     }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -4,6 +4,7 @@ import dev.gvart.genesara.engine.Tick
 import dev.gvart.genesara.player.AgentProfileLookup
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.BuildingsLookup
@@ -52,6 +53,7 @@ internal class WorldTickHandler(
     private val chestContents: ChestContentsStore,
     private val rarityRoller: RarityRoller,
     private val progression: SkillProgression,
+    private val scaling: LevelScalingAggregator,
     private val spawnLocationResolver: SpawnLocationResolver,
     private val groundItems: GroundItemStore,
     private val deathProcessor: DeathProcessor,
@@ -82,7 +84,8 @@ internal class WorldTickHandler(
             reduce(
                 state, command, balance, profiles, items, recipes, resources, skills, agents, equipment,
                 safeNodes, safeNodeResolver, buildings, buildingsLookup, buildingsCatalog, chestContents,
-                rarityRoller, progression, spawnLocationResolver, groundItems, deathProcessor, tick.number,
+                rarityRoller, progression, scaling, spawnLocationResolver, groundItems, deathProcessor,
+                tick.number,
             ).fold(
                 ifLeft = { rejection ->
                     log.info("Rejected {} at tick {}: {}", command, tick.number, rejection)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackKillIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackKillIntegrationTest.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.world.internal.combat
 
 import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentId
@@ -147,7 +148,7 @@ class AttackKillIntegrationTest {
         val (afterFirst, firstEvents) = assertNotNull(
             reduceAttack(
                 initial, firstCommand, balance, items, agents, equipment, progression,
-                deathProcessor, rng = Random(seed = 1L), tick = 1L,
+                deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 1L,
             ).getOrNull(),
         )
 
@@ -161,7 +162,7 @@ class AttackKillIntegrationTest {
         val (afterSecond, secondEvents) = assertNotNull(
             reduceAttack(
                 afterFirst, secondCommand, balance, items, agents, equipment, progression,
-                deathProcessor, rng = Random(seed = 1L), tick = 2L,
+                deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 2L,
             ).getOrNull(),
         )
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.world.internal.combat
 
 import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentId
@@ -93,7 +94,7 @@ class AttackReducerTest {
             reduceAttack(
                 state, WorldCommand.AttackTarget(attacker, target),
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed = 1L), tick = 5,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 5,
             ).getOrNull(),
         )
 
@@ -122,7 +123,7 @@ class AttackReducerTest {
                 state, WorldCommand.AttackTarget(attacker, target),
                 balance(), itemsWithSword(), agents(strength = 5, luck = 0, dex = 0),
                 StubEquipmentStore(),
-                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed = 1L), tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
             ).getOrNull(),
         )
 
@@ -146,7 +147,7 @@ class AttackReducerTest {
                 balance(), itemsWithSword(),
                 agents(strength = 10, luck = 0, dex = 0, targetDex = 99),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed), tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, tick = 1,
             ).getOrNull(),
         )
 
@@ -173,7 +174,7 @@ class AttackReducerTest {
                 balance(), itemsWithSword(),
                 agents(strength = 10, luck = 99, dex = 0, targetDex = 0),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed), tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, tick = 1,
             ).getOrNull(),
         )
 
@@ -196,7 +197,7 @@ class AttackReducerTest {
                 balance(), itemsWithUnmappedWeapon(),
                 agents(strength = 10, luck = 0, dex = 0),
                 unmappedWeaponEquipped(),
-                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed = 1L), tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
             ).getOrNull(),
         )
 
@@ -218,7 +219,7 @@ class AttackReducerTest {
                 state, command,
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed = 1L), tick = 7,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 7,
             ).getOrNull(),
         )
 
@@ -246,7 +247,7 @@ class AttackReducerTest {
                 balance(), itemsWithSword(),
                 agents(strength = 0, luck = 0, dex = 0),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed = 1L), tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
             ).getOrNull(),
         )
 
@@ -289,7 +290,7 @@ class AttackReducerTest {
                 state, command,
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed), tick = 5,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, tick = 5,
             ).getOrNull(),
         )
 
@@ -308,8 +309,8 @@ class AttackReducerTest {
             state, WorldCommand.AttackTarget(attacker, attacker),
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
-            stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), tick = 1,
+            deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
+            rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
         )
         assertEquals(WorldRejection.CannotAttackSelf(attacker), result.leftOrNull())
     }
@@ -321,8 +322,8 @@ class AttackReducerTest {
             state, WorldCommand.AttackTarget(attacker, target),
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
-            stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), tick = 1,
+            deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
+            rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
         )
         assertEquals(WorldRejection.NotInWorld(attacker), result.leftOrNull())
     }
@@ -334,8 +335,8 @@ class AttackReducerTest {
             state, WorldCommand.AttackTarget(attacker, target),
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
-            stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), tick = 1,
+            deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
+            rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
         )
         assertEquals(WorldRejection.TargetNotInWorld(attacker, target), result.leftOrNull())
     }
@@ -347,8 +348,8 @@ class AttackReducerTest {
             state, WorldCommand.AttackTarget(attacker, target),
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
-            stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), tick = 1,
+            deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
+            rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
         )
         assertEquals(
             WorldRejection.TargetOutOfRange(attacker, target, nodeAId, nodeBId, weaponRange = 1),
@@ -367,7 +368,7 @@ class AttackReducerTest {
             reduceAttack(
                 state, WorldCommand.AttackTarget(attacker, target),
                 balance(), itemsWithBow(), agents(strength = 0, luck = 0, dex = 10), bowEquipped(),
-                SkillProgression(skills, publisher), deathProcessor, rng = Random(seed = 1L), tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
             ).getOrNull(),
         )
 
@@ -387,8 +388,8 @@ class AttackReducerTest {
             state, WorldCommand.AttackTarget(attacker, target),
             balance(), itemsWithBow(), agents(strength = 10, luck = 0, dex = 0), bowEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
-            stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), tick = 1,
+            deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
+            rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
         )
         assertEquals(
             WorldRejection.TargetOutOfRange(attacker, target, nodeAId, nodeCId, weaponRange = 2),
@@ -403,10 +404,89 @@ class AttackReducerTest {
             state, WorldCommand.AttackTarget(attacker, target),
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
-            stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), tick = 1,
+            deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
+            rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
         )
         assertEquals(WorldRejection.TargetAlreadyDead(attacker, target), result.leftOrNull())
+    }
+
+    @Test
+    fun `slash damage scales with the attacker's SLASH_DAMAGE_BONUS — base 80 plus 50pct = 120`() {
+        val state = battleState(targetHp = 200)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val deathProcessor = stubDeathProcessor(skills, publisher)
+        val scaling = StubScaling(mapOf(dev.gvart.genesara.player.ScalingEffect.SLASH_DAMAGE_BONUS to 0.50))
+
+        val (next, events) = assertNotNull(
+            reduceAttack(
+                state, WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor,
+                rng = Random(seed = 1L), scaling = scaling, tick = 1,
+            ).getOrNull(),
+        )
+
+        val attacked = assertIs<WorldEvent.AgentAttacked>(events.single())
+        assertEquals(120, attacked.baseDamage)
+        assertEquals(120, attacked.hpLost)
+        assertEquals(80, next.bodyOf(target)!!.hp)
+    }
+
+    @Test
+    fun `Modifier perk doubles the slash scaling rate — Doubled Edge canary at L150`() {
+        val state = battleState(targetHp = 300)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val deathProcessor = stubDeathProcessor(skills, publisher)
+        // L150 unmodified would be 0.75 (150 × 0.005); the Doubled-Edge Modifier doubles it to 1.50.
+        val scaling = StubScaling(mapOf(dev.gvart.genesara.player.ScalingEffect.SLASH_DAMAGE_BONUS to 1.50))
+
+        val (_, events) = assertNotNull(
+            reduceAttack(
+                state, WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor,
+                rng = Random(seed = 1L), scaling = scaling, tick = 1,
+            ).getOrNull(),
+        )
+
+        val attacked = assertIs<WorldEvent.AgentAttacked>(events.single())
+        assertEquals(200, attacked.baseDamage, "80 × (1 + 1.50) = 200")
+    }
+
+    @Test
+    fun `MAGICAL damage type has no scaling effect mapped — base damage unchanged`() {
+        // Ensures the `when` exhaustiveness on DamageType handles MAGICAL with a no-op.
+        val state = battleState(targetHp = 100)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val deathProcessor = stubDeathProcessor(skills, publisher)
+        val scaling = StubScaling(mapOf(dev.gvart.genesara.player.ScalingEffect.SLASH_DAMAGE_BONUS to 5.0))
+
+        val (_, events) = assertNotNull(
+            reduceAttack(
+                state, WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithUnmappedWeapon(), agents(strength = 10, luck = 0, dex = 0),
+                unmappedWeaponEquipped(),
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor,
+                rng = Random(seed = 1L), scaling = scaling, tick = 1,
+            ).getOrNull(),
+        )
+
+        val attacked = assertIs<WorldEvent.AgentAttacked>(events.single())
+        assertEquals(DamageType.BLUNT, attacked.damageType)
+        // 5.0 SLASH bonus must not bleed into BLUNT damage.
+        assertEquals(20, attacked.baseDamage, "STR 10 × unarmed power 2 = 20, no SLASH bonus mapped to BLUNT")
+    }
+
+    private class StubScaling(
+        private val byEffect: Map<dev.gvart.genesara.player.ScalingEffect, Double>,
+    ) : dev.gvart.genesara.player.LevelScalingAggregator {
+        override fun bonusFor(
+            agent: dev.gvart.genesara.player.AgentId,
+            effect: dev.gvart.genesara.player.ScalingEffect,
+        ): Double = byEffect[effect] ?: 0.0
     }
 
     @Test
@@ -416,8 +496,8 @@ class AttackReducerTest {
             state, WorldCommand.AttackTarget(attacker, target),
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
-            stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), tick = 1,
+            deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
+            rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
         )
         assertEquals(
             WorldRejection.NotEnoughStamina(attacker, required = 5, available = 3),

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.world.internal.crafting
 import arrow.core.Either
 import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentId
@@ -159,7 +160,7 @@ class CraftReducerTest {
                 StubAgents(luckyAgent(luck = 5)),
                 fixedRoller(Rarity.UNCOMMON),
                 SkillProgression(skills, publisher),
-                tick = 7,
+                scaling = NoScaling, tick = 7,
             ).getOrNull(),
         )
 
@@ -202,7 +203,7 @@ class CraftReducerTest {
                 StubAgents(luckyAgent(luck = 1)),
                 fixedRoller(Rarity.RARE),
                 SkillProgression(skills, RecordingPublisher()),
-                tick = 3,
+                scaling = NoScaling, tick = 3,
             ).getOrNull(),
         )
 
@@ -242,7 +243,7 @@ class CraftReducerTest {
             StubAgents(luckyAgent()),
             fixedRoller(Rarity.COMMON),
             SkillProgression(skills, RecordingPublisher()),
-            tick = 1,
+            scaling = NoScaling, tick = 1,
         )
         val rejection = assertIs<WorldRejection.StackFull>(result.leftOrNull())
         assertEquals(healingSalve, rejection.item)
@@ -305,7 +306,7 @@ class CraftReducerTest {
             StubAgents(luckyAgent()),
             fixedRoller(Rarity.COMMON),
             SkillProgression(skills, RecordingPublisher()),
-            tick = 1,
+            scaling = NoScaling, tick = 1,
         )
         assertNotNull(result.getOrNull())
     }
@@ -353,7 +354,7 @@ class CraftReducerTest {
             StubAgents(weakAgent),
             fixedRoller(Rarity.COMMON),
             SkillProgression(skills, RecordingPublisher()),
-            tick = 1,
+            scaling = NoScaling, tick = 1,
         )
         assertIs<WorldRejection.OverEncumbered>(result.leftOrNull())
         assertTrue(store.inserted.isEmpty(), "no equipment row written on a rejected craft")
@@ -383,7 +384,7 @@ class CraftReducerTest {
             StubAgents(luckyAgent()),
             fixedRoller(Rarity.COMMON),
             SkillProgression(skills, publisher),
-            tick = 5,
+            scaling = NoScaling, tick = 5,
         )
         val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()
         assertEquals(alchemy, rec.skill)
@@ -406,7 +407,7 @@ class CraftReducerTest {
             StubAgents(luckyAgent(luck = 7)),
             capturingRoller,
             SkillProgression(skills, RecordingPublisher()),
-            tick = 1,
+            scaling = NoScaling, tick = 1,
         )
         assertEquals(25, capturingRoller.lastSkill)
         assertEquals(7, capturingRoller.lastLuck)
@@ -431,7 +432,7 @@ class CraftReducerTest {
         StubAgents(luckyAgent()),
         fixedRoller(Rarity.COMMON),
         SkillProgression(skills, RecordingPublisher()),
-        tick = 1,
+        scaling = NoScaling, tick = 1,
     )
 
     private fun luckyAgent(strength: Int = 20, luck: Int = 1): Agent = Agent(

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.world.internal.harvest
 
 import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentId
@@ -106,7 +107,7 @@ class HarvestReducerTest {
         val publisher = RecordingPublisher()
 
         val result = reduceHarvest(
-            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, tick = 7,
         )
 
         val (next, events) = assertNotNull(result.getOrNull())
@@ -132,7 +133,7 @@ class HarvestReducerTest {
         val publisher = RecordingPublisher()
 
         val result = reduceHarvest(
-            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), tick = 1,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, tick = 1,
         )
 
         val (next, events) = assertNotNull(result.getOrNull())
@@ -169,7 +170,7 @@ class HarvestReducerTest {
         val skills = StubSkillsRegistry().apply { slot(mining) }
 
         val result = reduceHarvest(
-            state, command, balance, regenItems, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), tick = 1,
+            state, command, balance, regenItems, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), scaling = NoScaling, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -185,7 +186,7 @@ class HarvestReducerTest {
         val skills = StubSkillsRegistry().apply { slot(foraging) }
 
         val result = reduceHarvest(
-            state, command, balance, items, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), tick = 1,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), scaling = NoScaling, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -199,7 +200,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
+            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
         )
 
         assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
@@ -213,7 +214,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, unknown), balance, emptyCatalog,
-            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
+            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
         )
 
         assertEquals(WorldRejection.UnknownItem(unknown), result.leftOrNull())
@@ -226,7 +227,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, berry), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
         )
 
         assertEquals(
@@ -242,7 +243,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
         )
 
         assertEquals(
@@ -258,7 +259,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
         )
 
         assertEquals(
@@ -274,7 +275,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -290,7 +291,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), highYield, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
         )
 
         val (next, events) = assertNotNull(result.getOrNull())
@@ -314,7 +315,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), tightBalance, items, store,
-            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
+            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
         )
 
         assertEquals(
@@ -333,7 +334,7 @@ class HarvestReducerTest {
         val result = reduceHarvest(
             state = stateWith(),
             WorldCommand.Harvest(agent, wood), tightBalance, items, store,
-            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
+            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -376,7 +377,7 @@ class HarvestReducerTest {
         val result = reduceHarvest(
             state = stateWith(),
             WorldCommand.Harvest(agent, wood), tightBalance, itemsWithHelmet, store,
-            skinnyAgents, helmetEquipped, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), tick = 1,
+            skinnyAgents, helmetEquipped, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
         )
 
         assertEquals(
@@ -394,7 +395,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, tick = 7,
         )
 
         assertEquals(listOf(lumberjacking to 1), skills.xpAddCalls)
@@ -414,7 +415,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, tick = 7,
         )
 
         val ev = publisher.events.filterIsInstance<AgentEvent.SkillMilestoneReached>().single()
@@ -435,7 +436,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, tick = 7,
         )
 
         val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()
@@ -452,7 +453,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, tick = 7,
         )
 
         assertTrue(publisher.events.none { it is AgentEvent.SkillRecommended })
@@ -469,7 +470,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, skillFreeItems,
-            store, agents, equipment, SkillProgression(skills, publisher), tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, tick = 7,
         )
 
         assertEquals(0, skills.xpAddCalls.size)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.world.internal.movement
 
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Climate
 import dev.gvart.genesara.world.Node
@@ -61,7 +62,7 @@ class MovementReducerTest {
     @Test
     fun `accepts move to adjacent node, deducts stamina, and emits AgentMoved`() {
         val command = WorldCommand.MoveAgent(agent, b)
-        val result = reduceMove(world, command, flatCost, NoBuildings, tick = 1)
+        val result = reduceMove(world, command, flatCost, NoBuildings, scaling = NoScaling, tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
@@ -79,7 +80,7 @@ class MovementReducerTest {
     @Test
     fun `rejects move when agent is unknown`() {
         val unknown = AgentId(UUID.randomUUID())
-        val result = reduceMove(world, WorldCommand.MoveAgent(unknown, b), flatCost, NoBuildings, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(unknown, b), flatCost, NoBuildings, scaling = NoScaling, tick = 1)
 
         assertTrue(result.isLeft())
         assertEquals(WorldRejection.UnknownAgent(unknown), result.leftOrNull())
@@ -88,14 +89,14 @@ class MovementReducerTest {
     @Test
     fun `rejects move to unknown node`() {
         val ghost = NodeId(99L)
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, ghost), flatCost, NoBuildings, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, ghost), flatCost, NoBuildings, scaling = NoScaling, tick = 1)
 
         assertEquals(WorldRejection.UnknownNode(ghost), result.leftOrNull())
     }
 
     @Test
     fun `rejects move to non-adjacent node`() {
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, c), flatCost, NoBuildings, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, c), flatCost, NoBuildings, scaling = NoScaling, tick = 1)
 
         assertEquals(WorldRejection.NotAdjacent(a, c), result.leftOrNull())
     }
@@ -103,7 +104,7 @@ class MovementReducerTest {
     @Test
     fun `rejects move when stamina is below cost`() {
         val expensive = balanceLookup(cost = 99)
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), expensive, NoBuildings, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), expensive, NoBuildings, scaling = NoScaling, tick = 1)
 
         assertEquals(
             WorldRejection.NotEnoughStamina(agent, required = 99, available = 10),
@@ -116,7 +117,7 @@ class MovementReducerTest {
         val unpainted = world.copy(
             regions = world.regions.mapValues { (_, r) -> r.copy(biome = null) },
         )
-        val result = reduceMove(unpainted, WorldCommand.MoveAgent(agent, b), flatCost, NoBuildings, tick = 1)
+        val result = reduceMove(unpainted, WorldCommand.MoveAgent(agent, b), flatCost, NoBuildings, scaling = NoScaling, tick = 1)
 
         assertEquals(WorldRejection.UnpaintedRegion(region), result.leftOrNull())
     }
@@ -131,7 +132,7 @@ class MovementReducerTest {
         val balance = object : BalanceLookup by flatCost {
             override fun isTraversable(terrain: Terrain): Boolean = terrain != Terrain.OCEAN
         }
-        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, NoBuildings, tick = 1)
+        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, NoBuildings, scaling = NoScaling, tick = 1)
 
         assertEquals(
             WorldRejection.TerrainNotTraversable(agent, b, Terrain.OCEAN),
@@ -168,7 +169,7 @@ class MovementReducerTest {
         val road = activeBuilding(node = a, hint = BuildingCategoryHint.INFRASTRUCTURE_ROAD)
         val buildings = StubBuildingsLookup(byNode = mapOf(a to listOf(road)))
 
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost10, buildings, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost10, buildings, scaling = NoScaling, tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
@@ -182,7 +183,7 @@ class MovementReducerTest {
         val road = activeBuilding(node = a, hint = BuildingCategoryHint.INFRASTRUCTURE_ROAD)
         val buildings = StubBuildingsLookup(byNode = mapOf(a to listOf(road)))
 
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost1, buildings, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost1, buildings, scaling = NoScaling, tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
@@ -203,7 +204,7 @@ class MovementReducerTest {
         val bridge = activeBuilding(node = b, hint = BuildingCategoryHint.INFRASTRUCTURE_BRIDGE)
         val buildings = StubBuildingsLookup(byNode = mapOf(b to listOf(bridge)))
 
-        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, buildings, tick = 1)
+        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, buildings, scaling = NoScaling, tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.world.internal.tick
 
 import dev.gvart.genesara.engine.Tick
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
 import dev.gvart.genesara.player.AgentProfile
 import dev.gvart.genesara.player.AgentProfileLookup
 import dev.gvart.genesara.player.SkillProgression
@@ -90,7 +91,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 7)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -112,7 +113,7 @@ class WorldTickHandlerTest {
 
         val cmd = WorldCommand.MoveAgent(agent, ghostId)
         queue.submit(cmd, appliesAtTick = 1)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
 
         handler.onTick(Tick(1, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -148,7 +149,7 @@ class WorldTickHandlerTest {
             override fun sleepRegenPerOfflineTick(): Int = 0
             override fun isTraversable(terrain: Terrain): Boolean = true
         }
-        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
+        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
 
         handler.onTick(Tick(2, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -164,7 +165,7 @@ class WorldTickHandlerTest {
         val queue = CommandQueue()
         val publisher = RecordingPublisher()
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 99)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 


### PR DESCRIPTION
Closes #66 — Step 3c of the skill-feature roadmap (`docs/skill-feature-sequence.md`).

## Summary
- **`:player`** — `ScalingEffect` enum (16 values, doc-pinned), `LevelEffect` on `Skill`, `PerkEffect.Modifier.target` migrated `String → ScalingEffect`, new `LevelScalingAggregator` interface + impl reading slotted skills + chosen Modifier perks.
- **`:world`** — Aggregator wired into 4 reducers: `AttackReducer` (per damage type, `MAGICAL` unmapped), `HarvestReducer` (`HARVEST_YIELD_BONUS`, capped by cell), `CraftReducer` (`CRAFT_QUALITY_BONUS` scales rarity-roller skill input), `MovementReducer` (`MOVEMENT_SPEED` divides cost, floors at 1).
- **YAML canary** — SWORD declares `level-effect: SLASH_DAMAGE_BONUS @ 0.005/level`; SWORD-150 milestone added with `Doubled Edge` (Modifier ×2 SLASH) + `Precision` (PassiveAura sibling).
- **Validators** — `SkillsValidator` rejects non-positive `perLevelPct` and partial level-effect blocks (symmetric in both lookup and props branches).
- **Tests** — Aggregator unit tests across L1/50/100/150 with/without Modifier, multi-skill summing, two-Modifier composition, cross-effect non-application, non-Modifier perks ignored. `AttackReducer` integration tests for scaled damage, Modifier-doubled scaling, `MAGICAL` no-op.
- `WorldEvent.AgentAttacked.baseDamage` KDoc updated to spell out the new post-scaling-pre-mitigation contract.

## Test plan
- [x] `./gradlew :player:test :world:test :app:test` — all green
- [x] `./gradlew compileKotlin compileTestKotlin` — all modules clean
- [x] `code-quality-reviewer` agent run on the slice; findings addressed (KDoc drift, validator symmetry, restates-the-name KDocs, two extra aggregator coverage cases)

## Out of scope (per #66)
- TriggeredPassive (#64), PassiveAura aggregator (#65), ActiveAbility (#67) — sibling Step 3 slices
- Catalog v1 (#68) — only the SWORD canary scaling lives here; other skills' `level-effect` fields land with the catalog
- Reducer integration tests for non-canary `ScalingEffect` paths (Harvest/Craft/Movement) — wired but not unit-tested with non-zero scaling; consistent with the codebase's canary-style coverage convention.