### PR TITLE
docs(skill-feature): tick Step 4 (#68) and advance current step to Step 5 (#31)

### DIFF
--- a/docs/skill-feature-sequence.md
+++ b/docs/skill-feature-sequence.md
@@ -10,7 +10,7 @@
 
 > **HOW TO USE.** When the user says "move on to next step", look here. The next unchecked box is the next slice. When a slice merges, tick the box and update **Current step** below. This file is the single source of truth for roadmap position; per-issue acceptance criteria stay tracked inside each GitHub issue.
 
-**Current step:** ⏭ **Step 4 — [#68](https://github.com/Genesara/genesara-engine/issues/68) Skill+perk catalog v1** (Steps 1–3 merged; all four effect-type slices live)
+**Current step:** ⏭ **Step 5 — [#31](https://github.com/Genesara/genesara-engine/issues/31) Behavior tracker** (Steps 1–4 merged; catalog v1 live with verb-wiring for new skills deferred to substrate slices)
 
 ### Track A — Phase 1 mechanics + catalog
 
@@ -21,7 +21,7 @@
   - [x] **Step 3b** — [#65](https://github.com/Genesara/genesara-engine/issues/65) PassiveAura aggregator
   - [x] **Step 3c** — [#66](https://github.com/Genesara/genesara-engine/issues/66) Per-level scaling + Modifier perk
   - [x] **Step 3d** — [#67](https://github.com/Genesara/genesara-engine/issues/67) Active ability system + `use_ability` *(soft-coordinates with #15 Combat)*
-- [ ] **Step 4** — [#68](https://github.com/Genesara/genesara-engine/issues/68) Skill+perk catalog v1 *(blocked by all of step 3)*
+- [x] **Step 4** — [#68](https://github.com/Genesara/genesara-engine/issues/68) Skill+perk catalog v1 *(catalog + class-lock landed in #75; harvest/craft/build verb-wiring for new skills — HUNTING, TRAPS, LEATHERWORKING, etc. — stays deferred to substrate slices when each gets its world content. Partial-close on this checkbox.)*
 
 ### Track B — Phase 4 class system
 
@@ -33,7 +33,7 @@
 ### Cross-issue ticks (apply when the parent step lands)
 
 - [x] When #67 (step 3d) merges → tick `use_ability` row in [#5](https://github.com/Genesara/genesara-engine/issues/5); add comment to [#35](https://github.com/Genesara/genesara-engine/issues/35) noting Mana's broadened consumer base.
-- [ ] When #68 (step 4) merges → tick the rows in [#5](https://github.com/Genesara/genesara-engine/issues/5) for every new skill that maps to a verb (HUNTING, TRAPS, new combat skills, new craft skills, TRACKING, FIRECRAFT).
+- [ ] When #68 (step 4) merges → tick the rows in [#5](https://github.com/Genesara/genesara-engine/issues/5) for every new skill that maps to a verb (HUNTING, TRAPS, new combat skills, new craft skills, TRACKING, FIRECRAFT). *(Pending: #68's catalog landed but verb-wiring is deferred to substrate slices; tick each row when its substrate slice lands.)*
 - [ ] When #34 (step 8) merges → coordinate naming with [#38](https://github.com/Genesara/genesara-engine/issues/38) for the TECHNICIAN ↔ Drone-Operator overlap.
 
 ### Combat-coupling note


### PR DESCRIPTION
## Summary

Roadmap doc bookkeeping after PR #75 (skill+perk catalog v1) merged.

- Tick Step 4 with a partial-close note matching the Step 8 precedent ("L100 stays deferred — partial-close on this checkbox"): catalog + class-lock landed; harvest/craft/build verb-wiring for new skills stays deferred to substrate slices.
- Advance **Current step** to Step 5 — #31 Behavior tracker.
- Annotate the cross-issue tick on #5 explaining why those rows stay unticked even though the parent slice merged.

## Test plan

- [x] No code change; doc-only.