### PR TITLE
feat(world,api): redis invalidation bus for cross-pod MCP push + static config (#83)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -4,8 +4,8 @@ import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.events.AgentEvent
 import dev.gvart.genesara.world.BodyDelta
 import dev.gvart.genesara.world.events.WorldEvent
-import io.modelcontextprotocol.server.McpSyncServer
-import io.modelcontextprotocol.spec.McpSchema.ResourcesUpdatedNotification
+import dev.gvart.genesara.world.invalidation.InvalidationBus
+import dev.gvart.genesara.world.invalidation.InvalidationMessage
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
@@ -22,7 +22,7 @@ import tools.jackson.databind.ObjectMapper
  */
 @Component
 internal class AgentEventDispatcher(
-    private val mcpServer: McpSyncServer,
+    private val bus: InvalidationBus,
     private val log: AgentEventLog,
     private val mapper: ObjectMapper,
 ) {
@@ -90,14 +90,13 @@ internal class AgentEventDispatcher(
             ?: (payload as? PassivesPayload)?.tick
             ?: 0L
         val appended = log.append(agent, type, tick, mapper.valueToTree(payload))
-        val uri = "agent://${agent.id}/events"
         logger.info("dispatch agent={} type={} tick={} seq={}", agent.id, type, tick, appended.seq)
         try {
-            mcpServer.notifyResourcesUpdated(ResourcesUpdatedNotification(uri))
+            bus.publish(InvalidationMessage.AgentNotify(agent))
         } catch (e: Exception) {
-            // Agent may not be subscribed (or no live session). The event remains in the log
-            // and will be read on next subscribe + read.
-            logger.debug("notifyResourcesUpdated for {} failed: {}", uri, e.message)
+            // Pub/sub is best-effort: the event is durable in the log and will be read on
+            // next subscribe + read; only the wakeup latency is affected.
+            logger.debug("publish AgentNotify for {} failed: {}", agent.id, e.message)
         }
     }
 

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/invalidation/AgentNotifyListener.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/invalidation/AgentNotifyListener.kt
@@ -1,0 +1,52 @@
+package dev.gvart.genesara.api.internal.mcp.invalidation
+
+import dev.gvart.genesara.world.invalidation.InvalidationBus
+import dev.gvart.genesara.world.invalidation.InvalidationMessage
+import io.modelcontextprotocol.server.McpSyncServer
+import io.modelcontextprotocol.spec.McpSchema.ResourcesUpdatedNotification
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.connection.MessageListener
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * Pod-local fan-out for [InvalidationMessage.AgentNotify]: every pod fires
+ * `notifyResourcesUpdated` on its own MCP server. The MCP protocol's per-server
+ * subscription set then filters out pods without a live session for the agent —
+ * only the pod hosting the agent's MCP connection actually pushes downstream.
+ */
+@Component
+internal class AgentNotifyListener(
+    private val container: RedisMessageListenerContainer,
+    private val mapper: ObjectMapper,
+    private val mcpServer: McpSyncServer,
+) : MessageListener {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @PostConstruct
+    fun subscribe() {
+        container.addMessageListener(this, ChannelTopic(InvalidationBus.CHANNEL))
+    }
+
+    override fun onMessage(message: Message, pattern: ByteArray?) {
+        val parsed = try {
+            mapper.readValue(message.body, InvalidationMessage::class.java)
+        } catch (t: Throwable) {
+            log.warn("Failed to deserialize invalidation message: {}", t.message)
+            return
+        }
+        if (parsed !is InvalidationMessage.AgentNotify) return
+        val uri = "agent://${parsed.agentId.id}/events"
+        try {
+            mcpServer.notifyResourcesUpdated(ResourcesUpdatedNotification(uri))
+        } catch (t: Throwable) {
+            log.debug("notifyResourcesUpdated for {} failed: {}", uri, t.message)
+        }
+    }
+
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
@@ -8,11 +8,9 @@ import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.events.WorldEvent
-import io.modelcontextprotocol.server.McpSyncServer
-import io.modelcontextprotocol.spec.McpSchema.ResourcesUpdatedNotification
+import dev.gvart.genesara.world.invalidation.InvalidationBus
+import dev.gvart.genesara.world.invalidation.InvalidationMessage
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import tools.jackson.databind.json.JsonMapper
@@ -23,9 +21,9 @@ import kotlin.test.assertEquals
 class AgentEventDispatcherTest {
 
     private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
-    private val mcp: McpSyncServer = mock(McpSyncServer::class.java)
+    private val bus: InvalidationBus = mock(InvalidationBus::class.java)
     private val log = FakeAgentEventLog()
-    private val dispatcher = AgentEventDispatcher(mcp, log, mapper)
+    private val dispatcher = AgentEventDispatcher(bus, log, mapper)
 
     private val agent = AgentId(UUID.randomUUID())
 
@@ -44,9 +42,7 @@ class AgentEventDispatcherTest {
         assertEquals(1L, envelope.seq)
         assertEquals(cmdId.toString(), envelope.payload.get("causedBy").asString())
 
-        val captor = ArgumentCaptor.forClass(ResourcesUpdatedNotification::class.java)
-        verify(mcp).notifyResourcesUpdated(captor.capture())
-        assertEquals("agent://${agent.id}/events", captor.value.uri())
+        verify(bus).publish(InvalidationMessage.AgentNotify(agent))
     }
 
     @Test
@@ -246,7 +242,7 @@ class AgentEventDispatcherTest {
 
         assertEquals(1, log.since(a1, 0).size)
         assertEquals(1, log.since(a2, 0).size)
-        verify(mcp).notifyResourcesUpdated(eq(ResourcesUpdatedNotification("agent://${a1.id}/events")))
-        verify(mcp).notifyResourcesUpdated(eq(ResourcesUpdatedNotification("agent://${a2.id}/events")))
+        verify(bus).publish(InvalidationMessage.AgentNotify(a1))
+        verify(bus).publish(InvalidationMessage.AgentNotify(a2))
     }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/invalidation/AgentNotifyListenerIntegrationTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/invalidation/AgentNotifyListenerIntegrationTest.kt
@@ -1,0 +1,119 @@
+package dev.gvart.genesara.api.internal.mcp.invalidation
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.invalidation.InvalidationBus
+import dev.gvart.genesara.world.invalidation.InvalidationMessage
+import io.modelcontextprotocol.server.McpSyncServer
+import io.modelcontextprotocol.spec.McpSchema.ResourcesUpdatedNotification
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.timeout
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.springframework.data.redis.connection.MessageListener
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Testcontainers
+class AgentNotifyListenerIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val redis: GenericContainer<*> =
+            GenericContainer(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379)
+    }
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+    private val resources = mutableListOf<AutoCloseable>()
+
+    @BeforeEach
+    fun flushRedis() {
+        val cf = LettuceConnectionFactory(redis.host, redis.firstMappedPort).apply { afterPropertiesSet() }
+        StringRedisTemplate(cf).connectionFactory!!.connection.serverCommands().flushDb()
+        cf.destroy()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        resources.reversed().forEach { runCatching { it.close() } }
+        resources.clear()
+    }
+
+    @Test
+    fun `AgentNotify on pod A fires notifyResourcesUpdated on pod B's MCP server`() {
+        val publisher = newPublisher()
+        val mcp: McpSyncServer = mock(McpSyncServer::class.java)
+        AgentNotifyListener(newContainer(), mapper, mcp).subscribe()
+
+        val agent = AgentId(UUID.randomUUID())
+        publisher.publish(InvalidationMessage.AgentNotify(agent))
+
+        val captor = ArgumentCaptor.forClass(ResourcesUpdatedNotification::class.java)
+        verify(mcp, timeout(5_000)).notifyResourcesUpdated(captor.capture())
+        assertEquals("agent://${agent.id}/events", captor.value.uri())
+    }
+
+    @Test
+    fun `WorldConfigInvalidate on the same channel does NOT trigger MCP notify`() {
+        val publisher = newPublisher()
+        val mcp: McpSyncServer = mock(McpSyncServer::class.java)
+        val container = newContainer()
+        AgentNotifyListener(container, mapper, mcp).subscribe()
+        val sentinel = subscribeSentinel(container)
+
+        publisher.publish(InvalidationMessage.WorldConfigInvalidate(WorldId(1L)))
+
+        assertTrue(sentinel.await(5, TimeUnit.SECONDS), "sentinel didn't arrive — pub/sub never delivered")
+        verifyNoInteractions(mcp)
+    }
+
+    private fun newPublisher(): InvalidationBus {
+        val cf = LettuceConnectionFactory(redis.host, redis.firstMappedPort).apply { afterPropertiesSet() }
+        resources += AutoCloseable { cf.destroy() }
+        val template = StringRedisTemplate(cf)
+        return object : InvalidationBus {
+            override fun publish(message: InvalidationMessage) {
+                template.convertAndSend(InvalidationBus.CHANNEL, mapper.writeValueAsString(message))
+            }
+        }
+    }
+
+    private fun newContainer(): RedisMessageListenerContainer {
+        val cf = LettuceConnectionFactory(redis.host, redis.firstMappedPort).apply { afterPropertiesSet() }
+        resources += AutoCloseable { cf.destroy() }
+        val container = RedisMessageListenerContainer().apply {
+            setConnectionFactory(cf)
+            afterPropertiesSet()
+            start()
+        }
+        resources += AutoCloseable { container.stop() }
+        return container
+    }
+
+    private fun subscribeSentinel(container: RedisMessageListenerContainer): CountDownLatch {
+        val latch = CountDownLatch(1)
+        container.addMessageListener(
+            MessageListener { _, _ -> latch.countDown() },
+            ChannelTopic(InvalidationBus.CHANNEL),
+        )
+        return latch
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/editor/JooqWorldEditingGateway.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/editor/JooqWorldEditingGateway.kt
@@ -36,6 +36,8 @@ import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.resources.ResourceSpawner
 import dev.gvart.genesara.world.internal.worldstate.WorldStaticConfig
+import dev.gvart.genesara.world.invalidation.InvalidationBus
+import dev.gvart.genesara.world.invalidation.InvalidationMessage
 import org.jooq.DSLContext
 import org.jooq.JSON
 import org.springframework.stereotype.Component
@@ -54,6 +56,7 @@ internal class JooqWorldEditingGateway(
     private val tickClock: TickClock,
     private val races: RaceLookup,
     private val balance: BalanceLookup,
+    private val invalidationBus: InvalidationBus,
 ) : WorldEditingGateway {
 
     override fun listWorlds(): List<World> =
@@ -98,6 +101,7 @@ internal class JooqWorldEditingGateway(
         paintInitialBiomesAndClimates(adjacency, worldId)
 
         staticConfig.reload()
+        invalidationBus.publish(InvalidationMessage.WorldConfigInvalidate(WorldId(worldId)))
 
         return getWorld(WorldId(worldId)) ?: error("just-inserted world disappeared: $worldId")
     }
@@ -226,6 +230,7 @@ internal class JooqWorldEditingGateway(
             linkToExistingNeighbors(worldId, newRegionId, g.neighborSphereIndices)
         }
         staticConfig.reload()
+        invalidationBus.publish(InvalidationMessage.WorldConfigInvalidate(worldId))
         return getRegion(worldId, sphereIndex)
             ?: error("region disappeared after upsert: world=${worldId.value} sphere=$sphereIndex")
     }
@@ -274,6 +279,7 @@ internal class JooqWorldEditingGateway(
             .where(REGIONS.ID.eq(existing.id.value))
             .execute()
         staticConfig.reload()
+        invalidationBus.publish(InvalidationMessage.WorldConfigInvalidate(worldId))
         return getRegion(worldId, sphereIndex)
             ?: error("region disappeared after patch: world=${worldId.value} sphere=$sphereIndex")
     }
@@ -304,6 +310,7 @@ internal class JooqWorldEditingGateway(
         val idByCoord = loadNodeIdsByCoord(region.id)
         wireHexAdjacency(idByCoord)
         staticConfig.reload()
+        invalidationBus.publish(InvalidationMessage.WorldConfigInvalidate(worldId))
         val nodes = loadNodesFor(region.id)
         seedResources(nodes, worldSeed = worldId.value)
         return nodes
@@ -350,6 +357,7 @@ internal class JooqWorldEditingGateway(
             repaintOrInsertTile(region.id, tile)
         }
         staticConfig.reload()
+        invalidationBus.publish(InvalidationMessage.WorldConfigInvalidate(worldId))
         seedResources(loadNodesFor(region.id), worldSeed = worldId.value)
         return tiles.size
     }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/invalidation/InvalidationListenerConfiguration.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/invalidation/InvalidationListenerConfiguration.kt
@@ -1,0 +1,18 @@
+package dev.gvart.genesara.world.internal.invalidation
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+
+@Configuration
+internal class InvalidationListenerConfiguration {
+
+    @Bean(destroyMethod = "stop")
+    fun invalidationListenerContainer(connectionFactory: RedisConnectionFactory): RedisMessageListenerContainer =
+        RedisMessageListenerContainer().apply {
+            setConnectionFactory(connectionFactory)
+            afterPropertiesSet()
+            start()
+        }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/invalidation/RedisInvalidationBus.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/invalidation/RedisInvalidationBus.kt
@@ -1,0 +1,18 @@
+package dev.gvart.genesara.world.internal.invalidation
+
+import dev.gvart.genesara.world.invalidation.InvalidationBus
+import dev.gvart.genesara.world.invalidation.InvalidationMessage
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+@Component
+internal class RedisInvalidationBus(
+    private val redis: StringRedisTemplate,
+    private val mapper: ObjectMapper,
+) : InvalidationBus {
+
+    override fun publish(message: InvalidationMessage) {
+        redis.convertAndSend(InvalidationBus.CHANNEL, mapper.writeValueAsString(message))
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/invalidation/WorldConfigInvalidateListener.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/invalidation/WorldConfigInvalidateListener.kt
@@ -1,0 +1,51 @@
+package dev.gvart.genesara.world.internal.invalidation
+
+import dev.gvart.genesara.world.internal.tick.lease.LeasedWorlds
+import dev.gvart.genesara.world.internal.worldstate.WorldStaticConfig
+import dev.gvart.genesara.world.invalidation.InvalidationBus
+import dev.gvart.genesara.world.invalidation.InvalidationMessage
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.connection.MessageListener
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.stereotype.Component
+import tools.jackson.databind.ObjectMapper
+
+@Component
+internal class WorldConfigInvalidateListener(
+    private val container: RedisMessageListenerContainer,
+    private val mapper: ObjectMapper,
+    private val leasedWorlds: LeasedWorlds,
+    private val staticConfig: WorldStaticConfig,
+) : MessageListener {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @PostConstruct
+    fun subscribe() {
+        container.addMessageListener(this, ChannelTopic(InvalidationBus.CHANNEL))
+    }
+
+    override fun onMessage(message: Message, pattern: ByteArray?) {
+        val parsed = try {
+            mapper.readValue(message.body, InvalidationMessage::class.java)
+        } catch (t: Throwable) {
+            log.warn("Failed to deserialize invalidation message: {}", t.message)
+            return
+        }
+        if (parsed !is InvalidationMessage.WorldConfigInvalidate) return
+        // WorldStaticConfig.reload() is global, not per-world — gating on "this pod
+        // leases at least one world" matches the actual blast radius. Pods with no
+        // leases skip the DB roundtrip; lease-acquire is responsible for getting
+        // fresh config when a world is later picked up.
+        if (leasedWorlds.held().isEmpty()) return
+        try {
+            staticConfig.reload()
+            log.info("Reloaded WorldStaticConfig in response to invalidation for world={}", parsed.worldId.value)
+        } catch (t: Throwable) {
+            log.warn("WorldStaticConfig.reload() failed for world={}: {}", parsed.worldId.value, t.message)
+        }
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/invalidation/InvalidationBus.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/invalidation/InvalidationBus.kt
@@ -1,0 +1,10 @@
+package dev.gvart.genesara.world.invalidation
+
+/** Cross-pod pub/sub fan-out for cache-invalidation and MCP wakeup signals. */
+interface InvalidationBus {
+    fun publish(message: InvalidationMessage)
+
+    companion object {
+        const val CHANNEL = "genesara:invalidation"
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/invalidation/InvalidationMessage.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/invalidation/InvalidationMessage.kt
@@ -1,0 +1,25 @@
+package dev.gvart.genesara.world.invalidation
+
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.WorldId
+
+/**
+ * Each `@JsonSubTypes.Type.name` is the wire-format discriminator on the cross-pod
+ * pub/sub channel. Stable contract: renaming a Kotlin class is fine, changing a
+ * discriminator silently breaks deserialization on the receiving pod.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = InvalidationMessage.AgentNotify::class, name = "agent-notify"),
+    JsonSubTypes.Type(value = InvalidationMessage.WorldConfigInvalidate::class, name = "world-config-invalidate"),
+)
+sealed interface InvalidationMessage {
+
+    /** Wakeup signal for agent's MCP event-resource subscribers, regardless of which pod holds the live session. */
+    data class AgentNotify(val agentId: AgentId) : InvalidationMessage
+
+    /** Static-config (region/node graph) for [worldId] has changed; lease holders for that world should reload. */
+    data class WorldConfigInvalidate(val worldId: WorldId) : InvalidationMessage
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/editor/JooqWorldEditingGatewayCreateWorldIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/editor/JooqWorldEditingGatewayCreateWorldIntegrationTest.kt
@@ -14,6 +14,7 @@ import dev.gvart.genesara.world.internal.resources.InitialResourceRow
 import dev.gvart.genesara.world.internal.resources.NodeResourceCell
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.resources.ResourceSpawner
+import dev.gvart.genesara.world.internal.testsupport.NoOpInvalidationBus
 import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
 import dev.gvart.genesara.world.internal.worldstate.WorldStaticConfig
 import dev.gvart.genesara.world.ItemId
@@ -98,6 +99,7 @@ class JooqWorldEditingGatewayCreateWorldIntegrationTest {
             tickClock = ZeroClock,
             races = StubRaceLookup,
             balance = NoTerrainSpawnsBalance,
+            invalidationBus = NoOpInvalidationBus,
         )
     }
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/editor/JooqWorldEditingGatewayStarterNodesIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/editor/JooqWorldEditingGatewayStarterNodesIntegrationTest.kt
@@ -29,6 +29,7 @@ import dev.gvart.genesara.world.internal.resources.NodeResourceCell
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.resources.ResourceSpawner
 import dev.gvart.genesara.world.internal.starter.JooqStarterNodeLookup
+import dev.gvart.genesara.world.internal.testsupport.NoOpInvalidationBus
 import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
 import dev.gvart.genesara.world.internal.worldstate.WorldStaticConfig
 import org.jooq.DSLContext
@@ -121,6 +122,7 @@ class JooqWorldEditingGatewayStarterNodesIntegrationTest {
             tickClock = ZeroClock,
             races = SingleRaceLookup(human),
             balance = OceanIsImpassable,
+            invalidationBus = NoOpInvalidationBus,
         )
         lookup = JooqStarterNodeLookup(dsl)
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/invalidation/RedisInvalidationBusIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/invalidation/RedisInvalidationBusIntegrationTest.kt
@@ -1,0 +1,151 @@
+package dev.gvart.genesara.world.internal.invalidation
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.invalidation.InvalidationBus
+import dev.gvart.genesara.world.invalidation.InvalidationMessage
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.connection.MessageListener
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import java.util.UUID
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+
+@Testcontainers
+class RedisInvalidationBusIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val redis: GenericContainer<*> =
+            GenericContainer(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379)
+    }
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+    private val pods = mutableListOf<Pod>()
+
+    @BeforeEach
+    fun flushRedis() {
+        val tmp = newPod().also { pods += it }
+        tmp.template.connectionFactory!!.connection.serverCommands().flushDb()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        pods.forEach { it.close() }
+        pods.clear()
+    }
+
+    @Test
+    fun `WorldConfigInvalidate published on pod A is delivered to pod B's listener`() {
+        val podA = newPod().also { pods += it }
+        val podB = newPod().also { pods += it }
+        val received = LinkedBlockingQueue<InvalidationMessage>()
+        podB.subscribe { received.put(it) }
+
+        podA.bus.publish(InvalidationMessage.WorldConfigInvalidate(WorldId(42L)))
+
+        val msg = received.poll(5, TimeUnit.SECONDS)
+        assertEquals(InvalidationMessage.WorldConfigInvalidate(WorldId(42L)), msg)
+    }
+
+    @Test
+    fun `AgentNotify published on pod A is delivered to pod B's listener`() {
+        val podA = newPod().also { pods += it }
+        val podB = newPod().also { pods += it }
+        val received = LinkedBlockingQueue<InvalidationMessage>()
+        podB.subscribe { received.put(it) }
+
+        val agent = AgentId(UUID.randomUUID())
+        podA.bus.publish(InvalidationMessage.AgentNotify(agent))
+
+        val msg = received.poll(5, TimeUnit.SECONDS)
+        assertEquals(InvalidationMessage.AgentNotify(agent), msg)
+    }
+
+    @Test
+    fun `mixed message types route to the correct deserialized subtype on the receiver`() {
+        val podA = newPod().also { pods += it }
+        val podB = newPod().also { pods += it }
+        val received = LinkedBlockingQueue<InvalidationMessage>()
+        podB.subscribe { received.put(it) }
+
+        val agent = AgentId(UUID.randomUUID())
+        podA.bus.publish(InvalidationMessage.WorldConfigInvalidate(WorldId(7L)))
+        podA.bus.publish(InvalidationMessage.AgentNotify(agent))
+
+        val first = received.poll(5, TimeUnit.SECONDS)
+        val second = received.poll(5, TimeUnit.SECONDS)
+        val both = setOf(first, second)
+        assertEquals(
+            setOf<InvalidationMessage>(
+                InvalidationMessage.WorldConfigInvalidate(WorldId(7L)),
+                InvalidationMessage.AgentNotify(agent),
+            ),
+            both,
+        )
+    }
+
+    @Test
+    fun `pod that does not subscribe receives nothing — no implicit broadcast`() {
+        val podA = newPod().also { pods += it }
+        val podB = newPod().also { pods += it }
+
+        podA.bus.publish(InvalidationMessage.WorldConfigInvalidate(WorldId(1L)))
+
+        assertEquals(0, podB.subscriberCount())
+    }
+
+    private fun newPod(): Pod {
+        val cf = LettuceConnectionFactory(redis.host, redis.firstMappedPort).apply {
+            afterPropertiesSet()
+        }
+        val template = StringRedisTemplate(cf)
+        val container = RedisMessageListenerContainer().apply {
+            setConnectionFactory(cf)
+            afterPropertiesSet()
+            start()
+        }
+        val bus = RedisInvalidationBus(template, mapper)
+        return Pod(cf, template, container, bus, mapper)
+    }
+
+    private class Pod(
+        private val cf: LettuceConnectionFactory,
+        val template: StringRedisTemplate,
+        private val container: RedisMessageListenerContainer,
+        val bus: RedisInvalidationBus,
+        private val mapper: tools.jackson.databind.ObjectMapper,
+    ) {
+        private var subscribers = 0
+
+        fun subscribe(handler: (InvalidationMessage) -> Unit) {
+            val listener = MessageListener { message: Message, _ ->
+                val parsed = mapper.readValue(message.body, InvalidationMessage::class.java)
+                handler(parsed)
+            }
+            container.addMessageListener(listener, ChannelTopic(InvalidationBus.CHANNEL))
+            subscribers += 1
+        }
+
+        fun subscriberCount(): Int = subscribers
+
+        fun close() {
+            container.stop()
+            cf.destroy()
+        }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/invalidation/WorldConfigInvalidateListenerIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/invalidation/WorldConfigInvalidateListenerIntegrationTest.kt
@@ -1,0 +1,173 @@
+package dev.gvart.genesara.world.internal.invalidation
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.internal.tick.lease.LeasedWorlds
+import dev.gvart.genesara.world.internal.worldstate.WorldStaticConfig
+import dev.gvart.genesara.world.invalidation.InvalidationBus
+import dev.gvart.genesara.world.invalidation.InvalidationMessage
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.connection.MessageListener
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Testcontainers
+class WorldConfigInvalidateListenerIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val redis: GenericContainer<*> =
+            GenericContainer(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379)
+    }
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+    private val resources = mutableListOf<AutoCloseable>()
+
+    @BeforeEach
+    fun flushRedis() {
+        val cf = LettuceConnectionFactory(redis.host, redis.firstMappedPort).apply { afterPropertiesSet() }
+        StringRedisTemplate(cf).connectionFactory!!.connection.serverCommands().flushDb()
+        cf.destroy()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        resources.reversed().forEach { runCatching { it.close() } }
+        resources.clear()
+    }
+
+    @Test
+    fun `reload fires when this pod holds at least one lease`() {
+        val publisher = newPublisher()
+        val reloadCount = AtomicInteger(0)
+        val reloadFired = CountDownLatch(1)
+        val container = newContainer()
+        WorldConfigInvalidateListener(
+            container,
+            mapper,
+            StaticLeasedWorlds(listOf(WorldId(11L))),
+            countingStaticConfig(reloadCount, reloadFired),
+        ).subscribe()
+
+        publisher.publish(InvalidationMessage.WorldConfigInvalidate(WorldId(11L)))
+
+        assertTrue(reloadFired.await(5, TimeUnit.SECONDS))
+        assertEquals(1, reloadCount.get())
+    }
+
+    @Test
+    fun `reload still fires for a world this pod does NOT lease, as long as something is leased`() {
+        val publisher = newPublisher()
+        val reloadCount = AtomicInteger(0)
+        val reloadFired = CountDownLatch(1)
+        val container = newContainer()
+        WorldConfigInvalidateListener(
+            container,
+            mapper,
+            StaticLeasedWorlds(listOf(WorldId(1L))),
+            countingStaticConfig(reloadCount, reloadFired),
+        ).subscribe()
+
+        publisher.publish(InvalidationMessage.WorldConfigInvalidate(WorldId(99L)))
+
+        assertTrue(reloadFired.await(5, TimeUnit.SECONDS))
+        assertEquals(1, reloadCount.get(), "reload is global; any-lease pod must reload on any world invalidation")
+    }
+
+    @Test
+    fun `reload does NOT fire when this pod holds no leases`() {
+        val publisher = newPublisher()
+        val reloadCount = AtomicInteger(0)
+        val container = newContainer()
+        WorldConfigInvalidateListener(
+            container,
+            mapper,
+            StaticLeasedWorlds(emptyList()),
+            countingStaticConfig(reloadCount, latch = null),
+        ).subscribe()
+        val sentinelArrived = subscribeSentinel(container)
+
+        publisher.publish(InvalidationMessage.WorldConfigInvalidate(WorldId(99L)))
+
+        assertTrue(sentinelArrived.await(5, TimeUnit.SECONDS), "sentinel didn't arrive — pub/sub never delivered")
+        assertEquals(0, reloadCount.get())
+    }
+
+    @Test
+    fun `AgentNotify on the same channel is ignored by the world-config listener`() {
+        val publisher = newPublisher()
+        val reloadCount = AtomicInteger(0)
+        val container = newContainer()
+        WorldConfigInvalidateListener(
+            container,
+            mapper,
+            StaticLeasedWorlds(listOf(WorldId(7L))),
+            countingStaticConfig(reloadCount, latch = null),
+        ).subscribe()
+        val sentinelArrived = subscribeSentinel(container)
+
+        publisher.publish(InvalidationMessage.AgentNotify(AgentId(UUID.randomUUID())))
+
+        assertTrue(sentinelArrived.await(5, TimeUnit.SECONDS))
+        assertEquals(0, reloadCount.get())
+    }
+
+    private fun subscribeSentinel(container: RedisMessageListenerContainer): CountDownLatch {
+        val latch = CountDownLatch(1)
+        container.addMessageListener(
+            MessageListener { _, _ -> latch.countDown() },
+            ChannelTopic(InvalidationBus.CHANNEL),
+        )
+        return latch
+    }
+
+    private fun newPublisher(): InvalidationBus {
+        val cf = LettuceConnectionFactory(redis.host, redis.firstMappedPort).apply { afterPropertiesSet() }
+        resources += AutoCloseable { cf.destroy() }
+        return RedisInvalidationBus(StringRedisTemplate(cf), mapper)
+    }
+
+    private fun newContainer(): RedisMessageListenerContainer {
+        val cf = LettuceConnectionFactory(redis.host, redis.firstMappedPort).apply { afterPropertiesSet() }
+        resources += AutoCloseable { cf.destroy() }
+        val container = RedisMessageListenerContainer().apply {
+            setConnectionFactory(cf)
+            afterPropertiesSet()
+            start()
+        }
+        resources += AutoCloseable { container.stop() }
+        return container
+    }
+
+    private fun countingStaticConfig(counter: AtomicInteger, latch: CountDownLatch?): WorldStaticConfig =
+        object : WorldStaticConfig(unusedDsl(), mapper) {
+            override fun reload() {
+                counter.incrementAndGet()
+                latch?.countDown()
+            }
+        }
+
+    private fun unusedDsl(): org.jooq.DSLContext =
+        org.jooq.impl.DSL.using(org.jooq.SQLDialect.POSTGRES)
+
+    private class StaticLeasedWorlds(private val held: List<WorldId>) : LeasedWorlds {
+        override fun held(): List<WorldId> = held
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/NoOpInvalidationBus.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/NoOpInvalidationBus.kt
@@ -1,0 +1,8 @@
+package dev.gvart.genesara.world.internal.testsupport
+
+import dev.gvart.genesara.world.invalidation.InvalidationBus
+import dev.gvart.genesara.world.invalidation.InvalidationMessage
+
+internal object NoOpInvalidationBus : InvalidationBus {
+    override fun publish(message: InvalidationMessage) = Unit
+}


### PR DESCRIPTION
## Summary

Closes the multi-pod functional gap from `docs/shard-readiness-sequence.md` Step 6 / issue #83.

- New `RedisInvalidationBus` over a single channel (`genesara:invalidation`) with a polymorphic `InvalidationMessage` (sealed: `AgentNotify`, `WorldConfigInvalidate`).
- `AgentEventDispatcher` now publishes `AgentNotify(agentId)` instead of calling `mcpServer.notifyResourcesUpdated` directly. Every pod's local `AgentNotifyListener` fires the notify on its own MCP server; MCP's per-server subscription set filters out pods without a live session for that agent. End-user push UX is preserved without session affinity.
- `JooqWorldEditingGateway` publishes `WorldConfigInvalidate(worldId)` after each `staticConfig.reload()`. Listener gate is **any-leased** (not per-world) — `WorldStaticConfig.reload()` is global, so gating per-worldId would be misleading. Pods that hold no leases skip the reload.
- One shared `RedisMessageListenerContainer` bean lives in `world` (consumed by listeners in both `world` and `api`); the container is started in the `@Bean` so the two listeners only register against it.

After this slice, the engine functionally supports multi-pod deployment.

## Design notes

- **Per-agent topic subscriptions deviation.** Issue text mentions per-agent subscribe/unsubscribe on MCP session connect/disconnect. Spring AI MCP doesn't expose clean session-lifecycle hooks, and the current design (broadcast + MCP's own per-server subscription filter) achieves the same end-user behavior with strictly less moving state. Documented as a deliberate choice; revisitable if Spring AI MCP exposes hooks later.
- **Editor publish failures propagate** out of the `@Transactional` boundary by design — Redis-down during admin geometry edit yields a clear failure rather than silent staleness on other pods. Dispatcher publish failures are caught (log only) — the event log is the source of truth, push is best-effort.
- **Forward-incompatible subtypes** are caught + logged at WARN by listeners; rolling deploys generate noise but stay correct.
- **Residual gap (out of scope, follow-up):** lease acquisition does not currently trigger a `staticConfig.reload()`, so a pod that newly leases a world after an invalidation may tick once on stale static config. Pre-existed before this slice.

## Test plan

- [x] `:world:test` green — includes new `RedisInvalidationBusIntegrationTest` (cross-pod publish/subscribe round-trip for both message types) and `WorldConfigInvalidateListenerIntegrationTest` (any-leased gate, AgentNotify-on-same-channel ignored, sentinel-after-negative for negative cases).
- [x] `:api:test` green — includes new `AgentNotifyListenerIntegrationTest` (cross-pod end-to-end MCP notify) and updated `AgentEventDispatcherTest` (verifies bus publish instead of direct mcp call).
- [x] `:app:test` green — full Spring context boots cleanly with the new beans wired across modules.
- [x] `code-quality-reviewer` agent pass: high/medium findings addressed (per-world filter → any-leased gate, dual-start race → start in @Bean, sleep-based negative tests → sentinel pattern).

Closes #83