### PR TITLE
feat(player,world): triggered-passive perk system + reducer hooks (#64)

### DIFF
--- a/docs/skill-feature-sequence.md
+++ b/docs/skill-feature-sequence.md
@@ -10,16 +10,16 @@
 
 > **HOW TO USE.** When the user says "move on to next step", look here. The next unchecked box is the next slice. When a slice merges, tick the box and update **Current step** below. This file is the single source of truth for roadmap position; per-issue acceptance criteria stay tracked inside each GitHub issue.
 
-**Current step:** ⏭ **Step 3 — effect-type slices** (Steps 1–2 merged)
+**Current step:** ⏭ **Step 3 — effect-type slices** (Steps 1, 2, 3a, 3c merged; 3b/3d remaining)
 
 ### Track A — Phase 1 mechanics + catalog
 
 - [x] **Step 1** — [#62](https://github.com/Genesara/genesara-engine/issues/62) Skill perks: data shape + canary perk *(foundation; blocks all others)*
 - [x] **Step 2** — [#63](https://github.com/Genesara/genesara-engine/issues/63) Perk selection flow (events + `select_perk`)
 - Step 3 — effect-type slices (any order; can be parallelised by independent contributors):
-  - [ ] **Step 3a** — [#64](https://github.com/Genesara/genesara-engine/issues/64) TriggeredPassive system *(soft-coordinates with #15 Combat — see "Combat-coupling note" below)*
+  - [x] **Step 3a** — [#64](https://github.com/Genesara/genesara-engine/issues/64) TriggeredPassive system *(soft-coordinates with #15 Combat — see "Combat-coupling note" below)*
   - [ ] **Step 3b** — [#65](https://github.com/Genesara/genesara-engine/issues/65) PassiveAura aggregator
-  - [ ] **Step 3c** — [#66](https://github.com/Genesara/genesara-engine/issues/66) Per-level scaling + Modifier perk
+  - [x] **Step 3c** — [#66](https://github.com/Genesara/genesara-engine/issues/66) Per-level scaling + Modifier perk
   - [ ] **Step 3d** — [#67](https://github.com/Genesara/genesara-engine/issues/67) Active ability system + `use_ability` *(soft-coordinates with #15 Combat)*
 - [ ] **Step 4** — [#68](https://github.com/Genesara/genesara-engine/issues/68) Skill+perk catalog v1 *(blocked by all of step 3)*
 

--- a/player/build.gradle.kts
+++ b/player/build.gradle.kts
@@ -19,5 +19,5 @@ dependencies {
 
 jooqModule {
     migrationsSubdir.set("player")
-    tableIncludes.set("agents|agent_profiles|agent_skills|agent_skill_slots|agent_skill_recommendations|agent_perks")
+    tableIncludes.set("agents|agent_profiles|agent_skills|agent_skill_slots|agent_skill_recommendations|agent_perks|agent_perk_cooldowns")
 }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/PerkCooldownStore.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/PerkCooldownStore.kt
@@ -1,0 +1,8 @@
+package dev.gvart.genesara.player
+
+interface PerkCooldownStore {
+
+    fun isReady(agent: AgentId, perk: PerkId, tick: Long): Boolean
+
+    fun arm(agent: AgentId, perk: PerkId, untilTick: Long)
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/TriggeredPassiveLookup.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/TriggeredPassiveLookup.kt
@@ -1,0 +1,11 @@
+package dev.gvart.genesara.player
+
+interface TriggeredPassiveLookup {
+
+    fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<TriggeredPerk>
+}
+
+data class TriggeredPerk(
+    val perk: Perk,
+    val effect: PerkEffect.TriggeredPassive,
+)

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/perks/TriggeredPassiveLookupImpl.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/perks/TriggeredPassiveLookupImpl.kt
@@ -1,0 +1,42 @@
+package dev.gvart.genesara.player.internal.perks
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentPerksRegistry
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkLookup
+import dev.gvart.genesara.player.TriggeredPassiveLookup
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import dev.gvart.genesara.player.TriggeredPerk
+import org.springframework.stereotype.Component
+
+// TODO(perks-hot-path): AttackReducer fires up to 5 triggers per attack, each
+// invoking matching() and re-snapshotting agent_perks + agent_skills. Add a
+// matchingMany(triggers: Set<…>) so one snapshot pair covers a whole attack —
+// or memoize per-tick — before this becomes the dominant query cost on the
+// combat path.
+@Component
+internal class TriggeredPassiveLookupImpl(
+    private val perks: PerkLookup,
+    private val perksRegistry: AgentPerksRegistry,
+    private val skillsRegistry: AgentSkillsRegistry,
+) : TriggeredPassiveLookup {
+
+    override fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<TriggeredPerk> {
+        val chosen = perksRegistry.snapshot(agent).perks
+        if (chosen.isEmpty()) return emptyList()
+
+        val slottedSkills = skillsRegistry.snapshot(agent).perSkill.values
+            .filter { it.slotIndex != null }
+            .mapTo(mutableSetOf()) { it.skill }
+        if (slottedSkills.isEmpty()) return emptyList()
+
+        return chosen.mapNotNull { chosenPerk ->
+            if (chosenPerk.skill !in slottedSkills) return@mapNotNull null
+            val perk = perks.byId(chosenPerk.perkId) ?: return@mapNotNull null
+            val effect = perk.effect as? PerkEffect.TriggeredPassive ?: return@mapNotNull null
+            if (effect.trigger != trigger) return@mapNotNull null
+            TriggeredPerk(perk, effect)
+        }
+    }
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqPerkCooldownStore.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqPerkCooldownStore.kt
@@ -1,0 +1,38 @@
+package dev.gvart.genesara.player.internal.store
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.PerkCooldownStore
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENT_PERK_COOLDOWNS
+import org.jooq.DSLContext
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+internal class JooqPerkCooldownStore(
+    private val dsl: DSLContext,
+) : PerkCooldownStore {
+
+    @Transactional(readOnly = true)
+    override fun isReady(agent: AgentId, perk: PerkId, tick: Long): Boolean {
+        val until = dsl.select(AGENT_PERK_COOLDOWNS.COOLDOWN_UNTIL_TICK)
+            .from(AGENT_PERK_COOLDOWNS)
+            .where(AGENT_PERK_COOLDOWNS.AGENT_ID.eq(agent.id))
+            .and(AGENT_PERK_COOLDOWNS.PERK_ID.eq(perk.value))
+            .fetchOne(AGENT_PERK_COOLDOWNS.COOLDOWN_UNTIL_TICK)
+            ?: return true
+        return tick >= until
+    }
+
+    @Transactional
+    override fun arm(agent: AgentId, perk: PerkId, untilTick: Long) {
+        dsl.insertInto(AGENT_PERK_COOLDOWNS)
+            .set(AGENT_PERK_COOLDOWNS.AGENT_ID, agent.id)
+            .set(AGENT_PERK_COOLDOWNS.PERK_ID, perk.value)
+            .set(AGENT_PERK_COOLDOWNS.COOLDOWN_UNTIL_TICK, untilTick)
+            .onConflict(AGENT_PERK_COOLDOWNS.AGENT_ID, AGENT_PERK_COOLDOWNS.PERK_ID)
+            .doUpdate()
+            .set(AGENT_PERK_COOLDOWNS.COOLDOWN_UNTIL_TICK, untilTick)
+            .execute()
+    }
+}

--- a/player/src/main/resources/db/migration/player/V206__agent_perk_cooldowns.sql
+++ b/player/src/main/resources/db/migration/player/V206__agent_perk_cooldowns.sql
@@ -1,0 +1,9 @@
+-- Per-agent internal cooldowns for TriggeredPassive perks.
+-- TODO(perks-maintenance): expired rows accumulate forever; add a sweep when
+-- the perk catalog grows beyond canary scale.
+CREATE TABLE agent_perk_cooldowns (
+    agent_id            UUID        NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    perk_id             VARCHAR(64) NOT NULL,
+    cooldown_until_tick BIGINT      NOT NULL,
+    PRIMARY KEY (agent_id, perk_id)
+);

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/perks/TriggeredPassiveLookupImplTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/perks/TriggeredPassiveLookupImplTest.kt
@@ -1,0 +1,205 @@
+package dev.gvart.genesara.player.internal.perks
+
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentPerk
+import dev.gvart.genesara.player.AgentPerksRegistry
+import dev.gvart.genesara.player.AgentPerksSnapshot
+import dev.gvart.genesara.player.AgentSkillState
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.Perk
+import dev.gvart.genesara.player.PerkChoice
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.PerkLookup
+import dev.gvart.genesara.player.RecordPerkResult
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.player.TriggeredPassiveEffectKind
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TriggeredPassiveLookupImplTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val sword = SkillId("SWORD")
+    private val bow = SkillId("BOW")
+
+    private val bleeder = perk(
+        id = "SWORD_BLEEDER",
+        skill = sword,
+        effect = triggered(TriggeredPassiveTrigger.ON_HIT_DEALT, TriggeredPassiveEffectKind.APPLY_STATUS_TO_TARGET, cd = 8),
+    )
+    private val swordCrit = perk(
+        id = "SWORD_CRIT_HEAL",
+        skill = sword,
+        effect = triggered(TriggeredPassiveTrigger.ON_CRIT, TriggeredPassiveEffectKind.HEAL_SELF, cd = 12),
+    )
+    private val bowKill = perk(
+        id = "BOW_HUNT_BOUNTY",
+        skill = bow,
+        effect = triggered(TriggeredPassiveTrigger.ON_KILL, TriggeredPassiveEffectKind.GRANT_BONUS_ITEM, cd = 30),
+    )
+    private val sharpen = perk(
+        id = "SWORD_SHARPEN_EDGE",
+        skill = sword,
+        effect = PerkEffect.PassiveAura(auraKey = "SLASH_DAMAGE_FLAT", magnitude = 5.0),
+    )
+
+    @Test
+    fun `returns empty when agent has chosen no perks`() {
+        val lookup = lookup(
+            perks = listOf(bleeder),
+            chosen = emptyList(),
+            slotted = mapOf(sword to 1),
+        )
+        assertTrue(lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_DEALT).isEmpty())
+    }
+
+    @Test
+    fun `returns empty when no skill is slotted, even if perk is chosen`() {
+        val lookup = lookup(
+            perks = listOf(bleeder),
+            chosen = listOf(bleeder),
+            slotted = emptyMap(),
+        )
+        assertTrue(lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_DEALT).isEmpty())
+    }
+
+    @Test
+    fun `returns empty when owning skill is not slotted`() {
+        val lookup = lookup(
+            perks = listOf(bleeder),
+            chosen = listOf(bleeder),
+            slotted = mapOf(bow to 1),
+        )
+        assertTrue(lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_DEALT).isEmpty())
+    }
+
+    @Test
+    fun `returns the matching perk when chosen + slotted + trigger lines up`() {
+        val lookup = lookup(
+            perks = listOf(bleeder),
+            chosen = listOf(bleeder),
+            slotted = mapOf(sword to 50),
+        )
+        val result = lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_DEALT)
+        assertEquals(1, result.size)
+        assertEquals(bleeder.id, result.single().perk.id)
+    }
+
+    @Test
+    fun `filters out perks bound to a different trigger`() {
+        val lookup = lookup(
+            perks = listOf(bleeder, swordCrit),
+            chosen = listOf(bleeder, swordCrit),
+            slotted = mapOf(sword to 100),
+        )
+        val onHit = lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_DEALT).map { it.perk.id }
+        assertEquals(listOf(bleeder.id), onHit)
+
+        val onCrit = lookup.matching(agent, TriggeredPassiveTrigger.ON_CRIT).map { it.perk.id }
+        assertEquals(listOf(swordCrit.id), onCrit)
+    }
+
+    @Test
+    fun `ignores non-TriggeredPassive effects`() {
+        val lookup = lookup(
+            perks = listOf(bleeder, sharpen),
+            chosen = listOf(bleeder, sharpen),
+            slotted = mapOf(sword to 50),
+        )
+        val result = lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_DEALT)
+        assertEquals(listOf(bleeder.id), result.map { it.perk.id })
+    }
+
+    @Test
+    fun `returns all matching perks across multiple slotted skills (no first-match-wins)`() {
+        val swordOnKill = perk(
+            id = "SWORD_VICTORY_ROAR",
+            skill = sword,
+            effect = triggered(TriggeredPassiveTrigger.ON_KILL, TriggeredPassiveEffectKind.GRANT_SELF_BUFF, cd = 5),
+        )
+        val lookup = lookup(
+            perks = listOf(swordOnKill, bowKill),
+            chosen = listOf(swordOnKill, bowKill),
+            slotted = mapOf(sword to 100, bow to 100),
+        )
+        val result = lookup.matching(agent, TriggeredPassiveTrigger.ON_KILL).map { it.perk.id }.toSet()
+        assertEquals(setOf(swordOnKill.id, bowKill.id), result)
+    }
+
+    private fun lookup(perks: List<Perk>, chosen: List<Perk>, slotted: Map<SkillId, Int>) =
+        TriggeredPassiveLookupImpl(
+            perks = StubPerkLookup(perks),
+            perksRegistry = StubPerksRegistry(chosen),
+            skillsRegistry = StubSkillsRegistry(slotted),
+        )
+
+    private fun perk(id: String, skill: SkillId, effect: PerkEffect): Perk = Perk(
+        id = PerkId(id),
+        skill = skill,
+        milestoneLevel = 50,
+        displayName = id,
+        description = id,
+        effect = effect,
+    )
+
+    private fun triggered(
+        trigger: TriggeredPassiveTrigger,
+        effectKind: TriggeredPassiveEffectKind,
+        cd: Int,
+    ) = PerkEffect.TriggeredPassive(
+        trigger = trigger,
+        effectKind = effectKind,
+        params = emptyMap(),
+        internalCooldownTicks = cd,
+    )
+
+    private class StubPerkLookup(private val perks: List<Perk>) : PerkLookup {
+        private val byId = perks.associateBy { it.id }
+        override fun byId(id: PerkId): Perk? = byId[id]
+        override fun choicesAt(skill: SkillId, milestoneLevel: Int): PerkChoice? = null
+        override fun choicesFor(skill: SkillId): List<PerkChoice> = emptyList()
+        override fun all(): List<Perk> = perks
+    }
+
+    private class StubPerksRegistry(private val chosen: List<Perk>) : AgentPerksRegistry {
+        override fun snapshot(agent: AgentId): AgentPerksSnapshot = AgentPerksSnapshot(
+            perks = chosen.map { p ->
+                AgentPerk(
+                    skill = p.skill,
+                    milestoneLevel = p.milestoneLevel,
+                    perkId = p.id,
+                    chosenAtTick = 0,
+                )
+            },
+        )
+        override fun recordChoice(agent: AgentId, perk: PerkId, tick: Long): RecordPerkResult =
+            RecordPerkResult.Recorded
+    }
+
+    private class StubSkillsRegistry(private val slotted: Map<SkillId, Int>) : AgentSkillsRegistry {
+        override fun snapshot(agent: AgentId): AgentSkillsSnapshot = AgentSkillsSnapshot(
+            perSkill = slotted.entries.mapIndexed { idx, (skill, level) ->
+                skill to AgentSkillState(
+                    skill = skill,
+                    xp = 0,
+                    level = level,
+                    slotIndex = idx,
+                    recommendCount = 0,
+                )
+            }.toMap(),
+            slotCount = slotted.size,
+            slotsFilled = slotted.size,
+        )
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int): AddXpResult =
+            AddXpResult.Unslotted
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? = null
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? = null
+    }
+}

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqPerkCooldownStoreIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqPerkCooldownStoreIntegrationTest.kt
@@ -1,0 +1,122 @@
+package dev.gvart.genesara.player.internal.store
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENTS
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENT_PERK_COOLDOWNS
+import dev.gvart.genesara.player.internal.testsupport.PlayerFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@Testcontainers
+class JooqPerkCooldownStoreIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("player_perk_cd_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = PlayerFlyway.pooledDataSource(postgres)
+            PlayerFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private val perk = PerkId("SWORD_BLEEDER")
+
+    private lateinit var store: JooqPerkCooldownStore
+    private var agent: AgentId = AgentId(UUID.randomUUID())
+
+    @BeforeEach
+    fun resetTables() {
+        dsl.truncate(AGENT_PERK_COOLDOWNS).cascade().execute()
+        dsl.truncate(AGENTS).cascade().execute()
+        agent = createAgent()
+        store = JooqPerkCooldownStore(dsl)
+    }
+
+    @Test
+    fun `unarmed perk is ready by default`() {
+        assertTrue(store.isReady(agent, perk, tick = 0L))
+    }
+
+    @Test
+    fun `arm blocks until the gate tick`() {
+        store.arm(agent, perk, untilTick = 10L)
+
+        assertFalse(store.isReady(agent, perk, tick = 9L))
+        assertTrue(store.isReady(agent, perk, tick = 10L), "gate tick is inclusive — perk fires at exactly until-tick")
+        assertTrue(store.isReady(agent, perk, tick = 11L))
+    }
+
+    @Test
+    fun `re-arm overwrites the prior gate tick`() {
+        store.arm(agent, perk, untilTick = 5L)
+        store.arm(agent, perk, untilTick = 20L)
+
+        assertFalse(store.isReady(agent, perk, tick = 10L))
+        assertTrue(store.isReady(agent, perk, tick = 20L))
+        assertEquals(1, dsl.fetchCount(AGENT_PERK_COOLDOWNS), "single (agent, perk) row is upserted")
+    }
+
+    @Test
+    fun `cooldowns are scoped per agent and per perk`() {
+        val otherAgent = createAgent()
+        val otherPerk = PerkId("SWORD_PRECISION")
+
+        store.arm(agent, perk, untilTick = 100L)
+
+        assertFalse(store.isReady(agent, perk, tick = 50L))
+        assertTrue(store.isReady(otherAgent, perk, tick = 50L))
+        assertTrue(store.isReady(agent, otherPerk, tick = 50L))
+    }
+
+    private fun createAgent(): AgentId {
+        val id = AgentId(UUID.randomUUID())
+        dsl.insertInto(AGENTS)
+            .set(AGENTS.ID, id.id)
+            .set(AGENTS.OWNER_ID, UUID.randomUUID())
+            .set(AGENTS.NAME, "test-${id.id.toString().take(6)}")
+            .set(AGENTS.RACE_ID, "human_commoner")
+            .set(AGENTS.LEVEL, 1)
+            .set(AGENTS.XP_CURRENT, 0)
+            .set(AGENTS.XP_TO_NEXT, 100)
+            .set(AGENTS.UNSPENT_ATTRIBUTE_POINTS, 5)
+            .set(AGENTS.STRENGTH, 5)
+            .set(AGENTS.DEXTERITY, 5)
+            .set(AGENTS.CONSTITUTION, 5)
+            .set(AGENTS.PERCEPTION, 5)
+            .set(AGENTS.INTELLIGENCE, 5)
+            .set(AGENTS.LUCK, 5)
+            .execute()
+        return id
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
@@ -1,6 +1,9 @@
 package dev.gvart.genesara.world.events
 
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.TriggeredPassiveEffectKind
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
 import dev.gvart.genesara.world.BodyDelta
 import dev.gvart.genesara.world.Building
 import dev.gvart.genesara.world.DamageType
@@ -269,5 +272,17 @@ sealed interface WorldEvent {
         val targetKilled: Boolean,
         override val tick: Long,
         val causedBy: UUID,
+    ) : WorldEvent
+
+    /** `target` is set only for combat triggers (OnHit*, OnCrit, OnKill, OnDodge). */
+    data class PerkTriggered(
+        val agent: AgentId,
+        val perkId: PerkId,
+        val trigger: TriggeredPassiveTrigger,
+        val effectKind: TriggeredPassiveEffectKind,
+        val params: Map<String, String>,
+        val target: AgentId?,
+        override val tick: Long,
+        val causedBy: UUID?,
     ) : WorldEvent
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -33,6 +33,7 @@ import dev.gvart.genesara.world.internal.death.reduceSetSafeNode
 import dev.gvart.genesara.world.internal.drink.reduceDrink
 import dev.gvart.genesara.world.internal.harvest.reduceHarvest
 import dev.gvart.genesara.world.internal.movement.reduceMove
+import dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcher
 import dev.gvart.genesara.world.internal.pickup.reducePickup
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.spawn.SpawnLocationResolver
@@ -64,6 +65,7 @@ internal fun reduce(
     spawnLocationResolver: SpawnLocationResolver,
     groundItems: GroundItemStore,
     deathProcessor: DeathProcessor,
+    triggeredPassives: TriggeredPassiveDispatcher,
     tick: Long,
     rng: Random = Random.Default,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = when (command) {
@@ -71,13 +73,19 @@ internal fun reduce(
     is WorldCommand.MoveAgent -> reduceMove(state, command, balance, buildingsLookup, scaling, tick)
     is WorldCommand.UnspawnAgent -> reduceUnspawn(state, command, tick)
     is WorldCommand.Harvest ->
-        reduceHarvest(state, command, balance, items, resources, agents, equipment, progression, scaling, tick)
+        reduceHarvest(
+            state, command, balance, items, resources, agents, equipment,
+            progression, scaling, triggeredPassives, tick,
+        )
     is WorldCommand.ConsumeItem -> reduceConsume(state, command, items, tick)
     is WorldCommand.Drink -> reduceDrink(state, command, balance, buildingsLookup, tick)
     is WorldCommand.SetSafeNode -> reduceSetSafeNode(state, command, safeNodes, tick)
     is WorldCommand.Respawn -> reduceRespawn(state, command, profiles, safeNodes, safeNodeResolver, tick)
     is WorldCommand.BuildStructure ->
-        reduceBuild(state, command, buildingsCatalog, skills, buildings, safeNodes, progression, tick)
+        reduceBuild(
+            state, command, buildingsCatalog, skills, buildings, safeNodes,
+            progression, triggeredPassives, tick,
+        )
     is WorldCommand.DepositToChest ->
         reduceDeposit(state, command, items, buildingsCatalog, buildings, chestContents, tick)
     is WorldCommand.WithdrawFromChest ->
@@ -85,13 +93,13 @@ internal fun reduce(
     is WorldCommand.CraftItem ->
         reduceCraft(
             state, command, balance, items, recipes, equipment, buildingsLookup,
-            skills, agents, rarityRoller, progression, scaling, tick,
+            skills, agents, rarityRoller, progression, scaling, triggeredPassives, tick,
         )
     is WorldCommand.Pickup ->
         reducePickup(state, command, balance, items, agents, equipment, groundItems, tick)
     is WorldCommand.AttackTarget ->
         reduceAttack(
             state, command, balance, items, agents, equipment, progression, scaling,
-            deathProcessor, rng, tick,
+            deathProcessor, triggeredPassives, rng, tick,
         )
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
@@ -8,6 +8,7 @@ import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
 import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.Building
 import dev.gvart.genesara.world.BuildingStatus
@@ -17,6 +18,8 @@ import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.inventory.AgentInventory
+import dev.gvart.genesara.world.internal.perks.TriggerContext
+import dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcher
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import java.util.UUID
 
@@ -33,6 +36,7 @@ internal fun reduceBuild(
     buildings: BuildingsStore,
     safeNodes: AgentSafeNodeGateway,
     progression: SkillProgression,
+    triggeredPassives: TriggeredPassiveDispatcher,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
@@ -101,7 +105,18 @@ internal fun reduceBuild(
     val next = state
         .updateBody(command.agent, body.spendStamina(def.staminaPerStep))
         .updateInventory(command.agent, nextInventory)
-    next to listOf(event)
+    val triggered = if (event is WorldEvent.BuildingCompleted) {
+        triggeredPassives.dispatch(
+            firer = command.agent,
+            trigger = TriggeredPassiveTrigger.ON_BUILD_COMPLETE,
+            ctx = TriggerContext.None,
+            tick = tick,
+            causedBy = command.commandId,
+        )
+    } else {
+        emptyList()
+    }
+    next to (listOf(event) + triggered)
 }
 
 private fun Raise<WorldRejection>.requireMaterials(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
@@ -9,6 +9,7 @@ import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
 import dev.gvart.genesara.world.DamageType
 import dev.gvart.genesara.world.EquipSlot
 import dev.gvart.genesara.world.EquipmentInstanceStore
@@ -21,6 +22,8 @@ import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.death.AttackCause
 import dev.gvart.genesara.world.internal.death.DeathProcessor
+import dev.gvart.genesara.world.internal.perks.TriggerContext
+import dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcher
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import kotlin.random.Random
 
@@ -51,6 +54,7 @@ internal fun reduceAttack(
     progression: SkillProgression,
     scaling: LevelScalingAggregator,
     deathProcessor: DeathProcessor,
+    triggeredPassives: TriggeredPassiveDispatcher,
     rng: Random,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
@@ -136,6 +140,55 @@ internal fun reduceAttack(
     )
 
     val emitted = mutableListOf<WorldEvent>(attackEvent)
+    val attackerCombatCtx = TriggerContext.Combat(target = command.target)
+    val defenderCombatCtx = TriggerContext.Combat(target = command.agent)
+    if (isDodged) {
+        emitted += triggeredPassives.dispatch(
+            firer = command.target,
+            trigger = TriggeredPassiveTrigger.ON_DODGE,
+            ctx = defenderCombatCtx,
+            tick = tick,
+            causedBy = command.commandId,
+        )
+    } else {
+        emitted += triggeredPassives.dispatch(
+            firer = command.agent,
+            trigger = TriggeredPassiveTrigger.ON_HIT_DEALT,
+            ctx = attackerCombatCtx,
+            tick = tick,
+            causedBy = command.commandId,
+        )
+        emitted += triggeredPassives.dispatch(
+            firer = command.target,
+            trigger = TriggeredPassiveTrigger.ON_HIT_TAKEN,
+            ctx = defenderCombatCtx,
+            tick = tick,
+            causedBy = command.commandId,
+        )
+        if (isCrit) {
+            emitted += triggeredPassives.dispatch(
+                firer = command.agent,
+                trigger = TriggeredPassiveTrigger.ON_CRIT,
+                ctx = attackerCombatCtx,
+                tick = tick,
+                causedBy = command.commandId,
+            )
+        }
+        // OnLowHp fires even on the killing blow so a "second wind" perk surfaces
+        // alongside the death — order in the stream is `OnHitTaken → OnLowHp → death`.
+        emitted += triggeredPassives.dispatch(
+            firer = command.target,
+            trigger = TriggeredPassiveTrigger.ON_LOW_HP,
+            ctx = TriggerContext.HpChange(
+                maxHp = targetBody.maxHp,
+                prevHp = targetBody.hp,
+                newHp = nextTargetBody.hp,
+            ),
+            tick = tick,
+            causedBy = command.commandId,
+        )
+    }
+
     if (nextTargetBody.hp == 0) {
         val (afterDeath, deathEvents) = deathProcessor.applyDeath(
             state = nextState,
@@ -147,6 +200,13 @@ internal fun reduceAttack(
         )
         nextState = afterDeath
         emitted += deathEvents
+        emitted += triggeredPassives.dispatch(
+            firer = command.agent,
+            trigger = TriggeredPassiveTrigger.ON_KILL,
+            ctx = attackerCombatCtx,
+            tick = tick,
+            causedBy = command.commandId,
+        )
     }
 
     nextState to emitted.toList()

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
@@ -11,6 +11,7 @@ import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.EquipmentInstance
 import dev.gvart.genesara.world.EquipmentInstanceStore
@@ -28,6 +29,8 @@ import dev.gvart.genesara.world.internal.inventory.AgentInventory
 import dev.gvart.genesara.world.internal.inventory.enforceCarryCap
 import dev.gvart.genesara.world.internal.inventory.equippedGrams
 import dev.gvart.genesara.world.internal.inventory.totalGrams
+import dev.gvart.genesara.world.internal.perks.TriggerContext
+import dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcher
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import java.util.UUID
 
@@ -50,6 +53,7 @@ internal fun reduceCraft(
     rarityRoller: RarityRoller,
     progression: SkillProgression,
     scaling: LevelScalingAggregator,
+    triggeredPassives: TriggeredPassiveDispatcher,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
@@ -121,7 +125,14 @@ internal fun reduceCraft(
     val next = state
         .updateBody(command.agent, body.spendStamina(recipe.staminaCost))
         .updateInventory(command.agent, mutation.nextInventory)
-    next to listOf(mutation.event)
+    val triggered = triggeredPassives.dispatch(
+        firer = command.agent,
+        trigger = TriggeredPassiveTrigger.ON_CRAFT_COMPLETE,
+        ctx = TriggerContext.None,
+        tick = tick,
+        causedBy = command.commandId,
+    )
+    next to (listOf(mutation.event) + triggered)
 }
 
 private fun Raise<WorldRejection>.requireMaterials(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
@@ -10,6 +10,7 @@ import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
 import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.ItemLookup
@@ -21,6 +22,8 @@ import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.inventory.enforceCarryCap
 import dev.gvart.genesara.world.internal.inventory.equippedGrams
 import dev.gvart.genesara.world.internal.inventory.totalGrams
+import dev.gvart.genesara.world.internal.perks.TriggerContext
+import dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcher
 import dev.gvart.genesara.world.internal.resources.NodeResourceCell
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.worldstate.WorldState
@@ -42,6 +45,7 @@ internal fun reduceHarvest(
     equipment: EquipmentInstanceStore,
     progression: SkillProgression,
     scaling: LevelScalingAggregator,
+    triggeredPassives: TriggeredPassiveDispatcher,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
@@ -93,7 +97,14 @@ internal fun reduceHarvest(
         tick = tick,
         causedBy = command.commandId,
     )
-    next to listOf(event)
+    val triggered = triggeredPassives.dispatch(
+        firer = command.agent,
+        trigger = TriggeredPassiveTrigger.ON_HARVEST_COMPLETE,
+        ctx = TriggerContext.None,
+        tick = tick,
+        causedBy = command.commandId,
+    )
+    next to (listOf(event) + triggered)
 }
 
 /**

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/perks/TriggeredPassiveDispatcher.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/perks/TriggeredPassiveDispatcher.kt
@@ -1,0 +1,82 @@
+package dev.gvart.genesara.world.internal.perks
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.PerkCooldownStore
+import dev.gvart.genesara.player.TriggeredPassiveLookup
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import dev.gvart.genesara.player.TriggeredPerk
+import dev.gvart.genesara.world.events.WorldEvent
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+sealed interface TriggerContext {
+    data object None : TriggerContext
+
+    data class Combat(val target: AgentId) : TriggerContext
+
+    data class HpChange(val maxHp: Int, val prevHp: Int, val newHp: Int) : TriggerContext
+}
+
+// TODO(perk-effects): slice 1 stops at PerkTriggered emission. Per-effect-kind
+// resolvers (HEAL_SELF, APPLY_STATUS_TO_TARGET, DEAL_BONUS_DAMAGE, …) attach to
+// the event in follow-up slices.
+interface TriggeredPassiveDispatcher {
+    fun dispatch(
+        firer: AgentId,
+        trigger: TriggeredPassiveTrigger,
+        ctx: TriggerContext,
+        tick: Long,
+        causedBy: UUID?,
+    ): List<WorldEvent>
+}
+
+@Component
+internal class TriggeredPassiveDispatcherImpl(
+    private val lookup: TriggeredPassiveLookup,
+    private val cooldowns: PerkCooldownStore,
+) : TriggeredPassiveDispatcher {
+
+    override fun dispatch(
+        firer: AgentId,
+        trigger: TriggeredPassiveTrigger,
+        ctx: TriggerContext,
+        tick: Long,
+        causedBy: UUID?,
+    ): List<WorldEvent> {
+        val candidates = lookup.matching(firer, trigger)
+        if (candidates.isEmpty()) return emptyList()
+
+        val emitted = mutableListOf<WorldEvent>()
+        for (candidate in candidates) {
+            if (!shouldFire(candidate, ctx)) continue
+            if (!cooldowns.isReady(firer, candidate.perk.id, tick)) continue
+
+            cooldowns.arm(firer, candidate.perk.id, tick + candidate.effect.internalCooldownTicks)
+            emitted += WorldEvent.PerkTriggered(
+                agent = firer,
+                perkId = candidate.perk.id,
+                trigger = trigger,
+                effectKind = candidate.effect.effectKind,
+                params = candidate.effect.params,
+                target = (ctx as? TriggerContext.Combat)?.target,
+                tick = tick,
+                causedBy = causedBy,
+            )
+        }
+        return emitted
+    }
+
+    private fun shouldFire(perk: TriggeredPerk, ctx: TriggerContext): Boolean = when (perk.effect.trigger) {
+        TriggeredPassiveTrigger.ON_LOW_HP -> evaluateHpBandCross(perk, ctx)
+        else -> true
+    }
+
+    // Descending-edge only: `prev > limit && new <= limit` is naturally idempotent —
+    // successive damage while already below the band cannot re-satisfy `prev > limit`.
+    private fun evaluateHpBandCross(perk: TriggeredPerk, ctx: TriggerContext): Boolean {
+        if (ctx !is TriggerContext.HpChange) return false
+        val thresholdPct = perk.effect.params["thresholdPct"]?.toIntOrNull() ?: return false
+        val limit = ctx.maxHp * thresholdPct / 100
+        return ctx.prevHp > limit && ctx.newHp <= limit
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -22,6 +22,7 @@ import dev.gvart.genesara.world.internal.death.DeathProcessor
 import dev.gvart.genesara.world.internal.death.SafeNodeResolver
 import dev.gvart.genesara.world.internal.death.processDeaths
 import dev.gvart.genesara.world.internal.passive.applyPassives
+import dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcher
 import dev.gvart.genesara.world.internal.reduce
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.spawn.SpawnLocationResolver
@@ -57,6 +58,7 @@ internal class WorldTickHandler(
     private val spawnLocationResolver: SpawnLocationResolver,
     private val groundItems: GroundItemStore,
     private val deathProcessor: DeathProcessor,
+    private val triggeredPassives: TriggeredPassiveDispatcher,
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -85,7 +87,7 @@ internal class WorldTickHandler(
                 state, command, balance, profiles, items, recipes, resources, skills, agents, equipment,
                 safeNodes, safeNodeResolver, buildings, buildingsLookup, buildingsCatalog, chestContents,
                 rarityRoller, progression, scaling, spawnLocationResolver, groundItems, deathProcessor,
-                tick.number,
+                triggeredPassives, tick.number,
             ).fold(
                 ifLeft = { rejection ->
                     log.info("Rejected {} at tick {}: {}", command, tick.number, rejection)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.buildings
 
+import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentSkillState
@@ -108,7 +109,7 @@ class BuildReducerTest {
         val (next, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                catalog, skills, store, safeNodes, SkillProgression(skills, publisher), tick = 7,
+                catalog, skills, store, safeNodes, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
             ).getOrNull(),
         )
 
@@ -138,7 +139,7 @@ class BuildReducerTest {
         val (next, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                catalog, skills, store, safeNodes, SkillProgression(skills, publisher), tick = 9,
+                catalog, skills, store, safeNodes, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 9,
             ).getOrNull(),
         )
 
@@ -163,7 +164,7 @@ class BuildReducerTest {
         val (_, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, publisher), tick = 11,
+                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 11,
             ).getOrNull(),
         )
 
@@ -191,7 +192,7 @@ class BuildReducerTest {
         val (next, _) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                customCatalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 1,
+                customCatalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
             ).getOrNull(),
         )
 
@@ -208,7 +209,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.SHELTER),
-            catalog, skills, store, safeNodes, SkillProgression(skills, RecordingPublisher()), tick = 11,
+            catalog, skills, store, safeNodes, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 11,
         )
 
         assertEquals(nodeId, safeNodes.set[agent])
@@ -224,7 +225,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, store, safeNodes, SkillProgression(skills, RecordingPublisher()), tick = 11,
+            catalog, skills, store, safeNodes, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 11,
         )
 
         assertEquals(emptyMap(), safeNodes.set)
@@ -236,7 +237,7 @@ class BuildReducerTest {
         val skills = StubSkillsRegistry()
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 1,
+            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
@@ -248,7 +249,7 @@ class BuildReducerTest {
         val skills = StubSkillsRegistry()
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 1,
+            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         assertEquals(WorldRejection.NotEnoughStamina(agent, required = 8, available = 3), result.leftOrNull())
@@ -264,7 +265,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 1,
+            catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         val rejection = assertIs<WorldRejection.InsufficientMaterials>(result.leftOrNull())
@@ -297,7 +298,7 @@ class BuildReducerTest {
         val (_, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agentB, BuildingType.CAMPFIRE),
-                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 5,
+                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 5,
             ).getOrNull(),
         )
 
@@ -316,7 +317,7 @@ class BuildReducerTest {
         val (_, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 12,
+                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 12,
             ).getOrNull(),
         )
 
@@ -342,7 +343,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            gatedCatalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 1,
+            gatedCatalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         val rejection = assertIs<WorldRejection.BuildingSkillTooLow>(result.leftOrNull())
@@ -365,7 +366,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            gatedCatalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 1,
+            gatedCatalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         assertNotNull(result.getOrNull())
@@ -383,7 +384,7 @@ class BuildReducerTest {
             val (next, events) = assertNotNull(
                 reduceBuild(
                     state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                    catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = (10 + i).toLong(),
+                    catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = (10 + i).toLong(),
                 ).getOrNull(),
             )
             state = next
@@ -406,7 +407,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), tick = 1,
+            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         assertEquals(listOf(carpentry to 1), skills.xpAddCalls)
@@ -420,7 +421,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, publisher), tick = 5,
+            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 5,
         )
 
         val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackKillIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackKillIntegrationTest.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.combat
 
+import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
@@ -148,7 +149,7 @@ class AttackKillIntegrationTest {
         val (afterFirst, firstEvents) = assertNotNull(
             reduceAttack(
                 initial, firstCommand, balance, items, agents, equipment, progression,
-                deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 1L,
+                deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1L,
             ).getOrNull(),
         )
 
@@ -162,7 +163,7 @@ class AttackKillIntegrationTest {
         val (afterSecond, secondEvents) = assertNotNull(
             reduceAttack(
                 afterFirst, secondCommand, balance, items, agents, equipment, progression,
-                deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 2L,
+                deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 2L,
             ).getOrNull(),
         )
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.combat
 
+import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
@@ -94,7 +95,7 @@ class AttackReducerTest {
             reduceAttack(
                 state, WorldCommand.AttackTarget(attacker, target),
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 5,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 5,
             ).getOrNull(),
         )
 
@@ -123,7 +124,7 @@ class AttackReducerTest {
                 state, WorldCommand.AttackTarget(attacker, target),
                 balance(), itemsWithSword(), agents(strength = 5, luck = 0, dex = 0),
                 StubEquipmentStore(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
             ).getOrNull(),
         )
 
@@ -147,7 +148,7 @@ class AttackReducerTest {
                 balance(), itemsWithSword(),
                 agents(strength = 10, luck = 0, dex = 0, targetDex = 99),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
             ).getOrNull(),
         )
 
@@ -174,7 +175,7 @@ class AttackReducerTest {
                 balance(), itemsWithSword(),
                 agents(strength = 10, luck = 99, dex = 0, targetDex = 0),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
             ).getOrNull(),
         )
 
@@ -197,7 +198,7 @@ class AttackReducerTest {
                 balance(), itemsWithUnmappedWeapon(),
                 agents(strength = 10, luck = 0, dex = 0),
                 unmappedWeaponEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
             ).getOrNull(),
         )
 
@@ -219,7 +220,7 @@ class AttackReducerTest {
                 state, command,
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 7,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
             ).getOrNull(),
         )
 
@@ -247,7 +248,7 @@ class AttackReducerTest {
                 balance(), itemsWithSword(),
                 agents(strength = 0, luck = 0, dex = 0),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
             ).getOrNull(),
         )
 
@@ -290,7 +291,7 @@ class AttackReducerTest {
                 state, command,
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, tick = 5,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 5,
             ).getOrNull(),
         )
 
@@ -310,7 +311,7 @@ class AttackReducerTest {
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
             deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
+            rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
         assertEquals(WorldRejection.CannotAttackSelf(attacker), result.leftOrNull())
     }
@@ -323,7 +324,7 @@ class AttackReducerTest {
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
             deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
+            rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
         assertEquals(WorldRejection.NotInWorld(attacker), result.leftOrNull())
     }
@@ -336,7 +337,7 @@ class AttackReducerTest {
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
             deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
+            rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
         assertEquals(WorldRejection.TargetNotInWorld(attacker, target), result.leftOrNull())
     }
@@ -349,7 +350,7 @@ class AttackReducerTest {
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
             deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
+            rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
         assertEquals(
             WorldRejection.TargetOutOfRange(attacker, target, nodeAId, nodeBId, weaponRange = 1),
@@ -368,7 +369,7 @@ class AttackReducerTest {
             reduceAttack(
                 state, WorldCommand.AttackTarget(attacker, target),
                 balance(), itemsWithBow(), agents(strength = 0, luck = 0, dex = 10), bowEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
             ).getOrNull(),
         )
 
@@ -389,7 +390,7 @@ class AttackReducerTest {
             balance(), itemsWithBow(), agents(strength = 10, luck = 0, dex = 0), bowEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
             deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
+            rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
         assertEquals(
             WorldRejection.TargetOutOfRange(attacker, target, nodeAId, nodeCId, weaponRange = 2),
@@ -405,7 +406,7 @@ class AttackReducerTest {
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
             deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
+            rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
         assertEquals(WorldRejection.TargetAlreadyDead(attacker, target), result.leftOrNull())
     }
@@ -423,7 +424,7 @@ class AttackReducerTest {
                 state, WorldCommand.AttackTarget(attacker, target),
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
                 SkillProgression(skills, publisher), deathProcessor = deathProcessor,
-                rng = Random(seed = 1L), scaling = scaling, tick = 1,
+                rng = Random(seed = 1L), scaling = scaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
             ).getOrNull(),
         )
 
@@ -447,7 +448,7 @@ class AttackReducerTest {
                 state, WorldCommand.AttackTarget(attacker, target),
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
                 SkillProgression(skills, publisher), deathProcessor = deathProcessor,
-                rng = Random(seed = 1L), scaling = scaling, tick = 1,
+                rng = Random(seed = 1L), scaling = scaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
             ).getOrNull(),
         )
 
@@ -470,7 +471,7 @@ class AttackReducerTest {
                 balance(), itemsWithUnmappedWeapon(), agents(strength = 10, luck = 0, dex = 0),
                 unmappedWeaponEquipped(),
                 SkillProgression(skills, publisher), deathProcessor = deathProcessor,
-                rng = Random(seed = 1L), scaling = scaling, tick = 1,
+                rng = Random(seed = 1L), scaling = scaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
             ).getOrNull(),
         )
 
@@ -497,7 +498,7 @@ class AttackReducerTest {
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
             deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), scaling = NoScaling, tick = 1,
+            rng = Random(seed = 1L), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
         assertEquals(
             WorldRejection.NotEnoughStamina(attacker, required = 5, available = 3),

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/BleederCanaryIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/BleederCanaryIntegrationTest.kt
@@ -1,0 +1,405 @@
+package dev.gvart.genesara.world.internal.combat
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AgentSkillState
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.DeathPenaltyOutcome
+import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
+import dev.gvart.genesara.player.Perk
+import dev.gvart.genesara.player.PerkCooldownStore
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.player.TriggeredPassiveEffectKind
+import dev.gvart.genesara.player.TriggeredPassiveLookup
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import dev.gvart.genesara.player.TriggeredPerk
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.DroppedItemView
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.Gauge
+import dev.gvart.genesara.world.GroundItemStore
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Rarity
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.ResourceSpawnRule
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.death.DeathProcessor
+import dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcherImpl
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+// Canary for issue #64 — proves the dispatcher is reachable from real reduceAttack
+// wiring with the SWORD-50 Bleeder perk. Cooldown gate semantics + band-cross
+// edge cases are covered by the dispatcher unit + cooldown-store integration tests;
+// here we only assert "the perk fires through the pipeline" and ordering invariants.
+class BleederCanaryIntegrationTest {
+
+    private val attacker = AgentId(UUID.randomUUID())
+    private val target = AgentId(UUID.randomUUID())
+    private val regionId = RegionId(1L)
+    private val nodeId = NodeId(1L)
+    private val rustySword = ItemId("RUSTY_SWORD")
+    private val swordSkill = SkillId("SWORD")
+    private val bleederId = PerkId("SWORD_BLEEDER")
+
+    private val region = Region(
+        id = regionId,
+        worldId = WorldId(1L),
+        sphereIndex = 0,
+        biome = Biome.PLAINS,
+        climate = Climate.OCEANIC,
+        centroid = Vec3(0.0, 0.0, 1.0),
+        faceVertices = emptyList(),
+        neighbors = emptySet(),
+    )
+    private val node = Node(nodeId, regionId, q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())
+
+    @Test
+    fun `Bleeder applies BLEED status on hit and respects internal cooldown`() {
+        val balance = combatBalance()
+        val items = StubItemLookup(swordItem())
+        val agents = StubAgentRegistry(
+            byId = mapOf(
+                attacker to AgentAttributes(strength = 5, luck = 0, dexterity = 0),
+                target to AgentAttributes(strength = 1, luck = 0, dexterity = 0),
+            ),
+        )
+        val equipment = StubEquipmentStore(
+            equippedByAgent = mapOf(
+                attacker to mapOf(
+                    EquipSlot.MAIN_HAND to EquipmentInstance(
+                        instanceId = UUID.randomUUID(),
+                        agentId = attacker,
+                        itemId = rustySword,
+                        rarity = Rarity.COMMON,
+                        durabilityCurrent = 50,
+                        durabilityMax = 50,
+                        creatorAgentId = null,
+                        createdAtTick = 0L,
+                        equippedInSlot = EquipSlot.MAIN_HAND,
+                    ),
+                ),
+            ),
+        )
+        val groundItems = StubGroundItemStore()
+        val deathProcessor = DeathProcessor(balance, agents, equipment, groundItems)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val progression = SkillProgression(skills, publisher)
+
+        val cd = InMemoryCooldownStore()
+        val dispatcher = TriggeredPassiveDispatcherImpl(BleederLookup(attacker), cd)
+
+        val initial = WorldState(
+            regions = mapOf(regionId to region),
+            nodes = mapOf(nodeId to node),
+            positions = mapOf(attacker to nodeId, target to nodeId),
+            bodies = mapOf(
+                attacker to AgentBody(hp = 100, maxHp = 100, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
+                target to AgentBody(hp = 200, maxHp = 200, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
+            ),
+            inventories = emptyMap(),
+        )
+
+        val firstCommand = WorldCommand.AttackTarget(attacker, target)
+        val (afterFirst, firstEvents) = assertNotNull(
+            reduceAttack(
+                initial, firstCommand, balance, items, agents, equipment, progression,
+                deathProcessor = deathProcessor, rng = Random(seed = 7L), scaling = NoScaling,
+                triggeredPassives = dispatcher, tick = 100L,
+            ).getOrNull(),
+        )
+
+        val firstAttacked = assertIs<WorldEvent.AgentAttacked>(firstEvents[0])
+        assertTrue(firstAttacked.hpLost > 0)
+        assertEquals(false, firstAttacked.isDodged)
+        val firstTriggered = firstEvents.filterIsInstance<WorldEvent.PerkTriggered>()
+        assertEquals(1, firstTriggered.size, "Bleeder fires once on the first hit")
+        firstTriggered.single().let {
+            assertEquals(attacker, it.agent)
+            assertEquals(bleederId, it.perkId)
+            assertEquals(TriggeredPassiveTrigger.ON_HIT_DEALT, it.trigger)
+            assertEquals(TriggeredPassiveEffectKind.APPLY_STATUS_TO_TARGET, it.effectKind)
+            assertEquals("BLEED", it.params["status"])
+            assertEquals("10", it.params["duration-ticks"])
+            assertEquals(target, it.target)
+        }
+        assertEquals(108L, cd.armedUntil[attacker to bleederId])
+
+        val secondCommand = WorldCommand.AttackTarget(attacker, target)
+        val (_, secondEvents) = assertNotNull(
+            reduceAttack(
+                afterFirst, secondCommand, balance, items, agents, equipment, progression,
+                deathProcessor = deathProcessor, rng = Random(seed = 7L), scaling = NoScaling,
+                triggeredPassives = dispatcher, tick = 105L,
+            ).getOrNull(),
+        )
+        assertTrue(secondEvents.none { it is WorldEvent.PerkTriggered }, "still on cooldown — no re-fire")
+    }
+
+    @Test
+    fun `OnHitTaken precedes OnLowHp in the event stream for the same hit`() {
+        val balance = combatBalance()
+        val items = StubItemLookup(swordItem())
+        val agents = StubAgentRegistry(
+            byId = mapOf(
+                attacker to AgentAttributes(strength = 10, luck = 0, dexterity = 0),
+                target to AgentAttributes(strength = 1, luck = 0, dexterity = 0),
+            ),
+        )
+        val equipment = StubEquipmentStore(
+            equippedByAgent = mapOf(
+                attacker to mapOf(
+                    EquipSlot.MAIN_HAND to EquipmentInstance(
+                        instanceId = UUID.randomUUID(),
+                        agentId = attacker,
+                        itemId = rustySword,
+                        rarity = Rarity.COMMON,
+                        durabilityCurrent = 50,
+                        durabilityMax = 50,
+                        creatorAgentId = null,
+                        createdAtTick = 0L,
+                        equippedInSlot = EquipSlot.MAIN_HAND,
+                    ),
+                ),
+            ),
+        )
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val progression = SkillProgression(skills, publisher)
+        val cd = InMemoryCooldownStore()
+        val dispatcher = TriggeredPassiveDispatcherImpl(BothTriggersLookup(target), cd)
+
+        val initial = WorldState(
+            regions = mapOf(regionId to region),
+            nodes = mapOf(nodeId to node),
+            positions = mapOf(attacker to nodeId, target to nodeId),
+            bodies = mapOf(
+                attacker to AgentBody(hp = 100, maxHp = 100, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
+                // 100 -> ~20 hp puts target across the 25% band in one hit.
+                target to AgentBody(hp = 100, maxHp = 100, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
+            ),
+            inventories = emptyMap(),
+        )
+
+        val (_, events) = assertNotNull(
+            reduceAttack(
+                initial, WorldCommand.AttackTarget(attacker, target),
+                balance, items, agents, equipment, progression,
+                deathProcessor = DeathProcessor(balance, agents, equipment, StubGroundItemStore()),
+                rng = Random(seed = 7L), scaling = NoScaling,
+                triggeredPassives = dispatcher, tick = 1L,
+            ).getOrNull(),
+        )
+
+        val hitTakenIdx = events.indexOfFirst {
+            it is WorldEvent.PerkTriggered && it.trigger == TriggeredPassiveTrigger.ON_HIT_TAKEN
+        }
+        val lowHpIdx = events.indexOfFirst {
+            it is WorldEvent.PerkTriggered && it.trigger == TriggeredPassiveTrigger.ON_LOW_HP
+        }
+        assertTrue(hitTakenIdx >= 0 && lowHpIdx >= 0, "both perks must fire on the same band-crossing hit")
+        assertTrue(hitTakenIdx < lowHpIdx, "OnHitTaken precedes OnLowHp so consumers can mitigate before low-hp logic")
+    }
+
+    private fun combatBalance(): BalanceLookup = object : BalanceLookup {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
+        override fun staminaRegenPerTick(climate: Climate) = 0
+        override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun xpLossOnDeath(): Int = 0
+        override fun killStreakWindowTicks(): Long = 1000L
+        override fun dropChanceForKillCount(killCount: Int): Double = 0.0
+    }
+
+    private fun swordItem() = mapOf(
+        rustySword to Item(
+            id = rustySword,
+            displayName = "Rusty Sword",
+            description = "",
+            category = ItemCategory.EQUIPMENT,
+            weightPerUnit = 1500,
+            maxStack = 1,
+            damageType = DamageType.SLASH,
+            weaponPower = 8,
+            combatSkill = swordSkill,
+            validSlots = setOf(EquipSlot.MAIN_HAND),
+        ),
+    )
+
+    // Two perks bound to the same defender — one on ON_HIT_TAKEN, one on ON_LOW_HP —
+    // so the AttackReducer fires both on the same band-crossing hit.
+    private inner class BothTriggersLookup(private val defender: AgentId) : TriggeredPassiveLookup {
+        private val onHitTaken = triggered(
+            id = "DEFENSIVE_REACTION",
+            trigger = TriggeredPassiveTrigger.ON_HIT_TAKEN,
+            effectKind = TriggeredPassiveEffectKind.GRANT_SELF_BUFF,
+            cd = 5,
+            params = mapOf("buff" to "STEELSKIN"),
+        )
+        private val onLowHp = triggered(
+            id = "LAST_STAND",
+            trigger = TriggeredPassiveTrigger.ON_LOW_HP,
+            effectKind = TriggeredPassiveEffectKind.HEAL_SELF,
+            cd = 30,
+            params = mapOf("thresholdPct" to "25", "amount" to "40"),
+        )
+
+        override fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<TriggeredPerk> =
+            if (agent != defender) {
+                emptyList()
+            } else when (trigger) {
+                TriggeredPassiveTrigger.ON_HIT_TAKEN -> listOf(onHitTaken)
+                TriggeredPassiveTrigger.ON_LOW_HP -> listOf(onLowHp)
+                else -> emptyList()
+            }
+
+        private fun triggered(
+            id: String,
+            trigger: TriggeredPassiveTrigger,
+            effectKind: TriggeredPassiveEffectKind,
+            cd: Int,
+            params: Map<String, String>,
+        ): TriggeredPerk {
+            val effect = PerkEffect.TriggeredPassive(trigger, effectKind, params, cd)
+            val perk = Perk(
+                id = PerkId(id),
+                skill = swordSkill,
+                milestoneLevel = 50,
+                displayName = id,
+                description = id,
+                effect = effect,
+            )
+            return TriggeredPerk(perk, effect)
+        }
+    }
+
+    private inner class BleederLookup(private val perkOwner: AgentId) : TriggeredPassiveLookup {
+        private val effect = PerkEffect.TriggeredPassive(
+            trigger = TriggeredPassiveTrigger.ON_HIT_DEALT,
+            effectKind = TriggeredPassiveEffectKind.APPLY_STATUS_TO_TARGET,
+            params = mapOf("status" to "BLEED", "duration-ticks" to "10"),
+            internalCooldownTicks = 8,
+        )
+        private val perk = Perk(
+            id = bleederId,
+            skill = swordSkill,
+            milestoneLevel = 50,
+            displayName = "Bleeder",
+            description = "Inflicts Bleed on hit",
+            effect = effect,
+        )
+
+        override fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<TriggeredPerk> =
+            if (agent == perkOwner && trigger == TriggeredPassiveTrigger.ON_HIT_DEALT) {
+                listOf(TriggeredPerk(perk, effect))
+            } else {
+                emptyList()
+            }
+    }
+
+    private class InMemoryCooldownStore : PerkCooldownStore {
+        val armedUntil = mutableMapOf<Pair<AgentId, PerkId>, Long>()
+        override fun isReady(agent: AgentId, perk: PerkId, tick: Long): Boolean {
+            val until = armedUntil[agent to perk] ?: return true
+            return tick >= until
+        }
+        override fun arm(agent: AgentId, perk: PerkId, untilTick: Long) {
+            armedUntil[agent to perk] = untilTick
+        }
+    }
+
+    private class StubItemLookup(private val byId: Map<ItemId, Item>) : ItemLookup {
+        override fun byId(id: ItemId): Item? = byId[id]
+        override fun all(): List<Item> = byId.values.toList()
+    }
+
+    private class StubAgentRegistry(
+        private val byId: Map<AgentId, AgentAttributes>,
+    ) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = byId[id]?.let {
+            Agent(id = id, owner = PlayerId(UUID.randomUUID()), name = "test", attributes = it)
+        }
+        override fun listForOwner(owner: PlayerId): List<Agent> = error("not used")
+        override fun applyDeathPenalty(agentId: AgentId, xpLossOnDeath: Int): DeathPenaltyOutcome? = null
+    }
+
+    private class StubEquipmentStore(
+        private val equippedByAgent: Map<AgentId, Map<EquipSlot, EquipmentInstance>> = emptyMap(),
+    ) : EquipmentInstanceStore {
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> =
+            equippedByAgent[agentId] ?: emptyMap()
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = error("not used")
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? =
+            error("not used")
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = error("not used")
+        override fun delete(instanceId: UUID): Boolean = true
+    }
+
+    private class StubGroundItemStore : GroundItemStore {
+        override fun deposit(node: NodeId, drop: DroppedItemView, droppedAtTick: Long) = Unit
+        override fun atNode(node: NodeId): List<GroundItemView> = error("not used")
+        override fun take(node: NodeId, dropId: UUID): GroundItemView? = error("not used")
+    }
+
+    private class StubSkillsRegistry : AgentSkillsRegistry {
+        override fun snapshot(agent: AgentId): AgentSkillsSnapshot =
+            AgentSkillsSnapshot(perSkill = emptyMap(), slotCount = 8, slotsFilled = 0)
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int): AddXpResult =
+            AddXpResult.Unslotted
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? = null
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? = null
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.crafting
 
+import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import arrow.core.Either
 import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AddXpResult
@@ -160,7 +161,7 @@ class CraftReducerTest {
                 StubAgents(luckyAgent(luck = 5)),
                 fixedRoller(Rarity.UNCOMMON),
                 SkillProgression(skills, publisher),
-                scaling = NoScaling, tick = 7,
+                scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
             ).getOrNull(),
         )
 
@@ -203,7 +204,7 @@ class CraftReducerTest {
                 StubAgents(luckyAgent(luck = 1)),
                 fixedRoller(Rarity.RARE),
                 SkillProgression(skills, RecordingPublisher()),
-                scaling = NoScaling, tick = 3,
+                scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 3,
             ).getOrNull(),
         )
 
@@ -243,7 +244,7 @@ class CraftReducerTest {
             StubAgents(luckyAgent()),
             fixedRoller(Rarity.COMMON),
             SkillProgression(skills, RecordingPublisher()),
-            scaling = NoScaling, tick = 1,
+            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
         val rejection = assertIs<WorldRejection.StackFull>(result.leftOrNull())
         assertEquals(healingSalve, rejection.item)
@@ -306,7 +307,7 @@ class CraftReducerTest {
             StubAgents(luckyAgent()),
             fixedRoller(Rarity.COMMON),
             SkillProgression(skills, RecordingPublisher()),
-            scaling = NoScaling, tick = 1,
+            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
         assertNotNull(result.getOrNull())
     }
@@ -354,7 +355,7 @@ class CraftReducerTest {
             StubAgents(weakAgent),
             fixedRoller(Rarity.COMMON),
             SkillProgression(skills, RecordingPublisher()),
-            scaling = NoScaling, tick = 1,
+            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
         assertIs<WorldRejection.OverEncumbered>(result.leftOrNull())
         assertTrue(store.inserted.isEmpty(), "no equipment row written on a rejected craft")
@@ -384,7 +385,7 @@ class CraftReducerTest {
             StubAgents(luckyAgent()),
             fixedRoller(Rarity.COMMON),
             SkillProgression(skills, publisher),
-            scaling = NoScaling, tick = 5,
+            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 5,
         )
         val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()
         assertEquals(alchemy, rec.skill)
@@ -407,7 +408,7 @@ class CraftReducerTest {
             StubAgents(luckyAgent(luck = 7)),
             capturingRoller,
             SkillProgression(skills, RecordingPublisher()),
-            scaling = NoScaling, tick = 1,
+            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
         assertEquals(25, capturingRoller.lastSkill)
         assertEquals(7, capturingRoller.lastLuck)
@@ -432,7 +433,7 @@ class CraftReducerTest {
         StubAgents(luckyAgent()),
         fixedRoller(Rarity.COMMON),
         SkillProgression(skills, RecordingPublisher()),
-        scaling = NoScaling, tick = 1,
+        scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
     )
 
     private fun luckyAgent(strength: Int = 20, luck: Int = 1): Agent = Agent(

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.harvest
 
+import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
@@ -107,7 +108,7 @@ class HarvestReducerTest {
         val publisher = RecordingPublisher()
 
         val result = reduceHarvest(
-            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, tick = 7,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
         )
 
         val (next, events) = assertNotNull(result.getOrNull())
@@ -133,7 +134,7 @@ class HarvestReducerTest {
         val publisher = RecordingPublisher()
 
         val result = reduceHarvest(
-            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, tick = 1,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         val (next, events) = assertNotNull(result.getOrNull())
@@ -170,7 +171,7 @@ class HarvestReducerTest {
         val skills = StubSkillsRegistry().apply { slot(mining) }
 
         val result = reduceHarvest(
-            state, command, balance, regenItems, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), scaling = NoScaling, tick = 1,
+            state, command, balance, regenItems, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -186,7 +187,7 @@ class HarvestReducerTest {
         val skills = StubSkillsRegistry().apply { slot(foraging) }
 
         val result = reduceHarvest(
-            state, command, balance, items, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), scaling = NoScaling, tick = 1,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -200,7 +201,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
+            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
@@ -214,7 +215,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, unknown), balance, emptyCatalog,
-            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
+            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         assertEquals(WorldRejection.UnknownItem(unknown), result.leftOrNull())
@@ -227,7 +228,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, berry), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         assertEquals(
@@ -243,7 +244,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         assertEquals(
@@ -259,7 +260,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         assertEquals(
@@ -275,7 +276,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -291,7 +292,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), highYield, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         val (next, events) = assertNotNull(result.getOrNull())
@@ -315,7 +316,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), tightBalance, items, store,
-            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
+            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         assertEquals(
@@ -334,7 +335,7 @@ class HarvestReducerTest {
         val result = reduceHarvest(
             state = stateWith(),
             WorldCommand.Harvest(agent, wood), tightBalance, items, store,
-            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
+            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -377,7 +378,7 @@ class HarvestReducerTest {
         val result = reduceHarvest(
             state = stateWith(),
             WorldCommand.Harvest(agent, wood), tightBalance, itemsWithHelmet, store,
-            skinnyAgents, helmetEquipped, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, tick = 1,
+            skinnyAgents, helmetEquipped, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
         )
 
         assertEquals(
@@ -395,7 +396,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
         )
 
         assertEquals(listOf(lumberjacking to 1), skills.xpAddCalls)
@@ -415,7 +416,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
         )
 
         val ev = publisher.events.filterIsInstance<AgentEvent.SkillMilestoneReached>().single()
@@ -436,7 +437,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
         )
 
         val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()
@@ -453,7 +454,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
         )
 
         assertTrue(publisher.events.none { it is AgentEvent.SkillRecommended })
@@ -470,7 +471,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, skillFreeItems,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
         )
 
         assertEquals(0, skills.xpAddCalls.size)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/perks/TriggeredPassiveDispatcherImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/perks/TriggeredPassiveDispatcherImplTest.kt
@@ -1,0 +1,250 @@
+package dev.gvart.genesara.world.internal.perks
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.Perk
+import dev.gvart.genesara.player.PerkCooldownStore
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.TriggeredPassiveEffectKind
+import dev.gvart.genesara.player.TriggeredPassiveLookup
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import dev.gvart.genesara.player.TriggeredPerk
+import dev.gvart.genesara.world.events.WorldEvent
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TriggeredPassiveDispatcherImplTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val target = AgentId(UUID.randomUUID())
+    private val cause = UUID.randomUUID()
+
+    private val bleeder = triggeredPerk(
+        id = "SWORD_BLEEDER",
+        trigger = TriggeredPassiveTrigger.ON_HIT_DEALT,
+        effectKind = TriggeredPassiveEffectKind.APPLY_STATUS_TO_TARGET,
+        cd = 8,
+        params = mapOf("status" to "BLEED", "duration-ticks" to "10"),
+    )
+
+    @Test
+    fun `emits PerkTriggered when perk matches and cooldown ready`() {
+        val cd = StubCooldownStore(initialReady = true)
+        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(bleeder)), cd)
+
+        val events = dispatcher.dispatch(
+            firer = agent,
+            trigger = TriggeredPassiveTrigger.ON_HIT_DEALT,
+            ctx = TriggerContext.Combat(target),
+            tick = 100L,
+            causedBy = cause,
+        )
+
+        assertEquals(1, events.size)
+        val ev = events.single() as WorldEvent.PerkTriggered
+        assertEquals(agent, ev.agent)
+        assertEquals(bleeder.perk.id, ev.perkId)
+        assertEquals(TriggeredPassiveTrigger.ON_HIT_DEALT, ev.trigger)
+        assertEquals(TriggeredPassiveEffectKind.APPLY_STATUS_TO_TARGET, ev.effectKind)
+        assertEquals(target, ev.target)
+        assertEquals(100L, ev.tick)
+        assertEquals(cause, ev.causedBy)
+        assertEquals(108L, cd.armedUntil[agent to bleeder.perk.id], "cd armed at fire-tick + internalCooldownTicks")
+    }
+
+    @Test
+    fun `skips perk when cooldown is not ready`() {
+        val cd = StubCooldownStore(initialReady = false)
+        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(bleeder)), cd)
+
+        val events = dispatcher.dispatch(
+            firer = agent,
+            trigger = TriggeredPassiveTrigger.ON_HIT_DEALT,
+            ctx = TriggerContext.Combat(target),
+            tick = 100L,
+            causedBy = cause,
+        )
+
+        assertTrue(events.isEmpty())
+        assertNull(cd.armedUntil[agent to bleeder.perk.id], "skipped fires must not arm cooldown")
+    }
+
+    @Test
+    fun `all matching perks fire on the same trigger (no first-match-wins)`() {
+        val rage = triggeredPerk(
+            id = "SWORD_RAGE",
+            trigger = TriggeredPassiveTrigger.ON_HIT_DEALT,
+            effectKind = TriggeredPassiveEffectKind.GRANT_SELF_BUFF,
+            cd = 5,
+            params = mapOf("buff" to "RAGE"),
+        )
+        val dispatcher = TriggeredPassiveDispatcherImpl(
+            StubLookup(listOf(bleeder, rage)),
+            StubCooldownStore(initialReady = true),
+        )
+
+        val events = dispatcher.dispatch(
+            firer = agent,
+            trigger = TriggeredPassiveTrigger.ON_HIT_DEALT,
+            ctx = TriggerContext.Combat(target),
+            tick = 0L,
+            causedBy = cause,
+        )
+
+        val perks = events.map { (it as WorldEvent.PerkTriggered).perkId }.toSet()
+        assertEquals(setOf(bleeder.perk.id, rage.perk.id), perks)
+    }
+
+    @Test
+    fun `target field is null for non-combat triggers`() {
+        val onHarvest = triggeredPerk(
+            id = "FORAGING_LUCKY",
+            trigger = TriggeredPassiveTrigger.ON_HARVEST_COMPLETE,
+            effectKind = TriggeredPassiveEffectKind.GRANT_BONUS_ITEM,
+            cd = 0,
+            params = mapOf("pool" to "BERRIES"),
+        )
+        val dispatcher = TriggeredPassiveDispatcherImpl(
+            StubLookup(listOf(onHarvest)),
+            StubCooldownStore(initialReady = true),
+        )
+
+        val ev = dispatcher.dispatch(
+            firer = agent,
+            trigger = TriggeredPassiveTrigger.ON_HARVEST_COMPLETE,
+            ctx = TriggerContext.None,
+            tick = 0L,
+            causedBy = cause,
+        ).single() as WorldEvent.PerkTriggered
+        assertNull(ev.target)
+    }
+
+    @Test
+    fun `OnLowHp fires only on the descending edge of the threshold band`() {
+        val perk = triggeredPerk(
+            id = "SOLDIER_LAST_STAND",
+            trigger = TriggeredPassiveTrigger.ON_LOW_HP,
+            effectKind = TriggeredPassiveEffectKind.HEAL_SELF,
+            cd = 30,
+            params = mapOf("thresholdPct" to "25", "amount" to "40"),
+        )
+        val dispatcher = TriggeredPassiveDispatcherImpl(
+            StubLookup(listOf(perk)),
+            StubCooldownStore(initialReady = true),
+        )
+
+        val crossingDown = dispatcher.dispatch(
+            firer = agent,
+            trigger = TriggeredPassiveTrigger.ON_LOW_HP,
+            ctx = TriggerContext.HpChange(maxHp = 100, prevHp = 30, newHp = 20),
+            tick = 0L,
+            causedBy = cause,
+        )
+        assertEquals(1, crossingDown.size)
+
+        val stillBelow = dispatcher.dispatch(
+            firer = agent,
+            trigger = TriggeredPassiveTrigger.ON_LOW_HP,
+            ctx = TriggerContext.HpChange(maxHp = 100, prevHp = 18, newHp = 10),
+            tick = 1L,
+            causedBy = cause,
+        )
+        assertTrue(stillBelow.isEmpty(), "subsequent damage while still below threshold must not re-fire")
+
+        val notCrossed = dispatcher.dispatch(
+            firer = agent,
+            trigger = TriggeredPassiveTrigger.ON_LOW_HP,
+            ctx = TriggerContext.HpChange(maxHp = 100, prevHp = 80, newHp = 50),
+            tick = 2L,
+            causedBy = cause,
+        )
+        assertTrue(notCrossed.isEmpty())
+    }
+
+    @Test
+    fun `OnLowHp inside the band but on cooldown does not fire`() {
+        val perk = triggeredPerk(
+            id = "SOLDIER_LAST_STAND",
+            trigger = TriggeredPassiveTrigger.ON_LOW_HP,
+            effectKind = TriggeredPassiveEffectKind.HEAL_SELF,
+            cd = 30,
+            params = mapOf("thresholdPct" to "25"),
+        )
+        val cd = StubCooldownStore(initialReady = false)
+        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(perk)), cd)
+
+        val events = dispatcher.dispatch(
+            firer = agent,
+            trigger = TriggeredPassiveTrigger.ON_LOW_HP,
+            ctx = TriggerContext.HpChange(maxHp = 100, prevHp = 30, newHp = 20),
+            tick = 0L,
+            causedBy = cause,
+        )
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `OnLowHp without threshold param skips silently`() {
+        val malformed = triggeredPerk(
+            id = "BROKEN",
+            trigger = TriggeredPassiveTrigger.ON_LOW_HP,
+            effectKind = TriggeredPassiveEffectKind.HEAL_SELF,
+            cd = 0,
+            params = emptyMap(),
+        )
+        val dispatcher = TriggeredPassiveDispatcherImpl(
+            StubLookup(listOf(malformed)),
+            StubCooldownStore(initialReady = true),
+        )
+
+        val events = dispatcher.dispatch(
+            firer = agent,
+            trigger = TriggeredPassiveTrigger.ON_LOW_HP,
+            ctx = TriggerContext.HpChange(maxHp = 100, prevHp = 50, newHp = 5),
+            tick = 0L,
+            causedBy = cause,
+        )
+        assertTrue(events.isEmpty())
+    }
+
+    private fun triggeredPerk(
+        id: String,
+        trigger: TriggeredPassiveTrigger,
+        effectKind: TriggeredPassiveEffectKind,
+        cd: Int,
+        params: Map<String, String>,
+    ): TriggeredPerk {
+        val effect = PerkEffect.TriggeredPassive(trigger, effectKind, params, cd)
+        val perk = Perk(
+            id = PerkId(id),
+            skill = SkillId("SWORD"),
+            milestoneLevel = 50,
+            displayName = id,
+            description = id,
+            effect = effect,
+        )
+        return TriggeredPerk(perk, effect)
+    }
+
+    // Returns whatever it was constructed with — the lookup contract guarantees
+    // pre-filtering by trigger; double-filtering here would mask dispatcher bugs.
+    private class StubLookup(private val perks: List<TriggeredPerk>) : TriggeredPassiveLookup {
+        override fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<TriggeredPerk> =
+            perks
+    }
+
+    private class StubCooldownStore(private val initialReady: Boolean) : PerkCooldownStore {
+        val armedUntil = mutableMapOf<Pair<AgentId, PerkId>, Long>()
+        override fun isReady(agent: AgentId, perk: PerkId, tick: Long): Boolean {
+            val until = armedUntil[agent to perk] ?: return initialReady
+            return tick >= until
+        }
+        override fun arm(agent: AgentId, perk: PerkId, untilTick: Long) {
+            armedUntil[agent to perk] = untilTick
+        }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/NoOpTriggeredPassiveDispatcher.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/NoOpTriggeredPassiveDispatcher.kt
@@ -1,0 +1,19 @@
+package dev.gvart.genesara.world.internal.testsupport
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.perks.TriggerContext
+import dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcher
+import java.util.UUID
+
+/** Default for reducer tests that don't exercise the perk surface. */
+internal object NoOpTriggeredPassiveDispatcher : TriggeredPassiveDispatcher {
+    override fun dispatch(
+        firer: AgentId,
+        trigger: TriggeredPassiveTrigger,
+        ctx: TriggerContext,
+        tick: Long,
+        causedBy: UUID?,
+    ): List<WorldEvent> = emptyList()
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.tick
 
+import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.engine.Tick
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
@@ -91,7 +92,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 7)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore), NoOpTriggeredPassiveDispatcher)
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -113,7 +114,7 @@ class WorldTickHandlerTest {
 
         val cmd = WorldCommand.MoveAgent(agent, ghostId)
         queue.submit(cmd, appliesAtTick = 1)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore), NoOpTriggeredPassiveDispatcher)
 
         handler.onTick(Tick(1, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -149,7 +150,7 @@ class WorldTickHandlerTest {
             override fun sleepRegenPerOfflineTick(): Int = 0
             override fun isTraversable(terrain: Terrain): Boolean = true
         }
-        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
+        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore), NoOpTriggeredPassiveDispatcher)
 
         handler.onTick(Tick(2, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -165,7 +166,7 @@ class WorldTickHandlerTest {
         val queue = CommandQueue()
         val publisher = RecordingPublisher()
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 99)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore))
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore), NoOpTriggeredPassiveDispatcher)
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 


### PR DESCRIPTION
Implements [Step 3a / issue #64](https://github.com/Genesara/genesara-engine/issues/64) — the TriggeredPassive perk-effect-type subsystem.

## Summary

- **`:player`** — `PerkCooldownStore` interface + jOOQ impl, V206 migration for `agent_perk_cooldowns`. `TriggeredPassiveLookup` interface + impl filtering chosen perks by slotted-skill + trigger.
- **`:world`** — `TriggeredPassiveDispatcher` + `TriggerContext` sealed type. New `WorldEvent.PerkTriggered` variant. Six fire-points wired into `AttackReducer` (`OnHitDealt/Taken/Crit/Kill/Dodge` + `OnLowHp` band-cross), one each into `HarvestReducer`, `CraftReducer`, `BuildReducer` — mirroring the `SkillProgression.accrueXp` injection pattern.
- **Canary** — SWORD-50 Bleeder fires `APPLY_STATUS_TO_TARGET` with `BLEED` on hit; cooldown gates re-fire; ordering test asserts `OnHitTaken` precedes `OnLowHp` in the event stream.

## Slice 1 contract

Dispatcher emits structured `PerkTriggered` events only — actual state mutations per effect kind (HEAL_SELF, DEAL_BONUS_DAMAGE, GRANT_BONUS_ITEM, …) ship in follow-up slices. The structured event is the seam downstream resolvers attach to without re-walking the perk catalog. `TODO(perk-effects)` marker in place on the dispatcher.

## OnLowHp idempotency

Band-cross predicate is `prev > limit && new <= limit` — naturally idempotent on the descending edge, no extra state needed. Successive damage while already below the band cannot re-satisfy `prev > limit`. Per-perk threshold via `params[\"thresholdPct\"]`.

## Deferred (raised to follow-ups)

- `WorldReducer.reduce` parameter list crossed a smell threshold — collecting per-tick services into a `ReducerContext` data class is the next cleanup.
- `TriggeredPassiveLookupImpl` re-snapshots agent_perks + agent_skills on every fire-point. AttackReducer fires up to 5 triggers per attack, so a busy combat tick does ~10 player-module queries today. `TODO(perks-hot-path)` placeholder for a `matchingMany(triggers)` shape.
- `agent_perk_cooldowns` rows accumulate forever for now. `TODO(perks-maintenance)` placeholder; not load-bearing at canary scale.
- Combat-trigger fire on the killing blow flows through; `OnLowHp` for non-combat HP-mutation paths (passive starvation tick) is deferred.

## Test plan

- [x] `:player` unit + Testcontainers integration — `PerkCooldownStore` upsert + isReady semantics, lookup filtering by slotted-skill + trigger
- [x] `:world` unit — dispatcher fire/skip/ordering, OnLowHp band-cross edge cases, OnLowHp + cooldown conjunction
- [x] `:world` integration — Bleeder canary through real `reduceAttack`; OnHitTaken < OnLowHp ordering through `reduceAttack`
- [x] `:player` + `:world` + `:api` full test sweep green

After merge:
- [ ] Tick acceptance items in #64
- [ ] Comment on #5 noting the new reducer hooks are co-located with skill-XP fire points but independent