### PR TITLE
docs(shard-readiness): tick Steps 5 (#82) and 6 (#83); mark initiative complete

### DIFF
--- a/docs/shard-readiness-sequence.md
+++ b/docs/shard-readiness-sequence.md
@@ -10,7 +10,7 @@
 
 > **HOW TO USE.** When the user says "move on to next step", look here. The next unchecked box is the next slice. When a slice merges, tick the box and update **Current step** below. This file is the single source of truth for roadmap position; per-issue acceptance criteria stay tracked inside each GitHub issue.
 
-**Current step:** ⏭ **Step 5 — [#82](https://github.com/Genesara/genesara-engine/issues/82) Redis-per-world `CommandQueue` with polymorphic serialization**
+**Status:** ✅ Initiative complete — all 6 steps merged.
 
 ### Sequence
 
@@ -18,8 +18,8 @@
 - [x] **Step 2** — [#79](https://github.com/Genesara/genesara-engine/issues/79) Surgical Redis moves: cooldowns, kill streaks, pending attack scales *(blocked by #78; can run in parallel with #80)*
 - [x] **Step 3** — [#80](https://github.com/Genesara/genesara-engine/issues/80) Per-world Redis lease (γ) with fenced writes + SIGTERM release *(blocked by #78; can run in parallel with #79)*
 - [x] **Step 4** — [#81](https://github.com/Genesara/genesara-engine/issues/81) Parallel per-world tick fan-out via `Dispatchers.IO` *(blocked by #80)*
-- [ ] **Step 5** — [#82](https://github.com/Genesara/genesara-engine/issues/82) Redis-per-world `CommandQueue` with polymorphic serialization *(blocked by #80; can run in parallel with #81)*
-- [ ] **Step 6** — [#83](https://github.com/Genesara/genesara-engine/issues/83) Cross-pod pub/sub — `RedisInvalidationBus` for MCP push + static config *(blocked by #82; closes the multi-pod functional gap)*
+- [x] **Step 5** — [#82](https://github.com/Genesara/genesara-engine/issues/82) Redis-per-world `CommandQueue` with polymorphic serialization *(blocked by #80; can run in parallel with #81)*
+- [x] **Step 6** — [#83](https://github.com/Genesara/genesara-engine/issues/83) Cross-pod pub/sub — `RedisInvalidationBus` for MCP push + static config *(blocked by #82; closes the multi-pod functional gap)*
 
 ```
                   ┌──────────────────────┐


### PR DESCRIPTION
## Summary

- Both remaining shard-readiness slices have already merged (Step 5 in #89 / 36e858c, Step 6 in #90 / 6dbd976), so tick both boxes in the sequence doc.
- Replace the **Current step** pointer with a **Status: ✅ Initiative complete** marker — there's no next step.
- Issue #82's acceptance checklist was also ticked and the issue closed (#83 was already closed when its PR landed).

## Test plan

- [ ] Doc renders correctly in GitHub markdown