### PR TITLE
ci: enforce conventional commit PR titles

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,33 @@
+name: Semantic PR
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            build
+            ci
+            chore
+            test
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" must start with a lowercase letter.
+            Example: feat(player): add skill catalog
+          wip: true


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/semantic-pr.yml` validating PR titles with `amannn/action-semantic-pull-request@v5`.
- Type allowlist mirrors `release-please-config.json` exactly: `feat`, `fix`, `perf`, `refactor`, `docs`, `build`, `ci`, `chore`, `test`.
- Subject must start with a lowercase letter; scope is optional; WIP/draft titles are skipped.
- Uses `pull_request_target` with `pull-requests: read` only — metadata-only, no PR code is checked out.

## Why
We squash-merge, so the PR title becomes the commit on main and feeds release-please. Catching bad titles at PR time prevents silent release-note misses.

## Test plan
- [ ] This PR's own title passes the new check (`ci: ...`).
- [ ] After merge, mark `lint-pr-title` as a required status check on `main` via branch protection.