### PR TITLE
feat(player,world,api): level-10 class choice + select_class (#33)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
@@ -8,6 +8,7 @@ import dev.gvart.genesara.api.internal.mcp.tools.attributes.AllocatePointsTool
 import dev.gvart.genesara.api.internal.mcp.tools.build.BuildTool
 import dev.gvart.genesara.api.internal.mcp.tools.chest.DepositToChestTool
 import dev.gvart.genesara.api.internal.mcp.tools.chest.WithdrawFromChestTool
+import dev.gvart.genesara.api.internal.mcp.tools.classselect.SelectClassTool
 import dev.gvart.genesara.api.internal.mcp.tools.consume.ConsumeTool
 import dev.gvart.genesara.api.internal.mcp.tools.craft.CraftTool
 import dev.gvart.genesara.api.internal.mcp.tools.drink.DrinkTool
@@ -62,6 +63,7 @@ internal class McpServerConfiguration {
         pickup: PickupTool,
         attack: AttackTool,
         useAbility: UseAbilityTool,
+        selectClass: SelectClassTool,
     ): ToolCallbackProvider =
         MethodToolCallbackProvider.builder()
             .toolObjects(
@@ -69,7 +71,7 @@ internal class McpServerConfiguration {
                 consume, drink, equipSkill, allocatePoints, inspect, getMap,
                 equipItem, unequipSlot,
                 setSafeNode, respawn, build, depositToChest, withdrawFromChest, craft, pickup, attack,
-                useAbility,
+                useAbility, selectClass,
             )
             .build()
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -63,6 +63,12 @@ internal class AgentEventDispatcher(
     fun on(event: AgentEvent.PerkChosen) = publish(event.agent, "perk.chosen", event)
 
     @EventListener
+    fun on(event: AgentEvent.ClassChoiceOffered) = publish(event.agent, "class.offered", event)
+
+    @EventListener
+    fun on(event: AgentEvent.ClassChosen) = publish(event.agent, "class.chosen", event)
+
+    @EventListener
     fun on(event: WorldEvent.ItemCrafted) = publish(event.agent, "item.crafted", event)
 
     @EventListener

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectClassResponse.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectClassResponse.kt
@@ -1,0 +1,24 @@
+package dev.gvart.genesara.api.internal.mcp.tools.classselect
+
+/**
+ * Response shape for `select_class`.
+ *
+ * - `kind = "ok"`: the class is now permanently set on the agent and the
+ *   pending offer columns are cleared.
+ * - `kind = "rejected"`: the choice was refused; `reason` carries the cause.
+ *   Possible reasons: `unknown_class`, `no_pending_offer`, `not_offered`,
+ *   `already_classed`, `unknown_agent`.
+ */
+data class SelectClassResponse(
+    val kind: String,
+    val classId: String,
+    val reason: String? = null,
+    val detail: String? = null,
+) {
+    companion object {
+        fun ok(classId: String) = SelectClassResponse("ok", classId)
+
+        fun rejected(classId: String, reason: String, detail: String? = null) =
+            SelectClassResponse("rejected", classId, reason, detail)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectClassResponse.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectClassResponse.kt
@@ -1,24 +1,27 @@
 package dev.gvart.genesara.api.internal.mcp.tools.classselect
 
+import dev.gvart.genesara.player.AgentClass
+
 /**
  * Response shape for `select_class`.
  *
  * - `kind = "ok"`: the class is now permanently set on the agent and the
  *   pending offer columns are cleared.
  * - `kind = "rejected"`: the choice was refused; `reason` carries the cause.
- *   Possible reasons: `unknown_class`, `no_pending_offer`, `not_offered`,
- *   `already_classed`, `unknown_agent`.
+ *   Possible reasons: `no_pending_offer`, `not_offered`, `already_classed`,
+ *   `unknown_agent`. (An unparseable class id is rejected by the MCP framework
+ *   before reaching the tool, the same way `EquipSlot` is.)
  */
 data class SelectClassResponse(
     val kind: String,
-    val classId: String,
+    val classId: AgentClass,
     val reason: String? = null,
     val detail: String? = null,
 ) {
     companion object {
-        fun ok(classId: String) = SelectClassResponse("ok", classId)
+        fun ok(classId: AgentClass) = SelectClassResponse("ok", classId)
 
-        fun rejected(classId: String, reason: String, detail: String? = null) =
+        fun rejected(classId: AgentClass, reason: String, detail: String? = null) =
             SelectClassResponse("rejected", classId, reason, detail)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectClassTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectClassTool.kt
@@ -36,24 +36,17 @@ internal class SelectClassTool(
             description = "Class id chosen from the ClassChoiceOffered event candidates " +
                 "(e.g. SOLDIER, SCOUT, RESEARCHER).",
         )
-        classId: String,
+        classId: AgentClass,
         toolContext: ToolContext,
     ): SelectClassResponse {
         touchActivity(toolContext, activity, "select_class")
         val agent = AgentContextHolder.current()
 
-        val parsed = runCatching { AgentClass.valueOf(classId) }.getOrNull()
-            ?: return SelectClassResponse.rejected(
-                classId = classId,
-                reason = "unknown_class",
-                detail = "Class id '$classId' is not in the catalog.",
-            )
-
-        return when (val outcome = agents.assignClass(agent, parsed)) {
+        return when (val outcome = agents.assignClass(agent, classId)) {
             AssignClassOutcome.Assigned -> {
                 val tick = tickClock.currentTick()
-                publisher.publishEvent(AgentEvent.ClassChosen(agent = agent, classId = parsed, tick = tick))
-                SelectClassResponse.ok(parsed.name)
+                publisher.publishEvent(AgentEvent.ClassChosen(agent = agent, classId = classId, tick = tick))
+                SelectClassResponse.ok(classId)
             }
 
             is AssignClassOutcome.AlreadyClassed -> SelectClassResponse.rejected(
@@ -72,7 +65,7 @@ internal class SelectClassTool(
                 classId = classId,
                 reason = "not_offered",
                 detail = "Pending offer is ${outcome.pending.first.name} or ${outcome.pending.second.name}; " +
-                    "$classId is not one of them.",
+                    "${classId.name} is not one of them.",
             )
 
             AssignClassOutcome.UnknownAgent -> SelectClassResponse.rejected(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectClassTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectClassTool.kt
@@ -1,0 +1,85 @@
+package dev.gvart.genesara.api.internal.mcp.tools.classselect
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AssignClassOutcome
+import dev.gvart.genesara.player.events.AgentEvent
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.ai.tool.annotation.ToolParam
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+internal class SelectClassTool(
+    private val agents: AgentRegistry,
+    private val tickClock: TickClock,
+    private val publisher: ApplicationEventPublisher,
+    private val activity: AgentActivityTracker,
+) {
+
+    @Tool(
+        name = "select_class",
+        description = "Permanently commit to one of the two classes offered by the level-10 " +
+            "ClassChoiceOffered event. IRREVERSIBLE — the class stays for the agent's lifetime; " +
+            "no respec. Pending offers come from ClassChoiceOffered events and are also surfaced " +
+            "as `pendingClassChoice` on get_status. Validates: the class id decodes, the agent " +
+            "has no class yet, and the chosen class is one of the two pending candidates.",
+    )
+    fun invoke(
+        @ToolParam(
+            required = true,
+            description = "Class id chosen from the ClassChoiceOffered event candidates " +
+                "(e.g. SOLDIER, SCOUT, RESEARCHER).",
+        )
+        classId: String,
+        toolContext: ToolContext,
+    ): SelectClassResponse {
+        touchActivity(toolContext, activity, "select_class")
+        val agent = AgentContextHolder.current()
+
+        val parsed = runCatching { AgentClass.valueOf(classId) }.getOrNull()
+            ?: return SelectClassResponse.rejected(
+                classId = classId,
+                reason = "unknown_class",
+                detail = "Class id '$classId' is not in the catalog.",
+            )
+
+        return when (val outcome = agents.assignClass(agent, parsed)) {
+            AssignClassOutcome.Assigned -> {
+                val tick = tickClock.currentTick()
+                publisher.publishEvent(AgentEvent.ClassChosen(agent = agent, classId = parsed, tick = tick))
+                SelectClassResponse.ok(parsed.name)
+            }
+
+            is AssignClassOutcome.AlreadyClassed -> SelectClassResponse.rejected(
+                classId = classId,
+                reason = "already_classed",
+                detail = "Agent is already ${outcome.existing.name} (class is forever, no respec).",
+            )
+
+            AssignClassOutcome.NoPendingOffer -> SelectClassResponse.rejected(
+                classId = classId,
+                reason = "no_pending_offer",
+                detail = "No pending class-choice offer — reach level 10 first.",
+            )
+
+            is AssignClassOutcome.NotInOffer -> SelectClassResponse.rejected(
+                classId = classId,
+                reason = "not_offered",
+                detail = "Pending offer is ${outcome.pending.first.name} or ${outcome.pending.second.name}; " +
+                    "$classId is not one of them.",
+            )
+
+            AssignClassOutcome.UnknownAgent -> SelectClassResponse.rejected(
+                classId = classId,
+                reason = "unknown_agent",
+                detail = "Agent ${agent.id} not found.",
+            )
+        }
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusTool.kt
@@ -48,6 +48,7 @@ internal class GetStatusTool(
             agentId = agent.id.id.toString(),
             name = agent.name,
             race = agent.race.value,
+            classId = agent.classId?.name,
             level = agent.level,
             xp = XpView(current = agent.xpCurrent, toNext = agent.xpToNext),
             attributes = AttributesView(
@@ -68,6 +69,7 @@ internal class GetStatusTool(
             location = location?.value,
             tick = engine.currentTick(),
             skills = buildSkillsView(agentId),
+            pendingClassChoice = agent.offeredClasses?.toList()?.map { it.name } ?: emptyList(),
         )
     }
 

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusTool.kt
@@ -48,7 +48,7 @@ internal class GetStatusTool(
             agentId = agent.id.id.toString(),
             name = agent.name,
             race = agent.race.value,
-            classId = agent.classId?.name,
+            classId = agent.classId,
             level = agent.level,
             xp = XpView(current = agent.xpCurrent, toNext = agent.xpToNext),
             attributes = AttributesView(
@@ -69,7 +69,7 @@ internal class GetStatusTool(
             location = location?.value,
             tick = engine.currentTick(),
             skills = buildSkillsView(agentId),
-            pendingClassChoice = agent.offeredClasses?.toList()?.map { it.name } ?: emptyList(),
+            pendingClassChoice = agent.offeredClasses?.toList() ?: emptyList(),
         )
     }
 

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolIo.kt
@@ -1,11 +1,13 @@
 package dev.gvart.genesara.api.internal.mcp.tools.getstatus
 
+import dev.gvart.genesara.player.AgentClass
+
 data class GetStatusResponse(
     val agentId: String,
     val name: String,
     val race: String,
-    /** Class id committed via `select_class`; null pre-level-10 or while a pick is pending. */
-    val classId: String? = null,
+    /** Class committed via `select_class`; null pre-level-10 or while a pick is pending. */
+    val classId: AgentClass? = null,
     val level: Int,
     val xp: XpView,
     val attributes: AttributesView,
@@ -21,12 +23,12 @@ data class GetStatusResponse(
     val activeEffects: List<String> = emptyList(),
     val skills: SkillsView,
     /**
-     * The two `AgentClass` ids offered by the level-10 event when [classId] is null.
+     * The two classes offered by the level-10 event when [classId] is null.
      * Empty list when no offer is pending (pre-level-10 or already classed). The agent
      * commits one via `select_class`. The list mirrors the scorer's ranking — the
      * first entry is the strongest fingerprint match — but either is a legal pick.
      */
-    val pendingClassChoice: List<String> = emptyList(),
+    val pendingClassChoice: List<AgentClass> = emptyList(),
 )
 
 data class XpView(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolIo.kt
@@ -4,6 +4,8 @@ data class GetStatusResponse(
     val agentId: String,
     val name: String,
     val race: String,
+    /** Class id committed via `select_class`; null pre-level-10 or while a pick is pending. */
+    val classId: String? = null,
     val level: Int,
     val xp: XpView,
     val attributes: AttributesView,
@@ -18,6 +20,13 @@ data class GetStatusResponse(
     val tick: Long,
     val activeEffects: List<String> = emptyList(),
     val skills: SkillsView,
+    /**
+     * The two `AgentClass` ids offered by the level-10 event when [classId] is null.
+     * Empty list when no offer is pending (pre-level-10 or already classed). The agent
+     * commits one via `select_class`. The list mirrors the scorer's ranking — the
+     * first entry is the strongest fingerprint match — but either is a legal pick.
+     */
+    val pendingClassChoice: List<String> = emptyList(),
 )
 
 data class XpView(

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectClassToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectClassToolTest.kt
@@ -1,0 +1,149 @@
+package dev.gvart.genesara.api.internal.mcp.tools.classselect
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AssignClassOutcome
+import dev.gvart.genesara.player.ClassOffer
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.account.PlayerId
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.context.ApplicationEventPublisher
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SelectClassToolTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val clock = MutableTestClock(Instant.parse("2026-01-01T00:00:00Z"))
+    private val activity = AgentActivityRegistry(clock)
+    private val tickClock = StubTickClock(currentTick = 9L)
+    private val toolContext = ToolContext(emptyMap())
+
+    @BeforeEach fun setUp() = AgentContextHolder.set(agent)
+    @AfterEach fun tearDown() = AgentContextHolder.clear()
+
+    @Test
+    fun `commits the chosen class and emits ClassChosen at the current tick`() {
+        val agents = StubAgentRegistry(assignResult = AssignClassOutcome.Assigned)
+        val publisher = RecordingPublisher()
+        val tool = SelectClassTool(agents, tickClock, publisher, activity)
+
+        val response = tool.invoke(classId = "SOLDIER", toolContext = toolContext)
+
+        assertEquals("ok", response.kind)
+        assertEquals("SOLDIER", response.classId)
+        val recorded = agents.assignCalls.single()
+        assertEquals(agent to AgentClass.SOLDIER, recorded)
+        val event = publisher.events.filterIsInstance<AgentEvent.ClassChosen>().single()
+        assertEquals(agent, event.agent)
+        assertEquals(AgentClass.SOLDIER, event.classId)
+        assertEquals(9L, event.tick)
+    }
+
+    @Test
+    fun `rejects an unknown class id before touching the registry`() {
+        val agents = StubAgentRegistry()
+        val publisher = RecordingPublisher()
+        val tool = SelectClassTool(agents, tickClock, publisher, activity)
+
+        val response = tool.invoke(classId = "DRAGONLORD", toolContext = toolContext)
+
+        assertEquals("rejected", response.kind)
+        assertEquals("unknown_class", response.reason)
+        assertTrue(agents.assignCalls.isEmpty())
+        assertTrue(publisher.events.isEmpty())
+    }
+
+    @Test
+    fun `rejects when no offer is pending`() {
+        val agents = StubAgentRegistry(assignResult = AssignClassOutcome.NoPendingOffer)
+        val publisher = RecordingPublisher()
+        val tool = SelectClassTool(agents, tickClock, publisher, activity)
+
+        val response = tool.invoke(classId = "SOLDIER", toolContext = toolContext)
+
+        assertEquals("rejected", response.kind)
+        assertEquals("no_pending_offer", response.reason)
+        assertTrue(publisher.events.none { it is AgentEvent.ClassChosen })
+    }
+
+    @Test
+    fun `rejects when the chosen class is not in the offer and surfaces the pending pair`() {
+        val pending = ClassOffer(AgentClass.SOLDIER, AgentClass.SCOUT)
+        val agents = StubAgentRegistry(assignResult = AssignClassOutcome.NotInOffer(pending))
+        val publisher = RecordingPublisher()
+        val tool = SelectClassTool(agents, tickClock, publisher, activity)
+
+        val response = tool.invoke(classId = "RESEARCHER", toolContext = toolContext)
+
+        assertEquals("not_offered", response.reason)
+        val detail = response.detail!!
+        assertTrue(detail.contains("SOLDIER"))
+        assertTrue(detail.contains("SCOUT"))
+    }
+
+    @Test
+    fun `rejects when the agent already has a class`() {
+        val agents = StubAgentRegistry(assignResult = AssignClassOutcome.AlreadyClassed(AgentClass.MEDIC))
+        val publisher = RecordingPublisher()
+        val tool = SelectClassTool(agents, tickClock, publisher, activity)
+
+        val response = tool.invoke(classId = "SOLDIER", toolContext = toolContext)
+
+        assertEquals("already_classed", response.reason)
+        assertTrue(response.detail!!.contains("MEDIC"))
+    }
+
+    @Test
+    fun `rejects when the agent row is missing`() {
+        val agents = StubAgentRegistry(assignResult = AssignClassOutcome.UnknownAgent)
+        val tool = SelectClassTool(agents, tickClock, RecordingPublisher(), activity)
+
+        val response = tool.invoke(classId = "SOLDIER", toolContext = toolContext)
+
+        assertEquals("unknown_agent", response.reason)
+    }
+
+    private class StubAgentRegistry(
+        private val assignResult: AssignClassOutcome = AssignClassOutcome.Assigned,
+    ) : AgentRegistry {
+        val assignCalls = mutableListOf<Pair<AgentId, AgentClass>>()
+
+        override fun find(id: AgentId): Agent? = Agent(id = id, owner = PlayerId(UUID.randomUUID()), name = "stub")
+        override fun listForOwner(owner: PlayerId): List<Agent> = emptyList()
+        override fun assignClass(agentId: AgentId, classId: AgentClass): AssignClassOutcome {
+            assignCalls += agentId to classId
+            return assignResult
+        }
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+
+    private class StubTickClock(private val currentTick: Long) : TickClock {
+        override fun currentTick(): Long = currentTick
+    }
+
+    private class MutableTestClock(private var now: Instant) : Clock() {
+        override fun instant(): Instant = now
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectClassToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectClassToolTest.kt
@@ -41,10 +41,10 @@ class SelectClassToolTest {
         val publisher = RecordingPublisher()
         val tool = SelectClassTool(agents, tickClock, publisher, activity)
 
-        val response = tool.invoke(classId = "SOLDIER", toolContext = toolContext)
+        val response = tool.invoke(classId = AgentClass.SOLDIER, toolContext = toolContext)
 
         assertEquals("ok", response.kind)
-        assertEquals("SOLDIER", response.classId)
+        assertEquals(AgentClass.SOLDIER, response.classId)
         val recorded = agents.assignCalls.single()
         assertEquals(agent to AgentClass.SOLDIER, recorded)
         val event = publisher.events.filterIsInstance<AgentEvent.ClassChosen>().single()
@@ -54,26 +54,12 @@ class SelectClassToolTest {
     }
 
     @Test
-    fun `rejects an unknown class id before touching the registry`() {
-        val agents = StubAgentRegistry()
-        val publisher = RecordingPublisher()
-        val tool = SelectClassTool(agents, tickClock, publisher, activity)
-
-        val response = tool.invoke(classId = "DRAGONLORD", toolContext = toolContext)
-
-        assertEquals("rejected", response.kind)
-        assertEquals("unknown_class", response.reason)
-        assertTrue(agents.assignCalls.isEmpty())
-        assertTrue(publisher.events.isEmpty())
-    }
-
-    @Test
     fun `rejects when no offer is pending`() {
         val agents = StubAgentRegistry(assignResult = AssignClassOutcome.NoPendingOffer)
         val publisher = RecordingPublisher()
         val tool = SelectClassTool(agents, tickClock, publisher, activity)
 
-        val response = tool.invoke(classId = "SOLDIER", toolContext = toolContext)
+        val response = tool.invoke(classId = AgentClass.SOLDIER, toolContext = toolContext)
 
         assertEquals("rejected", response.kind)
         assertEquals("no_pending_offer", response.reason)
@@ -87,7 +73,7 @@ class SelectClassToolTest {
         val publisher = RecordingPublisher()
         val tool = SelectClassTool(agents, tickClock, publisher, activity)
 
-        val response = tool.invoke(classId = "RESEARCHER", toolContext = toolContext)
+        val response = tool.invoke(classId = AgentClass.RESEARCHER, toolContext = toolContext)
 
         assertEquals("not_offered", response.reason)
         val detail = response.detail!!
@@ -101,7 +87,7 @@ class SelectClassToolTest {
         val publisher = RecordingPublisher()
         val tool = SelectClassTool(agents, tickClock, publisher, activity)
 
-        val response = tool.invoke(classId = "SOLDIER", toolContext = toolContext)
+        val response = tool.invoke(classId = AgentClass.SOLDIER, toolContext = toolContext)
 
         assertEquals("already_classed", response.reason)
         assertTrue(response.detail!!.contains("MEDIC"))
@@ -112,7 +98,7 @@ class SelectClassToolTest {
         val agents = StubAgentRegistry(assignResult = AssignClassOutcome.UnknownAgent)
         val tool = SelectClassTool(agents, tickClock, RecordingPublisher(), activity)
 
-        val response = tool.invoke(classId = "SOLDIER", toolContext = toolContext)
+        val response = tool.invoke(classId = AgentClass.SOLDIER, toolContext = toolContext)
 
         assertEquals("unknown_agent", response.reason)
     }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/Agent.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/Agent.kt
@@ -13,4 +13,21 @@ data class Agent(
     val xpToNext: Int = 100,
     val unspentAttributePoints: Int = 5,
     val attributes: AgentAttributes = AgentAttributes.DEFAULT,
+    /**
+     * Pending class-choice offer set by the level-10 emitter (#33). Null pre-
+     * level-10 and after the agent commits via `select_class`. Always non-null
+     * with exactly two distinct entries when present.
+     */
+    val offeredClasses: ClassOffer? = null,
 )
+
+/**
+ * The pair of [AgentClass]es offered to the agent at the level-10 event. The
+ * declaration order mirrors the scorer's ranking — [first] beats [second] —
+ * but the agent may commit either via `select_class`.
+ */
+data class ClassOffer(val first: AgentClass, val second: AgentClass) {
+    init { require(first != second) { "ClassOffer pair must be distinct, got $first twice" } }
+    fun contains(classId: AgentClass): Boolean = classId == first || classId == second
+    fun toList(): List<AgentClass> = listOf(first, second)
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
@@ -59,6 +59,54 @@ interface AgentRegistry {
         deltas: Map<Attribute, Int>,
     ): AllocateAttributesOutcome? =
         throw NotImplementedError("allocateAttributes not implemented for this AgentRegistry")
+
+    /**
+     * Add [delta] character XP to [agentId] atomically, cascading any number of
+     * level-ups in a single round trip. Each level-up bumps `level`, refills
+     * `xp_to_next` to `level * XP_PER_LEVEL` (linear), and grants
+     * [XP_PER_LEVEL_ATTRIBUTE_POINTS] unspent attribute points.
+     *
+     * **Level-10 cap.** When an agent without a class reaches level 10, the
+     * cascade halts at the level-10 boundary and surplus XP is dropped — they
+     * stay at level 10 with `xpCurrent = xpToNext` until they commit a class
+     * via `select_class`. Once classed, subsequent grants resume normal
+     * leveling. The flag [AddCharacterXpOutcome.cappedAtPendingClassChoice]
+     * reports whether this branch fired.
+     *
+     * Returns one of:
+     *  - [AddCharacterXpOutcome.Granted] — success; carries before/after level,
+     *    new XP bar state, and the unspent-attribute pool.
+     *  - [AddCharacterXpOutcome.NegativeDelta] — [delta] was < 0.
+     *  - `null` — the agent row was missing (state corruption); caller logs and
+     *    skips, same convention as [applyDeathPenalty].
+     *
+     * Default implementation throws `NotImplementedError` so test stubs can opt
+     * in only when they exercise the XP path; production [JooqAgentRegistry]
+     * provides the real implementation.
+     */
+    fun addCharacterXp(agentId: AgentId, delta: Int): AddCharacterXpOutcome? =
+        throw NotImplementedError("addCharacterXp not implemented for this AgentRegistry")
+
+    /**
+     * Set the pending class-choice offer for [agentId] to [offer]. Idempotent
+     * by design: returns [RecordClassOfferOutcome.AlreadyClassed] if the agent
+     * already has a class, [RecordClassOfferOutcome.AlreadyOffered] if a prior
+     * offer is still pending. The level-10 emitter calls this exactly once per
+     * eligible transition; the result decides whether the
+     * [dev.gvart.genesara.player.events.AgentEvent.ClassChoiceOffered] event
+     * is published.
+     */
+    fun recordPendingClassChoice(agentId: AgentId, offer: ClassOffer): RecordClassOfferOutcome =
+        throw NotImplementedError("recordPendingClassChoice not implemented for this AgentRegistry")
+
+    /**
+     * Commit the agent's class to [classId]. Validates the agent still has no
+     * class and that [classId] is one of the two pending offers; clears the
+     * pending offer columns on success. The class assignment is forever — no
+     * respec — mirroring the perk no-respec rule.
+     */
+    fun assignClass(agentId: AgentId, classId: AgentClass): AssignClassOutcome =
+        throw NotImplementedError("assignClass not implemented for this AgentRegistry")
 }
 
 /**
@@ -109,3 +157,39 @@ sealed interface AllocateAttributesOutcome {
 
 /** A single (attribute, milestone) pair crossed by an allocation. */
 data class AttributeMilestoneCrossing(val attribute: Attribute, val milestone: Int)
+
+/** Result of [AgentRegistry.addCharacterXp]. */
+sealed interface AddCharacterXpOutcome {
+    data class Granted(
+        val previousLevel: Int,
+        val currentLevel: Int,
+        val xpCurrent: Int,
+        val xpToNext: Int,
+        val unspentAttributePoints: Int,
+        /**
+         * True when the agent reached level 10 with no class assigned and the
+         * grant's surplus XP was dropped at the boundary. Caller can ignore;
+         * the flag exists for diagnostics and for future "queue actions" UX.
+         */
+        val cappedAtPendingClassChoice: Boolean,
+    ) : AddCharacterXpOutcome
+
+    data object NegativeDelta : AddCharacterXpOutcome
+}
+
+/** Result of [AgentRegistry.recordPendingClassChoice]. */
+sealed interface RecordClassOfferOutcome {
+    data object Recorded : RecordClassOfferOutcome
+    data object AlreadyClassed : RecordClassOfferOutcome
+    data class AlreadyOffered(val existing: ClassOffer) : RecordClassOfferOutcome
+    data object UnknownAgent : RecordClassOfferOutcome
+}
+
+/** Result of [AgentRegistry.assignClass]. */
+sealed interface AssignClassOutcome {
+    data object Assigned : AssignClassOutcome
+    data class AlreadyClassed(val existing: AgentClass) : AssignClassOutcome
+    data object NoPendingOffer : AssignClassOutcome
+    data class NotInOffer(val pending: ClassOffer) : AssignClassOutcome
+    data object UnknownAgent : AssignClassOutcome
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/classes/ClassFingerprintScorer.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/classes/ClassFingerprintScorer.kt
@@ -1,0 +1,33 @@
+package dev.gvart.genesara.player.classes
+
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.ClassDefinition
+
+/**
+ * Scores a behavior fingerprint snapshot against the class catalog and picks
+ * the top-2 candidates surfaced at the level-10 event (#33 / step 7).
+ *
+ * The score is a plain dot product: `score(c) = Σ snapshot[axis] * c.fingerprint[axis]`.
+ * Categories absent from either side contribute 0 — agents that have only ever
+ * gathered get a non-zero score for any class with a non-zero GATHER weight.
+ *
+ * Ties are broken by [AgentClass.ordinal] (declaration order in the enum) so
+ * the outcome is fully deterministic regardless of insertion order in the
+ * catalog map. Snapshot keys are `ActionCategory.name` strings — the caller in
+ * `:world` stringifies its internal enum, keeping the cross-module dependency
+ * uni-directional.
+ */
+object ClassFingerprintScorer {
+
+    fun scoreTopTwo(
+        snapshot: Map<String, Int>,
+        classes: List<ClassDefinition>,
+    ): List<AgentClass> = classes
+        .map { it.id to score(snapshot, it.behaviorFingerprint) }
+        .sortedWith(compareByDescending<Pair<AgentClass, Double>> { it.second }.thenBy { it.first.ordinal })
+        .take(2)
+        .map { it.first }
+
+    private fun score(snapshot: Map<String, Int>, fingerprint: Map<String, Double>): Double =
+        fingerprint.entries.sumOf { (axis, weight) -> (snapshot[axis] ?: 0) * weight }
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/events/AgentEvent.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/events/AgentEvent.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.player.events
 
+import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.PerkId
@@ -76,6 +77,34 @@ sealed interface AgentEvent {
         val agent: AgentId,
         val attribute: Attribute,
         val milestone: Int,
+        override val tick: Long,
+    ) : AgentEvent
+
+    /**
+     * Emitted once when an agent reaches level 10 with no class. The two
+     * [candidates] are the top-2 classes scored against the agent's behavior
+     * fingerprint; the agent commits one via `select_class`. Agent stays at
+     * level 10 until the pick is made (further character XP is capped at the
+     * level-10 boundary).
+     *
+     * The [candidates] list mirrors the scorer's ranking: index 0 is the
+     * strongest fingerprint match, index 1 the runner-up. Either is a legal
+     * pick — the order is informational, not a forced default.
+     */
+    data class ClassChoiceOffered(
+        val agent: AgentId,
+        val candidates: List<AgentClass>,
+        override val tick: Long,
+    ) : AgentEvent
+
+    /**
+     * Emitted when an agent commits to a class via `select_class`. The class
+     * choice is forever — there is no respec — mirroring the no-respec rule
+     * for skill perks.
+     */
+    data class ClassChosen(
+        val agent: AgentId,
+        val classId: AgentClass,
         override val tick: Long,
     ) : AgentEvent
 }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
@@ -6,17 +6,21 @@ import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentLastActiveStore
+import dev.gvart.genesara.player.AddCharacterXpOutcome
 import dev.gvart.genesara.player.AgentProfile
 import dev.gvart.genesara.player.AgentProfileRepository
 import dev.gvart.genesara.player.AgentRegistrar
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AllocateAttributesOutcome
+import dev.gvart.genesara.player.AssignClassOutcome
 import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.AttributeDerivation
 import dev.gvart.genesara.player.AttributeMilestoneCrossing
 import dev.gvart.genesara.player.AttributePointLoss
+import dev.gvart.genesara.player.ClassOffer
 import dev.gvart.genesara.player.DeathPenaltyOutcome
 import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.player.RecordClassOfferOutcome
 import dev.gvart.genesara.player.internal.jooq.tables.records.AgentsRecord
 import dev.gvart.genesara.player.internal.jooq.tables.references.AGENTS
 import dev.gvart.genesara.player.internal.race.RaceAssigner
@@ -209,6 +213,106 @@ internal class JooqAgentRegistry(
     )
 
     @Transactional
+    override fun addCharacterXp(agentId: AgentId, delta: Int): AddCharacterXpOutcome? {
+        if (delta < 0) return AddCharacterXpOutcome.NegativeDelta
+        val record = lockAgentRow(agentId) ?: return null
+
+        val previousLevel = record[AGENTS.LEVEL]!!
+        val previousClassId = record[AGENTS.CLASS_ID]
+        val previousXpCurrent = record[AGENTS.XP_CURRENT]!!
+        val previousXpToNext = record[AGENTS.XP_TO_NEXT]!!
+        val previousUnspent = record[AGENTS.UNSPENT_ATTRIBUTE_POINTS]!!
+
+        if (delta == 0) {
+            return AddCharacterXpOutcome.Granted(
+                previousLevel = previousLevel,
+                currentLevel = previousLevel,
+                xpCurrent = previousXpCurrent,
+                xpToNext = previousXpToNext,
+                unspentAttributePoints = previousUnspent,
+                cappedAtPendingClassChoice = false,
+            )
+        }
+
+        var level = previousLevel
+        var xpCurrent = previousXpCurrent + delta
+        var xpToNext = previousXpToNext
+        var unspent = previousUnspent
+        var capped = false
+
+        while (xpCurrent >= xpToNext) {
+            if (level >= LEVEL_TEN_PENDING_CHOICE_CAP && previousClassId == null) {
+                xpCurrent = xpToNext
+                capped = true
+                break
+            }
+            xpCurrent -= xpToNext
+            level += 1
+            xpToNext = level * XP_PER_LEVEL
+            unspent += UNSPENT_PER_LEVEL_UP
+        }
+
+        dsl.update(AGENTS)
+            .set(AGENTS.LEVEL, level)
+            .set(AGENTS.XP_CURRENT, xpCurrent)
+            .set(AGENTS.XP_TO_NEXT, xpToNext)
+            .set(AGENTS.UNSPENT_ATTRIBUTE_POINTS, unspent)
+            .where(AGENTS.ID.eq(agentId.id))
+            .execute()
+
+        return AddCharacterXpOutcome.Granted(
+            previousLevel = previousLevel,
+            currentLevel = level,
+            xpCurrent = xpCurrent,
+            xpToNext = xpToNext,
+            unspentAttributePoints = unspent,
+            cappedAtPendingClassChoice = capped,
+        )
+    }
+
+    @Transactional
+    override fun recordPendingClassChoice(agentId: AgentId, offer: ClassOffer): RecordClassOfferOutcome {
+        val record = lockAgentRow(agentId) ?: return RecordClassOfferOutcome.UnknownAgent
+        if (record[AGENTS.CLASS_ID] != null) return RecordClassOfferOutcome.AlreadyClassed
+        val existing = record.toClassOfferOrNull()
+        if (existing != null) return RecordClassOfferOutcome.AlreadyOffered(existing)
+
+        dsl.update(AGENTS)
+            .set(AGENTS.OFFERED_CLASS_A, offer.first.name)
+            .set(AGENTS.OFFERED_CLASS_B, offer.second.name)
+            .where(AGENTS.ID.eq(agentId.id))
+            .execute()
+        return RecordClassOfferOutcome.Recorded
+    }
+
+    @Transactional
+    override fun assignClass(agentId: AgentId, classId: AgentClass): AssignClassOutcome {
+        val record = lockAgentRow(agentId) ?: return AssignClassOutcome.UnknownAgent
+        record[AGENTS.CLASS_ID]?.let { existing ->
+            return AssignClassOutcome.AlreadyClassed(AgentClass.valueOf(existing))
+        }
+        val pending = record.toClassOfferOrNull() ?: return AssignClassOutcome.NoPendingOffer
+        if (!pending.contains(classId)) return AssignClassOutcome.NotInOffer(pending)
+
+        dsl.update(AGENTS)
+            .set(AGENTS.CLASS_ID, classId.name)
+            .setNull(AGENTS.OFFERED_CLASS_A)
+            .setNull(AGENTS.OFFERED_CLASS_B)
+            .where(AGENTS.ID.eq(agentId.id))
+            .execute()
+        return AssignClassOutcome.Assigned
+    }
+
+    private fun AgentsRecord.toClassOfferOrNull(): ClassOffer? {
+        val a = this[AGENTS.OFFERED_CLASS_A]?.let(AgentClass::valueOf) ?: return null
+        val b = this[AGENTS.OFFERED_CLASS_B]?.let(AgentClass::valueOf) ?: return null
+        // V207 enforces a != b at the DB layer; this guard keeps reads alive on a
+        // corrupt row instead of throwing through every find()/get_status call.
+        if (a == b) return null
+        return ClassOffer(a, b)
+    }
+
+    @Transactional
     override fun applyDeathPenalty(agentId: AgentId, xpLossOnDeath: Int): DeathPenaltyOutcome? {
         require(xpLossOnDeath >= 0) { "xpLossOnDeath must be non-negative, got $xpLossOnDeath" }
         val record = lockAgentRow(agentId) ?: return null
@@ -324,6 +428,7 @@ internal class JooqAgentRegistry(
             intelligence = this[AGENTS.INTELLIGENCE]!!,
             luck = this[AGENTS.LUCK]!!,
         ),
+        offeredClasses = toClassOfferOrNull(),
     )
 
     private companion object {
@@ -332,6 +437,8 @@ internal class JooqAgentRegistry(
         const val INITIAL_XP_TO_NEXT = 100
         const val INITIAL_UNSPENT_POINTS = 5
         const val XP_PER_LEVEL = 100
+        const val UNSPENT_PER_LEVEL_UP = 5
+        const val LEVEL_TEN_PENDING_CHOICE_CAP = 10
         val ATTRIBUTE_MILESTONES = listOf(50, 100, 200)
     }
 }

--- a/player/src/main/resources/db/migration/player/V207__agent_class_offers.sql
+++ b/player/src/main/resources/db/migration/player/V207__agent_class_offers.sql
@@ -1,0 +1,20 @@
+-- Persists the level-10 class-choice offer so `select_class` can validate the
+-- pick across pod / restart boundaries. Both columns are NULL when there is
+-- no pending offer (pre-level-10 or already classed); set together when the
+-- level-10 emitter fires; cleared together when the agent commits via
+-- `select_class`. We deliberately do not promote these to a JSONB list — the
+-- top-2 cardinality is a fixed design rule (#33), and two scalar columns are
+-- the cheapest read path on the hot status projection.
+ALTER TABLE agents
+    ADD COLUMN offered_class_a VARCHAR(32),
+    ADD COLUMN offered_class_b VARCHAR(32),
+    -- Both columns share the same lifecycle and the pair must be distinct.
+    -- The CHECK is the DB-side guard that lets the Kotlin side trust the
+    -- read path: `JooqAgentRegistry.toClassOfferOrNull` can return non-null
+    -- iff both columns are non-null and different.
+    ADD CONSTRAINT agents_class_offer_paired_check CHECK (
+        (offered_class_a IS NULL AND offered_class_b IS NULL)
+        OR (offered_class_a IS NOT NULL
+            AND offered_class_b IS NOT NULL
+            AND offered_class_a <> offered_class_b)
+    );

--- a/player/src/test/kotlin/dev/gvart/genesara/player/classes/ClassFingerprintScorerTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/classes/ClassFingerprintScorerTest.kt
@@ -1,0 +1,89 @@
+package dev.gvart.genesara.player.classes
+
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.ClassDefinition
+import dev.gvart.genesara.player.SkillId
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ClassFingerprintScorerTest {
+
+    @Test
+    fun `picks the two highest dot-product scores`() {
+        val classes = listOf(
+            classFor(AgentClass.SOLDIER, mapOf("COMBAT" to 1.0)),
+            classFor(AgentClass.HUNTER, mapOf("COMBAT" to 0.6, "GATHER" to 0.4)),
+            classFor(AgentClass.ARTISAN, mapOf("CRAFT" to 1.0)),
+            classFor(AgentClass.MERCHANT, mapOf("TRADE" to 1.0)),
+        )
+        val snapshot = mapOf("COMBAT" to 100, "GATHER" to 50)
+
+        val topTwo = ClassFingerprintScorer.scoreTopTwo(snapshot, classes)
+
+        // SOLDIER: 100. HUNTER: 60 + 20 = 80. ARTISAN/MERCHANT: 0.
+        assertEquals(listOf(AgentClass.SOLDIER, AgentClass.HUNTER), topTwo)
+    }
+
+    @Test
+    fun `ties break by AgentClass ordinal so the outcome is deterministic`() {
+        val classes = listOf(
+            classFor(AgentClass.MEDIC, mapOf("MEDICAL" to 1.0)),
+            classFor(AgentClass.SOLDIER, mapOf("MEDICAL" to 1.0)),
+            classFor(AgentClass.RESEARCHER, mapOf("MEDICAL" to 1.0)),
+        )
+        val snapshot = mapOf("MEDICAL" to 5)
+
+        val topTwo = ClassFingerprintScorer.scoreTopTwo(snapshot, classes)
+
+        // All three score 5; ordinal order is SOLDIER(0), MEDIC(5), RESEARCHER(7).
+        assertEquals(listOf(AgentClass.SOLDIER, AgentClass.MEDIC), topTwo)
+    }
+
+    @Test
+    fun `axes missing from the snapshot contribute zero`() {
+        val classes = listOf(
+            classFor(AgentClass.SCOUT, mapOf("EXPLORE" to 1.0, "SOCIAL" to 0.5)),
+            classFor(AgentClass.MERCHANT, mapOf("SOCIAL" to 1.0, "TRADE" to 1.0)),
+        )
+        val snapshot = mapOf("EXPLORE" to 10)
+
+        val topTwo = ClassFingerprintScorer.scoreTopTwo(snapshot, classes)
+
+        // SCOUT: 10. MERCHANT: 0.
+        assertEquals(listOf(AgentClass.SCOUT, AgentClass.MERCHANT), topTwo)
+    }
+
+    @Test
+    fun `empty snapshot still produces a top-2 ordered by enum ordinal`() {
+        val classes = listOf(
+            classFor(AgentClass.RESEARCHER, mapOf("SOCIAL" to 1.0)),
+            classFor(AgentClass.SOLDIER, mapOf("COMBAT" to 1.0)),
+            classFor(AgentClass.SCOUT, mapOf("EXPLORE" to 1.0)),
+        )
+
+        val topTwo = ClassFingerprintScorer.scoreTopTwo(emptyMap(), classes)
+
+        assertEquals(listOf(AgentClass.SOLDIER, AgentClass.SCOUT), topTwo)
+    }
+
+    @Test
+    fun `single-class catalog returns just that class`() {
+        val classes = listOf(classFor(AgentClass.SOLDIER, mapOf("COMBAT" to 1.0)))
+
+        val topTwo = ClassFingerprintScorer.scoreTopTwo(mapOf("COMBAT" to 1), classes)
+
+        assertEquals(listOf(AgentClass.SOLDIER), topTwo)
+    }
+
+    private fun classFor(id: AgentClass, fingerprint: Map<String, Double>) = ClassDefinition(
+        id = id,
+        displayName = id.name,
+        description = "",
+        sightRange = 3,
+        primarySkills = emptySet<SkillId>(),
+        neutralSkills = emptySet(),
+        forbiddenCombatSkills = emptySet(),
+        damageMultipliers = emptyMap(),
+        behaviorFingerprint = fingerprint,
+    )
+}

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryAddCharacterXpIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryAddCharacterXpIntegrationTest.kt
@@ -1,0 +1,244 @@
+package dev.gvart.genesara.player.internal.store
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AddCharacterXpOutcome
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentProfile
+import dev.gvart.genesara.player.AgentProfileRepository
+import dev.gvart.genesara.player.AttributeMods
+import dev.gvart.genesara.player.Race
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.player.RaceLookup
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENTS
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENT_PROFILES
+import dev.gvart.genesara.player.internal.race.RaceAssigner
+import dev.gvart.genesara.player.internal.race.RaceDefinitionProperties
+import dev.gvart.genesara.player.internal.race.RandomSource
+import dev.gvart.genesara.player.internal.testsupport.PlayerFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@Testcontainers
+class JooqAgentRegistryAddCharacterXpIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("xp_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = PlayerFlyway.pooledDataSource(postgres)
+            PlayerFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private val owner = PlayerId(UUID.randomUUID())
+
+    @BeforeEach
+    fun resetTables() {
+        dsl.truncate(AGENT_PROFILES).cascade().execute()
+        dsl.truncate(AGENTS).cascade().execute()
+    }
+
+    @Test
+    fun `partial-bar grant adds xp without leveling`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Steady")
+
+        val outcome = registry.addCharacterXp(agent.id, 50)
+
+        val granted = assertIs<AddCharacterXpOutcome.Granted>(outcome)
+        assertEquals(1, granted.previousLevel)
+        assertEquals(1, granted.currentLevel)
+        assertEquals(50, granted.xpCurrent)
+        assertEquals(100, granted.xpToNext)
+        assertEquals(5, granted.unspentAttributePoints)
+        assertEquals(false, granted.cappedAtPendingClassChoice)
+        val row = readAgent(agent.id)
+        assertEquals(50, row[AGENTS.XP_CURRENT])
+        assertEquals(1, row[AGENTS.LEVEL])
+    }
+
+    @Test
+    fun `single-level grant carries surplus xp into the next bar and adds 5 unspent points`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Climber")
+
+        val outcome = registry.addCharacterXp(agent.id, 130)
+
+        val granted = assertIs<AddCharacterXpOutcome.Granted>(outcome)
+        // Cross level 1→2: consume 100 of xp_to_next=100, level becomes 2,
+        // new xp_to_next = 200, surplus = 30 stays in the bar.
+        assertEquals(2, granted.currentLevel)
+        assertEquals(30, granted.xpCurrent)
+        assertEquals(200, granted.xpToNext)
+        assertEquals(10, granted.unspentAttributePoints, "5 starter + 5 from level-up")
+    }
+
+    @Test
+    fun `multi-level cascade scales xp_to_next linearly and accumulates unspent`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Sprinter")
+
+        val outcome = registry.addCharacterXp(agent.id, 100 + 200 + 300 + 50)
+
+        val granted = assertIs<AddCharacterXpOutcome.Granted>(outcome)
+        // 1→2 burns 100 (level 2, to_next 200), 2→3 burns 200 (level 3, to_next 300),
+        // 3→4 burns 300 (level 4, to_next 400). Surplus 50 stays.
+        assertEquals(4, granted.currentLevel)
+        assertEquals(50, granted.xpCurrent)
+        assertEquals(400, granted.xpToNext)
+        assertEquals(20, granted.unspentAttributePoints, "5 starter + 5 × 3 level-ups")
+    }
+
+    @Test
+    fun `unclassed agent caps at level 10 with full bar even when surplus xp would push further`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Pretender")
+        // Seed at level 9, full bar (xp 0, to_next 900) so a single grant tries to push past 10.
+        seed(agent.id, level = 9, xpCurrent = 0, xpToNext = 900)
+
+        val grantTotal = 900 + 1000 + 5000 // overshoots level 10 by a lot
+        val outcome = registry.addCharacterXp(agent.id, grantTotal)
+
+        val granted = assertIs<AddCharacterXpOutcome.Granted>(outcome)
+        assertEquals(9, granted.previousLevel)
+        assertEquals(10, granted.currentLevel)
+        assertEquals(1000, granted.xpCurrent, "bar parks at xp_to_next")
+        assertEquals(1000, granted.xpToNext)
+        assertEquals(true, granted.cappedAtPendingClassChoice)
+        val row = readAgent(agent.id)
+        assertEquals(10, row[AGENTS.LEVEL])
+        assertEquals(1000, row[AGENTS.XP_CURRENT])
+    }
+
+    @Test
+    fun `classed agent at level 10 levels past the cap`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Veteran")
+        seed(agent.id, level = 10, xpCurrent = 0, xpToNext = 1000, classId = AgentClass.SOLDIER)
+
+        val outcome = registry.addCharacterXp(agent.id, 1100)
+
+        val granted = assertIs<AddCharacterXpOutcome.Granted>(outcome)
+        assertEquals(10, granted.previousLevel)
+        assertEquals(11, granted.currentLevel)
+        assertEquals(100, granted.xpCurrent)
+        assertEquals(1100, granted.xpToNext)
+        assertEquals(false, granted.cappedAtPendingClassChoice)
+    }
+
+    @Test
+    fun `negative delta is rejected before any DB call`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Refunder")
+
+        val outcome = registry.addCharacterXp(agent.id, -10)
+
+        assertEquals(AddCharacterXpOutcome.NegativeDelta, outcome)
+        val row = readAgent(agent.id)
+        assertEquals(0, row[AGENTS.XP_CURRENT])
+        assertEquals(1, row[AGENTS.LEVEL])
+    }
+
+    @Test
+    fun `zero delta is a no-op success`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Idle")
+
+        val outcome = registry.addCharacterXp(agent.id, 0)
+
+        val granted = assertIs<AddCharacterXpOutcome.Granted>(outcome)
+        assertEquals(1, granted.currentLevel)
+        assertEquals(0, granted.xpCurrent)
+        assertEquals(false, granted.cappedAtPendingClassChoice)
+    }
+
+    @Test
+    fun `unregistered agent returns null`() {
+        val registry = registry()
+        assertNull(registry.addCharacterXp(AgentId(UUID.randomUUID()), 50))
+    }
+
+    private fun seed(
+        id: AgentId,
+        level: Int,
+        xpCurrent: Int,
+        xpToNext: Int,
+        classId: AgentClass? = null,
+    ) {
+        val update = dsl.update(AGENTS)
+            .set(AGENTS.LEVEL, level)
+            .set(AGENTS.XP_CURRENT, xpCurrent)
+            .set(AGENTS.XP_TO_NEXT, xpToNext)
+        if (classId != null) update.set(AGENTS.CLASS_ID, classId.name)
+        update.where(AGENTS.ID.eq(id.id)).execute()
+    }
+
+    private fun registry(): JooqAgentRegistry {
+        val race = Race(
+            id = RaceId("test_race"),
+            displayName = "Test",
+            weight = 1,
+            attributeMods = AttributeMods.NONE,
+            description = "",
+        )
+        val lookup = SingleRaceLookup(race)
+        val props = RaceDefinitionProperties(defaultId = race.id.value)
+        val assigner = RaceAssigner(lookup, props, FixedRandom)
+        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner)
+    }
+
+    private fun readAgent(id: AgentId) =
+        assertNotNull(dsl.selectFrom(AGENTS).where(AGENTS.ID.eq(id.id)).fetchOne())
+
+    private class SingleRaceLookup(private val race: Race) : RaceLookup {
+        override fun byId(id: RaceId): Race? = if (id == race.id) race else null
+        override fun all(): List<Race> = listOf(race)
+    }
+
+    private object FixedRandom : RandomSource {
+        override fun nextInt(boundExclusive: Int): Int = 0
+    }
+
+    private class JooqProfileRepository(private val dsl: DSLContext) : AgentProfileRepository {
+        override fun save(profile: AgentProfile) {
+            dsl.insertInto(AGENT_PROFILES)
+                .set(AGENT_PROFILES.AGENT_ID, profile.id.id)
+                .set(AGENT_PROFILES.MAX_HP, profile.maxHp)
+                .set(AGENT_PROFILES.MAX_STAMINA, profile.maxStamina)
+                .set(AGENT_PROFILES.MAX_MANA, profile.maxMana)
+                .execute()
+        }
+    }
+}

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryClassChoiceIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryClassChoiceIntegrationTest.kt
@@ -1,0 +1,237 @@
+package dev.gvart.genesara.player.internal.store
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentProfile
+import dev.gvart.genesara.player.AgentProfileRepository
+import dev.gvart.genesara.player.AssignClassOutcome
+import dev.gvart.genesara.player.AttributeMods
+import dev.gvart.genesara.player.ClassOffer
+import dev.gvart.genesara.player.Race
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.player.RaceLookup
+import dev.gvart.genesara.player.RecordClassOfferOutcome
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENTS
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENT_PROFILES
+import dev.gvart.genesara.player.internal.race.RaceAssigner
+import dev.gvart.genesara.player.internal.race.RaceDefinitionProperties
+import dev.gvart.genesara.player.internal.race.RandomSource
+import dev.gvart.genesara.player.internal.testsupport.PlayerFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@Testcontainers
+class JooqAgentRegistryClassChoiceIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("class_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = PlayerFlyway.pooledDataSource(postgres)
+            PlayerFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private val owner = PlayerId(UUID.randomUUID())
+    private val offer = ClassOffer(AgentClass.SOLDIER, AgentClass.SCOUT)
+
+    @BeforeEach
+    fun resetTables() {
+        dsl.truncate(AGENT_PROFILES).cascade().execute()
+        dsl.truncate(AGENTS).cascade().execute()
+    }
+
+    @Test
+    fun `recordPendingClassChoice writes both columns and is reflected on find`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Recruit")
+
+        val outcome = registry.recordPendingClassChoice(agent.id, offer)
+
+        assertEquals(RecordClassOfferOutcome.Recorded, outcome)
+        val row = readAgent(agent.id)
+        assertEquals("SOLDIER", row[AGENTS.OFFERED_CLASS_A])
+        assertEquals("SCOUT", row[AGENTS.OFFERED_CLASS_B])
+        assertNull(row[AGENTS.CLASS_ID])
+        val refreshed = registry.find(agent.id)
+        assertEquals(offer, refreshed?.offeredClasses)
+    }
+
+    @Test
+    fun `recordPendingClassChoice rejects when an offer is already pending`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Doubler")
+        registry.recordPendingClassChoice(agent.id, offer)
+
+        val outcome = registry.recordPendingClassChoice(
+            agent.id,
+            ClassOffer(AgentClass.HUNTER, AgentClass.MEDIC),
+        )
+
+        val rejection = assertIs<RecordClassOfferOutcome.AlreadyOffered>(outcome)
+        assertEquals(offer, rejection.existing, "the original offer is preserved")
+        val row = readAgent(agent.id)
+        assertEquals("SOLDIER", row[AGENTS.OFFERED_CLASS_A], "no overwrite")
+    }
+
+    @Test
+    fun `recordPendingClassChoice rejects when the agent already has a class`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Veteran")
+        dsl.update(AGENTS)
+            .set(AGENTS.CLASS_ID, AgentClass.MEDIC.name)
+            .where(AGENTS.ID.eq(agent.id.id))
+            .execute()
+
+        val outcome = registry.recordPendingClassChoice(agent.id, offer)
+
+        assertEquals(RecordClassOfferOutcome.AlreadyClassed, outcome)
+    }
+
+    @Test
+    fun `recordPendingClassChoice returns UnknownAgent for missing rows`() {
+        val registry = registry()
+
+        val outcome = registry.recordPendingClassChoice(AgentId(UUID.randomUUID()), offer)
+
+        assertEquals(RecordClassOfferOutcome.UnknownAgent, outcome)
+    }
+
+    @Test
+    fun `assignClass commits the chosen class and clears the offer columns`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Picker")
+        registry.recordPendingClassChoice(agent.id, offer)
+
+        val outcome = registry.assignClass(agent.id, AgentClass.SCOUT)
+
+        assertEquals(AssignClassOutcome.Assigned, outcome)
+        val row = readAgent(agent.id)
+        assertEquals("SCOUT", row[AGENTS.CLASS_ID])
+        assertNull(row[AGENTS.OFFERED_CLASS_A])
+        assertNull(row[AGENTS.OFFERED_CLASS_B])
+        val refreshed = registry.find(agent.id)
+        assertEquals(AgentClass.SCOUT, refreshed?.classId)
+        assertNull(refreshed?.offeredClasses)
+    }
+
+    @Test
+    fun `assignClass rejects when no offer is pending`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Eager")
+
+        val outcome = registry.assignClass(agent.id, AgentClass.SCOUT)
+
+        assertEquals(AssignClassOutcome.NoPendingOffer, outcome)
+        val row = readAgent(agent.id)
+        assertNull(row[AGENTS.CLASS_ID])
+    }
+
+    @Test
+    fun `assignClass rejects when the chosen class is not in the offer`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Stray")
+        registry.recordPendingClassChoice(agent.id, offer)
+
+        val outcome = registry.assignClass(agent.id, AgentClass.RESEARCHER)
+
+        val rejection = assertIs<AssignClassOutcome.NotInOffer>(outcome)
+        assertEquals(offer, rejection.pending)
+        val row = readAgent(agent.id)
+        assertNull(row[AGENTS.CLASS_ID], "no DB mutation on rejection")
+        assertEquals("SOLDIER", row[AGENTS.OFFERED_CLASS_A])
+    }
+
+    @Test
+    fun `assignClass rejects when the agent already has a class`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Locked")
+        dsl.update(AGENTS)
+            .set(AGENTS.CLASS_ID, AgentClass.MEDIC.name)
+            .where(AGENTS.ID.eq(agent.id.id))
+            .execute()
+
+        val outcome = registry.assignClass(agent.id, AgentClass.SCOUT)
+
+        val rejection = assertIs<AssignClassOutcome.AlreadyClassed>(outcome)
+        assertEquals(AgentClass.MEDIC, rejection.existing)
+    }
+
+    @Test
+    fun `assignClass returns UnknownAgent for missing rows`() {
+        val registry = registry()
+
+        val outcome = registry.assignClass(AgentId(UUID.randomUUID()), AgentClass.SCOUT)
+
+        assertEquals(AssignClassOutcome.UnknownAgent, outcome)
+    }
+
+    private fun registry(): JooqAgentRegistry {
+        val race = Race(
+            id = RaceId("test_race"),
+            displayName = "Test",
+            weight = 1,
+            attributeMods = AttributeMods.NONE,
+            description = "",
+        )
+        val lookup = SingleRaceLookup(race)
+        val props = RaceDefinitionProperties(defaultId = race.id.value)
+        val assigner = RaceAssigner(lookup, props, FixedRandom)
+        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner)
+    }
+
+    private fun readAgent(id: AgentId) =
+        assertNotNull(dsl.selectFrom(AGENTS).where(AGENTS.ID.eq(id.id)).fetchOne())
+
+    private class SingleRaceLookup(private val race: Race) : RaceLookup {
+        override fun byId(id: RaceId): Race? = if (id == race.id) race else null
+        override fun all(): List<Race> = listOf(race)
+    }
+
+    private object FixedRandom : RandomSource {
+        override fun nextInt(boundExclusive: Int): Int = 0
+    }
+
+    private class JooqProfileRepository(private val dsl: DSLContext) : AgentProfileRepository {
+        override fun save(profile: AgentProfile) {
+            dsl.insertInto(AGENT_PROFILES)
+                .set(AGENT_PROFILES.AGENT_ID, profile.id.id)
+                .set(AGENT_PROFILES.MAX_HP, profile.maxHp)
+                .set(AGENT_PROFILES.MAX_STAMINA, profile.maxStamina)
+                .set(AGENT_PROFILES.MAX_MANA, profile.maxMana)
+                .execute()
+        }
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgression.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgression.kt
@@ -1,0 +1,41 @@
+package dev.gvart.genesara.world.internal.classes
+
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AddCharacterXpOutcome
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import org.springframework.stereotype.Component
+
+/**
+ * Canonical character-XP grant entry point. Wraps the atomic
+ * [AgentRegistry.addCharacterXp] mutation and routes any 9 → 10 transition
+ * through [Level10ChoiceEmitter] so future XP-source slices (quest rewards,
+ * NPC kills) only need to call this method.
+ *
+ * Currently no reducer wires up to this class — Phase-1 verbs only grant
+ * skill XP via `SkillProgression`. The component exists so the level-10 flow
+ * is end-to-end exercisable from integration tests, and so the wiring point
+ * is fixed for the first XP-source slice that lands.
+ */
+@Component
+internal class CharacterXpProgression(
+    private val agents: AgentRegistry,
+    private val level10: Level10ChoiceEmitter,
+    private val tickClock: TickClock,
+) {
+
+    fun grant(agentId: AgentId, delta: Int): AddCharacterXpOutcome? {
+        val outcome = agents.addCharacterXp(agentId, delta) ?: return null
+        if (outcome is AddCharacterXpOutcome.Granted &&
+            outcome.previousLevel < LEVEL_TEN_THRESHOLD &&
+            outcome.currentLevel >= LEVEL_TEN_THRESHOLD
+        ) {
+            level10.tryEmitFor(agentId, tickClock.currentTick())
+        }
+        return outcome
+    }
+
+    private companion object {
+        const val LEVEL_TEN_THRESHOLD = 10
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/Level10ChoiceEmitter.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/Level10ChoiceEmitter.kt
@@ -1,0 +1,74 @@
+package dev.gvart.genesara.world.internal.classes
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.ClassLookup
+import dev.gvart.genesara.player.ClassOffer
+import dev.gvart.genesara.player.RecordClassOfferOutcome
+import dev.gvart.genesara.player.classes.ClassFingerprintScorer
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+/**
+ * Reads the per-agent behavior snapshot, scores it against the class catalog,
+ * persists the resulting top-2 as the agent's pending class offer, and
+ * publishes [AgentEvent.ClassChoiceOffered].
+ *
+ * Idempotency lives in [AgentRegistry.recordPendingClassChoice]: the DB write
+ * rejects when the agent is already classed or already has a pending offer,
+ * so a duplicate fire is a no-op for both the persistence and the event.
+ *
+ * TODO(#35 psionics): when psionic classes land, filter the catalog by
+ * `ClassDefinition.psionicEntry` against the agent's attribute thresholds
+ * before scoring. The field is deferred per #94, so v1 candidates are the
+ * full 8-class catalog.
+ */
+@Component
+internal class Level10ChoiceEmitter(
+    private val agents: AgentRegistry,
+    private val classes: ClassLookup,
+    private val behavior: BehaviorTracker,
+    private val publisher: ApplicationEventPublisher,
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun tryEmitFor(agentId: AgentId, tick: Long) {
+        val agent = agents.find(agentId)
+        if (agent == null) {
+            log.warn("Level-10 emit skipped for {}: agent row missing", agentId.id)
+            return
+        }
+        if (agent.classId != null) return
+        if (agent.offeredClasses != null) return
+        if (agent.level < LEVEL_TEN_THRESHOLD) return
+
+        val snapshot = behavior.snapshotFor(agentId).mapKeys { it.key.name }
+        val topTwo = ClassFingerprintScorer.scoreTopTwo(snapshot, classes.all())
+        if (topTwo.size < 2) {
+            log.warn(
+                "Level-10 emitter aborted for {}: catalog produced {} candidates",
+                agentId.id, topTwo.size,
+            )
+            return
+        }
+        val offer = ClassOffer(topTwo[0], topTwo[1])
+
+        when (val outcome = agents.recordPendingClassChoice(agentId, offer)) {
+            RecordClassOfferOutcome.Recorded ->
+                publisher.publishEvent(AgentEvent.ClassChoiceOffered(agentId, offer.toList(), tick))
+
+            RecordClassOfferOutcome.AlreadyClassed,
+            is RecordClassOfferOutcome.AlreadyOffered,
+            RecordClassOfferOutcome.UnknownAgent ->
+                log.debug("Level-10 emit skipped for {}: {}", agentId.id, outcome)
+        }
+    }
+
+    private companion object {
+        const val LEVEL_TEN_THRESHOLD = 10
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgressionTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgressionTest.kt
@@ -1,0 +1,158 @@
+package dev.gvart.genesara.world.internal.classes
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AddCharacterXpOutcome
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.NoOpClassLookup
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CharacterXpProgressionTest {
+
+    private val agentId = AgentId(UUID.randomUUID())
+    private val tick = 7L
+
+    @Test
+    fun `routes a 9-to-10 transition through the level-10 emitter`() {
+        val agents = SequencedRegistry(
+            grant = AddCharacterXpOutcome.Granted(
+                previousLevel = 9,
+                currentLevel = 10,
+                xpCurrent = 0,
+                xpToNext = 1000,
+                unspentAttributePoints = 50,
+                cappedAtPendingClassChoice = false,
+            ),
+            // Agent is at level 10 with no class — emitter conditions met but the
+            // catalog is empty (NoOpClassLookup) so the emitter aborts internally.
+            // That's fine for this test: we only assert the orchestrator routed
+            // through to it (recordCalls == 0 means we never reached the registry path,
+            // which would happen on the no-op catalog's empty list).
+            stateAfter = level10Unclassed(),
+        )
+        val emitter = RecordingEmitter(agents)
+        val progression = CharacterXpProgression(agents, emitter, FixedTickClock(tick))
+
+        progression.grant(agentId, 100)
+
+        assertEquals(1, emitter.invocations)
+        assertEquals(tick, emitter.lastTick)
+    }
+
+    @Test
+    fun `does not invoke the emitter when the level did not transition into 10`() {
+        val agents = SequencedRegistry(
+            grant = AddCharacterXpOutcome.Granted(
+                previousLevel = 5,
+                currentLevel = 6,
+                xpCurrent = 0,
+                xpToNext = 600,
+                unspentAttributePoints = 30,
+                cappedAtPendingClassChoice = false,
+            ),
+            stateAfter = level10Unclassed().copy(level = 6),
+        )
+        val emitter = RecordingEmitter(agents)
+        val progression = CharacterXpProgression(agents, emitter, FixedTickClock(tick))
+
+        progression.grant(agentId, 100)
+
+        assertEquals(0, emitter.invocations)
+    }
+
+    @Test
+    fun `does not invoke the emitter when transitioning past 10 from 10`() {
+        val agents = SequencedRegistry(
+            grant = AddCharacterXpOutcome.Granted(
+                previousLevel = 10,
+                currentLevel = 11,
+                xpCurrent = 0,
+                xpToNext = 1100,
+                unspentAttributePoints = 55,
+                cappedAtPendingClassChoice = false,
+            ),
+            stateAfter = level10Unclassed().copy(level = 11),
+        )
+        val emitter = RecordingEmitter(agents)
+        val progression = CharacterXpProgression(agents, emitter, FixedTickClock(tick))
+
+        progression.grant(agentId, 1100)
+
+        assertEquals(0, emitter.invocations, "the offer fires only once, on the 9→10 boundary")
+    }
+
+    @Test
+    fun `passes through a NegativeDelta outcome without touching the emitter`() {
+        val agents = SequencedRegistry(grant = AddCharacterXpOutcome.NegativeDelta, stateAfter = level10Unclassed())
+        val emitter = RecordingEmitter(agents)
+        val progression = CharacterXpProgression(agents, emitter, FixedTickClock(tick))
+
+        val outcome = progression.grant(agentId, -5)
+
+        assertEquals(AddCharacterXpOutcome.NegativeDelta, outcome)
+        assertEquals(0, emitter.invocations)
+    }
+
+    @Test
+    fun `unknown agent (null) is propagated and the emitter is not invoked`() {
+        val agents = SequencedRegistry(grant = null, stateAfter = level10Unclassed())
+        val emitter = RecordingEmitter(agents)
+        val progression = CharacterXpProgression(agents, emitter, FixedTickClock(tick))
+
+        val outcome = progression.grant(agentId, 100)
+
+        assertNull(outcome)
+        assertEquals(0, emitter.invocations)
+    }
+
+    private fun level10Unclassed() = Agent(
+        id = agentId,
+        owner = PlayerId(UUID.randomUUID()),
+        name = "Hopeful",
+        classId = null,
+        level = 10,
+    )
+
+    private inner class RecordingEmitter(agents: AgentRegistry) : Level10ChoiceEmitter(
+        agents = agents,
+        classes = NoOpClassLookup,
+        behavior = InMemoryBehaviorTracker(),
+        publisher = SilentPublisher,
+    ) {
+        var invocations = 0
+        var lastTick: Long = -1
+
+        override fun tryEmitFor(agentId: AgentId, tick: Long) {
+            invocations += 1
+            lastTick = tick
+        }
+    }
+
+    private class SequencedRegistry(
+        private val grant: AddCharacterXpOutcome?,
+        private val stateAfter: Agent,
+    ) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = stateAfter
+        override fun listForOwner(owner: PlayerId): List<Agent> = listOf(stateAfter)
+        override fun addCharacterXp(agentId: AgentId, delta: Int): AddCharacterXpOutcome? = grant
+    }
+
+    private object SilentPublisher : ApplicationEventPublisher {
+        override fun publishEvent(event: Any) {
+            // Discard — the test only cares whether tryEmitFor was reached.
+            assertTrue(true)
+        }
+    }
+
+    private class FixedTickClock(private val tick: Long) : TickClock {
+        override fun currentTick(): Long = tick
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/Level10ChoiceEmitterTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/Level10ChoiceEmitterTest.kt
@@ -1,0 +1,185 @@
+package dev.gvart.genesara.world.internal.classes
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.ClassDefinition
+import dev.gvart.genesara.player.ClassLookup
+import dev.gvart.genesara.player.ClassOffer
+import dev.gvart.genesara.player.NoOpClassLookup
+import dev.gvart.genesara.player.RecordClassOfferOutcome
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class Level10ChoiceEmitterTest {
+
+    private val agentId = AgentId(UUID.randomUUID())
+    private val owner = PlayerId(UUID.randomUUID())
+    private val tick = 42L
+
+    @Test
+    fun `emits ClassChoiceOffered with the top-2 candidates and persists the offer`() {
+        val behavior = InMemoryBehaviorTracker().also {
+            repeat(20) { _ -> it.record(agentId, ActionCategory.COMBAT, tick) }
+            repeat(5) { _ -> it.record(agentId, ActionCategory.GATHER, tick) }
+        }
+        val classes = StubClassLookup(
+            classFor(AgentClass.SOLDIER, mapOf("COMBAT" to 1.0)),
+            classFor(AgentClass.HUNTER, mapOf("COMBAT" to 0.6, "GATHER" to 0.4)),
+            classFor(AgentClass.ARTISAN, mapOf("CRAFT" to 1.0)),
+        )
+        val agents = StubAgentRegistry(initial = level10Unclassed())
+        val publisher = RecordingPublisher()
+        val emitter = Level10ChoiceEmitter(agents, classes, behavior, publisher)
+
+        emitter.tryEmitFor(agentId, tick)
+
+        val offer = ClassOffer(AgentClass.SOLDIER, AgentClass.HUNTER)
+        assertEquals(offer, agents.recordedOffer)
+        val event = publisher.events.filterIsInstance<AgentEvent.ClassChoiceOffered>().single()
+        assertEquals(agentId, event.agent)
+        assertEquals(listOf(AgentClass.SOLDIER, AgentClass.HUNTER), event.candidates)
+        assertEquals(tick, event.tick)
+    }
+
+    @Test
+    fun `is a no-op when the agent is below level 10`() {
+        val agents = StubAgentRegistry(initial = level10Unclassed().copy(level = 9))
+        val publisher = RecordingPublisher()
+        val emitter = Level10ChoiceEmitter(agents, NoOpClassLookup, InMemoryBehaviorTracker(), publisher)
+
+        emitter.tryEmitFor(agentId, tick)
+
+        assertTrue(publisher.events.isEmpty())
+        assertEquals(0, agents.recordCalls)
+    }
+
+    @Test
+    fun `is a no-op when the agent already has a class`() {
+        val agents = StubAgentRegistry(initial = level10Unclassed().copy(classId = AgentClass.SOLDIER))
+        val publisher = RecordingPublisher()
+        val emitter = Level10ChoiceEmitter(agents, NoOpClassLookup, InMemoryBehaviorTracker(), publisher)
+
+        emitter.tryEmitFor(agentId, tick)
+
+        assertTrue(publisher.events.isEmpty())
+        assertEquals(0, agents.recordCalls)
+    }
+
+    @Test
+    fun `is a no-op when an offer is already pending`() {
+        val agents = StubAgentRegistry(
+            initial = level10Unclassed().copy(offeredClasses = ClassOffer(AgentClass.SOLDIER, AgentClass.SCOUT)),
+        )
+        val publisher = RecordingPublisher()
+        val emitter = Level10ChoiceEmitter(agents, NoOpClassLookup, InMemoryBehaviorTracker(), publisher)
+
+        emitter.tryEmitFor(agentId, tick)
+
+        assertTrue(publisher.events.isEmpty())
+        assertEquals(0, agents.recordCalls)
+    }
+
+    @Test
+    fun `does not publish when the catalog returned fewer than two candidates`() {
+        val classes = StubClassLookup(classFor(AgentClass.SOLDIER, mapOf("COMBAT" to 1.0)))
+        val agents = StubAgentRegistry(initial = level10Unclassed())
+        val publisher = RecordingPublisher()
+        val emitter = Level10ChoiceEmitter(agents, classes, InMemoryBehaviorTracker(), publisher)
+
+        emitter.tryEmitFor(agentId, tick)
+
+        assertTrue(publisher.events.isEmpty())
+        assertEquals(0, agents.recordCalls, "no DB write when scoring is unsafe")
+    }
+
+    @Test
+    fun `does not publish when the registry rejects the offer at the DB layer`() {
+        val behavior = InMemoryBehaviorTracker().also {
+            it.record(agentId, ActionCategory.COMBAT, tick)
+        }
+        val classes = StubClassLookup(
+            classFor(AgentClass.SOLDIER, mapOf("COMBAT" to 1.0)),
+            classFor(AgentClass.HUNTER, mapOf("COMBAT" to 0.5)),
+        )
+        val agents = StubAgentRegistry(
+            initial = level10Unclassed(),
+            recordResult = RecordClassOfferOutcome.AlreadyClassed,
+        )
+        val publisher = RecordingPublisher()
+        val emitter = Level10ChoiceEmitter(agents, classes, behavior, publisher)
+
+        emitter.tryEmitFor(agentId, tick)
+
+        assertEquals(1, agents.recordCalls)
+        assertTrue(
+            publisher.events.none { it is AgentEvent.ClassChoiceOffered },
+            "registry rejection suppresses the event",
+        )
+    }
+
+    private fun level10Unclassed() = Agent(
+        id = agentId,
+        owner = owner,
+        name = "Hopeful",
+        classId = null,
+        level = 10,
+        offeredClasses = null,
+    )
+
+    private fun classFor(id: AgentClass, fingerprint: Map<String, Double>) = ClassDefinition(
+        id = id,
+        displayName = id.name,
+        description = "",
+        sightRange = 3,
+        primarySkills = emptySet<SkillId>(),
+        neutralSkills = emptySet(),
+        forbiddenCombatSkills = emptySet(),
+        damageMultipliers = emptyMap(),
+        behaviorFingerprint = fingerprint,
+    )
+
+    private class StubClassLookup(vararg defs: ClassDefinition) : ClassLookup {
+        private val list = defs.toList()
+        override fun byId(classId: AgentClass): ClassDefinition? = list.firstOrNull { it.id == classId }
+        override fun all(): List<ClassDefinition> = list
+        override fun sightRange(classId: AgentClass?): Int = 3
+        override fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double = 1.0
+        override fun damageMultiplier(classId: AgentClass?, damageType: String): Double = 1.0
+        override fun forbidsCombatSkill(classId: AgentClass?, combatSkill: SkillId): Boolean = false
+    }
+
+    private class StubAgentRegistry(
+        initial: Agent,
+        private val recordResult: RecordClassOfferOutcome = RecordClassOfferOutcome.Recorded,
+    ) : AgentRegistry {
+        private var current: Agent = initial
+        var recordedOffer: ClassOffer? = null
+        var recordCalls = 0
+
+        override fun find(id: AgentId): Agent? = if (id == current.id) current else null
+        override fun listForOwner(owner: PlayerId): List<Agent> = listOf(current)
+        override fun recordPendingClassChoice(agentId: AgentId, offer: ClassOffer): RecordClassOfferOutcome {
+            recordCalls += 1
+            if (recordResult == RecordClassOfferOutcome.Recorded) recordedOffer = offer
+            return recordResult
+        }
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Step 7 of the [skill-feature sequence](../blob/main/docs/skill-feature-sequence.md). Closes #33.

- Pure `ClassFingerprintScorer` (top-2 dot product against the catalog's `behaviorFingerprint`, tie-break by `AgentClass.ordinal`).
- `AgentRegistry.addCharacterXp` cascades level-ups with a level-10 cap for unclassed agents — XP parks at the boundary until `select_class` fires; resumes cleanly once the class is committed.
- `Level10ChoiceEmitter` reads the behavior tracker snapshot, scores the catalog, persists the offer, and publishes `AgentEvent.ClassChoiceOffered`. Idempotency is anchored at the DB row.
- `CharacterXpProgression` orchestrator routes only the 9→10 boundary through the emitter.
- `select_class` MCP tool commits the choice atomically and emits `ClassChosen`.
- V207 migration adds `offered_class_a/b` with a paired-non-null + distinct-pair `CHECK`.
- `get_status` now surfaces `classId` and `pendingClassChoice` so a missed `class.offered` event is recoverable on read (parity with `pendingPerkChoices`).

## Out of scope (flagged)

- **Psionic gate** (#35): the `psionicEntry` filter is a no-op for v1, marked with a `TODO(#35)` in the emitter.
- **`SelectPerkTool` not registered in `McpServerConfiguration.gameTools`**: discovered during this slice; pre-existing bug from #63 that makes `select_perk` uncallable from MCP. Not in scope here — recommend a separate one-line PR.

## Test plan

- [x] `ClassFingerprintScorerTest` — ranking, ordinal tie-break, missing axes, empty snapshot, single-class catalog.
- [x] `JooqAgentRegistryAddCharacterXpIntegrationTest` — Testcontainers Postgres; partial bar, single + multi-level cascade, level-10 cap unclassed, classed agent past 10, negative-delta reject, zero-delta no-op, missing agent.
- [x] `JooqAgentRegistryClassChoiceIntegrationTest` — Testcontainers; record/assign happy paths + every rejection branch.
- [x] `Level10ChoiceEmitterTest` — top-2 emission, all idempotency gates, registry-rejection passthrough.
- [x] `CharacterXpProgressionTest` — 9→10 routes to emitter; no-fire on non-10 transitions, on 10→11, on `NegativeDelta`, on missing agent.
- [x] `SelectClassToolTest` — ok + every rejection variant.
- [x] `./gradlew :player:test :world:test :api:test` — green.
- [x] `./gradlew build -x test` — green (Spring AOT + boot jar wires cleanly).