### PR TITLE
docs(skill-feature): tick Step 6 (#32) and advance current step to Step 7 (#33)

### DIFF
--- a/docs/skill-feature-sequence.md
+++ b/docs/skill-feature-sequence.md
@@ -10,7 +10,7 @@
 
 > **HOW TO USE.** When the user says "move on to next step", look here. The next unchecked box is the next slice. When a slice merges, tick the box and update **Current step** below. This file is the single source of truth for roadmap position; per-issue acceptance criteria stay tracked inside each GitHub issue.
 
-**Current step:** ⏭ **Step 6 — [#32](https://github.com/Genesara/genesara-engine/issues/32) Class catalog + `AgentClass` surgery** (Steps 1–5 merged; behavior tracker live with cumulative counters and `internal`-pinned exposure contract)
+**Current step:** ⏭ **Step 7 — [#33](https://github.com/Genesara/genesara-engine/issues/33) Level-10 event + `select_class`** (Steps 1–6 merged; class catalog live with 8 base classes, soft-XP / damage / hard-restriction wires in place, behaviorFingerprint populated and ready for the scoring algorithm)
 
 ### Track A — Phase 1 mechanics + catalog
 
@@ -26,7 +26,7 @@
 ### Track B — Phase 4 class system
 
 - [x] **Step 5** — [#31](https://github.com/Genesara/genesara-engine/issues/31) Behavior tracker *(landed in #92; `use_ability` already wired since #67 shipped first)*
-- [ ] **Step 6** — [#32](https://github.com/Genesara/genesara-engine/issues/32) Class catalog + `AgentClass` surgery *(blocked by step 5 + step 4)*
+- [x] **Step 6** — [#32](https://github.com/Genesara/genesara-engine/issues/32) Class catalog + `AgentClass` surgery *(landed in #94; 8 base classes pinned, ClassLookup public, soft-XP/damage/hard-restriction wires live; evolutions list and psionicEntry stay deferred to step 8 / psionics expansion)*
 - [ ] **Step 7** — [#33](https://github.com/Genesara/genesara-engine/issues/33) Level-10 event + `select_class`
 - [ ] **Step 8** — [#34](https://github.com/Genesara/genesara-engine/issues/34) Class evolution L50 + `select_evolution` *(L100 stays deferred — partial-close on this checkbox)*
 


### PR DESCRIPTION
## Summary

- Tick Step 6 box in `docs/skill-feature-sequence.md` (class catalog landed in #94)
- Advance "Current step" pointer to Step 7 (#33 Level-10 event + `select_class`)

## Test plan

- [x] Markdown renders cleanly in GitHub preview