### PR TITLE
feat(player,world): class catalog v1 + AgentClass surgery (#32)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemTool.kt
@@ -64,6 +64,7 @@ internal class EquipItemTool(
         EquipRejection.ALREADY_EQUIPPED -> "instance is already in another slot — unequip it first"
         EquipRejection.INSUFFICIENT_ATTRIBUTES -> "you don't meet the item's attribute requirements"
         EquipRejection.INSUFFICIENT_SKILLS -> "you don't meet the item's skill requirements"
+        EquipRejection.CLASS_FORBIDDEN -> "your class hard-bans this item's combat-skill"
         EquipRejection.OFF_HAND_OCCUPIED -> "OFF_HAND must be empty to equip a two-handed weapon"
         EquipRejection.OFF_HAND_BLOCKED_BY_TWO_HANDED -> "MAIN_HAND holds a two-handed weapon; OFF_HAND is locked"
         EquipRejection.SLOT_OCCUPIED -> "${slot.name} already holds another instance"

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentClass.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentClass.kt
@@ -1,16 +1,21 @@
 package dev.gvart.genesara.player
 
+/**
+ * The eight v1 base classes pinned by the skill-feature design (see
+ * `docs/skill-feature-sequence.md` decisions §18 + §19). Class evolutions at
+ * level 50 (24 branches, 3 per base class) land with #34 and append further
+ * entries here; PSIONICS / MAGE / CLERIC stayed dropped because v1 is low-magic.
+ *
+ * The string form is the storage key in `agents.class_id` (VARCHAR(32)); names
+ * are stable identifiers, not display strings.
+ */
 enum class AgentClass {
-    WARRIOR,
+    SOLDIER,
     SCOUT,
+    HUNTER,
+    ARTISAN,
     ENGINEER,
+    MEDIC,
     MERCHANT,
-    MAGE,
-    CLERIC,
-    FARMER,
-    COMMANDER,
-    RANGER,
-
-    /** Forward-declared for SCANNING's class-lock; full class roster surgery lives in #32. */
     RESEARCHER,
 }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/ClassDefinition.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/ClassDefinition.kt
@@ -1,0 +1,47 @@
+package dev.gvart.genesara.player
+
+/**
+ * Public catalog entry for a base class — the read shape consumers see.
+ *
+ * String-keyed maps for [damageMultipliers] and [behaviorFingerprint] are
+ * deliberate: the keys reference enums owned by `:world` (DamageType,
+ * ActionCategory) which `:player` cannot import without flipping module
+ * direction. Cross-validation that every key decodes lives next to those enums
+ * (see `:world`'s `ClassCatalogConsistencyValidator`).
+ */
+data class ClassDefinition(
+    val id: AgentClass,
+    val displayName: String,
+    val description: String,
+    /** Sight radius in nodes used by [ClassLookup.sightRange]. Must be > 0. */
+    val sightRange: Int,
+    /** Skills with a 1.5x XP multiplier when slotted. */
+    val primarySkills: Set<SkillId>,
+    /**
+     * Skills with a 1.0x XP multiplier when slotted (no penalty, no bonus).
+     * Skills *not* in [primarySkills] or [neutralSkills] accrue XP at 0.5x.
+     */
+    val neutralSkills: Set<SkillId>,
+    /**
+     * Combat skills the class cannot wield. The equip reducer rejects with
+     * `EquipRejection.CLASS_FORBIDDEN` when the equipped item's `combatSkill`
+     * sits in this set. RESEARCHER is the only v1 class with a non-empty list
+     * (FIREARMS — design table §14).
+     */
+    val forbiddenCombatSkills: Set<SkillId>,
+    /**
+     * Outgoing-damage multiplier per damage type, keyed by `DamageType.name`.
+     * Missing keys read as 1.0 at the call site.
+     */
+    val damageMultipliers: Map<String, Double>,
+    /**
+     * Per-axis weight used by the level-10 class-choice scoring algorithm
+     * (#33). Keyed by `ActionCategory.name`. Weights are non-negative; missing
+     * keys read as 0.0.
+     *
+     * TODO(level-10-event): unread by reducers in this slice — populated in
+     * step 6 (#32) so #33's scoring algorithm can ship without a YAML
+     * migration. Wire the reader when the level-10 event reducer lands.
+     */
+    val behaviorFingerprint: Map<String, Double>,
+)

--- a/player/src/main/kotlin/dev/gvart/genesara/player/ClassLookup.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/ClassLookup.kt
@@ -1,0 +1,60 @@
+package dev.gvart.genesara.player
+
+/**
+ * Read-only catalog access for the eight base classes. Replaces the narrower
+ * `ClassPropertiesLookup` from Phase 0 — the catalog now carries the soft-XP,
+ * damage-multiplier, hard-restriction, and behavior-fingerprint surfaces that
+ * skill-feature step 6 (#32) wired in.
+ */
+interface ClassLookup {
+
+    /** Catalog entry for [classId]; null when the YAML is missing the entry. */
+    fun byId(classId: AgentClass): ClassDefinition?
+
+    /** All entries in `AgentClass` declaration order. */
+    fun all(): List<ClassDefinition>
+
+    /**
+     * Sight radius in nodes used by `VisionRadiusImpl`. Returns the catalog
+     * default when [classId] is null (pre-level-10 agents).
+     */
+    fun sightRange(classId: AgentClass?): Int
+
+    /**
+     * Skill-XP multiplier for ([classId], [skill]). Primary skills return 1.5,
+     * neutral skills 1.0, off-build 0.5. Returns 1.0 when [classId] is null
+     * (no class assigned yet — agents at levels 1–9).
+     */
+    fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double
+
+    /**
+     * Outgoing-damage multiplier for ([classId], [damageType]) where
+     * [damageType] is a `DamageType.name`. Returns 1.0 when [classId] is null
+     * or the catalog declares no override for the type.
+     */
+    fun damageMultiplier(classId: AgentClass?, damageType: String): Double
+
+    /**
+     * True when [classId] hard-bans equipping items mapped to [combatSkill].
+     * Returns false when [classId] is null (unclassed agents have no
+     * restrictions).
+     */
+    fun forbidsCombatSkill(classId: AgentClass?, combatSkill: SkillId): Boolean
+}
+
+/**
+ * Permissive [ClassLookup] used as a default for callers that don't care about
+ * the class system — primarily tests. Mirrors the semantics for an unclassed
+ * (pre-level-10) agent: 1.0x XP, 1.0x damage, no hard restrictions, default
+ * sight range. Production wiring relies on Spring auto-wiring `ClassLookup` to
+ * the real bean; this object is the fallback when Kotlin default-arg expansion
+ * fires in a test that bypasses Spring.
+ */
+object NoOpClassLookup : ClassLookup {
+    override fun byId(classId: AgentClass): ClassDefinition? = null
+    override fun all(): List<ClassDefinition> = emptyList()
+    override fun sightRange(classId: AgentClass?): Int = 3
+    override fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double = 1.0
+    override fun damageMultiplier(classId: AgentClass?, damageType: String): Double = 1.0
+    override fun forbidsCombatSkill(classId: AgentClass?, combatSkill: SkillId): Boolean = false
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/ClassPropertiesLookup.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/ClassPropertiesLookup.kt
@@ -1,9 +1,0 @@
-package dev.gvart.genesara.player
-
-interface ClassPropertiesLookup {
-    /**
-     * Sight radius (in nodes) for the given class.
-     * Returns the default profile's sight when [classId] is null (pre-level-10 agents).
-     */
-    fun sightRange(classId: AgentClass?): Int
-}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/SkillProgression.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/SkillProgression.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.player
 
+import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.events.AgentEvent
 import dev.gvart.genesara.player.internal.progression.SkillProgressionImpl
 import org.springframework.context.ApplicationEventPublisher
@@ -17,6 +18,11 @@ interface SkillProgression {
      * [AgentSkillsRegistry.maybeRecommend] decides to fire, emits a single
      * [AgentEvent.SkillRecommended]. Both event types tag [commandId] as `causedBy` so
      * agents can correlate.
+     *
+     * Pass [classId] when the caller already has the agent row in scope (every
+     * combat / harvest / craft reducer does) — that skips the `AgentRegistry.find`
+     * round-trip the soft-XP scaler would otherwise pay on every grant. A null
+     * value is the legacy fallback: the impl falls back to `agents.find(agent)`.
      */
     fun accrueXp(
         agent: AgentId,
@@ -24,6 +30,7 @@ interface SkillProgression {
         delta: Int,
         tick: Long,
         commandId: UUID,
+        classId: AgentClass? = null,
     )
 }
 
@@ -34,14 +41,18 @@ interface SkillProgression {
  *
  * [perks] defaults to an empty catalog so reducer tests that don't care about perks
  * keep their existing call sites; pass a real [PerkLookup] when the test asserts on
- * `PerkChoiceOffered` emission.
+ * `PerkChoiceOffered` emission. [agents] and [classes] default to no-op stubs so
+ * tests that aren't asserting class-driven XP scaling get the previous unscaled
+ * (1.0x) behavior automatically.
  */
 @Suppress("FunctionName")
 fun SkillProgression(
     skills: AgentSkillsRegistry,
     publisher: ApplicationEventPublisher,
     perks: PerkLookup = NoPerks,
-): SkillProgression = SkillProgressionImpl(skills, perks, publisher)
+    agents: AgentRegistry = NoAgents,
+    classes: ClassLookup = NoClasses,
+): SkillProgression = SkillProgressionImpl(skills, perks, agents, classes, publisher)
 
 private object NoPerks : PerkLookup {
     override fun byId(id: PerkId): Perk? = null
@@ -49,3 +60,10 @@ private object NoPerks : PerkLookup {
     override fun choicesFor(skill: SkillId): List<PerkChoice> = emptyList()
     override fun all(): List<Perk> = emptyList()
 }
+
+private object NoAgents : AgentRegistry {
+    override fun find(id: AgentId): Agent? = null
+    override fun listForOwner(owner: PlayerId): List<Agent> = emptyList()
+}
+
+private val NoClasses: ClassLookup = NoOpClassLookup

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/ClassDefinitionLookup.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/ClassDefinitionLookup.kt
@@ -1,17 +1,63 @@
 package dev.gvart.genesara.player.internal.balance
 
 import dev.gvart.genesara.player.AgentClass
-import dev.gvart.genesara.player.ClassPropertiesLookup
+import dev.gvart.genesara.player.ClassDefinition
+import dev.gvart.genesara.player.ClassLookup
+import dev.gvart.genesara.player.SkillId
 import org.springframework.stereotype.Component
 
 @Component
 internal class ClassDefinitionLookup(
     private val props: ClassDefinitionProperties,
-) : ClassPropertiesLookup {
+) : ClassLookup {
+
+    private val byId: Map<AgentClass, ClassDefinition> =
+        AgentClass.entries
+            .mapNotNull { id -> props.classes[id]?.let { id to it.toDefinition(id) } }
+            .toMap()
+
+    override fun byId(classId: AgentClass): ClassDefinition? = byId[classId]
+
+    override fun all(): List<ClassDefinition> =
+        AgentClass.entries.mapNotNull { byId[it] }
 
     override fun sightRange(classId: AgentClass?): Int =
-        propertiesFor(classId).sightRange
+        classId?.let { byId[it]?.sightRange } ?: props.default.sightRange
 
-    private fun propertiesFor(classId: AgentClass?): ClassProperties =
-        classId?.let { props.classes[it] } ?: props.default
+    override fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double {
+        val def = classId?.let { byId[it] } ?: return 1.0
+        return when (skill) {
+            in def.primarySkills -> PRIMARY_SKILL_XP
+            in def.neutralSkills -> NEUTRAL_SKILL_XP
+            else -> OFF_BUILD_SKILL_XP
+        }
+    }
+
+    override fun damageMultiplier(classId: AgentClass?, damageType: String): Double {
+        val def = classId?.let { byId[it] } ?: return 1.0
+        return def.damageMultipliers[damageType] ?: 1.0
+    }
+
+    override fun forbidsCombatSkill(classId: AgentClass?, combatSkill: SkillId): Boolean {
+        val def = classId?.let { byId[it] } ?: return false
+        return combatSkill in def.forbiddenCombatSkills
+    }
+
+    private fun ClassProperties.toDefinition(id: AgentClass): ClassDefinition = ClassDefinition(
+        id = id,
+        displayName = displayName,
+        description = description,
+        sightRange = sightRange,
+        primarySkills = primarySkills.map(::SkillId).toSet(),
+        neutralSkills = neutralSkills.map(::SkillId).toSet(),
+        forbiddenCombatSkills = forbiddenCombatSkills.map(::SkillId).toSet(),
+        damageMultipliers = damageMultipliers,
+        behaviorFingerprint = behaviorFingerprint,
+    )
+
+    private companion object {
+        const val PRIMARY_SKILL_XP = 1.5
+        const val NEUTRAL_SKILL_XP = 1.0
+        const val OFF_BUILD_SKILL_XP = 0.5
+    }
 }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/ClassProperties.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/ClassProperties.kt
@@ -1,6 +1,21 @@
 package dev.gvart.genesara.player.internal.balance
 
+/**
+ * YAML-binding shape for a single class entry in `player-definition/classes.yaml`.
+ * Translation to the public [dev.gvart.genesara.player.ClassDefinition] happens in
+ * [ClassDefinitionLookup] after [ClassValidator] has run.
+ *
+ * String-typed lists are parsed into `SkillId`s in the lookup; raw strings here
+ * keep YAML binding boring and let the validator surface a single, readable
+ * "skill X is unknown" message instead of a binder failure.
+ */
 internal data class ClassProperties(
-    val displayName: String,
+    val displayName: String = "",
+    val description: String = "",
     val sightRange: Int = 3,
+    val primarySkills: List<String> = emptyList(),
+    val neutralSkills: List<String> = emptyList(),
+    val forbiddenCombatSkills: List<String> = emptyList(),
+    val damageMultipliers: Map<String, Double> = emptyMap(),
+    val behaviorFingerprint: Map<String, Double> = emptyMap(),
 )

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/ClassValidator.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/ClassValidator.kt
@@ -1,0 +1,107 @@
+package dev.gvart.genesara.player.internal.balance
+
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillLookup
+import jakarta.annotation.PostConstruct
+import org.springframework.stereotype.Component
+
+/**
+ * Startup sanity check on `player-definition/classes.yaml`. Catches the
+ * mistakes that would otherwise surface as confused agent UX or silent
+ * mis-scoring at the level-10 event:
+ *
+ *  - missing class entry (every [AgentClass] must have YAML)
+ *  - blank display-name / description
+ *  - non-positive sight-range
+ *  - skill ids in primary / neutral / forbidden lists that don't decode
+ *  - non-positive damage multipliers
+ *  - negative behavior-fingerprint weights
+ *
+ * Damage-type and action-category string keys are validated by a sibling
+ * validator in `:world` (those enums live there and `:player` cannot import).
+ */
+@Component
+internal class ClassValidator(
+    private val props: ClassDefinitionProperties,
+    private val skills: SkillLookup,
+) {
+
+    @PostConstruct
+    fun validate() {
+        val problems = mutableListOf<String>()
+        val skillIds: Set<SkillId> = skills.all().map { it.id }.toSet()
+
+        AgentClass.entries.forEach { id ->
+            val entry = props.classes[id]
+            if (entry == null) {
+                problems += "$id: no entry in player-definition/classes.yaml"
+                return@forEach
+            }
+            entry.collectProblems(id, skillIds, problems)
+        }
+
+        require(problems.isEmpty()) {
+            buildString {
+                append("Class catalog failed validation:\n")
+                problems.forEach { appendLine("  - $it") }
+            }
+        }
+    }
+
+    private fun ClassProperties.collectProblems(
+        id: AgentClass,
+        skillIds: Set<SkillId>,
+        out: MutableList<String>,
+    ) {
+        if (displayName.isBlank()) out += "$id: missing display-name"
+        if (description.isBlank()) out += "$id: missing description"
+        if (sightRange <= 0) out += "$id: sight-range must be > 0 (got $sightRange)"
+
+        validateSkillRefs(id, "primary-skills", primarySkills, skillIds, out)
+        validateSkillRefs(id, "neutral-skills", neutralSkills, skillIds, out)
+        validateSkillRefs(id, "forbidden-combat-skills", forbiddenCombatSkills, skillIds, out)
+
+        validateNoDuplicates(id, "primary-skills", primarySkills, out)
+        validateNoDuplicates(id, "neutral-skills", neutralSkills, out)
+        validateNoDuplicates(id, "forbidden-combat-skills", forbiddenCombatSkills, out)
+
+        val overlap = primarySkills.toSet() intersect neutralSkills.toSet()
+        if (overlap.isNotEmpty()) {
+            out += "$id: skills appear in both primary and neutral lists: ${overlap.sorted()}"
+        }
+
+        damageMultipliers.forEach { (type, mult) ->
+            if (mult <= 0.0) out += "$id: damage-multipliers.$type must be > 0 (got $mult)"
+        }
+        behaviorFingerprint.forEach { (axis, weight) ->
+            if (weight < 0.0) out += "$id: behavior-fingerprint.$axis must be >= 0 (got $weight)"
+        }
+    }
+
+    private fun validateSkillRefs(
+        id: AgentClass,
+        field: String,
+        refs: List<String>,
+        skillIds: Set<SkillId>,
+        out: MutableList<String>,
+    ) {
+        refs.forEach { raw ->
+            if (SkillId(raw) !in skillIds) {
+                out += "$id: $field references unknown skill id '$raw'"
+            }
+        }
+    }
+
+    private fun validateNoDuplicates(
+        id: AgentClass,
+        field: String,
+        refs: List<String>,
+        out: MutableList<String>,
+    ) {
+        val duplicates = refs.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
+        if (duplicates.isNotEmpty()) {
+            out += "$id: $field has duplicate entries: ${duplicates.sorted()}"
+        }
+    }
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/progression/SkillProgressionImpl.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/progression/SkillProgressionImpl.kt
@@ -1,8 +1,11 @@
 package dev.gvart.genesara.player.internal.progression
 
 import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.ClassLookup
 import dev.gvart.genesara.player.PerkLookup
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillProgression
@@ -15,6 +18,8 @@ import java.util.UUID
 internal class SkillProgressionImpl(
     private val skills: AgentSkillsRegistry,
     private val perks: PerkLookup,
+    private val agents: AgentRegistry,
+    private val classes: ClassLookup,
     private val publisher: ApplicationEventPublisher,
 ) : SkillProgression {
 
@@ -24,8 +29,10 @@ internal class SkillProgressionImpl(
         delta: Int,
         tick: Long,
         commandId: UUID,
+        classId: AgentClass?,
     ) {
-        when (val result = skills.addXpIfSlotted(agent, skill, delta)) {
+        val scaledDelta = scaleByClass(agent, skill, delta, classId)
+        when (val result = skills.addXpIfSlotted(agent, skill, scaledDelta)) {
             is AddXpResult.Accrued -> result.crossedMilestones.forEach { milestone ->
                 publisher.publishEvent(
                     AgentEvent.SkillMilestoneReached(
@@ -63,5 +70,23 @@ internal class SkillProgressionImpl(
                 )
             }
         }
+    }
+
+    /**
+     * Apply the per-class soft XP modifier (1.5 / 1.0 / 0.5) declared in
+     * `classes.yaml`. Pre-level-10 agents have no class and pass through at
+     * 1.0x. A non-positive [delta] short-circuits the registry read — the
+     * downstream registry is the canonical clamp anyway.
+     *
+     * The `coerceAtLeast(1)` floor keeps a single-XP off-build grant from
+     * silently rounding to 0; documented behavior, not a bug — agents who
+     * crossed the discovery gate (recommendation) deserve to see their xp
+     * counter tick even on off-build skills.
+     */
+    private fun scaleByClass(agent: AgentId, skill: SkillId, delta: Int, classId: AgentClass?): Int {
+        if (delta <= 0) return delta
+        val resolved = classId ?: agents.find(agent)?.classId ?: return delta
+        val multiplier = classes.skillXpMultiplier(resolved, skill)
+        return (delta * multiplier).toInt().coerceAtLeast(1)
     }
 }

--- a/player/src/main/resources/player-definition/classes.yaml
+++ b/player/src/main/resources/player-definition/classes.yaml
@@ -4,30 +4,226 @@ player:
     sight-range: 3
 
   classes:
-    WARRIOR:
-      display-name: Warrior
+
+    SOLDIER:
+      display-name: Soldier
+      description: >-
+        Frontline professional. Heavy melee with shield discipline; the soldier
+        is the canonical combat class for agents who answered the level-10 event
+        with a long fight history. Replaces the placeholder Warrior class.
       sight-range: 3
+      primary-skills:
+        [SWORD, SHIELD, AXE, CLUB, SPEAR, POLEARM, DUAL_WIELD, ATHLETICS, INTIMIDATION]
+      neutral-skills:
+        [BOW, CROSSBOW, FIREARMS, SURVIVAL, LEADERSHIP, ANATOMY]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        SLASH: 1.1
+        BLUNT: 1.1
+        PIERCE: 1.0
+        ENERGY: 0.95
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 1.0
+        GATHER: 0.0
+        CRAFT: 0.0
+        BUILD: 0.1
+        SOCIAL: 0.2
+        EXPLORE: 0.2
+        MEDICAL: 0.0
+        TRADE: 0.0
+
     SCOUT:
       display-name: Scout
+      description: >-
+        Mobile reconnaissance specialist. Light weapons, terrain reading, and
+        the long-distance eyes of a party. Replaces the placeholder Ranger.
+      sight-range: 4
+      primary-skills:
+        [BOW, CROSSBOW, DAGGER, THROWN, ACROBATICS, CLIMBING, SURVIVAL, CARTOGRAPHY, TRACKING, STEALTH]
+      neutral-skills:
+        [SWORD, SPEAR, ATHLETICS, FIRECRAFT, BEAST_LORE]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        PIERCE: 1.1
+        SLASH: 1.0
+        BLUNT: 0.9
+        ENERGY: 1.0
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 0.6
+        GATHER: 0.3
+        CRAFT: 0.0
+        BUILD: 0.0
+        SOCIAL: 0.1
+        EXPLORE: 1.0
+        MEDICAL: 0.0
+        TRADE: 0.1
+
+    HUNTER:
+      display-name: Hunter
+      description: >-
+        Wilderness predator. Bow, spear, and traps; tracks and brings down
+        beasts to feed and clothe a settlement. The other half of the
+        scout/ranger split — focused on the kill, not the map.
       sight-range: 3
+      primary-skills:
+        [BOW, SPEAR, THROWN, HUNTING, TRAPS, TRACKING, ANIMAL_HANDLING, BEAST_LORE, SURVIVAL, FIRECRAFT]
+      neutral-skills:
+        [DAGGER, AXE, COOKING, LEATHERWORKING, STEALTH]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        PIERCE: 1.15
+        SLASH: 1.05
+        BLUNT: 0.9
+        ENERGY: 0.9
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 0.7
+        GATHER: 0.8
+        CRAFT: 0.2
+        BUILD: 0.1
+        SOCIAL: 0.1
+        EXPLORE: 0.7
+        MEDICAL: 0.1
+        TRADE: 0.2
+
+    ARTISAN:
+      display-name: Artisan
+      description: >-
+        Workshop generalist. Forge, loom, kiln, and stove — the artisan turns
+        raw materials into finished goods. Designed for agents whose level-10
+        record skews toward sustained crafting at a settlement.
+      sight-range: 3
+      primary-skills:
+        [SMITHING, CARPENTRY, COOKING, ALCHEMY, LEATHERWORKING, TAILORING, JEWELRYCRAFTING, BREWING]
+      neutral-skills:
+        [FORAGING, LUMBERJACKING, MINING, ATHLETICS, PERSUASION]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        BLUNT: 1.05
+        SLASH: 1.0
+        PIERCE: 1.0
+        ENERGY: 0.95
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 0.0
+        GATHER: 0.4
+        CRAFT: 1.0
+        BUILD: 0.5
+        SOCIAL: 0.2
+        EXPLORE: 0.1
+        MEDICAL: 0.1
+        TRADE: 0.4
+
     ENGINEER:
       display-name: Engineer
+      description: >-
+        Mechanical and electrical specialist. Builds machines, drones, and
+        contraptions — the technical backbone of a high-tier base. Crossbows
+        and firearms are the engineer's preferred weapon mix.
       sight-range: 3
+      primary-skills:
+        [ENGINEERING, ELECTRONICS, SMITHING, CARPENTRY, ATHLETICS, FIREARMS, CROSSBOW]
+      neutral-skills:
+        [MINING, LUMBERJACKING, ALCHEMY, INTIMIDATION]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        ENERGY: 1.15
+        PIERCE: 1.05
+        BLUNT: 1.0
+        SLASH: 0.95
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 0.3
+        GATHER: 0.3
+        CRAFT: 0.7
+        BUILD: 1.0
+        SOCIAL: 0.1
+        EXPLORE: 0.2
+        MEDICAL: 0.0
+        TRADE: 0.2
+
+    MEDIC:
+      display-name: Medic
+      description: >-
+        Field doctor and herbalist. Keeps the party alive — heals, brews
+        antidotes, and reads bodies. Mana-tier focus actives at higher
+        milestones (per skill-feature §10).
+      sight-range: 3
+      primary-skills:
+        [MEDICINE, HERBALISM, ANATOMY, ALCHEMY, COOKING, FORAGING, PERSUASION]
+      neutral-skills:
+        [DAGGER, UNARMED, ATHLETICS, ACROBATICS, SURVIVAL]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        SLASH: 0.9
+        PIERCE: 0.95
+        BLUNT: 0.9
+        ENERGY: 0.95
+        MAGICAL: 1.0
+      behavior-fingerprint:
+        COMBAT: 0.1
+        GATHER: 0.3
+        CRAFT: 0.3
+        BUILD: 0.1
+        SOCIAL: 0.5
+        EXPLORE: 0.1
+        MEDICAL: 1.0
+        TRADE: 0.2
+
     MERCHANT:
       display-name: Merchant
+      description: >-
+        Negotiator, broker, and people-reader. Drives trade routes and
+        relationships across nodes — the agent the system surfaces when
+        level-10 behavior leans heavily toward say/trade verbs.
       sight-range: 3
-    MAGE:
-      display-name: Mage
-      sight-range: 3
-    CLERIC:
-      display-name: Cleric
-      sight-range: 3
-    FARMER:
-      display-name: Farmer
-      sight-range: 3
-    COMMANDER:
-      display-name: Commander
-      sight-range: 3
-    RANGER:
-      display-name: Ranger
-      sight-range: 3
+      primary-skills:
+        [PERSUASION, INTIMIDATION, LEADERSHIP, COOKING, BREWING, JEWELRYCRAFTING, PICKPOCKET]
+      neutral-skills:
+        [DAGGER, SWORD, ATHLETICS, FORAGING, ANIMAL_HANDLING, LOCKPICKING]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        SLASH: 1.0
+        PIERCE: 1.0
+        BLUNT: 1.0
+        ENERGY: 0.95
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 0.1
+        GATHER: 0.2
+        CRAFT: 0.3
+        BUILD: 0.1
+        SOCIAL: 1.0
+        EXPLORE: 0.3
+        MEDICAL: 0.0
+        TRADE: 1.0
+
+    RESEARCHER:
+      display-name: Researcher
+      description: >-
+        Knowledge specialist. Owns Scanning (the only class-locked skill in v1)
+        and is hard-banned from auto-firearms — the spec's single hard
+        restriction (skill-feature decision §14).
+      sight-range: 4
+      primary-skills:
+        [SCANNING, ALCHEMY, HERBALISM, ELECTRONICS, ANATOMY, BEAST_LORE, MEDICINE]
+      neutral-skills:
+        [ENGINEERING, JEWELRYCRAFTING, CARTOGRAPHY, PERSUASION]
+      forbidden-combat-skills: [FIREARMS]
+      damage-multipliers:
+        ENERGY: 1.1
+        MAGICAL: 1.1
+        SLASH: 0.85
+        PIERCE: 0.9
+        BLUNT: 0.85
+      behavior-fingerprint:
+        COMBAT: 0.0
+        GATHER: 0.4
+        CRAFT: 0.4
+        BUILD: 0.1
+        SOCIAL: 0.3
+        EXPLORE: 0.6
+        MEDICAL: 0.5
+        TRADE: 0.2

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/ClassValidatorTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/ClassValidatorTest.kt
@@ -1,0 +1,113 @@
+package dev.gvart.genesara.player.internal.balance
+
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.LevelEffect
+import dev.gvart.genesara.player.ScalingEffect
+import dev.gvart.genesara.player.Skill
+import dev.gvart.genesara.player.SkillCategory
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillLookup
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ClassValidatorTest {
+
+    private val knownSkills = setOf("SWORD", "BOW", "FORAGING", "FIREARMS").map { SkillId(it) }.toSet()
+
+    @Test
+    fun `every AgentClass entry must have YAML — missing entry fails loud`() {
+        val props = props(mapOf(AgentClass.SOLDIER to soldierShape()))
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassValidator(props, fakeSkills()).validate()
+        }
+        assertTrue(ex.message!!.contains("SCOUT: no entry"))
+    }
+
+    @Test
+    fun `unknown skill id in primary-skills surfaces a readable message`() {
+        val broken = soldierShape().copy(primarySkills = listOf("SWORD", "NOT_A_SKILL"))
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassValidator(props(allClasses(broken)), fakeSkills()).validate()
+        }
+        assertTrue(ex.message!!.contains("primary-skills references unknown skill id 'NOT_A_SKILL'"))
+    }
+
+    @Test
+    fun `non-positive sight-range fails`() {
+        val broken = soldierShape().copy(sightRange = 0)
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassValidator(props(allClasses(broken)), fakeSkills()).validate()
+        }
+        assertTrue(ex.message!!.contains("sight-range must be > 0"))
+    }
+
+    @Test
+    fun `non-positive damage multiplier fails`() {
+        val broken = soldierShape().copy(damageMultipliers = mapOf("SLASH" to 0.0))
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassValidator(props(allClasses(broken)), fakeSkills()).validate()
+        }
+        assertTrue(ex.message!!.contains("damage-multipliers.SLASH must be > 0"))
+    }
+
+    @Test
+    fun `negative behavior fingerprint weight fails`() {
+        val broken = soldierShape().copy(behaviorFingerprint = mapOf("COMBAT" to -0.1))
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassValidator(props(allClasses(broken)), fakeSkills()).validate()
+        }
+        assertTrue(ex.message!!.contains("behavior-fingerprint.COMBAT must be >= 0"))
+    }
+
+    @Test
+    fun `duplicate skill within primary list is rejected`() {
+        val broken = soldierShape().copy(primarySkills = listOf("SWORD", "SWORD", "BOW"))
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassValidator(props(allClasses(broken)), fakeSkills()).validate()
+        }
+        assertTrue(ex.message!!.contains("primary-skills has duplicate entries"))
+    }
+
+    @Test
+    fun `same skill in both primary and neutral is rejected`() {
+        val broken = soldierShape().copy(
+            primarySkills = listOf("SWORD", "BOW"),
+            neutralSkills = listOf("SWORD"),
+        )
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassValidator(props(allClasses(broken)), fakeSkills()).validate()
+        }
+        assertTrue(ex.message!!.contains("appear in both primary and neutral lists"))
+    }
+
+    private fun soldierShape() = ClassProperties(
+        displayName = "Soldier",
+        description = "Frontline pro.",
+        sightRange = 3,
+        primarySkills = listOf("SWORD"),
+        neutralSkills = listOf("BOW"),
+        forbiddenCombatSkills = emptyList(),
+        damageMultipliers = mapOf("SLASH" to 1.1),
+        behaviorFingerprint = mapOf("COMBAT" to 1.0),
+    )
+
+    private fun allClasses(template: ClassProperties): Map<AgentClass, ClassProperties> =
+        AgentClass.entries.associateWith { template }
+
+    private fun props(classes: Map<AgentClass, ClassProperties>) =
+        ClassDefinitionProperties(classes = classes)
+
+    private fun fakeSkills() = object : SkillLookup {
+        override fun byId(id: SkillId): Skill? = if (id in knownSkills) stubSkill(id) else null
+        override fun all(): List<Skill> = knownSkills.map(::stubSkill)
+    }
+
+    private fun stubSkill(id: SkillId) = Skill(
+        id = id,
+        displayName = id.value,
+        description = "stub",
+        category = SkillCategory.COMBAT,
+        levelEffect = LevelEffect(type = ScalingEffect.SLASH_DAMAGE_BONUS, perLevelPct = 0.005),
+    )
+}

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/ClassesYamlLoadingTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/ClassesYamlLoadingTest.kt
@@ -1,0 +1,100 @@
+package dev.gvart.genesara.player.internal.balance
+
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.SkillId
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ClassesYamlLoadingTest {
+
+    private lateinit var ctx: AnnotationConfigApplicationContext
+    private lateinit var lookup: ClassDefinitionLookup
+    private lateinit var skills: SkillLookupImpl
+    private lateinit var validator: ClassValidator
+
+    @BeforeAll
+    fun bootContext() {
+        ctx = AnnotationConfigApplicationContext().also {
+            ConfigurationPropertiesBindingPostProcessor.register(it)
+            it.register(ClassBalanceConfiguration::class.java)
+            it.register(SkillBalanceConfiguration::class.java)
+            it.refresh()
+        }
+        val classProps = ctx.getBean(ClassDefinitionProperties::class.java)
+        val skillProps = ctx.getBean(SkillDefinitionProperties::class.java)
+        skills = SkillLookupImpl(skillProps)
+        lookup = ClassDefinitionLookup(classProps)
+        validator = ClassValidator(classProps, skills)
+    }
+
+    @AfterAll
+    fun closeContext() {
+        ctx.close()
+    }
+
+    @Test
+    fun `classes_yaml binds the eight v1 base classes`() {
+        val all = lookup.all()
+        assertEquals(8, all.size)
+        assertEquals(AgentClass.entries.toSet(), all.map { it.id }.toSet())
+    }
+
+    @Test
+    fun `every class has populated metadata`() {
+        for (def in lookup.all()) {
+            assertTrue(def.displayName.isNotBlank(), "${def.id} must declare display-name")
+            assertTrue(def.description.isNotBlank(), "${def.id} must declare description")
+            assertTrue(def.sightRange > 0, "${def.id} sight-range must be > 0")
+            assertTrue(def.primarySkills.isNotEmpty(), "${def.id} must list at least one primary skill")
+            assertTrue(def.behaviorFingerprint.isNotEmpty(), "${def.id} must declare a behavior fingerprint")
+            assertTrue(def.damageMultipliers.isNotEmpty(), "${def.id} must declare at least one damage multiplier")
+        }
+    }
+
+    @Test
+    fun `RESEARCHER hard-bans FIREARMS — the only v1 hard restriction`() {
+        val researcher = assertNotNull(lookup.byId(AgentClass.RESEARCHER))
+        assertTrue(SkillId("FIREARMS") in researcher.forbiddenCombatSkills)
+
+        for (id in AgentClass.entries) {
+            if (id == AgentClass.RESEARCHER) continue
+            val def = assertNotNull(lookup.byId(id))
+            assertTrue(
+                def.forbiddenCombatSkills.isEmpty(),
+                "$id should not declare hard restrictions in v1 (only RESEARCHER does)",
+            )
+        }
+    }
+
+    @Test
+    fun `skill-XP multiplier follows the 1_5 1_0 0_5 ladder`() {
+        val soldier = assertNotNull(lookup.byId(AgentClass.SOLDIER))
+        val primary = soldier.primarySkills.first()
+        val neutral = soldier.neutralSkills.first()
+        val offBuild = SkillId("MEDICINE")
+
+        assertEquals(1.5, lookup.skillXpMultiplier(AgentClass.SOLDIER, primary))
+        assertEquals(1.0, lookup.skillXpMultiplier(AgentClass.SOLDIER, neutral))
+        assertEquals(0.5, lookup.skillXpMultiplier(AgentClass.SOLDIER, offBuild))
+    }
+
+    @Test
+    fun `null classId returns 1_0 multipliers and false for restrictions`() {
+        assertEquals(1.0, lookup.skillXpMultiplier(null, SkillId("SWORD")))
+        assertEquals(1.0, lookup.damageMultiplier(null, "SLASH"))
+        assertEquals(false, lookup.forbidsCombatSkill(null, SkillId("FIREARMS")))
+    }
+
+    @Test
+    fun `production catalog passes the player-side validator`() {
+        validator.validate()
+    }
+}

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/progression/SkillProgressionImplTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/progression/SkillProgressionImplTest.kt
@@ -1,10 +1,16 @@
 package dev.gvart.genesara.player.internal.progression
 
+import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillState
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.ClassDefinition
+import dev.gvart.genesara.player.ClassLookup
 import dev.gvart.genesara.player.Perk
 import dev.gvart.genesara.player.PerkChoice
 import dev.gvart.genesara.player.PerkEffect
@@ -30,7 +36,9 @@ class SkillProgressionImplTest {
         skills: AgentSkillsRegistry,
         publisher: ApplicationEventPublisher,
         perks: PerkLookup = StubPerkLookup(),
-    ) = SkillProgressionImpl(skills, perks, publisher)
+        agents: AgentRegistry = StubAgents(null),
+        classes: ClassLookup = StubClasses(),
+    ) = SkillProgressionImpl(skills, perks, agents, classes, publisher)
 
     @Test
     fun `slotted skill addXp with no milestone fires no events`() {
@@ -148,6 +156,43 @@ class SkillProgressionImplTest {
     }
 
     @Test
+    fun `class XP multiplier scales delta on the addXp call`() {
+        val skills = StubSkillsRegistry().apply { slot(skill) }
+        val publisher = RecordingPublisher()
+        val agents = StubAgents(AgentClass.HUNTER)
+        val classes = StubClasses(mapOf((AgentClass.HUNTER to skill) to 1.5))
+
+        progression(skills, publisher, agents = agents, classes = classes)
+            .accrueXp(agent, skill, delta = 10, tick = 1, commandId = commandId)
+
+        assertEquals(listOf(skill to 15), skills.xpAddCalls)
+    }
+
+    @Test
+    fun `off-build skill is scaled to half delta with at least 1 floor`() {
+        val skills = StubSkillsRegistry().apply { slot(skill) }
+        val publisher = RecordingPublisher()
+        val agents = StubAgents(AgentClass.HUNTER)
+        val classes = StubClasses(mapOf((AgentClass.HUNTER to skill) to 0.5))
+
+        progression(skills, publisher, agents = agents, classes = classes)
+            .accrueXp(agent, skill, delta = 1, tick = 1, commandId = commandId)
+
+        assertEquals(listOf(skill to 1), skills.xpAddCalls, "non-positive multiplier-rounded delta clamps to 1")
+    }
+
+    @Test
+    fun `unclassed agent receives the unscaled delta`() {
+        val skills = StubSkillsRegistry().apply { slot(skill) }
+        val publisher = RecordingPublisher()
+
+        progression(skills, publisher, agents = StubAgents(null))
+            .accrueXp(agent, skill, delta = 7, tick = 1, commandId = commandId)
+
+        assertEquals(listOf(skill to 7), skills.xpAddCalls)
+    }
+
+    @Test
     fun `slotted skill never triggers maybeRecommend even when it's scripted`() {
         val skills = StubSkillsRegistry().apply {
             slot(skill)
@@ -224,6 +269,30 @@ class SkillProgressionImplTest {
         override fun publishEvent(event: Any) {
             events += event
         }
+    }
+
+    private class StubAgents(private val classId: AgentClass?) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = Agent(
+            id = id,
+            owner = PlayerId(UUID.randomUUID()),
+            name = "stub",
+            classId = classId,
+        )
+        override fun listForOwner(owner: PlayerId): List<Agent> = emptyList()
+    }
+
+    private class StubClasses(
+        private val multipliers: Map<Pair<AgentClass, SkillId>, Double> = emptyMap(),
+    ) : ClassLookup {
+        override fun byId(classId: AgentClass): ClassDefinition? = null
+        override fun all(): List<ClassDefinition> = emptyList()
+        override fun sightRange(classId: AgentClass?): Int = 3
+        override fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double {
+            if (classId == null) return 1.0
+            return multipliers[classId to skill] ?: 1.0
+        }
+        override fun damageMultiplier(classId: AgentClass?, damageType: String): Double = 1.0
+        override fun forbidsCombatSkill(classId: AgentClass?, combatSkill: SkillId): Boolean = false
     }
 
     private class StubPerkLookup(private val perks: List<Perk> = emptyList()) : PerkLookup {

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentService.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentService.kt
@@ -35,9 +35,10 @@ interface EquipmentService {
      *  7. instance not already equipped elsewhere      → [EquipRejection.ALREADY_EQUIPPED]
      *  8. agent meets per-attribute requirements       → [EquipRejection.INSUFFICIENT_ATTRIBUTES]
      *  9. agent meets per-skill requirements           → [EquipRejection.INSUFFICIENT_SKILLS]
-     * 10. two-handed needs off-hand empty              → [EquipRejection.OFF_HAND_OCCUPIED]
-     * 11. off-hand free of two-handed lock             → [EquipRejection.OFF_HAND_BLOCKED_BY_TWO_HANDED]
-     * 12. target slot is empty                         → [EquipRejection.SLOT_OCCUPIED]
+     * 10. agent's class doesn't hard-ban the combat-skill → [EquipRejection.CLASS_FORBIDDEN]
+     * 11. two-handed needs off-hand empty              → [EquipRejection.OFF_HAND_OCCUPIED]
+     * 12. off-hand free of two-handed lock             → [EquipRejection.OFF_HAND_BLOCKED_BY_TWO_HANDED]
+     * 13. target slot is empty                         → [EquipRejection.SLOT_OCCUPIED]
      *
      * **Stat-drop note.** The requirement check fires only at equip time. An
      * agent who *drops* below a prerequisite later (e.g. de-leveling on
@@ -99,6 +100,12 @@ enum class EquipRejection {
     INSUFFICIENT_ATTRIBUTES,
     /** Agent's skill level(s) fall below the item's `requiredSkills` floor. */
     INSUFFICIENT_SKILLS,
+    /**
+     * Agent's class hard-bans the weapon's combat-skill (e.g. RESEARCHER cannot
+     * wield FIREARMS — skill-feature design table §14). Carries the offending
+     * skill id in [EquipResult.Rejected.detail].
+     */
+    CLASS_FORBIDDEN,
     /** Equipping a two-handed weapon to MAIN_HAND while OFF_HAND has an item. */
     OFF_HAND_OCCUPIED,
     /** Equipping anything to OFF_HAND while a two-handed weapon is in MAIN_HAND. */

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -5,6 +5,7 @@ import dev.gvart.genesara.player.ActivePerkLookup
 import dev.gvart.genesara.player.AgentProfileLookup
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.ClassLookup
 import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.PassiveAuraAggregator
 import dev.gvart.genesara.player.PerkCooldownStore
@@ -80,6 +81,7 @@ internal fun reduce(
     tickIntervalSeconds: Long,
     tick: Long,
     rng: Random = Random.Default,
+    classes: ClassLookup = dev.gvart.genesara.player.NoOpClassLookup,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = when (command) {
     is WorldCommand.SpawnAgent -> reduceSpawn(state, command, profiles, spawnLocationResolver, tick)
     is WorldCommand.MoveAgent -> reduceMove(state, command, balance, buildingsLookup, scaling, behaviorTracker, tick)
@@ -113,6 +115,7 @@ internal fun reduce(
         reduceAttack(
             state, command, balance, items, agents, equipment, progression, scaling,
             passiveAura, deathProcessor, triggeredPassives, pendingScales, behaviorTracker, rng, tick,
+            classes = classes,
         )
     is WorldCommand.UseAbility ->
         reduceUseAbility(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ClassCatalogConsistencyValidator.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ClassCatalogConsistencyValidator.kt
@@ -1,0 +1,44 @@
+package dev.gvart.genesara.world.internal.balance
+
+import dev.gvart.genesara.player.ClassLookup
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
+import jakarta.annotation.PostConstruct
+import org.springframework.stereotype.Component
+
+/**
+ * `:world`-side companion to `:player`'s ClassValidator. The class catalog
+ * stores [DamageType] and [ActionCategory] keys as raw strings because the
+ * enums live in `:world` and `:player` cannot import them. This validator
+ * decodes every string and fails startup loudly when a misspelling slips in,
+ * so runtime callers (`AttackReducer`, the level-10 scoring algorithm) can
+ * read the maps without a per-lookup `runCatching`.
+ */
+@Component
+internal class ClassCatalogConsistencyValidator(
+    private val classes: ClassLookup,
+) {
+
+    @PostConstruct
+    fun validate() {
+        val damageNames = DamageType.entries.map { it.name }.toSet()
+        val axisNames = ActionCategory.entries.map { it.name }.toSet()
+        val problems = mutableListOf<String>()
+
+        classes.all().forEach { def ->
+            def.damageMultipliers.keys
+                .filterNot { it in damageNames }
+                .forEach { problems += "${def.id}: damage-multipliers.$it does not match any DamageType (known: ${damageNames.sorted()})" }
+            def.behaviorFingerprint.keys
+                .filterNot { it in axisNames }
+                .forEach { problems += "${def.id}: behavior-fingerprint.$it does not match any ActionCategory (known: ${axisNames.sorted()})" }
+        }
+
+        require(problems.isEmpty()) {
+            buildString {
+                append("Class catalog cross-module validation failed:\n")
+                problems.forEach { appendLine("  - $it") }
+            }
+        }
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
@@ -5,6 +5,7 @@ import arrow.core.raise.either
 import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.ClassLookup
 import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.PassiveAuraAggregator
 import dev.gvart.genesara.player.ScalingEffect
@@ -64,6 +65,7 @@ internal fun reduceAttack(
     behaviorTracker: BehaviorTracker,
     rng: Random,
     tick: Long,
+    classes: ClassLookup = dev.gvart.genesara.player.NoOpClassLookup,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     ensure(command.agent != command.target) { WorldRejection.CannotAttackSelf(command.agent) }
 
@@ -111,7 +113,13 @@ internal fun reduceAttack(
     // chosen auras add on top. Order keeps "+5 Sharpen Edge" predictable regardless of
     // SWORD level, while "Doubled Edge" still doubles the per-level rate underneath.
     val auraBonus = scalingEffect?.let { passiveAura.bonusFor(command.agent, it) } ?: 0
-    val baseScaled = ((typedDamage * (1.0 + damageScaling)).toInt() + auraBonus).coerceAtLeast(0)
+    // Class outgoing-damage multiplier composes LAST — it scales the resolved
+    // (typed × per-level scaling + aura) base. Applying it earlier would
+    // double-multiply with `damageScaling` and silently shift the spec's "flat
+    // bonus" semantics into a compound one.
+    val classMod = classes.damageMultiplier(attacker.classId, weaponProfile.damageType.name)
+    val preClassScaled = ((typedDamage * (1.0 + damageScaling)).toInt() + auraBonus).coerceAtLeast(0)
+    val baseScaled = (preClassScaled * classMod).toInt().coerceAtLeast(0)
     // Read-and-clear before the rolls so a dodge still burns the staged buff —
     // matches "cost paid at cast, not refunded on miss" from spec §9.
     val pendingScalePct = pendingScales.consume(command.agent)
@@ -141,7 +149,7 @@ internal fun reduceAttack(
         .updateBody(command.target, nextTargetBody)
         .updateBody(command.agent, nextAttackerBody)
 
-    progression.accrueXp(command.agent, weaponProfile.combatSkill, balance.attackXpDelta(), tick, command.commandId)
+    progression.accrueXp(command.agent, weaponProfile.combatSkill, balance.attackXpDelta(), tick, command.commandId, attacker.classId)
     behaviorTracker.record(command.agent, ActionCategory.COMBAT, tick)
 
     val attackEvent = WorldEvent.AgentAttacked(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
@@ -123,7 +123,7 @@ internal fun reduceCraft(
 
     mutation.equipmentToInsert?.let(equipment::insert)
 
-    progression.accrueXp(command.agent, recipe.requiredSkill, delta = 1, tick, command.commandId)
+    progression.accrueXp(command.agent, recipe.requiredSkill, delta = 1, tick, command.commandId, agents.find(command.agent)?.classId)
     behaviorTracker.record(command.agent, ActionCategory.CRAFT, tick)
 
     val next = state

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentServiceImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentServiceImpl.kt
@@ -4,6 +4,7 @@ import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.Attribute
+import dev.gvart.genesara.player.ClassLookup
 import dev.gvart.genesara.world.EquipRejection
 import dev.gvart.genesara.world.EquipResult
 import dev.gvart.genesara.world.EquipSlot
@@ -27,6 +28,7 @@ internal class EquipmentServiceImpl(
     private val items: ItemLookup,
     private val agents: AgentRegistry,
     private val skills: AgentSkillsRegistry,
+    private val classes: ClassLookup = dev.gvart.genesara.player.NoOpClassLookup,
 ) : EquipmentService {
 
     private val log = LoggerFactory.getLogger(EquipmentServiceImpl::class.java)
@@ -48,6 +50,7 @@ internal class EquipmentServiceImpl(
         }
         checkAttributeRequirements(agentId, item)?.let { return it }
         checkSkillRequirements(agentId, item)?.let { return it }
+        checkClassHardRestriction(agentId, item)?.let { return it }
         validateLiveSlotMap(agentId, item, slot)?.let { return it }
 
         return assignToSlotWithRaceTranslation(instanceId, agentId, slot)
@@ -144,6 +147,24 @@ internal class EquipmentServiceImpl(
             }
         }
         return null
+    }
+
+    /**
+     * Hard-restriction check (skill-feature design table §14): rejects when the
+     * weapon's `combatSkill` sits in the agent class's `forbiddenCombatSkills`.
+     * Pre-level-10 agents (classId == null) pass through. Non-weapon items have
+     * a null `combatSkill` and also pass through.
+     */
+    private fun checkClassHardRestriction(agentId: AgentId, item: Item): EquipResult.Rejected? {
+        val combatSkill = item.combatSkill ?: return null
+        val agent = agents.find(agentId)
+            ?: error("equip: agent ${agentId.id} owns instances but isn't in the registry — state corruption")
+        if (!classes.forbidsCombatSkill(agent.classId, combatSkill)) return null
+        val className = agent.classId?.name ?: "Unclassed"
+        return EquipResult.Rejected(
+            EquipRejection.CLASS_FORBIDDEN,
+            detail = "$className cannot wield items mapped to ${combatSkill.value}",
+        )
     }
 
     /**

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
@@ -82,7 +82,7 @@ internal fun reduceHarvest(
 
     resources.decrement(nodeId, command.item, quantity, tick)
     itemDef.harvestSkill?.let { skill ->
-        progression.accrueXp(command.agent, skill, delta = quantity, tick, command.commandId)
+        progression.accrueXp(command.agent, skill, delta = quantity, tick, command.commandId, agentRecord.classId)
     }
     behaviorTracker.record(command.agent, ActionCategory.GATHER, tick)
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -4,7 +4,9 @@ import dev.gvart.genesara.player.ActivePerkLookup
 import dev.gvart.genesara.player.AgentProfileLookup
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.ClassLookup
 import dev.gvart.genesara.player.LevelScalingAggregator
+import dev.gvart.genesara.player.NoOpClassLookup
 import dev.gvart.genesara.player.PassiveAuraAggregator
 import dev.gvart.genesara.player.PerkCooldownStore
 import dev.gvart.genesara.player.SkillProgression
@@ -75,6 +77,7 @@ internal class WorldTickHandler(
     private val behaviorTracker: BehaviorTracker,
     private val leaseFence: WorldLeaseFence,
     @Value("\${application.tick.interval}") private val tickInterval: Duration,
+    private val classes: ClassLookup = NoOpClassLookup,
 ) : WorldTickRunner {
 
     private val log = LoggerFactory.getLogger(javaClass)
@@ -129,7 +132,7 @@ internal class WorldTickHandler(
                 safeNodes, safeNodeResolver, buildings, buildingsLookup, buildingsCatalog, chestContents,
                 rarityRoller, progression, scaling, passiveAura, spawnLocationResolver, groundItems,
                 deathProcessor, triggeredPassives, activePerks, perkCooldowns, pendingScales,
-                behaviorTracker, tickIntervalSeconds, number,
+                behaviorTracker, tickIntervalSeconds, number, classes = classes,
             ).fold(
                 ifLeft = { rejection ->
                     log.info("Rejected {} at tick {} world {}: {}", command, number, worldId.value, rejection)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImpl.kt
@@ -2,7 +2,7 @@ package dev.gvart.genesara.world.internal.vision
 
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentSkillsRegistry
-import dev.gvart.genesara.player.ClassPropertiesLookup
+import dev.gvart.genesara.player.ClassLookup
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.Terrain
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component
 
 @Component
 internal class VisionRadiusImpl(
-    private val classes: ClassPropertiesLookup,
+    private val classes: ClassLookup,
     private val skills: AgentSkillsRegistry,
     private val world: WorldQueryGateway,
 ) : VisionRadius {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/ClassCatalogConsistencyValidatorTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/ClassCatalogConsistencyValidatorTest.kt
@@ -1,0 +1,56 @@
+package dev.gvart.genesara.world.internal.balance
+
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.ClassDefinition
+import dev.gvart.genesara.player.ClassLookup
+import dev.gvart.genesara.player.SkillId
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ClassCatalogConsistencyValidatorTest {
+
+    @Test
+    fun `unknown DamageType key is rejected`() {
+        val def = soldier().copy(damageMultipliers = mapOf("SLASH" to 1.1, "PSIONIC" to 1.0))
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassCatalogConsistencyValidator(StubClasses(listOf(def))).validate()
+        }
+        assertTrue(ex.message!!.contains("damage-multipliers.PSIONIC does not match any DamageType"))
+    }
+
+    @Test
+    fun `unknown ActionCategory key is rejected`() {
+        val def = soldier().copy(behaviorFingerprint = mapOf("COMBAT" to 1.0, "MAGIC" to 1.0))
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassCatalogConsistencyValidator(StubClasses(listOf(def))).validate()
+        }
+        assertTrue(ex.message!!.contains("behavior-fingerprint.MAGIC does not match any ActionCategory"))
+    }
+
+    @Test
+    fun `valid catalog passes`() {
+        ClassCatalogConsistencyValidator(StubClasses(listOf(soldier()))).validate()
+    }
+
+    private fun soldier() = ClassDefinition(
+        id = AgentClass.SOLDIER,
+        displayName = "Soldier",
+        description = "Frontline pro.",
+        sightRange = 3,
+        primarySkills = setOf(SkillId("SWORD")),
+        neutralSkills = emptySet(),
+        forbiddenCombatSkills = emptySet(),
+        damageMultipliers = mapOf("SLASH" to 1.1),
+        behaviorFingerprint = mapOf("COMBAT" to 1.0),
+    )
+
+    private class StubClasses(private val defs: List<ClassDefinition>) : ClassLookup {
+        override fun byId(classId: AgentClass): ClassDefinition? = defs.firstOrNull { it.id == classId }
+        override fun all(): List<ClassDefinition> = defs
+        override fun sightRange(classId: AgentClass?): Int = 3
+        override fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double = 1.0
+        override fun damageMultiplier(classId: AgentClass?, damageType: String): Double = 1.0
+        override fun forbidsCombatSkill(classId: AgentClass?, combatSkill: SkillId): Boolean = false
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
@@ -90,6 +90,75 @@ class AttackReducerTest {
     private val unarmedSkill = SkillId("UNARMED")
 
     @Test
+    fun `class damage modifier composes after level scaling and aura — applies to the resolved base`() {
+        val state = battleState(targetHp = 1000)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val deathProcessor = stubDeathProcessor(skills, publisher)
+        val classes = object : dev.gvart.genesara.player.ClassLookup {
+            override fun byId(classId: dev.gvart.genesara.player.AgentClass): dev.gvart.genesara.player.ClassDefinition? = null
+            override fun all(): List<dev.gvart.genesara.player.ClassDefinition> = emptyList()
+            override fun sightRange(classId: dev.gvart.genesara.player.AgentClass?): Int = 3
+            override fun skillXpMultiplier(classId: dev.gvart.genesara.player.AgentClass?, skill: SkillId): Double = 1.0
+            override fun damageMultiplier(classId: dev.gvart.genesara.player.AgentClass?, damageType: String): Double = 2.0
+            override fun forbidsCombatSkill(classId: dev.gvart.genesara.player.AgentClass?, combatSkill: SkillId): Boolean = false
+        }
+        val plus50PctScaling = object : dev.gvart.genesara.player.LevelScalingAggregator {
+            override fun bonusFor(agent: AgentId, effect: dev.gvart.genesara.player.ScalingEffect): Double = 0.5
+        }
+        val plus10Aura = object : dev.gvart.genesara.player.PassiveAuraAggregator {
+            override fun bonusFor(agent: AgentId, effect: dev.gvart.genesara.player.ScalingEffect): Int = 10
+        }
+
+        val (_, events) = assertNotNull(
+            reduceAttack(
+                state, WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithSword(),
+                agentsWithAttackerClass(strength = 10, classId = dev.gvart.genesara.player.AgentClass.SOLDIER),
+                swordEquipped(),
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L),
+                scaling = plus50PctScaling, passiveAura = plus10Aura, triggeredPassives = NoOpTriggeredPassiveDispatcher,
+                pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 5, classes = classes,
+            ).getOrNull(),
+        )
+
+        val attacked = assertIs<WorldEvent.AgentAttacked>(events.single())
+        // typedDamage = 10*8 = 80; preClassScaled = (80 * 1.5).toInt() + 10 = 130;
+        // baseScaled = (130 * 2.0).toInt() = 260. Class composes AFTER aura.
+        assertEquals(260, attacked.baseDamage)
+    }
+
+    @Test
+    fun `class damage modifier scales the typed damage`() {
+        val state = battleState(targetHp = 200)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val deathProcessor = stubDeathProcessor(skills, publisher)
+        val classes = object : dev.gvart.genesara.player.ClassLookup {
+            override fun byId(classId: dev.gvart.genesara.player.AgentClass): dev.gvart.genesara.player.ClassDefinition? = null
+            override fun all(): List<dev.gvart.genesara.player.ClassDefinition> = emptyList()
+            override fun sightRange(classId: dev.gvart.genesara.player.AgentClass?): Int = 3
+            override fun skillXpMultiplier(classId: dev.gvart.genesara.player.AgentClass?, skill: SkillId): Double = 1.0
+            override fun damageMultiplier(classId: dev.gvart.genesara.player.AgentClass?, damageType: String): Double =
+                if (classId == dev.gvart.genesara.player.AgentClass.SOLDIER && damageType == "SLASH") 1.5 else 1.0
+            override fun forbidsCombatSkill(classId: dev.gvart.genesara.player.AgentClass?, combatSkill: SkillId): Boolean = false
+        }
+
+        val (_, events) = assertNotNull(
+            reduceAttack(
+                state, WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithSword(),
+                agentsWithAttackerClass(strength = 10, classId = dev.gvart.genesara.player.AgentClass.SOLDIER),
+                swordEquipped(),
+                SkillProgression(skills, publisher), deathProcessor = deathProcessor, rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher, pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 5, classes = classes,
+            ).getOrNull(),
+        )
+
+        val attacked = assertIs<WorldEvent.AgentAttacked>(events.single())
+        assertEquals(120, attacked.baseDamage, "10 STR * 8 weaponPower * 1.5 class SLASH mod = 120")
+    }
+
+    @Test
     fun `happy path — sword strike with no crit and no dodge, deterministic damage`() {
         val state = battleState(targetHp = 100)
         val skills = StubSkillsRegistry()
@@ -772,6 +841,15 @@ class AttackReducerTest {
             ),
         )
 
+    private fun agentsWithAttackerClass(strength: Int, classId: dev.gvart.genesara.player.AgentClass): AgentRegistry =
+        StubAgentRegistry(
+            byId = mapOf(
+                attacker to AgentAttributes(strength = strength, luck = 0, dexterity = 0),
+                target to AgentAttributes(dexterity = 0),
+            ),
+            classByAgent = mapOf(attacker to classId),
+        )
+
     private fun stubDeathProcessor(
         skills: AgentSkillsRegistry,
         publisher: ApplicationEventPublisher,
@@ -812,6 +890,7 @@ class AttackReducerTest {
     private class StubAgentRegistry(
         private val byId: Map<AgentId, AgentAttributes>,
         private val scriptedDeath: Map<AgentId, DeathPenaltyOutcome> = emptyMap(),
+        private val classByAgent: Map<AgentId, dev.gvart.genesara.player.AgentClass> = emptyMap(),
     ) : AgentRegistry {
         override fun find(id: AgentId): Agent? = byId[id]?.let {
             Agent(
@@ -819,6 +898,7 @@ class AttackReducerTest {
                 owner = PlayerId(UUID.randomUUID()),
                 name = "test",
                 attributes = it,
+                classId = classByAgent[id],
             )
         }
         override fun listForOwner(owner: PlayerId): List<Agent> = error("not used")

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentServiceImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentServiceImplTest.kt
@@ -513,6 +513,53 @@ class EquipmentServiceImplTest {
         assertEquals(setOf(EquipSlot.MAIN_HAND, EquipSlot.HELMET), map.keys)
     }
 
+    @Test
+    fun `equip rejects with CLASS_FORBIDDEN when the agent's class hard-bans the combat-skill`() {
+        val firearmId = ItemId("PISTOL")
+        val firearm = equipmentItem(firearmId, validSlots = setOf(EquipSlot.MAIN_HAND))
+            .copy(combatSkill = SkillId("FIREARMS"))
+        val itemsWithFirearm = StubItemLookup(mapOf(firearmId to firearm))
+        val instance = unequipped(firearmId)
+        val store = StubStore(listOf(instance))
+        val researcher = StubAgentRegistry(mapOf(agent to agentWith().copy(classId = dev.gvart.genesara.player.AgentClass.RESEARCHER)))
+        val classes = StubBannedFirearmsLookup
+        val service = EquipmentServiceImpl(store, itemsWithFirearm, researcher, skills, classes)
+
+        val result = service.equip(agent, instance.instanceId, EquipSlot.MAIN_HAND)
+
+        val rejected = assertIs<EquipResult.Rejected>(result)
+        assertEquals(EquipRejection.CLASS_FORBIDDEN, rejected.reason)
+        val detail = assertNotNull(rejected.detail)
+        assertTrue(detail.contains("RESEARCHER"))
+        assertTrue(detail.contains("FIREARMS"))
+    }
+
+    @Test
+    fun `equip allows the same firearm for a class that does not ban it`() {
+        val firearmId = ItemId("PISTOL")
+        val firearm = equipmentItem(firearmId, validSlots = setOf(EquipSlot.MAIN_HAND))
+            .copy(combatSkill = SkillId("FIREARMS"))
+        val itemsWithFirearm = StubItemLookup(mapOf(firearmId to firearm))
+        val instance = unequipped(firearmId)
+        val store = StubStore(listOf(instance))
+        val soldier = StubAgentRegistry(mapOf(agent to agentWith().copy(classId = dev.gvart.genesara.player.AgentClass.SOLDIER)))
+        val service = EquipmentServiceImpl(store, itemsWithFirearm, soldier, skills, StubBannedFirearmsLookup)
+
+        val result = service.equip(agent, instance.instanceId, EquipSlot.MAIN_HAND)
+
+        assertIs<EquipResult.Equipped>(result)
+    }
+
+    private object StubBannedFirearmsLookup : dev.gvart.genesara.player.ClassLookup {
+        override fun byId(classId: dev.gvart.genesara.player.AgentClass): dev.gvart.genesara.player.ClassDefinition? = null
+        override fun all(): List<dev.gvart.genesara.player.ClassDefinition> = emptyList()
+        override fun sightRange(classId: dev.gvart.genesara.player.AgentClass?): Int = 3
+        override fun skillXpMultiplier(classId: dev.gvart.genesara.player.AgentClass?, skill: SkillId): Double = 1.0
+        override fun damageMultiplier(classId: dev.gvart.genesara.player.AgentClass?, damageType: String): Double = 1.0
+        override fun forbidsCombatSkill(classId: dev.gvart.genesara.player.AgentClass?, combatSkill: SkillId): Boolean =
+            classId == dev.gvart.genesara.player.AgentClass.RESEARCHER && combatSkill == SkillId("FIREARMS")
+    }
+
     // ─────────────────────── helpers ───────────────────────
 
     private fun equipmentItem(

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImplTest.kt
@@ -7,7 +7,8 @@ import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.AgentSkillsSnapshot
-import dev.gvart.genesara.player.ClassPropertiesLookup
+import dev.gvart.genesara.player.ClassDefinition
+import dev.gvart.genesara.player.ClassLookup
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillSlotError
 import dev.gvart.genesara.world.BodyView
@@ -100,8 +101,13 @@ class VisionRadiusImplTest {
         return VisionRadiusImpl(constantBase(base), skills, stubWorld())
     }
 
-    private fun constantBase(base: Int) = object : ClassPropertiesLookup {
+    private fun constantBase(base: Int) = object : ClassLookup {
+        override fun byId(classId: AgentClass): ClassDefinition? = null
+        override fun all(): List<ClassDefinition> = emptyList()
         override fun sightRange(classId: AgentClass?): Int = base
+        override fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double = 1.0
+        override fun damageMultiplier(classId: AgentClass?, damageType: String): Double = 1.0
+        override fun forbidsCombatSkill(classId: AgentClass?, combatSkill: SkillId): Boolean = false
     }
 
     private fun stubWorld() = StubWorld(


### PR DESCRIPTION
## Summary

Skill-feature **step 6 / Issue #32**: pins the eight v1 base classes (SOLDIER, SCOUT, HUNTER, ARTISAN, ENGINEER, MEDIC, MERCHANT, RESEARCHER) and ships the catalog surface + three runtime hooks (soft XP, class damage, hard restriction).

- New `ClassDefinition` + `ClassLookup` in `:player` replacing the narrower `ClassPropertiesLookup`.
- `classes.yaml` v1: per-class display info, sight range, primary/neutral/forbidden skills, damage multipliers, 8-axis behavior fingerprint.
- Two startup validators: player-side (skill ID refs, blank fields, sign checks, dup detection) + world-side (DamageType / ActionCategory string keys decode).
- Wired soft XP scaling (1.5/1.0/0.5) into `SkillProgressionImpl`, per-class damage multiplier into `AttackReducer` (composes after level-scaling + aura), and `EquipRejection.CLASS_FORBIDDEN` into `EquipmentServiceImpl`. RESEARCHER → FIREARMS is the only v1 hard restriction (design table §14).

**Out of scope (deferred):** evolutions list (→ #34), `psionicEntry` (→ #35), level-10 event reader of `behaviorFingerprint` (→ #33).

## Test plan

- [x] `./gradlew :player:test :world:test :api:test` green (full suite, no daemon)
- [x] New `ClassesYamlLoadingTest` confirms 8 classes parse and RESEARCHER hard-bans FIREARMS
- [x] New `ClassValidatorTest` covers missing entry, unknown skill ref, non-positive sight range / multipliers, negative behavior weight, primary↔neutral overlap, intra-list duplicates
- [x] New `ClassCatalogConsistencyValidatorTest` covers unknown DamageType / ActionCategory string keys
- [x] `SkillProgressionImplTest` adds class-scaled XP delta tests (1.5x primary, 0.5x off-build with floor-at-1, 1.0x unclassed)
- [x] `AttackReducerTest` adds two class-damage-modifier tests asserting composition order (classMod applied **after** level scaling + aura)
- [x] `EquipmentServiceImplTest` adds CLASS_FORBIDDEN reject path + permissive path for non-banning class
- [x] `code-quality-reviewer` agent run; both material findings (hot-path `agents.find` redundancy + combat formula composition order) addressed in the same slice

## Follow-ups

- Tick `docs/skill-feature-sequence.md` Step 6 box and advance "Current step" to Step 7 (#33) — separate doc-only PR after this merges.
- Tick the matching acceptance-criteria checkboxes on issue #32.