### PR TITLE
feat(world): silent per-agent behavior tracker (#31)

### DIFF
--- a/world/build.gradle.kts
+++ b/world/build.gradle.kts
@@ -23,5 +23,5 @@ dependencies {
 
 jooqModule {
     migrationsSubdir.set("world")
-    tableIncludes.set("worlds|regions|region_neighbors|nodes|node_adjacency|agent_positions|agent_bodies|starter_nodes|agent_inventory|non_renewable_resources|agent_node_memory|agent_equipment_instances|agent_safe_nodes|node_buildings|building_chest_inventory|world_tick")
+    tableIncludes.set("worlds|regions|region_neighbors|nodes|node_adjacency|agent_positions|agent_bodies|starter_nodes|agent_inventory|non_renewable_resources|agent_node_memory|agent_equipment_instances|agent_safe_nodes|node_buildings|building_chest_inventory|world_tick|agent_action_counters")
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -21,6 +21,7 @@ import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
 import dev.gvart.genesara.world.internal.buildings.BuildingsCatalog
 import dev.gvart.genesara.world.internal.abilities.PendingAttackScaleStore
 import dev.gvart.genesara.world.internal.abilities.reduceUseAbility
@@ -75,17 +76,18 @@ internal fun reduce(
     activePerks: ActivePerkLookup,
     perkCooldowns: PerkCooldownStore,
     pendingScales: PendingAttackScaleStore,
+    behaviorTracker: BehaviorTracker,
     tickIntervalSeconds: Long,
     tick: Long,
     rng: Random = Random.Default,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = when (command) {
     is WorldCommand.SpawnAgent -> reduceSpawn(state, command, profiles, spawnLocationResolver, tick)
-    is WorldCommand.MoveAgent -> reduceMove(state, command, balance, buildingsLookup, scaling, tick)
+    is WorldCommand.MoveAgent -> reduceMove(state, command, balance, buildingsLookup, scaling, behaviorTracker, tick)
     is WorldCommand.UnspawnAgent -> reduceUnspawn(state, command, tick)
     is WorldCommand.Harvest ->
         reduceHarvest(
             state, command, balance, items, resources, agents, equipment,
-            progression, scaling, triggeredPassives, tick,
+            progression, scaling, triggeredPassives, behaviorTracker, tick,
         )
     is WorldCommand.ConsumeItem -> reduceConsume(state, command, items, tick)
     is WorldCommand.Drink -> reduceDrink(state, command, balance, buildingsLookup, tick)
@@ -94,7 +96,7 @@ internal fun reduce(
     is WorldCommand.BuildStructure ->
         reduceBuild(
             state, command, buildingsCatalog, skills, buildings, safeNodes,
-            progression, triggeredPassives, tick,
+            progression, triggeredPassives, behaviorTracker, tick,
         )
     is WorldCommand.DepositToChest ->
         reduceDeposit(state, command, items, buildingsCatalog, buildings, chestContents, tick)
@@ -103,18 +105,18 @@ internal fun reduce(
     is WorldCommand.CraftItem ->
         reduceCraft(
             state, command, balance, items, recipes, equipment, buildingsLookup,
-            skills, agents, rarityRoller, progression, scaling, triggeredPassives, tick,
+            skills, agents, rarityRoller, progression, scaling, triggeredPassives, behaviorTracker, tick,
         )
     is WorldCommand.Pickup ->
         reducePickup(state, command, balance, items, agents, equipment, groundItems, tick)
     is WorldCommand.AttackTarget ->
         reduceAttack(
             state, command, balance, items, agents, equipment, progression, scaling,
-            passiveAura, deathProcessor, triggeredPassives, pendingScales, rng, tick,
+            passiveAura, deathProcessor, triggeredPassives, pendingScales, behaviorTracker, rng, tick,
         )
     is WorldCommand.UseAbility ->
         reduceUseAbility(
             state, command, activePerks, perkCooldowns, pendingScales,
-            progression, balance, tickIntervalSeconds, tick,
+            progression, balance, behaviorTracker, tickIntervalSeconds, tick,
         )
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/abilities/AbilityResolver.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/abilities/AbilityResolver.kt
@@ -16,6 +16,8 @@ import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
+import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
 import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 
@@ -35,6 +37,7 @@ internal fun reduceUseAbility(
     pendingScales: PendingAttackScaleStore,
     progression: SkillProgression,
     balance: BalanceLookup,
+    behaviorTracker: BehaviorTracker,
     tickIntervalSeconds: Long,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
@@ -115,6 +118,7 @@ internal fun reduceUseAbility(
         tick,
         command.commandId,
     )
+    behaviorTracker.record(command.agent, ActionCategory.COMBAT, tick)
 
     val event = WorldEvent.AbilityUsed(
         agent = command.agent,

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/behavior/ActionCategory.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/behavior/ActionCategory.kt
@@ -1,0 +1,19 @@
+package dev.gvart.genesara.world.internal.behavior
+
+/**
+ * The 8-axis behavior fingerprint scored against per-class fingerprints at the
+ * level-10 event (#33) and L50 evolution (#34). **Internal by design** — the
+ * counters this enum keys must never surface through MCP tools or projections.
+ */
+internal enum class ActionCategory {
+    COMBAT,
+    GATHER,
+    CRAFT,
+    BUILD,
+    // TODO(verbs): SOCIAL/MEDICAL/TRADE remain unmapped to v1 verbs — wire
+    // when say/heal_other/trade reducers land.
+    SOCIAL,
+    EXPLORE,
+    MEDICAL,
+    TRADE,
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/behavior/BehaviorTracker.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/behavior/BehaviorTracker.kt
@@ -1,0 +1,19 @@
+package dev.gvart.genesara.world.internal.behavior
+
+import dev.gvart.genesara.player.AgentId
+
+/**
+ * Silent per-agent action counters that feed the level-10 class-choice
+ * fingerprint (#33) and, later, the L50 evolution scoring (#34).
+ *
+ * Contract — counters are **never** exposed to agents: no MCP tool, projection,
+ * or `get_status` field surfaces them. The interface stays `internal` to the
+ * world module so an accidental import from `:api` fails to compile.
+ */
+internal interface BehaviorTracker {
+
+    fun record(agent: AgentId, category: ActionCategory, tick: Long)
+
+    /** Cumulative count per category; categories the agent has never touched are absent. */
+    fun snapshotFor(agent: AgentId): Map<ActionCategory, Int>
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/behavior/JooqBehaviorTracker.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/behavior/JooqBehaviorTracker.kt
@@ -1,0 +1,51 @@
+package dev.gvart.genesara.world.internal.behavior
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_ACTION_COUNTERS
+import org.jooq.DSLContext
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+internal class JooqBehaviorTracker(
+    private val dsl: DSLContext,
+) : BehaviorTracker {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    override fun record(agent: AgentId, category: ActionCategory, tick: Long) {
+        dsl.insertInto(AGENT_ACTION_COUNTERS)
+            .set(AGENT_ACTION_COUNTERS.AGENT_ID, agent.id)
+            .set(AGENT_ACTION_COUNTERS.CATEGORY, category.name)
+            .set(AGENT_ACTION_COUNTERS.ACTION_COUNT, 1)
+            .set(AGENT_ACTION_COUNTERS.LAST_INCREMENTED_AT_TICK, tick)
+            .onConflict(AGENT_ACTION_COUNTERS.AGENT_ID, AGENT_ACTION_COUNTERS.CATEGORY)
+            .doUpdate()
+            .set(AGENT_ACTION_COUNTERS.ACTION_COUNT, AGENT_ACTION_COUNTERS.ACTION_COUNT.plus(1))
+            .set(AGENT_ACTION_COUNTERS.LAST_INCREMENTED_AT_TICK, tick)
+            .execute()
+    }
+
+    @Transactional(readOnly = true)
+    override fun snapshotFor(agent: AgentId): Map<ActionCategory, Int> =
+        dsl.select(AGENT_ACTION_COUNTERS.CATEGORY, AGENT_ACTION_COUNTERS.ACTION_COUNT)
+            .from(AGENT_ACTION_COUNTERS)
+            .where(AGENT_ACTION_COUNTERS.AGENT_ID.eq(agent.id))
+            .fetch()
+            .mapNotNull { row ->
+                val raw = row[AGENT_ACTION_COUNTERS.CATEGORY] ?: return@mapNotNull null
+                val category = runCatching { ActionCategory.valueOf(raw) }.getOrNull() ?: run {
+                    // Drop rather than throw: an old pod surviving past a
+                    // deploy that adds a category must keep scoring against
+                    // the categories it knows. Surfaces as a warn so the gap
+                    // doesn't go unnoticed forever.
+                    log.warn("agent_action_counters row for {} has unknown category '{}'; dropping from snapshot", agent.id, raw)
+                    return@mapNotNull null
+                }
+                val count = row[AGENT_ACTION_COUNTERS.ACTION_COUNT] ?: 0
+                category to count
+            }
+            .toMap()
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
@@ -17,6 +17,8 @@ import dev.gvart.genesara.world.BuildingsStore
 import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
+import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
 import dev.gvart.genesara.world.internal.inventory.AgentInventory
 import dev.gvart.genesara.world.internal.perks.TriggerContext
 import dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcher
@@ -37,6 +39,7 @@ internal fun reduceBuild(
     safeNodes: AgentSafeNodeGateway,
     progression: SkillProgression,
     triggeredPassives: TriggeredPassiveDispatcher,
+    behaviorTracker: BehaviorTracker,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
@@ -101,6 +104,7 @@ internal fun reduceBuild(
     if (event is WorldEvent.BuildingCompleted) applyCompletionSideEffects(resultBuilding, safeNodes, tick)
 
     progression.accrueXp(command.agent, def.requiredSkill, delta = 1, tick, command.commandId)
+    behaviorTracker.record(command.agent, ActionCategory.BUILD, tick)
 
     val next = state
         .updateBody(command.agent, body.spendStamina(def.staminaPerStep))

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
@@ -22,6 +22,8 @@ import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.abilities.PendingAttackScaleStore
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
+import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
 import dev.gvart.genesara.world.internal.death.AttackCause
 import dev.gvart.genesara.world.internal.death.DeathProcessor
 import dev.gvart.genesara.world.internal.perks.TriggerContext
@@ -59,6 +61,7 @@ internal fun reduceAttack(
     deathProcessor: DeathProcessor,
     triggeredPassives: TriggeredPassiveDispatcher,
     pendingScales: PendingAttackScaleStore,
+    behaviorTracker: BehaviorTracker,
     rng: Random,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
@@ -139,6 +142,7 @@ internal fun reduceAttack(
         .updateBody(command.agent, nextAttackerBody)
 
     progression.accrueXp(command.agent, weaponProfile.combatSkill, balance.attackXpDelta(), tick, command.commandId)
+    behaviorTracker.record(command.agent, ActionCategory.COMBAT, tick)
 
     val attackEvent = WorldEvent.AgentAttacked(
         attacker = command.agent,

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
@@ -25,6 +25,8 @@ import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
+import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
 import dev.gvart.genesara.world.internal.inventory.AgentInventory
 import dev.gvart.genesara.world.internal.inventory.enforceCarryCap
 import dev.gvart.genesara.world.internal.inventory.equippedGrams
@@ -54,6 +56,7 @@ internal fun reduceCraft(
     progression: SkillProgression,
     scaling: LevelScalingAggregator,
     triggeredPassives: TriggeredPassiveDispatcher,
+    behaviorTracker: BehaviorTracker,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
@@ -121,6 +124,7 @@ internal fun reduceCraft(
     mutation.equipmentToInsert?.let(equipment::insert)
 
     progression.accrueXp(command.agent, recipe.requiredSkill, delta = 1, tick, command.commandId)
+    behaviorTracker.record(command.agent, ActionCategory.CRAFT, tick)
 
     val next = state
         .updateBody(command.agent, body.spendStamina(recipe.staminaCost))

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
@@ -19,6 +19,8 @@ import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
+import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
 import dev.gvart.genesara.world.internal.inventory.enforceCarryCap
 import dev.gvart.genesara.world.internal.inventory.equippedGrams
 import dev.gvart.genesara.world.internal.inventory.totalGrams
@@ -46,6 +48,7 @@ internal fun reduceHarvest(
     progression: SkillProgression,
     scaling: LevelScalingAggregator,
     triggeredPassives: TriggeredPassiveDispatcher,
+    behaviorTracker: BehaviorTracker,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val nodeId = ensureNotNull(state.positions[command.agent]) {
@@ -81,6 +84,7 @@ internal fun reduceHarvest(
     itemDef.harvestSkill?.let { skill ->
         progression.accrueXp(command.agent, skill, delta = quantity, tick, command.commandId)
     }
+    behaviorTracker.record(command.agent, ActionCategory.GATHER, tick)
 
     // TODO(max-stack): reject (StackFull) when adding `quantity` would exceed maxStack.
     // TODO(events): emit WorldEvent.NodeResourceDepleted alongside ResourceHarvested when

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
@@ -12,6 +12,8 @@ import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
+import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 
 internal fun reduceMove(
@@ -20,6 +22,7 @@ internal fun reduceMove(
     balance: BalanceLookup,
     buildings: BuildingsLookup,
     scaling: LevelScalingAggregator,
+    behaviorTracker: BehaviorTracker,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val from = ensureNotNull(state.positions[command.agent]) {
@@ -53,6 +56,7 @@ internal fun reduceMove(
     val next = state
         .moveAgent(command.agent, command.to)
         .updateBody(command.agent, body.spendStamina(cost))
+    behaviorTracker.record(command.agent, ActionCategory.EXPLORE, tick)
     val event = WorldEvent.AgentMoved(command.agent, from, command.to, tick, causedBy = command.commandId)
 
     next to listOf(event)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -20,6 +20,7 @@ import dev.gvart.genesara.world.WorldId
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.abilities.PendingAttackScaleStore
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
 import dev.gvart.genesara.world.internal.buildings.BuildingsCatalog
 import dev.gvart.genesara.world.internal.crafting.RarityRoller
 import dev.gvart.genesara.world.internal.death.DeathProcessor
@@ -71,6 +72,7 @@ internal class WorldTickHandler(
     private val activePerks: ActivePerkLookup,
     private val perkCooldowns: PerkCooldownStore,
     private val pendingScales: PendingAttackScaleStore,
+    private val behaviorTracker: BehaviorTracker,
     private val leaseFence: WorldLeaseFence,
     @Value("\${application.tick.interval}") private val tickInterval: Duration,
 ) : WorldTickRunner {
@@ -127,7 +129,7 @@ internal class WorldTickHandler(
                 safeNodes, safeNodeResolver, buildings, buildingsLookup, buildingsCatalog, chestContents,
                 rarityRoller, progression, scaling, passiveAura, spawnLocationResolver, groundItems,
                 deathProcessor, triggeredPassives, activePerks, perkCooldowns, pendingScales,
-                tickIntervalSeconds, number,
+                behaviorTracker, tickIntervalSeconds, number,
             ).fold(
                 ifLeft = { rejection ->
                     log.info("Rejected {} at tick {} world {}: {}", command, number, worldId.value, rejection)

--- a/world/src/main/resources/db/migration/world/V18__agent_action_counters.sql
+++ b/world/src/main/resources/db/migration/world/V18__agent_action_counters.sql
@@ -1,0 +1,25 @@
+-- Phase 4 behavior tracker (issue #31): per-agent silent counters that drive
+-- the level-10 class-choice fingerprint and (later) the L50 evolution scoring.
+--
+-- TODO(permadeath-cleanup): no cross-module FK to player.agents (matches the
+-- agent_safe_nodes pattern); wire explicit cleanup when permadeath lands.
+--
+-- TODO(window): the sliding-window read for class evolution (#34) may need
+-- tick-bucketing on top of this single-row shape — `last_incremented_at_tick`
+-- buys us a recency hint without committing to that shape now.
+--
+-- No CHECK constraint on `category`: a check would force a migration on every
+-- new ActionCategory axis; trust the application enum and let unknown strings
+-- surface as a snapshot read miss (logged in JooqBehaviorTracker).
+--
+-- `action_count` rather than `count` keeps the column out of jOOQ's aggregate
+-- function namespace and mirrors the `recommend_count` pattern in
+-- agent_skill_recommendations.
+CREATE TABLE agent_action_counters
+(
+    agent_id                 UUID        NOT NULL,
+    category                 VARCHAR(16) NOT NULL,
+    action_count             INT         NOT NULL DEFAULT 0 CHECK (action_count >= 0),
+    last_incremented_at_tick BIGINT      NOT NULL,
+    PRIMARY KEY (agent_id, category)
+);

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/abilities/AbilityResolverTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/abilities/AbilityResolverTest.kt
@@ -33,6 +33,7 @@ import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
 import dev.gvart.genesara.world.internal.testsupport.InMemoryPendingAttackScaleStore
 import dev.gvart.genesara.world.internal.testsupport.InMemoryPerkCooldownStore
 import dev.gvart.genesara.world.internal.worldstate.WorldState
@@ -55,6 +56,7 @@ class AbilityResolverTest {
     private val ability = AbilityId("SWORD_POWER_STRIKE")
     private val perkId = PerkId("SWORD_POWER_STRIKE")
     private val swordSkill = SkillId("SWORD")
+    private val tracker = InMemoryBehaviorTracker()
 
     private val region = Region(
         id = regionId,
@@ -88,6 +90,7 @@ class AbilityResolverTest {
                 progression = SkillProgression(skills, publisher),
                 balance = combatBalance(),
                 pendingScales = pendingScales,
+                behaviorTracker = tracker,
                 tickIntervalSeconds = 5L,
                 tick = 100L,
             ).getOrNull(),
@@ -122,6 +125,7 @@ class AbilityResolverTest {
             progression = SkillProgression(SnapshotSkills(), RecordingPublisher()),
             balance = combatBalance(),
             pendingScales = pendingScales,
+            behaviorTracker = tracker,
             tickIntervalSeconds = 5L,
             tick = 1L,
         ).leftOrNull()
@@ -141,8 +145,9 @@ class AbilityResolverTest {
             progression = SkillProgression(SnapshotSkills(), RecordingPublisher()),
             balance = combatBalance(),
             pendingScales = pendingScales,
-                tickIntervalSeconds = 5L,
-                tick = 100L,
+            behaviorTracker = tracker,
+            tickIntervalSeconds = 5L,
+            tick = 100L,
         ).leftOrNull()
         val onCd = assertIs<WorldRejection.AbilityOnCooldown>(rejection)
         assertEquals(200L, onCd.readyAtTick)
@@ -162,6 +167,7 @@ class AbilityResolverTest {
             progression = SkillProgression(skills, RecordingPublisher()),
             balance = combatBalance(),
             pendingScales = pendingScales,
+            behaviorTracker = tracker,
             tickIntervalSeconds = 5L,
             tick = 1L,
         ).leftOrNull()
@@ -189,6 +195,7 @@ class AbilityResolverTest {
             progression = SkillProgression(SnapshotSkills(), RecordingPublisher()),
             balance = combatBalance(),
             pendingScales = pendingScales,
+            behaviorTracker = tracker,
             tickIntervalSeconds = 5L,
             tick = 1L,
         ).leftOrNull()
@@ -206,6 +213,7 @@ class AbilityResolverTest {
             progression = SkillProgression(SnapshotSkills(), RecordingPublisher()),
             balance = combatBalance(),
             pendingScales = pendingScales,
+            behaviorTracker = tracker,
             tickIntervalSeconds = 5L,
             tick = 1L,
         ).leftOrNull()
@@ -250,6 +258,7 @@ class AbilityResolverTest {
             progression = SkillProgression(SnapshotSkills(), RecordingPublisher()),
             balance = combatBalance(),
             pendingScales = pendingScales,
+            behaviorTracker = tracker,
             tickIntervalSeconds = 5L,
             tick = 1L,
         ).leftOrNull()

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/abilities/PowerStrikeCanaryIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/abilities/PowerStrikeCanaryIntegrationTest.kt
@@ -53,6 +53,7 @@ import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.combat.reduceAttack
 import dev.gvart.genesara.world.internal.death.DeathProcessor
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
 import dev.gvart.genesara.world.internal.testsupport.InMemoryPendingAttackScaleStore
 import dev.gvart.genesara.world.internal.testsupport.InMemoryPerkCooldownStore
 import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
@@ -77,6 +78,7 @@ class PowerStrikeCanaryIntegrationTest {
     private val swordSkill = SkillId("SWORD")
     private val abilityId = AbilityId("SWORD_POWER_STRIKE")
     private val perkId = PerkId("SWORD_POWER_STRIKE")
+    private val tracker = InMemoryBehaviorTracker()
 
     private val region = Region(
         id = regionId,
@@ -146,6 +148,7 @@ class PowerStrikeCanaryIntegrationTest {
                 pendingScales = pendingScales,
                 progression = progression,
                 balance = balance,
+                behaviorTracker = tracker,
                 tickIntervalSeconds = TICK_INTERVAL_SECONDS,
                 tick = 100L,
             ).getOrNull(),
@@ -161,7 +164,7 @@ class PowerStrikeCanaryIntegrationTest {
                 afterUse, WorldCommand.AttackTarget(attacker, target),
                 balance, items, agents, equipment, progression, NoScaling, NoAura,
                 deathProcessor, NoOpTriggeredPassiveDispatcher, baselineScales,
-                rng = Random(seed = 7L), tick = 101L,
+                tracker, rng = Random(seed = 7L), tick = 101L,
             ).getOrNull(),
         )
         val baseline = assertIs<WorldEvent.AgentAttacked>(baselineEvents.single())
@@ -171,7 +174,7 @@ class PowerStrikeCanaryIntegrationTest {
                 afterUse, WorldCommand.AttackTarget(attacker, target),
                 balance, items, agents, equipment, progression, NoScaling, NoAura,
                 deathProcessor, NoOpTriggeredPassiveDispatcher, pendingScales,
-                rng = Random(seed = 7L), tick = 101L,
+                tracker, rng = Random(seed = 7L), tick = 101L,
             ).getOrNull(),
         )
         val scaled = assertIs<WorldEvent.AgentAttacked>(attackEvents.single())
@@ -183,7 +186,7 @@ class PowerStrikeCanaryIntegrationTest {
                 afterAttack, WorldCommand.AttackTarget(attacker, target),
                 balance, items, agents, equipment, progression, NoScaling, NoAura,
                 deathProcessor, NoOpTriggeredPassiveDispatcher, pendingScales,
-                rng = Random(seed = 7L), tick = 102L,
+                tracker, rng = Random(seed = 7L), tick = 102L,
             ).getOrNull(),
         )
         val secondAttack = assertIs<WorldEvent.AgentAttacked>(secondAttackEvents.single())
@@ -213,14 +216,14 @@ class PowerStrikeCanaryIntegrationTest {
 
         val first = reduceUseAbility(
             state, WorldCommand.UseAbility(attacker, abilityId, target),
-            activePerks, cooldowns, pendingScales, progression, balance, TICK_INTERVAL_SECONDS, tick = 50L,
+            activePerks, cooldowns, pendingScales, progression, balance, tracker, TICK_INTERVAL_SECONDS, tick = 50L,
         ).getOrNull()
         assertNotNull(first)
 
         val (afterFirst, _) = first
         val rejection = reduceUseAbility(
             afterFirst, WorldCommand.UseAbility(attacker, abilityId, target),
-            activePerks, cooldowns, pendingScales, progression, balance, TICK_INTERVAL_SECONDS, tick = 51L,
+            activePerks, cooldowns, pendingScales, progression, balance, tracker, TICK_INTERVAL_SECONDS, tick = 51L,
         ).leftOrNull()
         assertIs<dev.gvart.genesara.world.WorldRejection.AbilityOnCooldown>(rejection)
 
@@ -229,7 +232,7 @@ class PowerStrikeCanaryIntegrationTest {
                 bodies = afterFirst.bodies + (attacker to afterFirst.bodyOf(attacker)!!.copy(stamina = 50)),
             ),
             WorldCommand.UseAbility(attacker, abilityId, target),
-            activePerks, cooldowns, pendingScales, progression, balance, TICK_INTERVAL_SECONDS, tick = 55L,
+            activePerks, cooldowns, pendingScales, progression, balance, tracker, TICK_INTERVAL_SECONDS, tick = 55L,
         ).getOrNull()
         assertTrue(later != null, "After the cooldown elapses the cast succeeds again")
     }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/abilities/PowerStrikeTtlExpiryIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/abilities/PowerStrikeTtlExpiryIntegrationTest.kt
@@ -52,6 +52,7 @@ import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.combat.reduceAttack
 import dev.gvart.genesara.world.internal.death.DeathProcessor
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
 import dev.gvart.genesara.world.internal.testsupport.InMemoryPerkCooldownStore
 import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.world.internal.worldstate.WorldState
@@ -95,6 +96,7 @@ class PowerStrikeTtlExpiryIntegrationTest {
     private val nodeId = NodeId(1L)
     private val rustySword = ItemId("RUSTY_SWORD")
     private val swordSkill = SkillId("SWORD")
+    private val tracker = InMemoryBehaviorTracker()
     private val abilityId = AbilityId("SWORD_POWER_STRIKE")
     private val perkId = PerkId("SWORD_POWER_STRIKE")
 
@@ -182,6 +184,7 @@ class PowerStrikeTtlExpiryIntegrationTest {
                 pendingScales = pendingScales,
                 progression = progression,
                 balance = balance,
+                behaviorTracker = tracker,
                 tickIntervalSeconds = 1L,
                 tick = 100L,
             ).getOrNull(),
@@ -193,7 +196,7 @@ class PowerStrikeTtlExpiryIntegrationTest {
                 afterUse, WorldCommand.AttackTarget(attacker, target),
                 balance, items, agents, equipment, progression, NoScaling, NoAura,
                 deathProcessor, NoOpTriggeredPassiveDispatcher, pendingScales,
-                rng = Random(seed = 7L), tick = 1000L,
+                tracker, rng = Random(seed = 7L), tick = 1000L,
             ).getOrNull(),
         )
         val attack = assertIs<WorldEvent.AgentAttacked>(attackEvents.single())
@@ -204,7 +207,7 @@ class PowerStrikeTtlExpiryIntegrationTest {
                 initial, WorldCommand.AttackTarget(attacker, target),
                 balance, items, agents, equipment, progression, NoScaling, NoAura,
                 deathProcessor, NoOpTriggeredPassiveDispatcher, baselineScales,
-                rng = Random(seed = 7L), tick = 1000L,
+                tracker, rng = Random(seed = 7L), tick = 1000L,
             ).getOrNull(),
         )
         val baseline = assertIs<WorldEvent.AgentAttacked>(baselineEvents.single())

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/behavior/BehaviorTrackerExposureContractTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/behavior/BehaviorTrackerExposureContractTest.kt
@@ -1,0 +1,26 @@
+package dev.gvart.genesara.world.internal.behavior
+
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KVisibility
+import kotlin.test.assertEquals
+
+/**
+ * Phase 4 issue #31 acceptance criterion: the silent counters must never be
+ * reachable through any public-facing IO. The strongest guard is Kotlin's
+ * `internal` modifier — a dependent module that imports either type fails to
+ * compile because the symbol is invisible across module boundaries. This
+ * fixture pins that contract so a future "make it public for X" change has to
+ * delete the test deliberately, not silently flip the visibility.
+ */
+class BehaviorTrackerExposureContractTest {
+
+    @Test
+    fun `ActionCategory stays internal to the world module`() {
+        assertEquals(KVisibility.INTERNAL, ActionCategory::class.visibility)
+    }
+
+    @Test
+    fun `BehaviorTracker stays internal to the world module`() {
+        assertEquals(KVisibility.INTERNAL, BehaviorTracker::class.visibility)
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/behavior/BehaviorTrackerHookpointsTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/behavior/BehaviorTrackerHookpointsTest.kt
@@ -1,0 +1,36 @@
+package dev.gvart.genesara.world.internal.behavior
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class BehaviorTrackerHookpointsTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val other = AgentId(UUID.randomUUID())
+
+    @Test
+    fun `record bumps the (agent, category) counter and stamps the tick`() {
+        val tracker = InMemoryBehaviorTracker()
+
+        tracker.record(agent, ActionCategory.COMBAT, tick = 3L)
+        tracker.record(agent, ActionCategory.COMBAT, tick = 11L)
+
+        assertEquals(mapOf(ActionCategory.COMBAT to 2), tracker.snapshotFor(agent))
+        assertEquals(11L, tracker.lastTickFor(agent, ActionCategory.COMBAT))
+    }
+
+    @Test
+    fun `snapshotFor isolates by agent`() {
+        val tracker = InMemoryBehaviorTracker()
+        tracker.record(agent, ActionCategory.COMBAT, tick = 1L)
+        tracker.record(other, ActionCategory.GATHER, tick = 1L)
+
+        assertEquals(mapOf(ActionCategory.COMBAT to 1), tracker.snapshotFor(agent))
+        assertEquals(mapOf(ActionCategory.GATHER to 1), tracker.snapshotFor(other))
+        assertNull(tracker.lastTickFor(agent, ActionCategory.GATHER))
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/behavior/JooqBehaviorTrackerIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/behavior/JooqBehaviorTrackerIntegrationTest.kt
@@ -1,0 +1,125 @@
+package dev.gvart.genesara.world.internal.behavior
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_ACTION_COUNTERS
+import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+
+@Testcontainers
+class JooqBehaviorTrackerIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("behavior_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = WorldFlyway.pooledDataSource(postgres)
+            WorldFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private lateinit var tracker: JooqBehaviorTracker
+    private val agent = AgentId(UUID.randomUUID())
+    private val other = AgentId(UUID.randomUUID())
+
+    @BeforeEach
+    fun reset() {
+        dsl.truncate(AGENT_ACTION_COUNTERS).cascade().execute()
+        tracker = JooqBehaviorTracker(dsl)
+    }
+
+    @Test
+    fun `record inserts at 1 for a fresh (agent, category) pair`() {
+        tracker.record(agent, ActionCategory.COMBAT, tick = 5L)
+
+        assertEquals(mapOf(ActionCategory.COMBAT to 1), tracker.snapshotFor(agent))
+    }
+
+    @Test
+    fun `record increments on repeat and stamps the latest tick`() {
+        tracker.record(agent, ActionCategory.GATHER, tick = 1L)
+        tracker.record(agent, ActionCategory.GATHER, tick = 7L)
+        tracker.record(agent, ActionCategory.GATHER, tick = 9L)
+
+        assertEquals(mapOf(ActionCategory.GATHER to 3), tracker.snapshotFor(agent))
+        val storedTick = dsl.select(AGENT_ACTION_COUNTERS.LAST_INCREMENTED_AT_TICK)
+            .from(AGENT_ACTION_COUNTERS)
+            .where(AGENT_ACTION_COUNTERS.AGENT_ID.eq(agent.id))
+            .and(AGENT_ACTION_COUNTERS.CATEGORY.eq(ActionCategory.GATHER.name))
+            .fetchOne(AGENT_ACTION_COUNTERS.LAST_INCREMENTED_AT_TICK)
+        assertEquals(9L, storedTick)
+    }
+
+    @Test
+    fun `snapshot exposes every category the agent has touched`() {
+        tracker.record(agent, ActionCategory.COMBAT, tick = 1L)
+        tracker.record(agent, ActionCategory.COMBAT, tick = 2L)
+        tracker.record(agent, ActionCategory.CRAFT, tick = 3L)
+        tracker.record(agent, ActionCategory.EXPLORE, tick = 4L)
+
+        assertEquals(
+            mapOf(
+                ActionCategory.COMBAT to 2,
+                ActionCategory.CRAFT to 1,
+                ActionCategory.EXPLORE to 1,
+            ),
+            tracker.snapshotFor(agent),
+        )
+    }
+
+    @Test
+    fun `snapshot is empty for an agent with no recorded activity`() {
+        assertEquals(emptyMap(), tracker.snapshotFor(agent))
+    }
+
+    @Test
+    fun `agents do not see each other's counters`() {
+        tracker.record(agent, ActionCategory.COMBAT, tick = 1L)
+        tracker.record(other, ActionCategory.GATHER, tick = 1L)
+        tracker.record(other, ActionCategory.GATHER, tick = 2L)
+
+        assertEquals(mapOf(ActionCategory.COMBAT to 1), tracker.snapshotFor(agent))
+        assertEquals(mapOf(ActionCategory.GATHER to 2), tracker.snapshotFor(other))
+    }
+
+    @Test
+    fun `snapshot drops rows whose category column is unparseable`() {
+        dsl.insertInto(AGENT_ACTION_COUNTERS)
+            .set(AGENT_ACTION_COUNTERS.AGENT_ID, agent.id)
+            .set(AGENT_ACTION_COUNTERS.CATEGORY, "QUANTUM_FORAGING")
+            .set(AGENT_ACTION_COUNTERS.ACTION_COUNT, 7)
+            .set(AGENT_ACTION_COUNTERS.LAST_INCREMENTED_AT_TICK, 1L)
+            .execute()
+        tracker.record(agent, ActionCategory.COMBAT, tick = 1L)
+
+        assertEquals(mapOf(ActionCategory.COMBAT to 1), tracker.snapshotFor(agent))
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.buildings
 
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
 import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.AgentId
@@ -49,6 +50,7 @@ class BuildReducerTest {
     private val wood = ItemId("WOOD")
     private val stone = ItemId("STONE")
     private val carpentry = SkillId("CARPENTRY")
+    private val tracker = InMemoryBehaviorTracker()
 
     private val region = Region(
         id = regionId,
@@ -109,7 +111,7 @@ class BuildReducerTest {
         val (next, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                catalog, skills, store, safeNodes, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
+                catalog, skills, store, safeNodes, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
             ).getOrNull(),
         )
 
@@ -139,7 +141,7 @@ class BuildReducerTest {
         val (next, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                catalog, skills, store, safeNodes, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 9,
+                catalog, skills, store, safeNodes, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 9,
             ).getOrNull(),
         )
 
@@ -164,7 +166,7 @@ class BuildReducerTest {
         val (_, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 11,
+                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 11,
             ).getOrNull(),
         )
 
@@ -192,7 +194,7 @@ class BuildReducerTest {
         val (next, _) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                customCatalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+                customCatalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
             ).getOrNull(),
         )
 
@@ -209,7 +211,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.SHELTER),
-            catalog, skills, store, safeNodes, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 11,
+            catalog, skills, store, safeNodes, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 11,
         )
 
         assertEquals(nodeId, safeNodes.set[agent])
@@ -225,7 +227,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, store, safeNodes, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 11,
+            catalog, skills, store, safeNodes, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 11,
         )
 
         assertEquals(emptyMap(), safeNodes.set)
@@ -237,7 +239,7 @@ class BuildReducerTest {
         val skills = StubSkillsRegistry()
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
@@ -249,7 +251,7 @@ class BuildReducerTest {
         val skills = StubSkillsRegistry()
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(WorldRejection.NotEnoughStamina(agent, required = 8, available = 3), result.leftOrNull())
@@ -265,7 +267,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val rejection = assertIs<WorldRejection.InsufficientMaterials>(result.leftOrNull())
@@ -298,7 +300,7 @@ class BuildReducerTest {
         val (_, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agentB, BuildingType.CAMPFIRE),
-                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 5,
+                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 5,
             ).getOrNull(),
         )
 
@@ -317,7 +319,7 @@ class BuildReducerTest {
         val (_, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 12,
+                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 12,
             ).getOrNull(),
         )
 
@@ -343,7 +345,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            gatedCatalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            gatedCatalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val rejection = assertIs<WorldRejection.BuildingSkillTooLow>(result.leftOrNull())
@@ -366,7 +368,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            gatedCatalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            gatedCatalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertNotNull(result.getOrNull())
@@ -384,7 +386,7 @@ class BuildReducerTest {
             val (next, events) = assertNotNull(
                 reduceBuild(
                     state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                    catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = (10 + i).toLong(),
+                    catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = (10 + i).toLong(),
                 ).getOrNull(),
             )
             state = next
@@ -407,7 +409,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(listOf(carpentry to 1), skills.xpAddCalls)
@@ -421,7 +423,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 5,
+            catalog, skills, StubBuildingsStore(), StubSafeNodes(), SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 5,
         )
 
         val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackKillIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackKillIntegrationTest.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.combat
 
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
 import dev.gvart.genesara.world.internal.testsupport.InMemoryPendingAttackScaleStore
 import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.account.PlayerId
@@ -70,6 +71,7 @@ class AttackKillIntegrationTest {
     private val target = AgentId(UUID.randomUUID())
     private val regionId = RegionId(1L)
     private val nodeId = NodeId(1L)
+    private val tracker = InMemoryBehaviorTracker()
 
     private val region = Region(
         id = regionId,
@@ -151,7 +153,7 @@ class AttackKillIntegrationTest {
         val (afterFirst, firstEvents) = assertNotNull(
             reduceAttack(
                 initial, firstCommand, balance, items, agents, equipment, progression,
-                deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1L,
+                deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1L,
             ).getOrNull(),
         )
 
@@ -165,7 +167,7 @@ class AttackKillIntegrationTest {
         val (afterSecond, secondEvents) = assertNotNull(
             reduceAttack(
                 afterFirst, secondCommand, balance, items, agents, equipment, progression,
-                deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 2L,
+                deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 2L,
             ).getOrNull(),
         )
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.combat
 
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
 import dev.gvart.genesara.world.internal.testsupport.InMemoryPendingAttackScaleStore
 import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.account.PlayerId
@@ -46,6 +47,7 @@ import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
 import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.death.DeathProcessor
 import dev.gvart.genesara.world.internal.worldstate.WorldState
@@ -62,6 +64,7 @@ class AttackReducerTest {
 
     private val attacker = AgentId(UUID.randomUUID())
     private val target = AgentId(UUID.randomUUID())
+    private val tracker = InMemoryBehaviorTracker()
     private val regionId = RegionId(1L)
     private val nodeAId = NodeId(1L)
     private val nodeBId = NodeId(2L)
@@ -97,7 +100,7 @@ class AttackReducerTest {
             reduceAttack(
                 state, WorldCommand.AttackTarget(attacker, target),
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 5,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 5,
             ).getOrNull(),
         )
 
@@ -112,6 +115,7 @@ class AttackReducerTest {
         assertEquals(20, next.bodyOf(target)!!.hp)
         assertEquals(45, next.bodyOf(attacker)!!.stamina, "stamina cost 5")
         assertEquals(listOf(swordSkill to 1), skills.xpAddCalls)
+        assertEquals(mapOf(ActionCategory.COMBAT to 1), tracker.snapshotFor(attacker))
     }
 
     @Test
@@ -126,7 +130,7 @@ class AttackReducerTest {
                 state, WorldCommand.AttackTarget(attacker, target),
                 balance(), itemsWithSword(), agents(strength = 5, luck = 0, dex = 0),
                 StubEquipmentStore(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
             ).getOrNull(),
         )
 
@@ -150,7 +154,7 @@ class AttackReducerTest {
                 balance(), itemsWithSword(),
                 agents(strength = 10, luck = 0, dex = 0, targetDex = 99),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
             ).getOrNull(),
         )
 
@@ -177,7 +181,7 @@ class AttackReducerTest {
                 balance(), itemsWithSword(),
                 agents(strength = 10, luck = 99, dex = 0, targetDex = 0),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
             ).getOrNull(),
         )
 
@@ -200,7 +204,7 @@ class AttackReducerTest {
                 balance(), itemsWithUnmappedWeapon(),
                 agents(strength = 10, luck = 0, dex = 0),
                 unmappedWeaponEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
             ).getOrNull(),
         )
 
@@ -222,7 +226,7 @@ class AttackReducerTest {
                 state, command,
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 7,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 7,
             ).getOrNull(),
         )
 
@@ -250,7 +254,7 @@ class AttackReducerTest {
                 balance(), itemsWithSword(),
                 agents(strength = 0, luck = 0, dex = 0),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
             ).getOrNull(),
         )
 
@@ -293,7 +297,7 @@ class AttackReducerTest {
                 state, command,
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0),
                 swordEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 5,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 5,
             ).getOrNull(),
         )
 
@@ -313,7 +317,7 @@ class AttackReducerTest {
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
             deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+            rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
         )
         assertEquals(WorldRejection.CannotAttackSelf(attacker), result.leftOrNull())
     }
@@ -326,7 +330,7 @@ class AttackReducerTest {
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
             deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+            rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
         )
         assertEquals(WorldRejection.NotInWorld(attacker), result.leftOrNull())
     }
@@ -339,7 +343,7 @@ class AttackReducerTest {
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
             deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+            rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
         )
         assertEquals(WorldRejection.TargetNotInWorld(attacker, target), result.leftOrNull())
     }
@@ -352,7 +356,7 @@ class AttackReducerTest {
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
             deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+            rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
         )
         assertEquals(
             WorldRejection.TargetOutOfRange(attacker, target, nodeAId, nodeBId, weaponRange = 1),
@@ -371,7 +375,7 @@ class AttackReducerTest {
             reduceAttack(
                 state, WorldCommand.AttackTarget(attacker, target),
                 balance(), itemsWithBow(), agents(strength = 0, luck = 0, dex = 10), bowEquipped(),
-                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
             ).getOrNull(),
         )
 
@@ -392,7 +396,7 @@ class AttackReducerTest {
             balance(), itemsWithBow(), agents(strength = 10, luck = 0, dex = 0), bowEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
             deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+            rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
         )
         assertEquals(
             WorldRejection.TargetOutOfRange(attacker, target, nodeAId, nodeCId, weaponRange = 2),
@@ -408,7 +412,7 @@ class AttackReducerTest {
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
             deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+            rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
         )
         assertEquals(WorldRejection.TargetAlreadyDead(attacker, target), result.leftOrNull())
     }
@@ -426,7 +430,7 @@ class AttackReducerTest {
                 state, WorldCommand.AttackTarget(attacker, target),
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
                 SkillProgression(skills, publisher), deathProcessor = deathProcessor,
-                rng = Random(seed = 1L), scaling = scaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+                rng = Random(seed = 1L), scaling = scaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
             ).getOrNull(),
         )
 
@@ -450,7 +454,7 @@ class AttackReducerTest {
                 state, WorldCommand.AttackTarget(attacker, target),
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
                 SkillProgression(skills, publisher), deathProcessor = deathProcessor,
-                rng = Random(seed = 1L), scaling = scaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+                rng = Random(seed = 1L), scaling = scaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
             ).getOrNull(),
         )
 
@@ -473,7 +477,7 @@ class AttackReducerTest {
                 balance(), itemsWithUnmappedWeapon(), agents(strength = 10, luck = 0, dex = 0),
                 unmappedWeaponEquipped(),
                 SkillProgression(skills, publisher), deathProcessor = deathProcessor,
-                rng = Random(seed = 1L), scaling = scaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+                rng = Random(seed = 1L), scaling = scaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
             ).getOrNull(),
         )
 
@@ -515,7 +519,7 @@ class AttackReducerTest {
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
                 SkillProgression(skills, publisher), deathProcessor = deathProcessor,
                 rng = Random(seed = 1L), scaling = NoScaling, passiveAura = aura,
-                triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+                triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
             ).getOrNull(),
         )
 
@@ -539,7 +543,7 @@ class AttackReducerTest {
                 balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
                 SkillProgression(skills, publisher), deathProcessor = deathProcessor,
                 rng = Random(seed = 1L), scaling = scaling, passiveAura = aura,
-                triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+                triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
             ).getOrNull(),
         )
 
@@ -565,7 +569,7 @@ class AttackReducerTest {
                 unmappedWeaponEquipped(),
                 SkillProgression(skills, publisher), deathProcessor = deathProcessor,
                 rng = Random(seed = 1L), scaling = NoScaling, passiveAura = aura,
-                triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+                triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
             ).getOrNull(),
         )
 
@@ -582,7 +586,7 @@ class AttackReducerTest {
             balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
             SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
             deathProcessor = stubDeathProcessor(StubSkillsRegistry(), RecordingPublisher()),
-            rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1,
+            rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
         )
         assertEquals(
             WorldRejection.NotEnoughStamina(attacker, required = 5, available = 3),

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/BleederCanaryIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/BleederCanaryIntegrationTest.kt
@@ -52,6 +52,7 @@ import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.death.DeathProcessor
 import dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcherImpl
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
 import dev.gvart.genesara.world.internal.testsupport.InMemoryPendingAttackScaleStore
 import dev.gvart.genesara.world.internal.testsupport.InMemoryPerkCooldownStore
 import dev.gvart.genesara.world.internal.worldstate.WorldState
@@ -77,6 +78,7 @@ class BleederCanaryIntegrationTest {
     private val rustySword = ItemId("RUSTY_SWORD")
     private val swordSkill = SkillId("SWORD")
     private val bleederId = PerkId("SWORD_BLEEDER")
+    private val tracker = InMemoryBehaviorTracker()
 
     private val region = Region(
         id = regionId,
@@ -142,7 +144,7 @@ class BleederCanaryIntegrationTest {
             reduceAttack(
                 initial, firstCommand, balance, items, agents, equipment, progression,
                 deathProcessor = deathProcessor, rng = Random(seed = 7L), scaling = NoScaling,
-                passiveAura = NoAura, triggeredPassives = dispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 100L,
+                passiveAura = NoAura, triggeredPassives = dispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 100L,
             ).getOrNull(),
         )
 
@@ -167,7 +169,7 @@ class BleederCanaryIntegrationTest {
             reduceAttack(
                 afterFirst, secondCommand, balance, items, agents, equipment, progression,
                 deathProcessor = deathProcessor, rng = Random(seed = 7L), scaling = NoScaling,
-                passiveAura = NoAura, triggeredPassives = dispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 105L,
+                passiveAura = NoAura, triggeredPassives = dispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 105L,
             ).getOrNull(),
         )
         assertTrue(secondEvents.none { it is WorldEvent.PerkTriggered }, "still on cooldown — no re-fire")
@@ -224,7 +226,7 @@ class BleederCanaryIntegrationTest {
                 balance, items, agents, equipment, progression,
                 deathProcessor = DeathProcessor(balance, agents, equipment, StubGroundItemStore()),
                 rng = Random(seed = 7L), scaling = NoScaling,
-                passiveAura = NoAura, triggeredPassives = dispatcher, pendingScales = InMemoryPendingAttackScaleStore(), tick = 1L,
+                passiveAura = NoAura, triggeredPassives = dispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1L,
             ).getOrNull(),
         )
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.crafting
 
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
 import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import arrow.core.Either
 import dev.gvart.genesara.account.PlayerId
@@ -64,6 +65,7 @@ class CraftReducerTest {
 
     private val agent = AgentId(UUID.randomUUID())
     private val ownerId = PlayerId(UUID.randomUUID())
+    private val tracker = InMemoryBehaviorTracker()
     private val regionId = RegionId(1L)
     private val nodeId = NodeId(1L)
 
@@ -161,7 +163,7 @@ class CraftReducerTest {
                 StubAgents(luckyAgent(luck = 5)),
                 fixedRoller(Rarity.UNCOMMON),
                 SkillProgression(skills, publisher),
-                scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
+                scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
             ).getOrNull(),
         )
 
@@ -204,7 +206,7 @@ class CraftReducerTest {
                 StubAgents(luckyAgent(luck = 1)),
                 fixedRoller(Rarity.RARE),
                 SkillProgression(skills, RecordingPublisher()),
-                scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 3,
+                scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 3,
             ).getOrNull(),
         )
 
@@ -244,7 +246,7 @@ class CraftReducerTest {
             StubAgents(luckyAgent()),
             fixedRoller(Rarity.COMMON),
             SkillProgression(skills, RecordingPublisher()),
-            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
         val rejection = assertIs<WorldRejection.StackFull>(result.leftOrNull())
         assertEquals(healingSalve, rejection.item)
@@ -307,7 +309,7 @@ class CraftReducerTest {
             StubAgents(luckyAgent()),
             fixedRoller(Rarity.COMMON),
             SkillProgression(skills, RecordingPublisher()),
-            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
         assertNotNull(result.getOrNull())
     }
@@ -355,7 +357,7 @@ class CraftReducerTest {
             StubAgents(weakAgent),
             fixedRoller(Rarity.COMMON),
             SkillProgression(skills, RecordingPublisher()),
-            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
         assertIs<WorldRejection.OverEncumbered>(result.leftOrNull())
         assertTrue(store.inserted.isEmpty(), "no equipment row written on a rejected craft")
@@ -385,7 +387,7 @@ class CraftReducerTest {
             StubAgents(luckyAgent()),
             fixedRoller(Rarity.COMMON),
             SkillProgression(skills, publisher),
-            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 5,
+            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 5,
         )
         val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()
         assertEquals(alchemy, rec.skill)
@@ -408,7 +410,7 @@ class CraftReducerTest {
             StubAgents(luckyAgent(luck = 7)),
             capturingRoller,
             SkillProgression(skills, RecordingPublisher()),
-            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
         assertEquals(25, capturingRoller.lastSkill)
         assertEquals(7, capturingRoller.lastLuck)
@@ -433,7 +435,7 @@ class CraftReducerTest {
         StubAgents(luckyAgent()),
         fixedRoller(Rarity.COMMON),
         SkillProgression(skills, RecordingPublisher()),
-        scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+        scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
     )
 
     private fun luckyAgent(strength: Int = 20, luck: Int = 1): Agent = Agent(

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.harvest
 
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
 import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AddXpResult
@@ -39,6 +40,7 @@ import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
 import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.resources.InitialResourceRow
 import dev.gvart.genesara.world.internal.resources.NodeResourceCell
@@ -63,6 +65,7 @@ class HarvestReducerTest {
     private val foraging = SkillId("FORAGING")
     private val lumberjacking = SkillId("LUMBERJACKING")
     private val mining = SkillId("MINING")
+    private val tracker = InMemoryBehaviorTracker()
 
     private val region = Region(
         id = regionId,
@@ -108,7 +111,7 @@ class HarvestReducerTest {
         val publisher = RecordingPublisher()
 
         val result = reduceHarvest(
-            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
         )
 
         val (next, events) = assertNotNull(result.getOrNull())
@@ -123,6 +126,7 @@ class HarvestReducerTest {
         assertEquals(1, harvested.quantity)
         assertEquals(7L, harvested.tick)
         assertEquals(command.commandId, harvested.causedBy)
+        assertEquals(mapOf(ActionCategory.GATHER to 1), tracker.snapshotFor(agent))
     }
 
     @Test
@@ -134,7 +138,7 @@ class HarvestReducerTest {
         val publisher = RecordingPublisher()
 
         val result = reduceHarvest(
-            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val (next, events) = assertNotNull(result.getOrNull())
@@ -171,7 +175,7 @@ class HarvestReducerTest {
         val skills = StubSkillsRegistry().apply { slot(mining) }
 
         val result = reduceHarvest(
-            state, command, balance, regenItems, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            state, command, balance, regenItems, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -187,7 +191,7 @@ class HarvestReducerTest {
         val skills = StubSkillsRegistry().apply { slot(foraging) }
 
         val result = reduceHarvest(
-            state, command, balance, items, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -201,7 +205,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
@@ -215,7 +219,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, unknown), balance, emptyCatalog,
-            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(WorldRejection.UnknownItem(unknown), result.leftOrNull())
@@ -228,7 +232,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, berry), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(
@@ -244,7 +248,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(
@@ -260,7 +264,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(
@@ -276,7 +280,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -292,7 +296,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), highYield, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val (next, events) = assertNotNull(result.getOrNull())
@@ -316,7 +320,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), tightBalance, items, store,
-            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(
@@ -335,7 +339,7 @@ class HarvestReducerTest {
         val result = reduceHarvest(
             state = stateWith(),
             WorldCommand.Harvest(agent, wood), tightBalance, items, store,
-            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -378,7 +382,7 @@ class HarvestReducerTest {
         val result = reduceHarvest(
             state = stateWith(),
             WorldCommand.Harvest(agent, wood), tightBalance, itemsWithHelmet, store,
-            skinnyAgents, helmetEquipped, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 1,
+            skinnyAgents, helmetEquipped, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(
@@ -396,7 +400,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
         )
 
         assertEquals(listOf(lumberjacking to 1), skills.xpAddCalls)
@@ -416,7 +420,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
         )
 
         val ev = publisher.events.filterIsInstance<AgentEvent.SkillMilestoneReached>().single()
@@ -437,7 +441,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
         )
 
         val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()
@@ -454,7 +458,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
         )
 
         assertTrue(publisher.events.none { it is AgentEvent.SkillRecommended })
@@ -471,7 +475,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, skillFreeItems,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
         )
 
         assertEquals(0, skills.xpAddCalls.size)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
@@ -18,7 +18,9 @@ import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
 import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -35,6 +37,7 @@ class MovementReducerTest {
     private val c = NodeId(3L)
 
     private val flatCost = balanceLookup(cost = 1)
+    private val tracker = InMemoryBehaviorTracker()
 
     private val world = WorldState(
         regions = mapOf(
@@ -62,7 +65,7 @@ class MovementReducerTest {
     @Test
     fun `accepts move to adjacent node, deducts stamina, and emits AgentMoved`() {
         val command = WorldCommand.MoveAgent(agent, b)
-        val result = reduceMove(world, command, flatCost, NoBuildings, scaling = NoScaling, tick = 1)
+        val result = reduceMove(world, command, flatCost, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
@@ -73,6 +76,7 @@ class MovementReducerTest {
                     WorldEvent.AgentMoved(agent, a, b, tick = 1, causedBy = command.commandId),
                     events.single(),
                 )
+                assertEquals(mapOf(ActionCategory.EXPLORE to 1), tracker.snapshotFor(agent))
             },
         )
     }
@@ -80,7 +84,7 @@ class MovementReducerTest {
     @Test
     fun `rejects move when agent is unknown`() {
         val unknown = AgentId(UUID.randomUUID())
-        val result = reduceMove(world, WorldCommand.MoveAgent(unknown, b), flatCost, NoBuildings, scaling = NoScaling, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(unknown, b), flatCost, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         assertTrue(result.isLeft())
         assertEquals(WorldRejection.UnknownAgent(unknown), result.leftOrNull())
@@ -89,14 +93,14 @@ class MovementReducerTest {
     @Test
     fun `rejects move to unknown node`() {
         val ghost = NodeId(99L)
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, ghost), flatCost, NoBuildings, scaling = NoScaling, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, ghost), flatCost, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         assertEquals(WorldRejection.UnknownNode(ghost), result.leftOrNull())
     }
 
     @Test
     fun `rejects move to non-adjacent node`() {
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, c), flatCost, NoBuildings, scaling = NoScaling, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, c), flatCost, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         assertEquals(WorldRejection.NotAdjacent(a, c), result.leftOrNull())
     }
@@ -104,7 +108,7 @@ class MovementReducerTest {
     @Test
     fun `rejects move when stamina is below cost`() {
         val expensive = balanceLookup(cost = 99)
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), expensive, NoBuildings, scaling = NoScaling, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), expensive, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         assertEquals(
             WorldRejection.NotEnoughStamina(agent, required = 99, available = 10),
@@ -117,7 +121,7 @@ class MovementReducerTest {
         val unpainted = world.copy(
             regions = world.regions.mapValues { (_, r) -> r.copy(biome = null) },
         )
-        val result = reduceMove(unpainted, WorldCommand.MoveAgent(agent, b), flatCost, NoBuildings, scaling = NoScaling, tick = 1)
+        val result = reduceMove(unpainted, WorldCommand.MoveAgent(agent, b), flatCost, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         assertEquals(WorldRejection.UnpaintedRegion(region), result.leftOrNull())
     }
@@ -132,7 +136,7 @@ class MovementReducerTest {
         val balance = object : BalanceLookup by flatCost {
             override fun isTraversable(terrain: Terrain): Boolean = terrain != Terrain.OCEAN
         }
-        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, NoBuildings, scaling = NoScaling, tick = 1)
+        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         assertEquals(
             WorldRejection.TerrainNotTraversable(agent, b, Terrain.OCEAN),
@@ -169,7 +173,7 @@ class MovementReducerTest {
         val road = activeBuilding(node = a, hint = BuildingCategoryHint.INFRASTRUCTURE_ROAD)
         val buildings = StubBuildingsLookup(byNode = mapOf(a to listOf(road)))
 
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost10, buildings, scaling = NoScaling, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost10, buildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
@@ -183,7 +187,7 @@ class MovementReducerTest {
         val road = activeBuilding(node = a, hint = BuildingCategoryHint.INFRASTRUCTURE_ROAD)
         val buildings = StubBuildingsLookup(byNode = mapOf(a to listOf(road)))
 
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost1, buildings, scaling = NoScaling, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost1, buildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
@@ -204,7 +208,7 @@ class MovementReducerTest {
         val bridge = activeBuilding(node = b, hint = BuildingCategoryHint.INFRASTRUCTURE_BRIDGE)
         val buildings = StubBuildingsLookup(byNode = mapOf(b to listOf(bridge)))
 
-        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, buildings, scaling = NoScaling, tick = 1)
+        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, buildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/InMemoryBehaviorTracker.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/InMemoryBehaviorTracker.kt
@@ -1,0 +1,26 @@
+package dev.gvart.genesara.world.internal.testsupport
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
+import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
+
+// Single-threaded by design — reducer tests run sequentially. Wrap calls in
+// a lock if a future test fans out parallel reducers against a shared instance.
+internal class InMemoryBehaviorTracker : BehaviorTracker {
+    private val counts = mutableMapOf<Pair<AgentId, ActionCategory>, Int>()
+    private val lastTicks = mutableMapOf<Pair<AgentId, ActionCategory>, Long>()
+
+    override fun record(agent: AgentId, category: ActionCategory, tick: Long) {
+        val key = agent to category
+        counts.merge(key, 1, Int::plus)
+        lastTicks[key] = tick
+    }
+
+    override fun snapshotFor(agent: AgentId): Map<ActionCategory, Int> =
+        counts.entries
+            .filter { it.key.first == agent }
+            .associate { it.key.second to it.value }
+
+    fun lastTickFor(agent: AgentId, category: ActionCategory): Long? =
+        lastTicks[agent to category]
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.tick
 
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
 import dev.gvart.genesara.world.internal.testsupport.InMemoryPendingAttackScaleStore
 import dev.gvart.genesara.world.internal.testsupport.InMemoryPerkCooldownStore
 import dev.gvart.genesara.world.internal.testsupport.NoOpActivePerkLookup
@@ -213,7 +214,7 @@ class WorldTickHandlerTest {
         NoScaling, NoAura, NoopSpawnLocationResolver, NoopGroundItemStore,
         DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore),
         NoOpTriggeredPassiveDispatcher, NoOpActivePerkLookup, InMemoryPerkCooldownStore(),
-        InMemoryPendingAttackScaleStore(), fence, java.time.Duration.ofSeconds(5L),
+        InMemoryPendingAttackScaleStore(), InMemoryBehaviorTracker(), fence, java.time.Duration.ofSeconds(5L),
     )
 
     private object AlwaysHeldLeaseFence : WorldLeaseFence {


### PR DESCRIPTION
## Summary

- Lands **Step 5** of [`docs/skill-feature-sequence.md`](../blob/main/docs/skill-feature-sequence.md) — Phase 4 issue #31. Adds an 8-axis `ActionCategory` enum and a `BehaviorTracker` Spring component (`JooqBehaviorTracker`) backing the silent counters that feed the level-10 class-choice fingerprint (#33) and the L50 evolution scoring (#34).
- Reducer hookpoints on the success path: `Move`→EXPLORE, `Harvest`→GATHER, `Build`→BUILD, `Craft`→CRAFT, `Attack`→COMBAT, `UseAbility`→COMBAT. `consume`/`drink` deliberately not bumped (survival baseline). `SOCIAL`/`MEDICAL`/`TRADE` enum members reserved with a `TODO(verbs)` for the say/heal_other/trade reducers.
- Exposure contract is enforced primarily by Kotlin's `internal` modifier (compile-time gate against `:api`) and pinned by a reflection-based contract test, satisfying the issue's "fails compilation if exposed" criterion. Cumulative-only for v1; the migration keeps `last_incremented_at_tick` so the sliding-window read deferred to #34 can layer on without a schema break.

## Test plan

- [x] `./gradlew :world:test` — all green (10 new tests across `BehaviorTrackerExposureContractTest`, `BehaviorTrackerHookpointsTest`, `JooqBehaviorTrackerIntegrationTest`, plus inline tracker assertions on the happy paths in `MovementReducerTest`, `HarvestReducerTest`, `AttackReducerTest`).
- [x] `./gradlew test` — full repo suite green; downstream `:api`/`:app` modules still compile (the `internal` types are not visible to them, as required).
- [x] Code-quality-reviewer agent pass: rewrote a misleading rollback KDoc on `JooqBehaviorTracker.record`, added `log.warn` on the unknown-category drop branch, dropped a redundant `agent_id` index (PK covers it), added `TODO(permadeath-cleanup)` and `TODO(window)` markers on the migration, and trimmed comment-rule violations.

## Out of scope

- Sliding-window read for class evolution (#34) — deferred per the issue's recommendation; cumulative is sufficient for the level-10 fingerprint.
- Counter surface on any MCP IO type — explicitly forbidden, guarded by `internal` + contract test.