### PR TITLE
feat(player,world,api): active-ability perk system + use_ability tool (#67)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp
 
 import dev.gvart.genesara.api.internal.mcp.events.EventLogProperties
 import dev.gvart.genesara.api.internal.mcp.presence.PresenceProperties
+import dev.gvart.genesara.api.internal.mcp.tools.abilities.UseAbilityTool
 import dev.gvart.genesara.api.internal.mcp.tools.attack.AttackTool
 import dev.gvart.genesara.api.internal.mcp.tools.attributes.AllocatePointsTool
 import dev.gvart.genesara.api.internal.mcp.tools.build.BuildTool
@@ -60,6 +61,7 @@ internal class McpServerConfiguration {
         craft: CraftTool,
         pickup: PickupTool,
         attack: AttackTool,
+        useAbility: UseAbilityTool,
     ): ToolCallbackProvider =
         MethodToolCallbackProvider.builder()
             .toolObjects(
@@ -67,6 +69,7 @@ internal class McpServerConfiguration {
                 consume, drink, equipSkill, allocatePoints, inspect, getMap,
                 equipItem, unequipSlot,
                 setSafeNode, respawn, build, depositToChest, withdrawFromChest, craft, pickup, attack,
+                useAbility,
             )
             .build()
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/abilities/UseAbilityTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/abilities/UseAbilityTool.kt
@@ -1,0 +1,51 @@
+package dev.gvart.genesara.api.internal.mcp.tools.abilities
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AbilityId
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.ai.tool.annotation.ToolParam
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+internal class UseAbilityTool(
+    private val world: WorldCommandGateway,
+    private val engine: TickClock,
+    private val activity: AgentActivityTracker,
+) {
+
+    @Tool(
+        name = "use_ability",
+        description = "Cast an active ability granted by a chosen perk on a slotted skill (e.g. SWORD_POWER_STRIKE). " +
+            "Pays the perk's resource cost (HP / Stamina / Mana) at cast and arms the perk cooldown. " +
+            "`targetAgentId` is required for SINGLE_AGENT abilities (target must be in the caster's node) " +
+            "and must be omitted for SELF / AREA_SELF_NODE abilities. Reducer-level rejections — unknown " +
+            "ability, on cooldown, insufficient resource, target shape mismatch — surface as " +
+            "CommandRejected on the agent's event stream after the tick lands.",
+    )
+    fun invoke(
+        @ToolParam(required = true, description = "Ability id (e.g. SWORD_POWER_STRIKE) granted by a chosen perk.")
+        abilityId: String,
+        @ToolParam(required = false, description = "Target agent id for SINGLE_AGENT abilities; omit for SELF / AREA_SELF_NODE.")
+        targetAgentId: UUID?,
+        toolContext: ToolContext,
+    ): UseAbilityResponse {
+        touchActivity(toolContext, activity, "use_ability")
+        val agent = AgentContextHolder.current()
+        val command = WorldCommand.UseAbility(
+            agent = agent,
+            ability = AbilityId(abilityId),
+            target = targetAgentId?.let(::AgentId),
+        )
+        val nextTick = engine.currentTick() + 1
+        world.submit(command, appliesAtTick = nextTick)
+        return UseAbilityResponse.queued(command.commandId, nextTick, abilityId, targetAgentId)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/abilities/UseAbilityToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/abilities/UseAbilityToolIo.kt
@@ -1,0 +1,17 @@
+package dev.gvart.genesara.api.internal.mcp.tools.abilities
+
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
+import java.util.UUID
+
+data class UseAbilityResponse(
+    val kind: CommandAckKind,
+    val abilityId: String,
+    val targetAgentId: UUID?,
+    val commandId: UUID,
+    val appliesAtTick: Long,
+) {
+    companion object {
+        fun queued(commandId: UUID, appliesAtTick: Long, abilityId: String, targetAgentId: UUID?) =
+            UseAbilityResponse(CommandAckKind.QUEUED, abilityId, targetAgentId, commandId, appliesAtTick)
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/abilities/UseAbilityToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/abilities/UseAbilityToolTest.kt
@@ -1,0 +1,95 @@
+package dev.gvart.genesara.api.internal.mcp.tools.abilities
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AbilityId
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class UseAbilityToolTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val target = AgentId(UUID.randomUUID())
+    private val clock = MutableTestClock(Instant.parse("2026-01-01T00:00:00Z"))
+    private val activity = AgentActivityRegistry(clock)
+    private val gateway = RecordingGateway()
+    private val tickClock = StubTickClock(currentTick = 50L)
+    private val toolContext = ToolContext(emptyMap())
+
+    @BeforeEach fun setUp() = AgentContextHolder.set(agent)
+    @AfterEach fun tearDown() = AgentContextHolder.clear()
+
+    @Test
+    fun `queues a UseAbility command at the next tick with target id`() {
+        val tool = UseAbilityTool(gateway, tickClock, activity)
+
+        val response = tool.invoke("SWORD_POWER_STRIKE", target.id, toolContext)
+
+        assertEquals(CommandAckKind.QUEUED, response.kind)
+        assertEquals("SWORD_POWER_STRIKE", response.abilityId)
+        assertEquals(target.id, response.targetAgentId)
+        assertEquals(51L, response.appliesAtTick)
+        val (cmd, appliesAt) = gateway.submissions.single()
+        val use = assertNotNull(cmd as? WorldCommand.UseAbility)
+        assertEquals(agent, use.agent)
+        assertEquals(AbilityId("SWORD_POWER_STRIKE"), use.ability)
+        assertEquals(target, use.target)
+        assertEquals(51L, appliesAt)
+        assertEquals(use.commandId, response.commandId)
+    }
+
+    @Test
+    fun `omitting targetAgentId yields a self_or_area-shaped command`() {
+        val tool = UseAbilityTool(gateway, tickClock, activity)
+
+        val response = tool.invoke("HEAL_SELF", null, toolContext)
+
+        assertNull(response.targetAgentId)
+        val use = assertNotNull(gateway.submissions.single().first as? WorldCommand.UseAbility)
+        assertNull(use.target)
+    }
+
+    @Test
+    fun `touches activity registry on every successful invocation`() {
+        val tool = UseAbilityTool(gateway, tickClock, activity)
+
+        assertTrue(agent !in activity.staleAgents(clock.instant().minusSeconds(60)))
+
+        tool.invoke("SWORD_POWER_STRIKE", target.id, toolContext)
+
+        assertTrue(agent in activity.staleAgents(clock.instant().plusSeconds(60)))
+    }
+
+    private class RecordingGateway : WorldCommandGateway {
+        val submissions = mutableListOf<Pair<WorldCommand, Long>>()
+        override fun submit(command: WorldCommand, appliesAtTick: Long) {
+            submissions += command to appliesAtTick
+        }
+    }
+
+    private class StubTickClock(private val currentTick: Long) : TickClock {
+        override fun currentTick(): Long = currentTick
+    }
+
+    private class MutableTestClock(private var now: Instant) : Clock() {
+        override fun instant(): Instant = now
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AbilityId.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AbilityId.kt
@@ -1,0 +1,8 @@
+package dev.gvart.genesara.player
+
+@JvmInline
+value class AbilityId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "AbilityId must not be blank" }
+    }
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/ActivePerkLookup.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/ActivePerkLookup.kt
@@ -1,0 +1,17 @@
+package dev.gvart.genesara.player
+
+/**
+ * Resolves an [AbilityId] to the chosen [Perk] backing it for a specific agent —
+ * but only when the parent skill is currently slotted, mirroring
+ * [TriggeredPassiveLookup]'s slot gate. Returns null when no chosen perk grants
+ * [ability], the perk's parent skill is not in a slot, or the perk effect is not
+ * an [PerkEffect.ActiveAbility].
+ */
+interface ActivePerkLookup {
+    fun byAbility(agent: AgentId, ability: AbilityId): ActivePerk?
+}
+
+data class ActivePerk(
+    val perk: Perk,
+    val effect: PerkEffect.ActiveAbility,
+)

--- a/player/src/main/kotlin/dev/gvart/genesara/player/PerkCooldownStore.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/PerkCooldownStore.kt
@@ -5,4 +5,12 @@ interface PerkCooldownStore {
     fun isReady(agent: AgentId, perk: PerkId, tick: Long): Boolean
 
     fun arm(agent: AgentId, perk: PerkId, untilTick: Long)
+
+    /**
+     * Tick the cooldown is armed until, or null when no row exists yet (the
+     * perk has never been armed for this agent). Distinct from [isReady] so
+     * callers that need the wait duration for a rejection message can read it
+     * without a follow-up query.
+     */
+    fun readyAtTick(agent: AgentId, perk: PerkId): Long?
 }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/PerkEffect.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/PerkEffect.kt
@@ -3,12 +3,21 @@ package dev.gvart.genesara.player
 /** Closed union of perk effect kinds — see `docs/skill-feature-sequence.md` decisions §5/§7/§8/§10/§11. */
 sealed interface PerkEffect {
 
+    /**
+     * Agent calls `use_ability(abilityId, target?)`, the reducer pays [costAmount]
+     * of [costResource] at cast, the [effectKind] resolves at the next tick, and
+     * [PerkCooldownStore] arms for [cooldownTicks]. [effectParams] mirrors
+     * [TriggeredPassive.params] — string-typed bag the resolver parses per
+     * [effectKind] (e.g. SCALE_NEXT_ATTACK reads `multiplierPct`).
+     */
     data class ActiveAbility(
-        val abilityId: String,
+        val abilityId: AbilityId,
         val costResource: AbilityCostResource,
         val costAmount: Int,
         val target: AbilityTarget,
         val cooldownTicks: Int,
+        val effectKind: AbilityEffectKind,
+        val effectParams: Map<String, String>,
     ) : PerkEffect
 
     /**
@@ -43,6 +52,16 @@ sealed interface PerkEffect {
 enum class AbilityCostResource { HP, STAMINA, MANA }
 
 enum class AbilityTarget { SELF, SINGLE_AGENT, AREA_SELF_NODE }
+
+enum class AbilityEffectKind {
+    /** Buff stored on the agent; consumed by the next [WorldCommand.AttackTarget] resolver as a damage multiplier. */
+    SCALE_NEXT_ATTACK,
+    HEAL_SELF,
+    DEAL_BONUS_DAMAGE,
+    APPLY_STATUS_TO_TARGET,
+    GRANT_SELF_BUFF,
+    TELEPORT_NODES,
+}
 
 enum class TriggeredPassiveTrigger {
     ON_HIT_TAKEN,

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/PerkLookupImpl.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/PerkLookupImpl.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.player.internal.balance
 
+import dev.gvart.genesara.player.AbilityId
 import dev.gvart.genesara.player.Perk
 import dev.gvart.genesara.player.PerkChoice
 import dev.gvart.genesara.player.PerkEffect
@@ -61,11 +62,13 @@ internal class PerkLookupImpl(
 
     private fun PerkEffectProperties.toEffect(): PerkEffect = when (type) {
         PerkEffectType.ACTIVE_ABILITY -> PerkEffect.ActiveAbility(
-            abilityId = abilityId!!,
+            abilityId = AbilityId(abilityId!!),
             costResource = costResource!!,
             costAmount = costAmount!!,
             target = abilityTarget!!,
             cooldownTicks = cooldownTicks!!,
+            effectKind = abilityEffectKind!!,
+            effectParams = abilityEffectParams,
         )
         PerkEffectType.PASSIVE_AURA -> PerkEffect.PassiveAura(
             target = auraTarget!!,

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/PerksValidator.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/PerksValidator.kt
@@ -13,6 +13,7 @@ internal object PerksValidator {
     fun collectProblems(props: SkillDefinitionProperties): List<String> {
         val problems = mutableListOf<String>()
         val perkIdLocations = mutableMapOf<String, MutableList<String>>()
+        val abilityIdLocations = mutableMapOf<String, MutableList<String>>()
 
         for ((skillKey, skillProps) in props.catalog) {
             if (skillProps.milestones.isEmpty()) continue
@@ -34,6 +35,10 @@ internal object PerksValidator {
                     if (perk.id.isNotBlank()) {
                         perkIdLocations.getOrPut(perk.id) { mutableListOf() } += "$skillKey/$rawLevel#$idx"
                     }
+                    val abilityId = perk.effect.takeIf { it.type == PerkEffectType.ACTIVE_ABILITY }?.abilityId
+                    if (!abilityId.isNullOrBlank()) {
+                        abilityIdLocations.getOrPut(abilityId) { mutableListOf() } += "$skillKey/$rawLevel#$idx"
+                    }
                 }
             }
         }
@@ -42,6 +47,11 @@ internal object PerksValidator {
             .filterValues { it.size > 1 }
             .forEach { (id, locations) ->
                 problems += "perk id '$id' is declared in multiple places: ${locations.joinToString(", ")}"
+            }
+        abilityIdLocations
+            .filterValues { it.size > 1 }
+            .forEach { (id, locations) ->
+                problems += "ability id '$id' is declared in multiple perks: ${locations.joinToString(", ")}"
             }
 
         return problems
@@ -67,11 +77,14 @@ internal object PerksValidator {
                 requireField(effect.costAmount, "$location.effect.cost-amount", problems)
                 requireField(effect.abilityTarget, "$location.effect.ability-target", problems)
                 requireField(effect.cooldownTicks, "$location.effect.cooldown-ticks", problems)
+                requireField(effect.abilityEffectKind, "$location.effect.ability-effect-kind", problems)
                 if (effect.costAmount != null && effect.costAmount < 0) {
                     problems += "$location.effect.cost-amount: must be >= 0"
                 }
-                if (effect.cooldownTicks != null && effect.cooldownTicks < 0) {
-                    problems += "$location.effect.cooldown-ticks: must be >= 0"
+                if (effect.cooldownTicks != null && effect.cooldownTicks <= 0) {
+                    // Strictly positive: the spec promises "ability goes on cooldown" — a
+                    // zero CD turns the active into a free-spam; let's catch that at load.
+                    problems += "$location.effect.cooldown-ticks: must be > 0"
                 }
             }
             PerkEffectType.PASSIVE_AURA -> {

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/SkillProperties.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/SkillProperties.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.player.internal.balance
 
 import dev.gvart.genesara.player.AbilityCostResource
+import dev.gvart.genesara.player.AbilityEffectKind
 import dev.gvart.genesara.player.AbilityTarget
 import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillCategory
@@ -44,6 +45,10 @@ internal data class PerkEffectProperties(
     val costAmount: Int? = null,
     val abilityTarget: AbilityTarget? = null,
     val cooldownTicks: Int? = null,
+    /** ACTIVE_ABILITY only — what the resolver does after the resource is paid. */
+    val abilityEffectKind: AbilityEffectKind? = null,
+    /** ACTIVE_ABILITY only — string-typed knobs the resolver reads per [abilityEffectKind]. */
+    val abilityEffectParams: Map<String, String> = emptyMap(),
     val auraTarget: ScalingEffect? = null,
     val auraMagnitude: Int? = null,
     val trigger: TriggeredPassiveTrigger? = null,

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/perks/ActivePerkLookupImpl.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/perks/ActivePerkLookupImpl.kt
@@ -1,0 +1,37 @@
+package dev.gvart.genesara.player.internal.perks
+
+import dev.gvart.genesara.player.AbilityId
+import dev.gvart.genesara.player.ActivePerk
+import dev.gvart.genesara.player.ActivePerkLookup
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentPerksRegistry
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkLookup
+import org.springframework.stereotype.Component
+
+@Component
+internal class ActivePerkLookupImpl(
+    private val perks: PerkLookup,
+    private val perksRegistry: AgentPerksRegistry,
+    private val skillsRegistry: AgentSkillsRegistry,
+) : ActivePerkLookup {
+
+    override fun byAbility(agent: AgentId, ability: AbilityId): ActivePerk? {
+        val chosen = perksRegistry.snapshot(agent).perks
+        if (chosen.isEmpty()) return null
+
+        val slottedSkills = skillsRegistry.snapshot(agent).perSkill.values
+            .filter { it.slotIndex != null }
+            .mapTo(mutableSetOf()) { it.skill }
+        if (slottedSkills.isEmpty()) return null
+
+        for (chosenPerk in chosen) {
+            if (chosenPerk.skill !in slottedSkills) continue
+            val perk = perks.byId(chosenPerk.perkId) ?: continue
+            val effect = perk.effect as? PerkEffect.ActiveAbility ?: continue
+            if (effect.abilityId == ability) return ActivePerk(perk, effect)
+        }
+        return null
+    }
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqPerkCooldownStore.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqPerkCooldownStore.kt
@@ -15,14 +15,17 @@ internal class JooqPerkCooldownStore(
 
     @Transactional(readOnly = true)
     override fun isReady(agent: AgentId, perk: PerkId, tick: Long): Boolean {
-        val until = dsl.select(AGENT_PERK_COOLDOWNS.COOLDOWN_UNTIL_TICK)
+        val until = readyAtTick(agent, perk) ?: return true
+        return tick >= until
+    }
+
+    @Transactional(readOnly = true)
+    override fun readyAtTick(agent: AgentId, perk: PerkId): Long? =
+        dsl.select(AGENT_PERK_COOLDOWNS.COOLDOWN_UNTIL_TICK)
             .from(AGENT_PERK_COOLDOWNS)
             .where(AGENT_PERK_COOLDOWNS.AGENT_ID.eq(agent.id))
             .and(AGENT_PERK_COOLDOWNS.PERK_ID.eq(perk.value))
             .fetchOne(AGENT_PERK_COOLDOWNS.COOLDOWN_UNTIL_TICK)
-            ?: return true
-        return tick >= until
-    }
 
     @Transactional
     override fun arm(agent: AgentId, perk: PerkId, untilTick: Long) {

--- a/player/src/main/resources/player-definition/skills.yaml
+++ b/player/src/main/resources/player-definition/skills.yaml
@@ -77,6 +77,37 @@ skills:
               type: PASSIVE_AURA
               aura-target: SLASH_DAMAGE_BONUS
               aura-magnitude: 5
+        "100":
+          - id: SWORD_POWER_STRIKE
+            display-name: Power Strike
+            description: >-
+              Active ability — pay 20 Stamina, the next basic attack within the
+              cooldown window deals 1.5× damage. Targets a single agent in the
+              caster's node; the buff is consumed by the next attack regardless
+              of dodge/crit outcome.
+            effect:
+              type: ACTIVE_ABILITY
+              ability-id: SWORD_POWER_STRIKE
+              cost-resource: STAMINA
+              cost-amount: 20
+              ability-target: SINGLE_AGENT
+              cooldown-ticks: 5
+              ability-effect-kind: SCALE_NEXT_ATTACK
+              ability-effect-params:
+                multiplierPct: "150"
+          - id: SWORD_RIPOSTE
+            display-name: Riposte
+            description: >-
+              On a successful dodge, the next basic attack lands as a guaranteed
+              follow-up. Slot-1 perk — TriggeredPassive shape mirrors Bleeder.
+            effect:
+              type: TRIGGERED_PASSIVE
+              trigger: ON_DODGE
+              effect-kind: GRANT_SELF_BUFF
+              params:
+                buff: RIPOSTE_READY
+                duration-ticks: "3"
+              internal-cooldown-ticks: 6
         "150":
           - id: SWORD_DOUBLED_EDGE
             display-name: Doubled Edge

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/PerkLookupImplTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/PerkLookupImplTest.kt
@@ -1,5 +1,9 @@
 package dev.gvart.genesara.player.internal.balance
 
+import dev.gvart.genesara.player.AbilityCostResource
+import dev.gvart.genesara.player.AbilityEffectKind
+import dev.gvart.genesara.player.AbilityId
+import dev.gvart.genesara.player.AbilityTarget
 import dev.gvart.genesara.player.PerkEffect
 import dev.gvart.genesara.player.PerkId
 import dev.gvart.genesara.player.ScalingEffect
@@ -33,6 +37,50 @@ class PerkLookupImplTest {
         val aura = assertIs<PerkEffect.PassiveAura>(sharpen.effect)
         assertEquals(ScalingEffect.SLASH_DAMAGE_BONUS, aura.target)
         assertEquals(5, aura.magnitude)
+    }
+
+    @Test
+    fun `byId returns an ActiveAbility perk with effectKind and params translated`() {
+        val props = SkillDefinitionProperties(
+            catalog = mapOf(
+                "SWORD" to SkillProperties(
+                    displayName = "Sword",
+                    description = "blade",
+                    category = SkillCategory.COMBAT,
+                    milestones = mapOf(
+                        "100" to listOf(
+                            PerkProperties(
+                                id = "SWORD_POWER_STRIKE",
+                                displayName = "Power Strike",
+                                description = "1.5x next attack",
+                                effect = PerkEffectProperties(
+                                    type = PerkEffectType.ACTIVE_ABILITY,
+                                    abilityId = "SWORD_POWER_STRIKE",
+                                    costResource = AbilityCostResource.STAMINA,
+                                    costAmount = 20,
+                                    abilityTarget = AbilityTarget.SINGLE_AGENT,
+                                    cooldownTicks = 5,
+                                    abilityEffectKind = AbilityEffectKind.SCALE_NEXT_ATTACK,
+                                    abilityEffectParams = mapOf("multiplierPct" to "150"),
+                                ),
+                            ),
+                            passiveAuraPerk("SWORD_BUDDY"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val lookup = PerkLookupImpl(props)
+
+        val perk = assertNotNull(lookup.byId(PerkId("SWORD_POWER_STRIKE")))
+        val active = assertIs<PerkEffect.ActiveAbility>(perk.effect)
+        assertEquals(AbilityId("SWORD_POWER_STRIKE"), active.abilityId)
+        assertEquals(AbilityCostResource.STAMINA, active.costResource)
+        assertEquals(20, active.costAmount)
+        assertEquals(AbilityTarget.SINGLE_AGENT, active.target)
+        assertEquals(5, active.cooldownTicks)
+        assertEquals(AbilityEffectKind.SCALE_NEXT_ATTACK, active.effectKind)
+        assertEquals("150", active.effectParams["multiplierPct"])
     }
 
     @Test

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/PerksValidatorTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/PerksValidatorTest.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.player.internal.balance
 
 import dev.gvart.genesara.player.AbilityCostResource
+import dev.gvart.genesara.player.AbilityEffectKind
 import dev.gvart.genesara.player.AbilityTarget
 import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillCategory
@@ -264,11 +265,12 @@ class PerksValidatorTest {
         description = id,
         effect = PerkEffectProperties(
             type = PerkEffectType.ACTIVE_ABILITY,
-            abilityId = "stub_ability",
+            abilityId = "stub_ability_$id",
             costResource = AbilityCostResource.STAMINA,
             costAmount = 10,
             abilityTarget = AbilityTarget.SELF,
             cooldownTicks = 30,
+            abilityEffectKind = AbilityEffectKind.HEAL_SELF,
         ),
     )
 }

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/perks/ActivePerkLookupImplTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/perks/ActivePerkLookupImplTest.kt
@@ -1,0 +1,167 @@
+package dev.gvart.genesara.player.internal.perks
+
+import dev.gvart.genesara.player.AbilityCostResource
+import dev.gvart.genesara.player.AbilityEffectKind
+import dev.gvart.genesara.player.AbilityId
+import dev.gvart.genesara.player.AbilityTarget
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentPerk
+import dev.gvart.genesara.player.AgentPerksRegistry
+import dev.gvart.genesara.player.AgentPerksSnapshot
+import dev.gvart.genesara.player.AgentSkillState
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.Perk
+import dev.gvart.genesara.player.PerkChoice
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.PerkLookup
+import dev.gvart.genesara.player.RecordPerkResult
+import dev.gvart.genesara.player.ScalingEffect
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillSlotError
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ActivePerkLookupImplTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val sword = SkillId("SWORD")
+    private val bow = SkillId("BOW")
+    private val powerStrikeId = AbilityId("SWORD_POWER_STRIKE")
+
+    private val powerStrikePerk = perk(
+        id = "SWORD_POWER_STRIKE",
+        skill = sword,
+        effect = active(powerStrikeId),
+    )
+    private val sharpenAuraPerk = perk(
+        id = "SWORD_SHARPEN_EDGE",
+        skill = sword,
+        effect = PerkEffect.PassiveAura(target = ScalingEffect.SLASH_DAMAGE_BONUS, magnitude = 5),
+    )
+
+    @Test
+    fun `byAbility returns the active perk when chosen and parent skill is slotted`() {
+        val lookup = lookup(
+            perks = listOf(powerStrikePerk),
+            chosen = listOf(powerStrikePerk),
+            slotted = mapOf(sword to 100),
+        )
+        val active = assertNotNull(lookup.byAbility(agent, powerStrikeId))
+        assertEquals(powerStrikePerk.id, active.perk.id)
+        assertEquals(powerStrikeId, active.effect.abilityId)
+    }
+
+    @Test
+    fun `byAbility returns null when the ability id is unknown`() {
+        val lookup = lookup(
+            perks = listOf(powerStrikePerk),
+            chosen = listOf(powerStrikePerk),
+            slotted = mapOf(sword to 100),
+        )
+        assertNull(lookup.byAbility(agent, AbilityId("PHANTOM_ABILITY")))
+    }
+
+    @Test
+    fun `byAbility returns null when the parent skill is not slotted`() {
+        val lookup = lookup(
+            perks = listOf(powerStrikePerk),
+            chosen = listOf(powerStrikePerk),
+            slotted = mapOf(bow to 50),
+        )
+        assertNull(lookup.byAbility(agent, powerStrikeId))
+    }
+
+    @Test
+    fun `byAbility returns null when no perk has been chosen yet`() {
+        val lookup = lookup(
+            perks = listOf(powerStrikePerk),
+            chosen = emptyList(),
+            slotted = mapOf(sword to 100),
+        )
+        assertNull(lookup.byAbility(agent, powerStrikeId))
+    }
+
+    @Test
+    fun `byAbility ignores non-active perk effects under the same skill`() {
+        val lookup = lookup(
+            perks = listOf(sharpenAuraPerk),
+            chosen = listOf(sharpenAuraPerk),
+            slotted = mapOf(sword to 50),
+        )
+        assertNull(lookup.byAbility(agent, powerStrikeId))
+    }
+
+    private fun lookup(perks: List<Perk>, chosen: List<Perk>, slotted: Map<SkillId, Int>) =
+        ActivePerkLookupImpl(
+            perks = StubPerkLookup(perks),
+            perksRegistry = StubPerksRegistry(chosen),
+            skillsRegistry = StubSkillsRegistry(slotted),
+        )
+
+    private fun perk(id: String, skill: SkillId, effect: PerkEffect): Perk = Perk(
+        id = PerkId(id),
+        skill = skill,
+        milestoneLevel = 100,
+        displayName = id,
+        description = id,
+        effect = effect,
+    )
+
+    private fun active(abilityId: AbilityId): PerkEffect.ActiveAbility = PerkEffect.ActiveAbility(
+        abilityId = abilityId,
+        costResource = AbilityCostResource.STAMINA,
+        costAmount = 20,
+        target = AbilityTarget.SINGLE_AGENT,
+        cooldownTicks = 5,
+        effectKind = AbilityEffectKind.SCALE_NEXT_ATTACK,
+        effectParams = mapOf("multiplierPct" to "150"),
+    )
+
+    private class StubPerkLookup(private val perks: List<Perk>) : PerkLookup {
+        private val byId = perks.associateBy { it.id }
+        override fun byId(id: PerkId): Perk? = byId[id]
+        override fun choicesAt(skill: SkillId, milestoneLevel: Int): PerkChoice? = null
+        override fun choicesFor(skill: SkillId): List<PerkChoice> = emptyList()
+        override fun all(): List<Perk> = perks
+    }
+
+    private class StubPerksRegistry(private val chosen: List<Perk>) : AgentPerksRegistry {
+        override fun snapshot(agent: AgentId): AgentPerksSnapshot = AgentPerksSnapshot(
+            perks = chosen.map {
+                AgentPerk(
+                    skill = it.skill,
+                    milestoneLevel = it.milestoneLevel,
+                    perkId = it.id,
+                    chosenAtTick = 0,
+                )
+            },
+        )
+        override fun recordChoice(agent: AgentId, perk: PerkId, tick: Long): RecordPerkResult =
+            RecordPerkResult.Recorded
+    }
+
+    private class StubSkillsRegistry(private val slotted: Map<SkillId, Int>) : AgentSkillsRegistry {
+        override fun snapshot(agent: AgentId): AgentSkillsSnapshot = AgentSkillsSnapshot(
+            perSkill = slotted.entries.mapIndexed { idx, (skill, level) ->
+                skill to AgentSkillState(
+                    skill = skill,
+                    xp = 0,
+                    level = level,
+                    slotIndex = idx,
+                    recommendCount = 0,
+                )
+            }.toMap(),
+            slotCount = slotted.size,
+            slotsFilled = slotted.size,
+        )
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int): AddXpResult = AddXpResult.Unslotted
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? = null
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? = null
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
@@ -1,5 +1,8 @@
 package dev.gvart.genesara.world
 
+import dev.gvart.genesara.player.AbilityCostResource
+import dev.gvart.genesara.player.AbilityId
+import dev.gvart.genesara.player.AbilityTarget
 import dev.gvart.genesara.player.AgentId
 import java.util.UUID
 
@@ -255,4 +258,46 @@ sealed interface WorldRejection {
      * only on the rare race where the death sweep hasn't yet removed them.
      */
     data class TargetAlreadyDead(val attacker: AgentId, val target: AgentId) : WorldRejection
+
+    /**
+     * Agent does not have a chosen perk granting [ability] — either no perk maps
+     * to this id, or the perk's parent skill is not in a slot. Distinguishing the
+     * two would leak the catalog (`ActivePerkLookup` deliberately collapses both
+     * to null), so the rejection collapses too.
+     */
+    data class UnknownAbility(val agent: AgentId, val ability: AbilityId) : WorldRejection
+
+    /** Ability is on internal cooldown; [readyAtTick] is the earliest tick it can be cast again. */
+    data class AbilityOnCooldown(
+        val agent: AgentId,
+        val ability: AbilityId,
+        val readyAtTick: Long,
+    ) : WorldRejection
+
+    /** Ability requires [resource] at [required], agent has [available]. */
+    data class InsufficientAbilityResource(
+        val agent: AgentId,
+        val ability: AbilityId,
+        val resource: AbilityCostResource,
+        val required: Int,
+        val available: Int,
+    ) : WorldRejection
+
+    /**
+     * Target shape mismatch — the supplied/missing target does not match the
+     * ability's [expected] shape (e.g. SINGLE_AGENT requires a target id;
+     * SELF / AREA_SELF_NODE forbid one).
+     */
+    data class AbilityTargetMismatch(
+        val agent: AgentId,
+        val ability: AbilityId,
+        val expected: AbilityTarget,
+    ) : WorldRejection
+
+    /** SINGLE_AGENT ability target is not in the caster's node. */
+    data class AbilityTargetNotInSameNode(
+        val agent: AgentId,
+        val ability: AbilityId,
+        val target: AgentId,
+    ) : WorldRejection
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.commands
 
+import dev.gvart.genesara.player.AbilityId
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.ItemId
@@ -146,6 +147,21 @@ sealed interface WorldCommand {
     data class AttackTarget(
         override val agent: AgentId,
         val target: AgentId,
+        override val commandId: UUID = UUID.randomUUID(),
+    ) : WorldCommand
+
+    /**
+     * Cast an active ability granted by a chosen perk on a slotted skill. The
+     * [target] is required when the ability's `AbilityTarget` is `SINGLE_AGENT`,
+     * forbidden when `SELF` / `AREA_SELF_NODE`. The reducer pays the resource
+     * cost at cast and arms the perk cooldown; the effect resolves at this same
+     * tick (a `ScaleNextAttack` buff lands on the agent and is consumed by the
+     * next [AttackTarget] reducer call).
+     */
+    data class UseAbility(
+        override val agent: AgentId,
+        val ability: AbilityId,
+        val target: AgentId? = null,
         override val commandId: UUID = UUID.randomUUID(),
     ) : WorldCommand
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
@@ -1,5 +1,8 @@
 package dev.gvart.genesara.world.events
 
+import dev.gvart.genesara.player.AbilityCostResource
+import dev.gvart.genesara.player.AbilityEffectKind
+import dev.gvart.genesara.player.AbilityId
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.PerkId
 import dev.gvart.genesara.player.TriggeredPassiveEffectKind
@@ -284,5 +287,24 @@ sealed interface WorldEvent {
         val target: AgentId?,
         override val tick: Long,
         val causedBy: UUID?,
+    ) : WorldEvent
+
+    /**
+     * Outcome of a successful [dev.gvart.genesara.world.commands.WorldCommand.UseAbility].
+     * The perk cooldown is now armed until [readyAtTick]; for `SCALE_NEXT_ATTACK`
+     * the buff lives on the agent until consumed by the next AttackTarget reducer.
+     */
+    data class AbilityUsed(
+        val agent: AgentId,
+        val perkId: PerkId,
+        val abilityId: AbilityId,
+        val target: AgentId?,
+        val effectKind: AbilityEffectKind,
+        val params: Map<String, String>,
+        val costResource: AbilityCostResource,
+        val costAmount: Int,
+        val readyAtTick: Long,
+        override val tick: Long,
+        val causedBy: UUID,
     ) : WorldEvent
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -1,11 +1,13 @@
 package dev.gvart.genesara.world.internal
 
 import arrow.core.Either
+import dev.gvart.genesara.player.ActivePerkLookup
 import dev.gvart.genesara.player.AgentProfileLookup
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.PassiveAuraAggregator
+import dev.gvart.genesara.player.PerkCooldownStore
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.BuildingsLookup
@@ -20,6 +22,7 @@ import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.buildings.BuildingsCatalog
+import dev.gvart.genesara.world.internal.abilities.reduceUseAbility
 import dev.gvart.genesara.world.internal.buildings.reduceBuild
 import dev.gvart.genesara.world.internal.buildings.reduceDeposit
 import dev.gvart.genesara.world.internal.buildings.reduceWithdraw
@@ -68,6 +71,8 @@ internal fun reduce(
     groundItems: GroundItemStore,
     deathProcessor: DeathProcessor,
     triggeredPassives: TriggeredPassiveDispatcher,
+    activePerks: ActivePerkLookup,
+    perkCooldowns: PerkCooldownStore,
     tick: Long,
     rng: Random = Random.Default,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = when (command) {
@@ -104,4 +109,6 @@ internal fun reduce(
             state, command, balance, items, agents, equipment, progression, scaling,
             passiveAura, deathProcessor, triggeredPassives, rng, tick,
         )
+    is WorldCommand.UseAbility ->
+        reduceUseAbility(state, command, activePerks, perkCooldowns, progression, balance, tick)
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/abilities/AbilityResolver.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/abilities/AbilityResolver.kt
@@ -1,0 +1,136 @@
+package dev.gvart.genesara.world.internal.abilities
+
+import arrow.core.Either
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import arrow.core.raise.ensureNotNull
+import dev.gvart.genesara.player.AbilityCostResource
+import dev.gvart.genesara.player.AbilityEffectKind
+import dev.gvart.genesara.player.AbilityTarget
+import dev.gvart.genesara.player.ActivePerk
+import dev.gvart.genesara.player.ActivePerkLookup
+import dev.gvart.genesara.player.PerkCooldownStore
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+
+// Validation order pays the cheap reads first so a misuse short-circuits before
+// we touch the cooldown row or charge a resource. The cooldown is armed BEFORE
+// the resource is spent so a future spend that grows a precondition still leaves
+// the cast committed — matches "cost paid at cast, not refunded" from spec §9.
+//
+// Effect kinds other than SCALE_NEXT_ATTACK ship the discriminator + params on
+// [WorldEvent.AbilityUsed]; downstream resolvers attach in later slices,
+// mirroring [dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcher].
+internal fun reduceUseAbility(
+    state: WorldState,
+    command: WorldCommand.UseAbility,
+    activePerks: ActivePerkLookup,
+    cooldowns: PerkCooldownStore,
+    progression: SkillProgression,
+    balance: BalanceLookup,
+    tick: Long,
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
+    val casterNode = ensureNotNull(state.positions[command.agent]) {
+        WorldRejection.NotInWorld(command.agent)
+    }
+
+    val active: ActivePerk = ensureNotNull(activePerks.byAbility(command.agent, command.ability)) {
+        WorldRejection.UnknownAbility(command.agent, command.ability)
+    }
+    val effect: PerkEffect.ActiveAbility = active.effect
+
+    when (effect.target) {
+        AbilityTarget.SELF, AbilityTarget.AREA_SELF_NODE -> ensure(command.target == null) {
+            WorldRejection.AbilityTargetMismatch(command.agent, command.ability, effect.target)
+        }
+        AbilityTarget.SINGLE_AGENT -> {
+            val target = ensureNotNull(command.target) {
+                WorldRejection.AbilityTargetMismatch(command.agent, command.ability, effect.target)
+            }
+            val targetNode = ensureNotNull(state.positions[target]) {
+                WorldRejection.AbilityTargetNotInSameNode(command.agent, command.ability, target)
+            }
+            ensure(targetNode == casterNode) {
+                WorldRejection.AbilityTargetNotInSameNode(command.agent, command.ability, target)
+            }
+        }
+    }
+
+    val until = cooldowns.readyAtTick(command.agent, active.perk.id) ?: 0L
+    ensure(tick >= until) {
+        WorldRejection.AbilityOnCooldown(
+            agent = command.agent,
+            ability = command.ability,
+            readyAtTick = until,
+        )
+    }
+
+    val body = state.bodyOf(command.agent)
+        ?: error("Invariant violated: agent ${command.agent} positioned but has no body")
+    val available = body.availableOf(effect.costResource)
+    ensure(available >= effect.costAmount) {
+        WorldRejection.InsufficientAbilityResource(
+            agent = command.agent,
+            ability = command.ability,
+            resource = effect.costResource,
+            required = effect.costAmount,
+            available = available,
+        )
+    }
+
+    val readyAtTick = tick + effect.cooldownTicks
+    cooldowns.arm(command.agent, active.perk.id, readyAtTick)
+
+    val nextBody = body.spend(effect.costResource, effect.costAmount)
+    var nextState = state.updateBody(command.agent, nextBody)
+
+    if (effect.effectKind == AbilityEffectKind.SCALE_NEXT_ATTACK) {
+        val multiplierPct = effect.effectParams["multiplierPct"]?.toIntOrNull()
+            ?: error(
+                "ActiveAbility ${effect.abilityId.value} declared SCALE_NEXT_ATTACK without a numeric " +
+                    "multiplierPct param — PerksValidator should reject malformed params at startup.",
+            )
+        nextState = nextState.stagePendingAttackScale(command.agent, multiplierPct)
+    }
+
+    progression.accrueXp(
+        command.agent,
+        active.perk.skill,
+        balance.useAbilityXpDelta(),
+        tick,
+        command.commandId,
+    )
+
+    val event = WorldEvent.AbilityUsed(
+        agent = command.agent,
+        perkId = active.perk.id,
+        abilityId = effect.abilityId,
+        target = command.target,
+        effectKind = effect.effectKind,
+        params = effect.effectParams,
+        costResource = effect.costResource,
+        costAmount = effect.costAmount,
+        readyAtTick = readyAtTick,
+        tick = tick,
+        causedBy = command.commandId,
+    )
+    nextState to listOf<WorldEvent>(event)
+}
+
+private fun AgentBody.availableOf(resource: AbilityCostResource): Int = when (resource) {
+    AbilityCostResource.HP -> hp
+    AbilityCostResource.STAMINA -> stamina
+    AbilityCostResource.MANA -> mana
+}
+
+private fun AgentBody.spend(resource: AbilityCostResource, amount: Int): AgentBody = when (resource) {
+    AbilityCostResource.HP -> takeDamage(amount)
+    AbilityCostResource.STAMINA -> spendStamina(amount)
+    AbilityCostResource.MANA -> spendMana(amount)
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -192,6 +192,14 @@ internal interface BalanceLookup {
 
     /** XP delta granted to the weapon's combat-skill per successful attack. Mirrors craft/build at 1. */
     fun attackXpDelta(): Int = 1
+
+    /**
+     * XP delta granted to the parent skill of an ability per successful
+     * `use_ability` cast. Mirrors [attackXpDelta] at 1; lets the ability path
+     * train its own skill the same way [WorldCommand.AttackTarget] trains the
+     * weapon's combat skill.
+     */
+    fun useAbilityXpDelta(): Int = 1
 }
 
 @Component

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/body/AgentBody.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/body/AgentBody.kt
@@ -28,6 +28,9 @@ internal data class AgentBody(
     fun regenStamina(amount: Int): AgentBody =
         copy(stamina = (stamina + amount).coerceIn(0, maxStamina))
 
+    fun spendMana(cost: Int): AgentBody =
+        copy(mana = (mana - cost).coerceAtLeast(0))
+
     fun takeDamage(amount: Int): AgentBody =
         copy(hp = (hp - amount).coerceAtLeast(0))
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
@@ -106,7 +106,15 @@ internal fun reduceAttack(
     // chosen auras add on top. Order keeps "+5 Sharpen Edge" predictable regardless of
     // SWORD level, while "Doubled Edge" still doubles the per-level rate underneath.
     val auraBonus = scalingEffect?.let { passiveAura.bonusFor(command.agent, it) } ?: 0
-    val scaledDamage = ((typedDamage * (1.0 + damageScaling)).toInt() + auraBonus).coerceAtLeast(0)
+    val baseScaled = ((typedDamage * (1.0 + damageScaling)).toInt() + auraBonus).coerceAtLeast(0)
+    // Read-and-clear before the rolls so a dodge still burns the staged buff
+    // (matches "cost paid at cast, not refunded on miss" from spec §9).
+    val (stateAfterScaleConsume, pendingScalePct) = state.consumePendingAttackScale(command.agent)
+    val scaledDamage = if (pendingScalePct != null) {
+        (baseScaled.toLong() * pendingScalePct / 100).toInt().coerceAtLeast(0)
+    } else {
+        baseScaled
+    }
 
     // Dodge rolls FIRST so a successful dodge short-circuits the crit roll. Otherwise a crit
     // followed by a dodge would burn the RNG cursor on a discarded crit and shift downstream
@@ -124,7 +132,7 @@ internal fun reduceAttack(
 
     val nextTargetBody = targetBody.takeDamage(hpLost)
     val nextAttackerBody = attackerBody.spendStamina(staminaCost)
-    var nextState = state
+    var nextState = stateAfterScaleConsume
         .updateBody(command.target, nextTargetBody)
         .updateBody(command.agent, nextAttackerBody)
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -1,11 +1,13 @@
 package dev.gvart.genesara.world.internal.tick
 
 import dev.gvart.genesara.engine.Tick
+import dev.gvart.genesara.player.ActivePerkLookup
 import dev.gvart.genesara.player.AgentProfileLookup
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.PassiveAuraAggregator
+import dev.gvart.genesara.player.PerkCooldownStore
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.BuildingsLookup
@@ -61,6 +63,8 @@ internal class WorldTickHandler(
     private val groundItems: GroundItemStore,
     private val deathProcessor: DeathProcessor,
     private val triggeredPassives: TriggeredPassiveDispatcher,
+    private val activePerks: ActivePerkLookup,
+    private val perkCooldowns: PerkCooldownStore,
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -89,7 +93,7 @@ internal class WorldTickHandler(
                 state, command, balance, profiles, items, recipes, resources, skills, agents, equipment,
                 safeNodes, safeNodeResolver, buildings, buildingsLookup, buildingsCatalog, chestContents,
                 rarityRoller, progression, scaling, passiveAura, spawnLocationResolver, groundItems,
-                deathProcessor, triggeredPassives, tick.number,
+                deathProcessor, triggeredPassives, activePerks, perkCooldowns, tick.number,
             ).fold(
                 ifLeft = { rejection ->
                     log.info("Rejected {} at tick {}: {}", command, tick.number, rejection)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldState.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldState.kt
@@ -16,6 +16,18 @@ internal data class WorldState(
     val bodies: Map<AgentId, AgentBody>,
     val inventories: Map<AgentId, AgentInventory>,
     val killStreaks: Map<AgentId, AgentKillStreak> = emptyMap(),
+    /**
+     * One-shot damage multiplier (whole percent) staged by an `ActiveAbility`
+     * with `effectKind = SCALE_NEXT_ATTACK`. Read and cleared by the next
+     * successful [AttackReducer] call from this agent. Percent-encoded so a
+     * 1.5× perk lands as `150` without floating-point drift.
+     *
+     * TODO(active-ability-buff-expiry): the staged buff has no time bound — an
+     * agent who casts Power Strike and then crafts/logs out for hours pops the
+     * buff on the eventual next attack. Add a `(pct, expiresAtTick)` shape and
+     * discard on read past expiry, or clear on unspawn / weapon swap.
+     */
+    val pendingAttackScales: Map<AgentId, Int> = emptyMap(),
 ) {
 
     fun isAdjacent(from: NodeId, to: NodeId): Boolean =
@@ -42,6 +54,14 @@ internal data class WorldState(
 
     fun updateKillStreak(agent: AgentId, streak: AgentKillStreak): WorldState =
         copy(killStreaks = killStreaks + (agent to streak))
+
+    fun stagePendingAttackScale(agent: AgentId, multiplierPct: Int): WorldState =
+        copy(pendingAttackScales = pendingAttackScales + (agent to multiplierPct))
+
+    fun consumePendingAttackScale(agent: AgentId): Pair<WorldState, Int?> {
+        val scale = pendingAttackScales[agent] ?: return this to null
+        return copy(pendingAttackScales = pendingAttackScales - agent) to scale
+    }
 
     /**
      * Public-API surface for the Phase 2 combat reducer. Encapsulates the
@@ -75,6 +95,7 @@ internal data class WorldState(
             bodies = emptyMap(),
             inventories = emptyMap(),
             killStreaks = emptyMap(),
+            pendingAttackScales = emptyMap(),
         )
     }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/abilities/AbilityResolverTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/abilities/AbilityResolverTest.kt
@@ -1,0 +1,314 @@
+package dev.gvart.genesara.world.internal.abilities
+
+import dev.gvart.genesara.player.AbilityCostResource
+import dev.gvart.genesara.player.AbilityEffectKind
+import dev.gvart.genesara.player.AbilityId
+import dev.gvart.genesara.player.AbilityTarget
+import dev.gvart.genesara.player.ActivePerk
+import dev.gvart.genesara.player.ActivePerkLookup
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.Perk
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.Gauge
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.ResourceSpawnRule
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.testsupport.InMemoryPerkCooldownStore
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AbilityResolverTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val target = AgentId(UUID.randomUUID())
+    private val regionId = RegionId(1L)
+    private val nodeA = NodeId(1L)
+    private val nodeB = NodeId(2L)
+    private val ability = AbilityId("SWORD_POWER_STRIKE")
+    private val perkId = PerkId("SWORD_POWER_STRIKE")
+    private val swordSkill = SkillId("SWORD")
+
+    private val region = Region(
+        id = regionId,
+        worldId = WorldId(1L),
+        sphereIndex = 0,
+        biome = Biome.PLAINS,
+        climate = Climate.OCEANIC,
+        centroid = Vec3(0.0, 0.0, 1.0),
+        faceVertices = emptyList(),
+        neighbors = emptySet(),
+    )
+    private val nodeAObj = Node(nodeA, regionId, q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())
+    private val nodeBObj = Node(nodeB, regionId, q = 1, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())
+
+    @Test
+    fun `success path stages SCALE_NEXT_ATTACK buff, deducts stamina, arms cooldown, accrues XP`() {
+        val cd = InMemoryPerkCooldownStore()
+        val lookups = StubActivePerkLookup(active = powerStrike())
+        val skills = SnapshotSkills()
+        val publisher = RecordingPublisher()
+        val state = baseState(stamina = 50)
+
+        val command = WorldCommand.UseAbility(agent, ability, target = target)
+        val (next, events) = assertNotNull(
+            reduceUseAbility(
+                state = state,
+                command = command,
+                activePerks = lookups,
+                cooldowns = cd,
+                progression = SkillProgression(skills, publisher),
+                balance = combatBalance(),
+                tick = 100L,
+            ).getOrNull(),
+        )
+
+        assertEquals(150, next.pendingAttackScales[agent])
+        assertEquals(30, next.bodyOf(agent)?.stamina, "20 stamina deducted from 50")
+        assertEquals(105L, cd.armedUntil[agent to perkId])
+
+        val event = assertIs<WorldEvent.AbilityUsed>(events.single())
+        assertEquals(ability, event.abilityId)
+        assertEquals(target, event.target)
+        assertEquals(AbilityEffectKind.SCALE_NEXT_ATTACK, event.effectKind)
+        assertEquals(20, event.costAmount)
+        assertEquals(AbilityCostResource.STAMINA, event.costResource)
+        assertEquals(105L, event.readyAtTick)
+        assertEquals(command.commandId, event.causedBy)
+
+        assertTrue(skills.xpDeltas.any { it.first == swordSkill && it.second == 1 })
+    }
+
+    @Test
+    fun `rejects unknown ability when agent has no chosen perk granting it`() {
+        val cd = InMemoryPerkCooldownStore()
+        val lookups = StubActivePerkLookup(active = null)
+
+        val rejection = reduceUseAbility(
+            state = baseState(stamina = 50),
+            command = WorldCommand.UseAbility(agent, ability, target = target),
+            activePerks = lookups,
+            cooldowns = cd,
+            progression = SkillProgression(SnapshotSkills(), RecordingPublisher()),
+            balance = combatBalance(),
+            tick = 1L,
+        ).leftOrNull()
+        val unknown = assertIs<WorldRejection.UnknownAbility>(rejection)
+        assertEquals(ability, unknown.ability)
+    }
+
+    @Test
+    fun `rejects when ability is on cooldown — readyAtTick surfaces in the rejection`() {
+        val cd = InMemoryPerkCooldownStore().apply { arm(agent, perkId, untilTick = 200L) }
+
+        val rejection = reduceUseAbility(
+            state = baseState(stamina = 50),
+            command = WorldCommand.UseAbility(agent, ability, target = target),
+            activePerks = StubActivePerkLookup(active = powerStrike()),
+            cooldowns = cd,
+            progression = SkillProgression(SnapshotSkills(), RecordingPublisher()),
+            balance = combatBalance(),
+            tick = 100L,
+        ).leftOrNull()
+        val onCd = assertIs<WorldRejection.AbilityOnCooldown>(rejection)
+        assertEquals(200L, onCd.readyAtTick)
+    }
+
+    @Test
+    fun `rejects when stamina is below the cost — does not arm cooldown or deduct anything`() {
+        val cd = InMemoryPerkCooldownStore()
+        val skills = SnapshotSkills()
+        val state = baseState(stamina = 5)
+
+        val rejection = reduceUseAbility(
+            state = state,
+            command = WorldCommand.UseAbility(agent, ability, target = target),
+            activePerks = StubActivePerkLookup(active = powerStrike()),
+            cooldowns = cd,
+            progression = SkillProgression(skills, RecordingPublisher()),
+            balance = combatBalance(),
+            tick = 1L,
+        ).leftOrNull()
+        val short = assertIs<WorldRejection.InsufficientAbilityResource>(rejection)
+        assertEquals(AbilityCostResource.STAMINA, short.resource)
+        assertEquals(20, short.required)
+        assertEquals(5, short.available)
+        assertNull(cd.armedUntil[agent to perkId], "rejection must not arm the cooldown")
+        assertTrue(skills.xpDeltas.isEmpty(), "rejection must not accrue XP")
+    }
+
+    @Test
+    fun `rejects SINGLE_AGENT ability when target is in a different node`() {
+        val cd = InMemoryPerkCooldownStore()
+        val state = baseState(stamina = 50).copy(
+            positions = mapOf(agent to nodeA, target to nodeB),
+            nodes = mapOf(nodeA to nodeAObj, nodeB to nodeBObj),
+        )
+
+        val rejection = reduceUseAbility(
+            state = state,
+            command = WorldCommand.UseAbility(agent, ability, target = target),
+            activePerks = StubActivePerkLookup(active = powerStrike()),
+            cooldowns = cd,
+            progression = SkillProgression(SnapshotSkills(), RecordingPublisher()),
+            balance = combatBalance(),
+            tick = 1L,
+        ).leftOrNull()
+        val mismatch = assertIs<WorldRejection.AbilityTargetNotInSameNode>(rejection)
+        assertEquals(target, mismatch.target)
+    }
+
+    @Test
+    fun `rejects SINGLE_AGENT ability when target is omitted`() {
+        val rejection = reduceUseAbility(
+            state = baseState(stamina = 50),
+            command = WorldCommand.UseAbility(agent, ability, target = null),
+            activePerks = StubActivePerkLookup(active = powerStrike()),
+            cooldowns = InMemoryPerkCooldownStore(),
+            progression = SkillProgression(SnapshotSkills(), RecordingPublisher()),
+            balance = combatBalance(),
+            tick = 1L,
+        ).leftOrNull()
+        val mismatch = assertIs<WorldRejection.AbilityTargetMismatch>(rejection)
+        assertEquals(AbilityTarget.SINGLE_AGENT, mismatch.expected)
+    }
+
+    @Test
+    fun `rejects SELF ability when target is supplied`() {
+        val selfBuff = ActivePerk(
+            perk = Perk(
+                id = perkId,
+                skill = swordSkill,
+                milestoneLevel = 100,
+                displayName = "Self Buff",
+                description = "",
+                effect = PerkEffect.ActiveAbility(
+                    abilityId = ability,
+                    costResource = AbilityCostResource.STAMINA,
+                    costAmount = 5,
+                    target = AbilityTarget.SELF,
+                    cooldownTicks = 5,
+                    effectKind = AbilityEffectKind.HEAL_SELF,
+                    effectParams = mapOf("amount" to "10"),
+                ),
+            ),
+            effect = PerkEffect.ActiveAbility(
+                abilityId = ability,
+                costResource = AbilityCostResource.STAMINA,
+                costAmount = 5,
+                target = AbilityTarget.SELF,
+                cooldownTicks = 5,
+                effectKind = AbilityEffectKind.HEAL_SELF,
+                effectParams = mapOf("amount" to "10"),
+            ),
+        )
+        val rejection = reduceUseAbility(
+            state = baseState(stamina = 50),
+            command = WorldCommand.UseAbility(agent, ability, target = target),
+            activePerks = StubActivePerkLookup(active = selfBuff),
+            cooldowns = InMemoryPerkCooldownStore(),
+            progression = SkillProgression(SnapshotSkills(), RecordingPublisher()),
+            balance = combatBalance(),
+            tick = 1L,
+        ).leftOrNull()
+        val mismatch = assertIs<WorldRejection.AbilityTargetMismatch>(rejection)
+        assertEquals(AbilityTarget.SELF, mismatch.expected)
+    }
+
+    private fun powerStrike(): ActivePerk {
+        val effect = PerkEffect.ActiveAbility(
+            abilityId = ability,
+            costResource = AbilityCostResource.STAMINA,
+            costAmount = 20,
+            target = AbilityTarget.SINGLE_AGENT,
+            cooldownTicks = 5,
+            effectKind = AbilityEffectKind.SCALE_NEXT_ATTACK,
+            effectParams = mapOf("multiplierPct" to "150"),
+        )
+        val perk = Perk(
+            id = perkId,
+            skill = swordSkill,
+            milestoneLevel = 100,
+            displayName = "Power Strike",
+            description = "",
+            effect = effect,
+        )
+        return ActivePerk(perk, effect)
+    }
+
+    private fun baseState(stamina: Int) = WorldState(
+        regions = mapOf(regionId to region),
+        nodes = mapOf(nodeA to nodeAObj),
+        positions = mapOf(agent to nodeA, target to nodeA),
+        bodies = mapOf(
+            agent to AgentBody(hp = 100, maxHp = 100, stamina = stamina, maxStamina = 100, mana = 0, maxMana = 0),
+            target to AgentBody(hp = 100, maxHp = 100, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
+        ),
+        inventories = emptyMap(),
+    )
+
+    private fun combatBalance(): BalanceLookup = object : BalanceLookup {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
+        override fun staminaRegenPerTick(climate: Climate) = 0
+        override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+    }
+
+    private class StubActivePerkLookup(private val active: ActivePerk?) : ActivePerkLookup {
+        override fun byAbility(agent: AgentId, ability: AbilityId): ActivePerk? = active
+    }
+
+    private class SnapshotSkills : AgentSkillsRegistry {
+        val xpDeltas = mutableListOf<Pair<SkillId, Int>>()
+        override fun snapshot(agent: AgentId): AgentSkillsSnapshot =
+            AgentSkillsSnapshot(perSkill = emptyMap(), slotCount = 8, slotsFilled = 0)
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int): AddXpResult {
+            xpDeltas += skill to delta
+            return AddXpResult.Unslotted
+        }
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? = null
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? = null
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/abilities/PowerStrikeCanaryIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/abilities/PowerStrikeCanaryIntegrationTest.kt
@@ -1,6 +1,12 @@
-package dev.gvart.genesara.world.internal.combat
+package dev.gvart.genesara.world.internal.abilities
 
 import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AbilityCostResource
+import dev.gvart.genesara.player.AbilityEffectKind
+import dev.gvart.genesara.player.AbilityId
+import dev.gvart.genesara.player.AbilityTarget
+import dev.gvart.genesara.player.ActivePerk
+import dev.gvart.genesara.player.ActivePerkLookup
 import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentAttributes
@@ -13,16 +19,11 @@ import dev.gvart.genesara.player.DeathPenaltyOutcome
 import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
 import dev.gvart.genesara.player.PassiveAuraAggregator.Companion.NoAura
 import dev.gvart.genesara.player.Perk
-import dev.gvart.genesara.player.PerkCooldownStore
 import dev.gvart.genesara.player.PerkEffect
 import dev.gvart.genesara.player.PerkId
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.player.SkillSlotError
-import dev.gvart.genesara.player.TriggeredPassiveEffectKind
-import dev.gvart.genesara.player.TriggeredPassiveLookup
-import dev.gvart.genesara.player.TriggeredPassiveTrigger
-import dev.gvart.genesara.player.TriggeredPerk
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Climate
 import dev.gvart.genesara.world.DamageType
@@ -50,8 +51,10 @@ import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.combat.reduceAttack
 import dev.gvart.genesara.world.internal.death.DeathProcessor
-import dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcherImpl
+import dev.gvart.genesara.world.internal.testsupport.InMemoryPerkCooldownStore
+import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
@@ -60,13 +63,10 @@ import kotlin.random.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-// Canary for issue #64 — proves the dispatcher is reachable from real reduceAttack
-// wiring with the SWORD-50 Bleeder perk. Cooldown gate semantics + band-cross
-// edge cases are covered by the dispatcher unit + cooldown-store integration tests;
-// here we only assert "the perk fires through the pipeline" and ordering invariants.
-class BleederCanaryIntegrationTest {
+class PowerStrikeCanaryIntegrationTest {
 
     private val attacker = AgentId(UUID.randomUUID())
     private val target = AgentId(UUID.randomUUID())
@@ -74,7 +74,8 @@ class BleederCanaryIntegrationTest {
     private val nodeId = NodeId(1L)
     private val rustySword = ItemId("RUSTY_SWORD")
     private val swordSkill = SkillId("SWORD")
-    private val bleederId = PerkId("SWORD_BLEEDER")
+    private val abilityId = AbilityId("SWORD_POWER_STRIKE")
+    private val perkId = PerkId("SWORD_POWER_STRIKE")
 
     private val region = Region(
         id = regionId,
@@ -89,7 +90,7 @@ class BleederCanaryIntegrationTest {
     private val node = Node(nodeId, regionId, q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())
 
     @Test
-    fun `Bleeder applies BLEED status on hit and respects internal cooldown`() {
+    fun `Power Strike stages SCALE_NEXT_ATTACK and the next attack scales damage by 1_5x`() {
         val balance = combatBalance()
         val items = StubItemLookup(swordItem())
         val agents = StubAgentRegistry(
@@ -115,14 +116,12 @@ class BleederCanaryIntegrationTest {
                 ),
             ),
         )
-        val groundItems = StubGroundItemStore()
-        val deathProcessor = DeathProcessor(balance, agents, equipment, groundItems)
-        val skills = StubSkillsRegistry()
         val publisher = RecordingPublisher()
+        val skills = StubSkillsRegistry()
         val progression = SkillProgression(skills, publisher)
-
-        val cd = InMemoryCooldownStore()
-        val dispatcher = TriggeredPassiveDispatcherImpl(BleederLookup(attacker), cd)
+        val deathProcessor = DeathProcessor(balance, agents, equipment, StubGroundItemStore())
+        val cooldowns = InMemoryPerkCooldownStore()
+        val activePerks = SinglePerkLookup(attacker, abilityId, powerStrikeEffect())
 
         val initial = WorldState(
             regions = mapOf(regionId to region),
@@ -135,106 +134,110 @@ class BleederCanaryIntegrationTest {
             inventories = emptyMap(),
         )
 
-        val firstCommand = WorldCommand.AttackTarget(attacker, target)
-        val (afterFirst, firstEvents) = assertNotNull(
-            reduceAttack(
-                initial, firstCommand, balance, items, agents, equipment, progression,
-                deathProcessor = deathProcessor, rng = Random(seed = 7L), scaling = NoScaling,
-                passiveAura = NoAura, triggeredPassives = dispatcher, tick = 100L,
+        val useCmd = WorldCommand.UseAbility(attacker, abilityId, target = target)
+        val (afterUse, useEvents) = assertNotNull(
+            reduceUseAbility(
+                state = initial,
+                command = useCmd,
+                activePerks = activePerks,
+                cooldowns = cooldowns,
+                progression = progression,
+                balance = balance,
+                tick = 100L,
             ).getOrNull(),
         )
+        assertIs<WorldEvent.AbilityUsed>(useEvents.single())
+        assertEquals(150, afterUse.pendingAttackScales[attacker])
+        assertEquals(30, afterUse.bodyOf(attacker)?.stamina, "Power Strike pays 20 stamina at cast")
+        assertEquals(105L, cooldowns.armedUntil[attacker to perkId])
 
-        val firstAttacked = assertIs<WorldEvent.AgentAttacked>(firstEvents[0])
-        assertTrue(firstAttacked.hpLost > 0)
-        assertEquals(false, firstAttacked.isDodged)
-        val firstTriggered = firstEvents.filterIsInstance<WorldEvent.PerkTriggered>()
-        assertEquals(1, firstTriggered.size, "Bleeder fires once on the first hit")
-        firstTriggered.single().let {
-            assertEquals(attacker, it.agent)
-            assertEquals(bleederId, it.perkId)
-            assertEquals(TriggeredPassiveTrigger.ON_HIT_DEALT, it.trigger)
-            assertEquals(TriggeredPassiveEffectKind.APPLY_STATUS_TO_TARGET, it.effectKind)
-            assertEquals("BLEED", it.params["status"])
-            assertEquals("10", it.params["duration-ticks"])
-            assertEquals(target, it.target)
-        }
-        assertEquals(108L, cd.armedUntil[attacker to bleederId])
-
-        val secondCommand = WorldCommand.AttackTarget(attacker, target)
-        val (_, secondEvents) = assertNotNull(
+        val unscaledState = afterUse.copy(pendingAttackScales = emptyMap())
+        val (_, baselineEvents) = assertNotNull(
             reduceAttack(
-                afterFirst, secondCommand, balance, items, agents, equipment, progression,
-                deathProcessor = deathProcessor, rng = Random(seed = 7L), scaling = NoScaling,
-                passiveAura = NoAura, triggeredPassives = dispatcher, tick = 105L,
+                unscaledState, WorldCommand.AttackTarget(attacker, target),
+                balance, items, agents, equipment, progression, NoScaling, NoAura,
+                deathProcessor, NoOpTriggeredPassiveDispatcher,
+                rng = Random(seed = 7L), tick = 101L,
             ).getOrNull(),
         )
-        assertTrue(secondEvents.none { it is WorldEvent.PerkTriggered }, "still on cooldown — no re-fire")
+        val baseline = assertIs<WorldEvent.AgentAttacked>(baselineEvents.single())
+
+        val (afterAttack, attackEvents) = assertNotNull(
+            reduceAttack(
+                afterUse, WorldCommand.AttackTarget(attacker, target),
+                balance, items, agents, equipment, progression, NoScaling, NoAura,
+                deathProcessor, NoOpTriggeredPassiveDispatcher,
+                rng = Random(seed = 7L), tick = 101L,
+            ).getOrNull(),
+        )
+        val scaled = assertIs<WorldEvent.AgentAttacked>(attackEvents.single())
+        assertEquals(baseline.baseDamage * 150 / 100, scaled.baseDamage)
+        assertNull(afterAttack.pendingAttackScales[attacker], "Single-shot buff is consumed by the first attack")
+
+        val (_, secondAttackEvents) = assertNotNull(
+            reduceAttack(
+                afterAttack, WorldCommand.AttackTarget(attacker, target),
+                balance, items, agents, equipment, progression, NoScaling, NoAura,
+                deathProcessor, NoOpTriggeredPassiveDispatcher,
+                rng = Random(seed = 7L), tick = 102L,
+            ).getOrNull(),
+        )
+        val secondAttack = assertIs<WorldEvent.AgentAttacked>(secondAttackEvents.single())
+        assertEquals(baseline.baseDamage, secondAttack.baseDamage, "Second attack lands at baseline")
     }
 
     @Test
-    fun `OnHitTaken precedes OnLowHp in the event stream for the same hit`() {
-        val balance = combatBalance()
-        val items = StubItemLookup(swordItem())
-        val agents = StubAgentRegistry(
-            byId = mapOf(
-                attacker to AgentAttributes(strength = 10, luck = 0, dexterity = 0),
-                target to AgentAttributes(strength = 1, luck = 0, dexterity = 0),
-            ),
-        )
-        val equipment = StubEquipmentStore(
-            equippedByAgent = mapOf(
-                attacker to mapOf(
-                    EquipSlot.MAIN_HAND to EquipmentInstance(
-                        instanceId = UUID.randomUUID(),
-                        agentId = attacker,
-                        itemId = rustySword,
-                        rarity = Rarity.COMMON,
-                        durabilityCurrent = 50,
-                        durabilityMax = 50,
-                        creatorAgentId = null,
-                        createdAtTick = 0L,
-                        equippedInSlot = EquipSlot.MAIN_HAND,
-                    ),
-                ),
-            ),
-        )
-        val skills = StubSkillsRegistry()
+    fun `cooldown rejects a back-to-back Power Strike cast`() {
+        val cooldowns = InMemoryPerkCooldownStore()
+        val activePerks = SinglePerkLookup(attacker, abilityId, powerStrikeEffect())
         val publisher = RecordingPublisher()
+        val skills = StubSkillsRegistry()
         val progression = SkillProgression(skills, publisher)
-        val cd = InMemoryCooldownStore()
-        val dispatcher = TriggeredPassiveDispatcherImpl(BothTriggersLookup(target), cd)
+        val balance = combatBalance()
 
-        val initial = WorldState(
+        val state = WorldState(
             regions = mapOf(regionId to region),
             nodes = mapOf(nodeId to node),
             positions = mapOf(attacker to nodeId, target to nodeId),
             bodies = mapOf(
                 attacker to AgentBody(hp = 100, maxHp = 100, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
-                // 100 -> ~20 hp puts target across the 25% band in one hit.
-                target to AgentBody(hp = 100, maxHp = 100, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
+                target to AgentBody(hp = 200, maxHp = 200, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
             ),
             inventories = emptyMap(),
         )
 
-        val (_, events) = assertNotNull(
-            reduceAttack(
-                initial, WorldCommand.AttackTarget(attacker, target),
-                balance, items, agents, equipment, progression,
-                deathProcessor = DeathProcessor(balance, agents, equipment, StubGroundItemStore()),
-                rng = Random(seed = 7L), scaling = NoScaling,
-                passiveAura = NoAura, triggeredPassives = dispatcher, tick = 1L,
-            ).getOrNull(),
-        )
+        val first = reduceUseAbility(
+            state, WorldCommand.UseAbility(attacker, abilityId, target),
+            activePerks, cooldowns, progression, balance, tick = 50L,
+        ).getOrNull()
+        assertNotNull(first)
 
-        val hitTakenIdx = events.indexOfFirst {
-            it is WorldEvent.PerkTriggered && it.trigger == TriggeredPassiveTrigger.ON_HIT_TAKEN
-        }
-        val lowHpIdx = events.indexOfFirst {
-            it is WorldEvent.PerkTriggered && it.trigger == TriggeredPassiveTrigger.ON_LOW_HP
-        }
-        assertTrue(hitTakenIdx >= 0 && lowHpIdx >= 0, "both perks must fire on the same band-crossing hit")
-        assertTrue(hitTakenIdx < lowHpIdx, "OnHitTaken precedes OnLowHp so consumers can mitigate before low-hp logic")
+        val (afterFirst, _) = first
+        val rejection = reduceUseAbility(
+            afterFirst, WorldCommand.UseAbility(attacker, abilityId, target),
+            activePerks, cooldowns, progression, balance, tick = 51L,
+        ).leftOrNull()
+        assertIs<dev.gvart.genesara.world.WorldRejection.AbilityOnCooldown>(rejection)
+
+        val later = reduceUseAbility(
+            afterFirst.copy(
+                bodies = afterFirst.bodies + (attacker to afterFirst.bodyOf(attacker)!!.copy(stamina = 50)),
+            ),
+            WorldCommand.UseAbility(attacker, abilityId, target),
+            activePerks, cooldowns, progression, balance, tick = 55L,
+        ).getOrNull()
+        assertTrue(later != null, "After the cooldown elapses the cast succeeds again")
     }
+
+    private fun powerStrikeEffect(): PerkEffect.ActiveAbility = PerkEffect.ActiveAbility(
+        abilityId = abilityId,
+        costResource = AbilityCostResource.STAMINA,
+        costAmount = 20,
+        target = AbilityTarget.SINGLE_AGENT,
+        cooldownTicks = 5,
+        effectKind = AbilityEffectKind.SCALE_NEXT_ATTACK,
+        effectParams = mapOf("multiplierPct" to "150"),
+    )
 
     private fun combatBalance(): BalanceLookup = object : BalanceLookup {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
@@ -250,7 +253,6 @@ class BleederCanaryIntegrationTest {
         override fun drinkThirstRefill(): Int = 25
         override fun sleepRegenPerOfflineTick(): Int = 0
         override fun isTraversable(terrain: Terrain): Boolean = true
-        override fun xpLossOnDeath(): Int = 0
         override fun killStreakWindowTicks(): Long = 1000L
         override fun dropChanceForKillCount(killCount: Int): Double = 0.0
     }
@@ -270,87 +272,25 @@ class BleederCanaryIntegrationTest {
         ),
     )
 
-    // Two perks bound to the same defender — one on ON_HIT_TAKEN, one on ON_LOW_HP —
-    // so the AttackReducer fires both on the same band-crossing hit.
-    private inner class BothTriggersLookup(private val defender: AgentId) : TriggeredPassiveLookup {
-        private val onHitTaken = triggered(
-            id = "DEFENSIVE_REACTION",
-            trigger = TriggeredPassiveTrigger.ON_HIT_TAKEN,
-            effectKind = TriggeredPassiveEffectKind.GRANT_SELF_BUFF,
-            cd = 5,
-            params = mapOf("buff" to "STEELSKIN"),
-        )
-        private val onLowHp = triggered(
-            id = "LAST_STAND",
-            trigger = TriggeredPassiveTrigger.ON_LOW_HP,
-            effectKind = TriggeredPassiveEffectKind.HEAL_SELF,
-            cd = 30,
-            params = mapOf("thresholdPct" to "25", "amount" to "40"),
-        )
-
-        override fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<TriggeredPerk> =
-            if (agent != defender) {
-                emptyList()
-            } else when (trigger) {
-                TriggeredPassiveTrigger.ON_HIT_TAKEN -> listOf(onHitTaken)
-                TriggeredPassiveTrigger.ON_LOW_HP -> listOf(onLowHp)
-                else -> emptyList()
-            }
-
-        private fun triggered(
-            id: String,
-            trigger: TriggeredPassiveTrigger,
-            effectKind: TriggeredPassiveEffectKind,
-            cd: Int,
-            params: Map<String, String>,
-        ): TriggeredPerk {
-            val effect = PerkEffect.TriggeredPassive(trigger, effectKind, params, cd)
-            val perk = Perk(
-                id = PerkId(id),
-                skill = swordSkill,
-                milestoneLevel = 50,
-                displayName = id,
-                description = id,
+    private inner class SinglePerkLookup(
+        private val owner: AgentId,
+        private val ability: AbilityId,
+        private val effect: PerkEffect.ActiveAbility,
+    ) : ActivePerkLookup {
+        override fun byAbility(agent: AgentId, ability: AbilityId): ActivePerk? {
+            if (agent != owner || ability != this.ability) return null
+            return ActivePerk(
+                perk = Perk(
+                    id = perkId,
+                    skill = swordSkill,
+                    milestoneLevel = 100,
+                    displayName = "Power Strike",
+                    description = "",
+                    effect = effect,
+                ),
                 effect = effect,
             )
-            return TriggeredPerk(perk, effect)
         }
-    }
-
-    private inner class BleederLookup(private val perkOwner: AgentId) : TriggeredPassiveLookup {
-        private val effect = PerkEffect.TriggeredPassive(
-            trigger = TriggeredPassiveTrigger.ON_HIT_DEALT,
-            effectKind = TriggeredPassiveEffectKind.APPLY_STATUS_TO_TARGET,
-            params = mapOf("status" to "BLEED", "duration-ticks" to "10"),
-            internalCooldownTicks = 8,
-        )
-        private val perk = Perk(
-            id = bleederId,
-            skill = swordSkill,
-            milestoneLevel = 50,
-            displayName = "Bleeder",
-            description = "Inflicts Bleed on hit",
-            effect = effect,
-        )
-
-        override fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<TriggeredPerk> =
-            if (agent == perkOwner && trigger == TriggeredPassiveTrigger.ON_HIT_DEALT) {
-                listOf(TriggeredPerk(perk, effect))
-            } else {
-                emptyList()
-            }
-    }
-
-    private class InMemoryCooldownStore : PerkCooldownStore {
-        val armedUntil = mutableMapOf<Pair<AgentId, PerkId>, Long>()
-        override fun isReady(agent: AgentId, perk: PerkId, tick: Long): Boolean {
-            val until = armedUntil[agent to perk] ?: return true
-            return tick >= until
-        }
-        override fun arm(agent: AgentId, perk: PerkId, untilTick: Long) {
-            armedUntil[agent to perk] = untilTick
-        }
-        override fun readyAtTick(agent: AgentId, perk: PerkId): Long? = armedUntil[agent to perk]
     }
 
     private class StubItemLookup(private val byId: Map<ItemId, Item>) : ItemLookup {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/perks/TriggeredPassiveDispatcherImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/perks/TriggeredPassiveDispatcherImplTest.kt
@@ -246,5 +246,6 @@ class TriggeredPassiveDispatcherImplTest {
         override fun arm(agent: AgentId, perk: PerkId, untilTick: Long) {
             armedUntil[agent to perk] = untilTick
         }
+        override fun readyAtTick(agent: AgentId, perk: PerkId): Long? = armedUntil[agent to perk]
     }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/InMemoryPerkCooldownStore.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/InMemoryPerkCooldownStore.kt
@@ -1,0 +1,22 @@
+package dev.gvart.genesara.world.internal.testsupport
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.PerkCooldownStore
+import dev.gvart.genesara.player.PerkId
+
+/** In-memory test stand-in shared by reducer/integration tests that need a real CD store. */
+internal class InMemoryPerkCooldownStore : PerkCooldownStore {
+
+    val armedUntil = mutableMapOf<Pair<AgentId, PerkId>, Long>()
+
+    override fun isReady(agent: AgentId, perk: PerkId, tick: Long): Boolean {
+        val until = armedUntil[agent to perk] ?: return true
+        return tick >= until
+    }
+
+    override fun arm(agent: AgentId, perk: PerkId, untilTick: Long) {
+        armedUntil[agent to perk] = untilTick
+    }
+
+    override fun readyAtTick(agent: AgentId, perk: PerkId): Long? = armedUntil[agent to perk]
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/NoOpActivePerkLookup.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/NoOpActivePerkLookup.kt
@@ -1,0 +1,11 @@
+package dev.gvart.genesara.world.internal.testsupport
+
+import dev.gvart.genesara.player.AbilityId
+import dev.gvart.genesara.player.ActivePerk
+import dev.gvart.genesara.player.ActivePerkLookup
+import dev.gvart.genesara.player.AgentId
+
+/** Default for reducer tests that don't exercise the active-ability surface. */
+internal object NoOpActivePerkLookup : ActivePerkLookup {
+    override fun byAbility(agent: AgentId, ability: AbilityId): ActivePerk? = null
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -1,5 +1,7 @@
 package dev.gvart.genesara.world.internal.tick
 
+import dev.gvart.genesara.world.internal.testsupport.InMemoryPerkCooldownStore
+import dev.gvart.genesara.world.internal.testsupport.NoOpActivePerkLookup
 import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.engine.Tick
 import dev.gvart.genesara.player.AgentId
@@ -93,7 +95,7 @@ class WorldTickHandlerTest {
         val publisher = RecordingPublisher()
 
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 7)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoAura, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore), NoOpTriggeredPassiveDispatcher)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoAura, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore), NoOpTriggeredPassiveDispatcher, NoOpActivePerkLookup, InMemoryPerkCooldownStore())
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -115,7 +117,7 @@ class WorldTickHandlerTest {
 
         val cmd = WorldCommand.MoveAgent(agent, ghostId)
         queue.submit(cmd, appliesAtTick = 1)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoAura, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore), NoOpTriggeredPassiveDispatcher)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoAura, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore), NoOpTriggeredPassiveDispatcher, NoOpActivePerkLookup, InMemoryPerkCooldownStore())
 
         handler.onTick(Tick(1, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -151,7 +153,7 @@ class WorldTickHandlerTest {
             override fun sleepRegenPerOfflineTick(): Int = 0
             override fun isTraversable(terrain: Terrain): Boolean = true
         }
-        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoAura, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore), NoOpTriggeredPassiveDispatcher)
+        val handler = WorldTickHandler(queue, repo, publisher, regen, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoAura, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore), NoOpTriggeredPassiveDispatcher, NoOpActivePerkLookup, InMemoryPerkCooldownStore())
 
         handler.onTick(Tick(2, Instant.parse("2026-01-01T00:00:00Z")))
 
@@ -167,7 +169,7 @@ class WorldTickHandlerTest {
         val queue = CommandQueue()
         val publisher = RecordingPublisher()
         queue.submit(WorldCommand.MoveAgent(agent, northId), appliesAtTick = 99)
-        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoAura, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore), NoOpTriggeredPassiveDispatcher)
+        val handler = WorldTickHandler(queue, repo, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore, NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog, NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher), NoScaling, NoAura, NoopSpawnLocationResolver, NoopGroundItemStore, DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore), NoOpTriggeredPassiveDispatcher, NoOpActivePerkLookup, InMemoryPerkCooldownStore())
 
         handler.onTick(Tick(7, Instant.parse("2026-01-01T00:00:00Z")))
 


### PR DESCRIPTION
## Summary

Step 3d of the [skill-feature roadmap](docs/skill-feature-sequence.md) — ActiveAbility perk effect + `use_ability` MCP tool. Closes #67.

- **Perk shape:** `PerkEffect.ActiveAbility(abilityId, costResource, costAmount, target, cooldownTicks, effectKind, effectParams)`. Validator enforces unique ability ids and `cooldownTicks > 0`.
- **MCP verb:** `use_ability(abilityId, targetAgentId?)` — queue+ack, mirrors `attack`. `target` required for `SINGLE_AGENT`, forbidden for `SELF` / `AREA_SELF_NODE`.
- **AbilityResolver:** validates ownership (slotted skill + chosen perk), target shape + same-node, cooldown ready, resource available; pays cost at cast; arms CD; stages effect.
- **`SCALE_NEXT_ATTACK`:** one-shot percent-encoded buff on `WorldState.pendingAttackScales`. `AttackReducer` reads-and-clears BEFORE the dodge/crit rolls — dodge still burns the buff (matches "cost paid at cast, not refunded" §9). Other kinds ride out on `WorldEvent.AbilityUsed` for later slices.
- **Cooldown store:** existing `PerkCooldownStore` reused (key is `(agent, perkId)`); extended with `readyAtTick(...)` for actionable rejection messages. `ActivePerkLookup` mirrors `TriggeredPassiveLookup`'s slot gate; `UnknownAbility` collapses "no perk" + "unslotted skill" to keep the catalog hidden.
- **XP:** `use_ability` hits `SkillProgression.accrueXp(parentSkill, useAbilityXpDelta=1)` — extends the recommendation hook (#5).
- **Canary:** SWORD-100 Power Strike (Stamina 20, CD 5 ticks, SingleAgent, 1.5×) + Riposte counter perk. RNG-pinned test proves baseline×1.5 == scaled, and the buff is single-shot.

## Test plan

- [x] `:player:test` — `ActivePerkLookupImplTest`, extended `PerkLookupImplTest` + `PerksValidatorTest`.
- [x] `:world:test` — `AbilityResolverTest` (success / unknown / CD / cost / target-out-of-node / target-shape mismatch), `PowerStrikeCanaryIntegrationTest` (1.5× scaling, single-shot consumption, CD blocks back-to-back), preserved `BleederCanaryIntegrationTest`.
- [x] `:api:test` — `UseAbilityToolTest` (queue ack, optional target, activity touch).
- [x] Full `./gradlew test` green.

## Cross-issue ticks (post-merge)

- #5 — `use_ability` extends the skill-XP recommendation hook (new row).
- #35 — Mana now consumed by future RESEARCHER/MEDIC actives (not exclusively psionic) — comment, do not close.
- `docs/skill-feature-sequence.md` — tick Step 3d.

## Out of scope (called out in #67)

- Multi-node `RangedNode(distance)` target shape.
- Channeling / charge-up actives.
- Ability XP independent of parent skill.
- Buff lifetime: SCALE_NEXT_ATTACK has no expiry today (TODO on `WorldState.pendingAttackScales`).