### PR TITLE
docs(skill-feature): tick #34/#38 cross-issue coordination after step 8 merge

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
@@ -9,6 +9,7 @@ import dev.gvart.genesara.api.internal.mcp.tools.build.BuildTool
 import dev.gvart.genesara.api.internal.mcp.tools.chest.DepositToChestTool
 import dev.gvart.genesara.api.internal.mcp.tools.chest.WithdrawFromChestTool
 import dev.gvart.genesara.api.internal.mcp.tools.classselect.SelectClassTool
+import dev.gvart.genesara.api.internal.mcp.tools.classselect.SelectEvolutionTool
 import dev.gvart.genesara.api.internal.mcp.tools.consume.ConsumeTool
 import dev.gvart.genesara.api.internal.mcp.tools.craft.CraftTool
 import dev.gvart.genesara.api.internal.mcp.tools.drink.DrinkTool
@@ -64,6 +65,7 @@ internal class McpServerConfiguration {
         attack: AttackTool,
         useAbility: UseAbilityTool,
         selectClass: SelectClassTool,
+        selectEvolution: SelectEvolutionTool,
     ): ToolCallbackProvider =
         MethodToolCallbackProvider.builder()
             .toolObjects(
@@ -71,7 +73,7 @@ internal class McpServerConfiguration {
                 consume, drink, equipSkill, allocatePoints, inspect, getMap,
                 equipItem, unequipSlot,
                 setSafeNode, respawn, build, depositToChest, withdrawFromChest, craft, pickup, attack,
-                useAbility, selectClass,
+                useAbility, selectClass, selectEvolution,
             )
             .build()
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -69,6 +69,12 @@ internal class AgentEventDispatcher(
     fun on(event: AgentEvent.ClassChosen) = publish(event.agent, "class.chosen", event)
 
     @EventListener
+    fun on(event: AgentEvent.EvolutionChoiceOffered) = publish(event.agent, "evolution.offered", event)
+
+    @EventListener
+    fun on(event: AgentEvent.ClassEvolved) = publish(event.agent, "class.evolved", event)
+
+    @EventListener
     fun on(event: WorldEvent.ItemCrafted) = publish(event.agent, "item.crafted", event)
 
     @EventListener

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectEvolutionResponse.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectEvolutionResponse.kt
@@ -1,0 +1,31 @@
+package dev.gvart.genesara.api.internal.mcp.tools.classselect
+
+import dev.gvart.genesara.player.AgentClass
+
+/**
+ * Response shape for `select_evolution`.
+ *
+ * - `kind = "ok"`: the evolution is now permanently set on the agent;
+ *   `class_id` is the chosen evolution class, the pending offer columns are
+ *   cleared, and `from` carries the previous (base) class id.
+ * - `kind = "rejected"`: the choice was refused; `reason` carries the cause.
+ *   Possible reasons: `no_pending_offer`, `not_offered`, `no_class_assigned`,
+ *   `already_evolved`, `unknown_agent`. (An unparseable class id is rejected
+ *   by the MCP framework before reaching the tool, the same way `EquipSlot`
+ *   is.)
+ */
+data class SelectEvolutionResponse(
+    val kind: String,
+    val classId: AgentClass,
+    val from: AgentClass? = null,
+    val reason: String? = null,
+    val detail: String? = null,
+) {
+    companion object {
+        fun ok(from: AgentClass, to: AgentClass) =
+            SelectEvolutionResponse(kind = "ok", classId = to, from = from)
+
+        fun rejected(classId: AgentClass, reason: String, detail: String? = null) =
+            SelectEvolutionResponse(kind = "rejected", classId = classId, reason = reason, detail = detail)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectEvolutionTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectEvolutionTool.kt
@@ -1,0 +1,99 @@
+package dev.gvart.genesara.api.internal.mcp.tools.classselect
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AssignEvolutionOutcome
+import dev.gvart.genesara.player.events.AgentEvent
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.ai.tool.annotation.ToolParam
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+internal class SelectEvolutionTool(
+    private val agents: AgentRegistry,
+    private val tickClock: TickClock,
+    private val publisher: ApplicationEventPublisher,
+    private val activity: AgentActivityTracker,
+) {
+
+    @Tool(
+        name = "select_evolution",
+        description = "Permanently commit to one of the two evolution classes offered by the " +
+            "level-50 EvolutionChoiceOffered event. IRREVERSIBLE — the evolution overwrites the " +
+            "agent's class for the rest of its lifetime; no respec, no cross-tree pivot. Pending " +
+            "offers come from EvolutionChoiceOffered events and are also surfaced as " +
+            "`pendingEvolutionChoice` on get_status. Validates: the class id decodes, the agent " +
+            "is on a base class, and the chosen class is one of the two pending candidates.",
+    )
+    fun invoke(
+        @ToolParam(
+            required = true,
+            description = "Evolution class id chosen from the EvolutionChoiceOffered event " +
+                "candidates (e.g. HEAVY_SOLDIER, RANGER, SCHOLAR).",
+        )
+        classId: AgentClass,
+        toolContext: ToolContext,
+    ): SelectEvolutionResponse {
+        touchActivity(toolContext, activity, "select_evolution")
+        val agent = AgentContextHolder.current()
+
+        return when (val outcome = agents.assignEvolution(agent, classId)) {
+            is AssignEvolutionOutcome.Assigned -> {
+                val tick = tickClock.currentTick()
+                publisher.publishEvent(
+                    AgentEvent.ClassEvolved(
+                        agent = agent,
+                        fromClass = outcome.from,
+                        toClass = outcome.to,
+                        tick = tick,
+                    )
+                )
+                SelectEvolutionResponse.ok(from = outcome.from, to = outcome.to)
+            }
+
+            AssignEvolutionOutcome.NoClassAssigned -> SelectEvolutionResponse.rejected(
+                classId = classId,
+                reason = "no_class_assigned",
+                detail = "Agent has no class yet — pick a base class via select_class first.",
+            )
+
+            is AssignEvolutionOutcome.AlreadyEvolved -> SelectEvolutionResponse.rejected(
+                classId = classId,
+                reason = "already_evolved",
+                detail = "Agent is already evolved into ${outcome.existing.name} (evolution is forever, no respec).",
+            )
+
+            AssignEvolutionOutcome.NoPendingOffer -> SelectEvolutionResponse.rejected(
+                classId = classId,
+                reason = "no_pending_offer",
+                detail = "No pending evolution-choice offer — reach level 50 first.",
+            )
+
+            is AssignEvolutionOutcome.NotInOffer -> SelectEvolutionResponse.rejected(
+                classId = classId,
+                reason = "not_offered",
+                detail = "Pending offer is ${outcome.pending.first.name} or ${outcome.pending.second.name}; " +
+                    "${classId.name} is not one of them.",
+            )
+
+            is AssignEvolutionOutcome.WrongParent -> SelectEvolutionResponse.rejected(
+                classId = classId,
+                reason = "wrong_parent",
+                detail = "${classId.name} is an evolution of ${outcome.actualParent ?: "no class"}; " +
+                    "the agent's class is ${outcome.expectedParent.name}. Cross-tree evolution is forbidden.",
+            )
+
+            AssignEvolutionOutcome.UnknownAgent -> SelectEvolutionResponse.rejected(
+                classId = classId,
+                reason = "unknown_agent",
+                detail = "Agent ${agent.id} not found.",
+            )
+        }
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusTool.kt
@@ -70,6 +70,7 @@ internal class GetStatusTool(
             tick = engine.currentTick(),
             skills = buildSkillsView(agentId),
             pendingClassChoice = agent.offeredClasses?.toList() ?: emptyList(),
+            pendingEvolutionChoice = agent.offeredEvolutions?.toList() ?: emptyList(),
         )
     }
 

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolIo.kt
@@ -29,6 +29,14 @@ data class GetStatusResponse(
      * first entry is the strongest fingerprint match — but either is a legal pick.
      */
     val pendingClassChoice: List<AgentClass> = emptyList(),
+    /**
+     * The two evolutions offered by the level-50 event when the agent is on a
+     * base class. Empty list when no evolution offer is pending (pre-L50,
+     * mid-L50-pending, or already evolved). The agent commits one via
+     * `select_evolution`. The list mirrors the scorer's ranking — first entry
+     * is the strongest fingerprint match — but either is a legal pick.
+     */
+    val pendingEvolutionChoice: List<AgentClass> = emptyList(),
 )
 
 data class XpView(

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectEvolutionToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/classselect/SelectEvolutionToolTest.kt
@@ -1,0 +1,166 @@
+package dev.gvart.genesara.api.internal.mcp.tools.classselect
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AssignEvolutionOutcome
+import dev.gvart.genesara.player.ClassOffer
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.account.PlayerId
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.context.ApplicationEventPublisher
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SelectEvolutionToolTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val clock = MutableTestClock(Instant.parse("2026-01-01T00:00:00Z"))
+    private val activity = AgentActivityRegistry(clock)
+    private val tickClock = StubTickClock(currentTick = 50L)
+    private val toolContext = ToolContext(emptyMap())
+
+    @BeforeEach fun setUp() = AgentContextHolder.set(agent)
+    @AfterEach fun tearDown() = AgentContextHolder.clear()
+
+    @Test
+    fun `commits the chosen evolution and emits ClassEvolved at the current tick`() {
+        val agents = StubAgentRegistry(
+            assignResult = AssignEvolutionOutcome.Assigned(
+                from = AgentClass.SOLDIER,
+                to = AgentClass.HEAVY_SOLDIER,
+            ),
+        )
+        val publisher = RecordingPublisher()
+        val tool = SelectEvolutionTool(agents, tickClock, publisher, activity)
+
+        val response = tool.invoke(classId = AgentClass.HEAVY_SOLDIER, toolContext = toolContext)
+
+        assertEquals("ok", response.kind)
+        assertEquals(AgentClass.HEAVY_SOLDIER, response.classId)
+        assertEquals(AgentClass.SOLDIER, response.from)
+        val event = publisher.events.filterIsInstance<AgentEvent.ClassEvolved>().single()
+        assertEquals(agent, event.agent)
+        assertEquals(AgentClass.SOLDIER, event.fromClass)
+        assertEquals(AgentClass.HEAVY_SOLDIER, event.toClass)
+        assertEquals(50L, event.tick)
+    }
+
+    @Test
+    fun `rejects when no evolution offer is pending`() {
+        val agents = StubAgentRegistry(assignResult = AssignEvolutionOutcome.NoPendingOffer)
+        val publisher = RecordingPublisher()
+        val tool = SelectEvolutionTool(agents, tickClock, publisher, activity)
+
+        val response = tool.invoke(classId = AgentClass.HEAVY_SOLDIER, toolContext = toolContext)
+
+        assertEquals("rejected", response.kind)
+        assertEquals("no_pending_offer", response.reason)
+        assertTrue(publisher.events.none { it is AgentEvent.ClassEvolved })
+    }
+
+    @Test
+    fun `rejects when the chosen class is not in the offer and surfaces the pending pair`() {
+        val pending = ClassOffer(AgentClass.HEAVY_SOLDIER, AgentClass.STEALTH_SOLDIER)
+        val agents = StubAgentRegistry(assignResult = AssignEvolutionOutcome.NotInOffer(pending))
+        val publisher = RecordingPublisher()
+        val tool = SelectEvolutionTool(agents, tickClock, publisher, activity)
+
+        val response = tool.invoke(classId = AgentClass.COMMANDER, toolContext = toolContext)
+
+        assertEquals("not_offered", response.reason)
+        val detail = response.detail!!
+        assertTrue(detail.contains("HEAVY_SOLDIER"))
+        assertTrue(detail.contains("STEALTH_SOLDIER"))
+    }
+
+    @Test
+    fun `rejects when the agent has no class assigned`() {
+        val agents = StubAgentRegistry(assignResult = AssignEvolutionOutcome.NoClassAssigned)
+        val tool = SelectEvolutionTool(agents, tickClock, RecordingPublisher(), activity)
+
+        val response = tool.invoke(classId = AgentClass.HEAVY_SOLDIER, toolContext = toolContext)
+
+        assertEquals("no_class_assigned", response.reason)
+    }
+
+    @Test
+    fun `rejects when the agent already evolved`() {
+        val agents = StubAgentRegistry(
+            assignResult = AssignEvolutionOutcome.AlreadyEvolved(AgentClass.STEALTH_SOLDIER),
+        )
+        val publisher = RecordingPublisher()
+        val tool = SelectEvolutionTool(agents, tickClock, publisher, activity)
+
+        val response = tool.invoke(classId = AgentClass.HEAVY_SOLDIER, toolContext = toolContext)
+
+        assertEquals("already_evolved", response.reason)
+        assertTrue(response.detail!!.contains("STEALTH_SOLDIER"))
+    }
+
+    @Test
+    fun `rejects when the agent row is missing`() {
+        val agents = StubAgentRegistry(assignResult = AssignEvolutionOutcome.UnknownAgent)
+        val tool = SelectEvolutionTool(agents, tickClock, RecordingPublisher(), activity)
+
+        val response = tool.invoke(classId = AgentClass.HEAVY_SOLDIER, toolContext = toolContext)
+
+        assertEquals("unknown_agent", response.reason)
+    }
+
+    @Test
+    fun `rejects when the chosen class belongs to a different parent tree`() {
+        val agents = StubAgentRegistry(
+            assignResult = AssignEvolutionOutcome.WrongParent(
+                expectedParent = AgentClass.SOLDIER,
+                actualParent = AgentClass.SCOUT,
+            ),
+        )
+        val tool = SelectEvolutionTool(agents, tickClock, RecordingPublisher(), activity)
+
+        val response = tool.invoke(classId = AgentClass.RANGER, toolContext = toolContext)
+
+        assertEquals("wrong_parent", response.reason)
+        val detail = response.detail!!
+        assertTrue(detail.contains("SCOUT"))
+        assertTrue(detail.contains("SOLDIER"))
+    }
+
+    private class StubAgentRegistry(
+        private val assignResult: AssignEvolutionOutcome,
+    ) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = Agent(id = id, owner = PlayerId(UUID.randomUUID()), name = "stub")
+        override fun listForOwner(owner: PlayerId): List<Agent> = emptyList()
+        override fun assignEvolution(agentId: AgentId, evolutionId: AgentClass): AssignEvolutionOutcome =
+            assignResult
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+
+    private class StubTickClock(private val currentTick: Long) : TickClock {
+        override fun currentTick(): Long = currentTick
+    }
+
+    private class MutableTestClock(private var now: Instant) : Clock() {
+        override fun instant(): Instant = now
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+}

--- a/docs/lore/mechanics-reference.md
+++ b/docs/lore/mechanics-reference.md
@@ -198,10 +198,36 @@ Soldier (level 10)
 - Each class data row: `{id, baseClassId?, parentClassId?, hardRestrictions, softModifiers, eligibleSkills, requiredAttributes}`.
 - Evolution events fire on additional level milestones + behavior-fingerprint thresholds.
 
+### 4.1 Class evolution at level 50 (skill-feature step 8 / #34)
+
+**Pinned by step 8.** L50 is the only evolution milestone in v1; L100 is deferred until the L50 system has run for a while and produced behaviour data worth re-grilling.
+
+- **Trigger.** When an agent on a base class crosses the level-49 → level-50 boundary, the world emits an `EvolutionChoiceOffered{agent, fromClass, candidates: List<AgentClass>, tick}` event. Until the agent commits via `select_evolution(classId)`, further character XP is capped at the level-50 boundary (mirror of the level-10 cap).
+- **Candidate pool.** Restricted to the parent class's `evolutions: List<AgentClass>` from the catalog. The scorer ranks the windowed snapshot against each candidate's behavior fingerprint; the top-2 is offered.
+- **Window definition.** The "recent" window is **counters since `select_class` committed** — i.e., the agent's L10 → L50 behaviour. Implementation: `agent_action_counters.baseline_count` is snapshotted from `action_count` at class assignment; `snapshotForWindow` returns `action_count - baseline_count`. This keeps the storage cumulative (one row per agent×category) while delivering the "agent who pivoted playstyle can evolve down a new branch" guarantee — the L1 → L10 counts that drove the class pick no longer dominate the L50 score.
+- **Commit.** `select_evolution(classId)` validates that the chosen class is one of the offered candidates AND that `ClassLookup.byId(classId).parentClass == agent.classId`. On success it overwrites `agent.class_id` with the evolution class id and emits `ClassEvolved{agent, fromClass, toClass, tick}`. The agent's class id is now the evolution class — `class_id` is single-column; the catalog carries the parent link.
+- **Hard / soft modifiers.** The evolution's catalog row is the source of truth for `forbiddenCombatSkills`, `damageMultipliers`, `primarySkills`, and `neutralSkills`. There is no automatic inheritance from the parent — the YAML must explicitly carry forward parent restrictions (e.g., RESEARCHER's auto-firearm ban appears in every Researcher evolution). The cross-module validator catches a missing parent forbid as a startup failure rather than letting it slip into combat.
+
+### 4.2 The 24 evolution branches (3 per base class)
+
+Pinned by skill-feature decision §20. Names are stable identifiers in `AgentClass`. Per-evolution YAML carries its own `parent-class`, primary/neutral skills, damage multipliers, behavior fingerprint, and forbid list; base class entries declare a matching `evolutions: [..]` list.
+
+| Base | Evolution branches |
+|------|-------------------|
+| **SOLDIER** | `HEAVY_SOLDIER` · `STEALTH_SOLDIER` · `COMMANDER` |
+| **SCOUT** | `RANGER` · `SNIPER` · `PATHFINDER` |
+| **HUNTER** | `BEASTMASTER` · `TRAPPER` · `POACHER` |
+| **ARTISAN** | `SMITH` · `CHEF` · `JEWELER` |
+| **ENGINEER** | `TECHNICIAN` · `ARTILLERIST` · `ARCHITECT` |
+| **MEDIC** | `SURGEON` · `APOTHECARY` · `FIELD_MEDIC` |
+| **MERCHANT** | `NEGOTIATOR` · `SMUGGLER` · `CARAVAN_MASTER` |
+| **RESEARCHER** | `SCHOLAR` · `ALCHEMIST` · `NATURALIST` |
+
+`TECHNICIAN` overlaps with #38 (Drones, class-locked) — coordinate naming when #38 lands per the skill-feature cross-issue note.
+
 **Open.**
-- Full class catalog (base classes + branches).
-- Behavior-tracker scoring weights.
-- Specific evolution thresholds.
+- Full per-branch behavior weights (initial values land in step 8; expect re-grilling once L50 events run live).
+- Sub-branch evolution at L100 (deferred — design when L50 produces real data).
 
 ---
 

--- a/docs/skill-feature-sequence.md
+++ b/docs/skill-feature-sequence.md
@@ -10,7 +10,7 @@
 
 > **HOW TO USE.** When the user says "move on to next step", look here. The next unchecked box is the next slice. When a slice merges, tick the box and update **Current step** below. This file is the single source of truth for roadmap position; per-issue acceptance criteria stay tracked inside each GitHub issue.
 
-**Current step:** ⏭ **Step 8 — [#34](https://github.com/Genesara/genesara-engine/issues/34) Class evolution L50 + `select_evolution`** (Steps 1–7 merged; level-10 event live, `ClassFingerprintScorer` deterministic, `select_class` MCP tool wired, `get_status` surfaces `classId` + `pendingClassChoice` for read-path recovery; psionic gate stays deferred to #35 as a no-op)
+**Current step:** ✅ **Step 8 merged — initiative complete pending L100.** All of Track A + Track B Steps 5–8 landed; L100 evolution + perk verb-wiring for the new substrate-blocked skills are the only remaining unticks. (Step 8 — [#34](https://github.com/Genesara/genesara-engine/issues/34) Class evolution L50 + `select_evolution`: 24 evolutions in `AgentClass` + `classes.yaml`, `parentClass`/`evolutions` wired across `ClassDefinition` + `ClassLookup`, `BehaviorTracker.markBaseline`/`snapshotForWindow` with `baseline_count` column, `Level50EvolutionEmitter` + `select_evolution` MCP tool, L50 cap in `addCharacterXp` with `cappedAtPendingEvolutionChoice` flag, parent-forbid inheritance enforced in `ClassValidator`, `>= 2` evolutions enforced in `ClassCatalogConsistencyValidator`, `WrongParent`/`InvalidCandidate` defensive guards; L100 + equipment re-validation on evolution stay deferred.)
 
 ### Track A — Phase 1 mechanics + catalog
 
@@ -28,7 +28,7 @@
 - [x] **Step 5** — [#31](https://github.com/Genesara/genesara-engine/issues/31) Behavior tracker *(landed in #92; `use_ability` already wired since #67 shipped first)*
 - [x] **Step 6** — [#32](https://github.com/Genesara/genesara-engine/issues/32) Class catalog + `AgentClass` surgery *(landed in #94; 8 base classes pinned, ClassLookup public, soft-XP/damage/hard-restriction wires live; evolutions list and psionicEntry stay deferred to step 8 / psionics expansion)*
 - [x] **Step 7** — [#33](https://github.com/Genesara/genesara-engine/issues/33) Level-10 event + `select_class` *(landed in #101; `ClassFingerprintScorer` + `Level10ChoiceEmitter` + `select_class` tool live, `addCharacterXp` caps unclassed agents at level 10, `get_status` surfaces `classId` and `pendingClassChoice`. Psionic gate stays deferred to #35 — partial-close on that checkbox.)*
-- [ ] **Step 8** — [#34](https://github.com/Genesara/genesara-engine/issues/34) Class evolution L50 + `select_evolution` *(L100 stays deferred — partial-close on this checkbox)*
+- [x] **Step 8** — [#34](https://github.com/Genesara/genesara-engine/issues/34) Class evolution L50 + `select_evolution` *(L50 flow live; L100 stays deferred — partial-close on this checkbox)*
 
 ### Cross-issue ticks (apply when the parent step lands)
 

--- a/docs/skill-feature-sequence.md
+++ b/docs/skill-feature-sequence.md
@@ -34,7 +34,7 @@
 
 - [x] When #67 (step 3d) merges → tick `use_ability` row in [#5](https://github.com/Genesara/genesara-engine/issues/5); add comment to [#35](https://github.com/Genesara/genesara-engine/issues/35) noting Mana's broadened consumer base.
 - [ ] When #68 (step 4) merges → tick the rows in [#5](https://github.com/Genesara/genesara-engine/issues/5) for every new skill that maps to a verb (HUNTING, TRAPS, new combat skills, new craft skills, TRACKING, FIRECRAFT). *(Pending: #68's catalog landed but verb-wiring is deferred to substrate slices; tick each row when its substrate slice lands.)*
-- [ ] When #34 (step 8) merges → coordinate naming with [#38](https://github.com/Genesara/genesara-engine/issues/38) for the TECHNICIAN ↔ Drone-Operator overlap.
+- [x] When #34 (step 8) merges → coordinate naming with [#38](https://github.com/Genesara/genesara-engine/issues/38) for the TECHNICIAN ↔ Drone-Operator overlap. *(Comment landed on #38 noting TECHNICIAN is the ENGINEER L50 branch + drone class lock should key off ENGINEER + TECHNICIAN.)*
 
 ### Combat-coupling note
 

--- a/player/src/main/kotlin/dev/gvart/genesara/player/Agent.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/Agent.kt
@@ -19,12 +19,22 @@ data class Agent(
      * with exactly two distinct entries when present.
      */
     val offeredClasses: ClassOffer? = null,
+    /**
+     * Pending L50 evolution-choice offer set by the L50 emitter (#34). Null
+     * pre-L50, between L10 commit and L50 transition, or after the agent
+     * commits via `select_evolution`. Always non-null with exactly two distinct
+     * entries when present, and both entries are guaranteed to be evolutions
+     * of the agent's current [classId] (the L50 emitter scores against
+     * `ClassLookup.evolutionsOf(classId)`).
+     */
+    val offeredEvolutions: ClassOffer? = null,
 )
 
 /**
- * The pair of [AgentClass]es offered to the agent at the level-10 event. The
- * declaration order mirrors the scorer's ranking — [first] beats [second] —
- * but the agent may commit either via `select_class`.
+ * The pair of [AgentClass]es offered to the agent at a class milestone — the
+ * L10 class choice (#33) and the L50 evolution choice (#34) share the same
+ * shape. The declaration order mirrors the scorer's ranking — [first] beats
+ * [second] — but the agent may commit either via the matching MCP tool.
  */
 data class ClassOffer(val first: AgentClass, val second: AgentClass) {
     init { require(first != second) { "ClassOffer pair must be distinct, got $first twice" } }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentClass.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentClass.kt
@@ -2,20 +2,58 @@ package dev.gvart.genesara.player
 
 /**
  * The eight v1 base classes pinned by the skill-feature design (see
- * `docs/skill-feature-sequence.md` decisions §18 + §19). Class evolutions at
- * level 50 (24 branches, 3 per base class) land with #34 and append further
- * entries here; PSIONICS / MAGE / CLERIC stayed dropped because v1 is low-magic.
+ * `docs/skill-feature-sequence.md` decisions §18 + §19) plus the 24 L50
+ * evolution branches added by step 8 / #34 (see
+ * `docs/lore/mechanics-reference.md` §4.2 for the table). PSIONICS / MAGE /
+ * CLERIC stayed dropped because v1 is low-magic.
+ *
+ * Declaration order matters: the L10 / L50 fingerprint scorers break ties by
+ * [ordinal] (see `ClassFingerprintScorer`). Evolutions are grouped under their
+ * parent so the 24 branch ids land in catalog order.
  *
  * The string form is the storage key in `agents.class_id` (VARCHAR(32)); names
- * are stable identifiers, not display strings.
+ * are stable identifiers, not display strings. Evolutions overwrite the base
+ * class in `class_id` — the catalog (`ClassDefinition.parentClass`) is the
+ * single source of the parent link, no second column.
  */
 enum class AgentClass {
     SOLDIER,
+    HEAVY_SOLDIER,
+    STEALTH_SOLDIER,
+    COMMANDER,
+
     SCOUT,
+    RANGER,
+    SNIPER,
+    PATHFINDER,
+
     HUNTER,
+    BEASTMASTER,
+    TRAPPER,
+    POACHER,
+
     ARTISAN,
+    SMITH,
+    CHEF,
+    JEWELER,
+
     ENGINEER,
+    TECHNICIAN,
+    ARTILLERIST,
+    ARCHITECT,
+
     MEDIC,
+    SURGEON,
+    APOTHECARY,
+    FIELD_MEDIC,
+
     MERCHANT,
+    NEGOTIATOR,
+    SMUGGLER,
+    CARAVAN_MASTER,
+
     RESEARCHER,
+    SCHOLAR,
+    ALCHEMIST,
+    NATURALIST,
 }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
@@ -107,6 +107,30 @@ interface AgentRegistry {
      */
     fun assignClass(agentId: AgentId, classId: AgentClass): AssignClassOutcome =
         throw NotImplementedError("assignClass not implemented for this AgentRegistry")
+
+    /**
+     * Set the pending L50 evolution-choice offer for [agentId] to [offer].
+     * Idempotent: rejects when the agent has no class yet (pre-L10), is
+     * already on an evolution class, or already has a pending evolution offer.
+     * The L50 emitter calls this exactly once per eligible transition; the
+     * outcome decides whether
+     * [dev.gvart.genesara.player.events.AgentEvent.EvolutionChoiceOffered] is
+     * published.
+     */
+    fun recordPendingEvolutionChoice(agentId: AgentId, offer: ClassOffer): RecordEvolutionOfferOutcome =
+        throw NotImplementedError("recordPendingEvolutionChoice not implemented for this AgentRegistry")
+
+    /**
+     * Commit the agent's evolution to [evolutionId]. Validates that the agent
+     * is on a base class, that [evolutionId] is one of the two pending
+     * evolution offers, AND that [evolutionId] is a real evolution of the
+     * agent's current class (callers in `:api` must inject the catalog check
+     * — this method only verifies offer membership). Overwrites `class_id`
+     * with [evolutionId] and clears the pending offer columns on success.
+     * Evolution is forever — mirror of the L10 no-respec rule.
+     */
+    fun assignEvolution(agentId: AgentId, evolutionId: AgentClass): AssignEvolutionOutcome =
+        throw NotImplementedError("assignEvolution not implemented for this AgentRegistry")
 }
 
 /**
@@ -168,10 +192,18 @@ sealed interface AddCharacterXpOutcome {
         val unspentAttributePoints: Int,
         /**
          * True when the agent reached level 10 with no class assigned and the
-         * grant's surplus XP was dropped at the boundary. Caller can ignore;
-         * the flag exists for diagnostics and for future "queue actions" UX.
+         * grant's surplus XP was dropped at the boundary. Mutually exclusive
+         * with [cappedAtPendingEvolutionChoice]: at most one cap fires per
+         * grant.
          */
         val cappedAtPendingClassChoice: Boolean,
+        /**
+         * True when the agent reached level 50 still on a base class (no
+         * evolution chosen) and the grant's surplus XP was dropped at the
+         * boundary. The caller (`CharacterXpProgression`) routes the event
+         * through `Level50EvolutionEmitter`; this flag stays for diagnostics.
+         */
+        val cappedAtPendingEvolutionChoice: Boolean = false,
     ) : AddCharacterXpOutcome
 
     data object NegativeDelta : AddCharacterXpOutcome
@@ -192,4 +224,42 @@ sealed interface AssignClassOutcome {
     data object NoPendingOffer : AssignClassOutcome
     data class NotInOffer(val pending: ClassOffer) : AssignClassOutcome
     data object UnknownAgent : AssignClassOutcome
+}
+
+/** Result of [AgentRegistry.recordPendingEvolutionChoice]. */
+sealed interface RecordEvolutionOfferOutcome {
+    data object Recorded : RecordEvolutionOfferOutcome
+    /** Agent has no class yet — pre-L10 path; the L50 emitter should never reach this. */
+    data object NoClassAssigned : RecordEvolutionOfferOutcome
+    /** Agent is already on an evolution class (parentClass != null in the catalog). */
+    data class AlreadyEvolved(val existing: AgentClass) : RecordEvolutionOfferOutcome
+    data class AlreadyOffered(val existing: ClassOffer) : RecordEvolutionOfferOutcome
+    /**
+     * One of the offer entries is not a valid evolution of the agent's current
+     * class per the catalog. Defensive guard against a future caller that
+     * bypasses the L50 emitter and constructs an offer from the wrong tree.
+     */
+    data class InvalidCandidate(val candidate: AgentClass, val expectedParent: AgentClass) :
+        RecordEvolutionOfferOutcome
+
+    data object UnknownAgent : RecordEvolutionOfferOutcome
+}
+
+/** Result of [AgentRegistry.assignEvolution]. */
+sealed interface AssignEvolutionOutcome {
+    /** Carries the previous (base) class id and the new (evolution) class id for the event payload. */
+    data class Assigned(val from: AgentClass, val to: AgentClass) : AssignEvolutionOutcome
+    /** Agent has no class yet — should never happen if `select_evolution` is gated correctly. */
+    data object NoClassAssigned : AssignEvolutionOutcome
+    /** Agent is already on an evolution class — re-evolution / cross-tree pivot is not allowed in v1. */
+    data class AlreadyEvolved(val existing: AgentClass) : AssignEvolutionOutcome
+    data object NoPendingOffer : AssignEvolutionOutcome
+    data class NotInOffer(val pending: ClassOffer) : AssignEvolutionOutcome
+    /**
+     * The chosen class is in the offer pair AND not already taken, but the catalog
+     * says its parent is a different base class than the agent's current class.
+     * Guards against cross-tree pivots that bypass the L50 emitter.
+     */
+    data class WrongParent(val expectedParent: AgentClass, val actualParent: AgentClass?) : AssignEvolutionOutcome
+    data object UnknownAgent : AssignEvolutionOutcome
 }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/ClassDefinition.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/ClassDefinition.kt
@@ -36,12 +36,22 @@ data class ClassDefinition(
     val damageMultipliers: Map<String, Double>,
     /**
      * Per-axis weight used by the level-10 class-choice scoring algorithm
-     * (#33). Keyed by `ActionCategory.name`. Weights are non-negative; missing
-     * keys read as 0.0.
-     *
-     * TODO(level-10-event): unread by reducers in this slice — populated in
-     * step 6 (#32) so #33's scoring algorithm can ship without a YAML
-     * migration. Wire the reader when the level-10 event reducer lands.
+     * (#33) and the L50 evolution scoring algorithm (#34). Keyed by
+     * `ActionCategory.name`. Weights are non-negative; missing keys read as 0.0.
      */
     val behaviorFingerprint: Map<String, Double>,
+    /**
+     * Back-link to the base class for evolution entries (e.g. HEAVY_SOLDIER →
+     * SOLDIER). Null on base classes. Set from YAML `parent-class` and
+     * cross-validated against the parent's [evolutions] list at startup.
+     */
+    val parentClass: AgentClass? = null,
+    /**
+     * Evolution branches available to this class at the L50 event (#34). Empty
+     * on evolution entries (single L50 evolution per agent in v1; L100 sub-
+     * branches stay deferred). The L50 emitter scores the agent's windowed
+     * fingerprint against each entry's [behaviorFingerprint] and offers the
+     * top-2.
+     */
+    val evolutions: List<AgentClass> = emptyList(),
 )

--- a/player/src/main/kotlin/dev/gvart/genesara/player/ClassLookup.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/ClassLookup.kt
@@ -11,8 +11,21 @@ interface ClassLookup {
     /** Catalog entry for [classId]; null when the YAML is missing the entry. */
     fun byId(classId: AgentClass): ClassDefinition?
 
-    /** All entries in `AgentClass` declaration order. */
+    /** All entries (base + evolutions) in `AgentClass` declaration order. */
     fun all(): List<ClassDefinition>
+
+    /**
+     * Base classes only (entries with `parentClass == null`). The L10 fingerprint
+     * scorer iterates this list — evolutions are never offered at level 10.
+     */
+    fun baseClasses(): List<ClassDefinition>
+
+    /**
+     * The L50 evolution candidates declared by [parent]. Empty when [parent] is
+     * itself an evolution or has no entry. The L50 fingerprint scorer iterates
+     * this list against the windowed behavior snapshot.
+     */
+    fun evolutionsOf(parent: AgentClass): List<ClassDefinition>
 
     /**
      * Sight radius in nodes used by `VisionRadiusImpl`. Returns the catalog
@@ -53,6 +66,8 @@ interface ClassLookup {
 object NoOpClassLookup : ClassLookup {
     override fun byId(classId: AgentClass): ClassDefinition? = null
     override fun all(): List<ClassDefinition> = emptyList()
+    override fun baseClasses(): List<ClassDefinition> = emptyList()
+    override fun evolutionsOf(parent: AgentClass): List<ClassDefinition> = emptyList()
     override fun sightRange(classId: AgentClass?): Int = 3
     override fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double = 1.0
     override fun damageMultiplier(classId: AgentClass?, damageType: String): Double = 1.0

--- a/player/src/main/kotlin/dev/gvart/genesara/player/events/AgentEvent.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/events/AgentEvent.kt
@@ -107,4 +107,34 @@ sealed interface AgentEvent {
         val classId: AgentClass,
         override val tick: Long,
     ) : AgentEvent
+
+    /**
+     * Emitted once when an agent on a base class reaches level 50. The two
+     * [candidates] are the top-2 evolutions of [fromClass] scored against the
+     * agent's *windowed* behavior fingerprint (counters since `select_class`
+     * committed — see `mechanics-reference.md` §4.1). Agent stays at level 50
+     * until the pick is made (further character XP is capped at the level-50
+     * boundary). The agent commits one via `select_evolution`; either pick is
+     * legal.
+     */
+    data class EvolutionChoiceOffered(
+        val agent: AgentId,
+        val fromClass: AgentClass,
+        val candidates: List<AgentClass>,
+        override val tick: Long,
+    ) : AgentEvent
+
+    /**
+     * Emitted when an agent commits to an evolution via `select_evolution`.
+     * [fromClass] is the base class and [toClass] is the chosen evolution;
+     * both are recorded so subscribers can recompute class-derived state
+     * (e.g. equipment hard-restriction caches) without an extra read.
+     * Evolution is forever — mirror of the L10 no-respec rule.
+     */
+    data class ClassEvolved(
+        val agent: AgentId,
+        val fromClass: AgentClass,
+        val toClass: AgentClass,
+        override val tick: Long,
+    ) : AgentEvent
 }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/ClassDefinitionLookup.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/ClassDefinitionLookup.kt
@@ -21,6 +21,14 @@ internal class ClassDefinitionLookup(
     override fun all(): List<ClassDefinition> =
         AgentClass.entries.mapNotNull { byId[it] }
 
+    override fun baseClasses(): List<ClassDefinition> =
+        AgentClass.entries.mapNotNull { byId[it] }.filter { it.parentClass == null }
+
+    override fun evolutionsOf(parent: AgentClass): List<ClassDefinition> =
+        byId[parent]?.evolutions
+            ?.mapNotNull { byId[it] }
+            ?: emptyList()
+
     override fun sightRange(classId: AgentClass?): Int =
         classId?.let { byId[it]?.sightRange } ?: props.default.sightRange
 
@@ -53,6 +61,8 @@ internal class ClassDefinitionLookup(
         forbiddenCombatSkills = forbiddenCombatSkills.map(::SkillId).toSet(),
         damageMultipliers = damageMultipliers,
         behaviorFingerprint = behaviorFingerprint,
+        parentClass = parentClass,
+        evolutions = evolutions,
     )
 
     private companion object {

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/ClassProperties.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/ClassProperties.kt
@@ -18,4 +18,8 @@ internal data class ClassProperties(
     val forbiddenCombatSkills: List<String> = emptyList(),
     val damageMultipliers: Map<String, Double> = emptyMap(),
     val behaviorFingerprint: Map<String, Double> = emptyMap(),
+    /** Back-link from an evolution to its base class. Null on base classes. */
+    val parentClass: dev.gvart.genesara.player.AgentClass? = null,
+    /** Forward-link from a base class to its L50 evolution branches. Empty on evolutions. */
+    val evolutions: List<dev.gvart.genesara.player.AgentClass> = emptyList(),
 )

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/ClassValidator.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/ClassValidator.kt
@@ -41,10 +41,65 @@ internal class ClassValidator(
             entry.collectProblems(id, skillIds, problems)
         }
 
+        validateEvolutionLinks(problems)
+
         require(problems.isEmpty()) {
             buildString {
                 append("Class catalog failed validation:\n")
                 problems.forEach { appendLine("  - $it") }
+            }
+        }
+    }
+
+    /**
+     * Cross-check the parent ↔ evolutions back-link for the L50 system (#34):
+     *  - every `evolutions` entry must point at a class with `parent-class` set to the parent,
+     *  - every `parent-class` ref must point at a base class (no chained evolutions in v1),
+     *  - the parent's `evolutions` list must contain this class,
+     *  - the parent must not list itself as an evolution.
+     */
+    private fun validateEvolutionLinks(out: MutableList<String>) {
+        AgentClass.entries.forEach { id ->
+            val entry = props.classes[id] ?: return@forEach
+
+            entry.parentClass?.let { parent ->
+                val parentEntry = props.classes[parent]
+                if (parentEntry == null) {
+                    out += "$id: parent-class $parent has no entry"
+                    return@let
+                }
+                if (parentEntry.parentClass != null) {
+                    out += "$id: parent-class $parent is itself an evolution (chained evolutions are out of scope in v1)"
+                }
+                if (id !in parentEntry.evolutions) {
+                    out += "$id: parent-class $parent does not list $id in its evolutions"
+                }
+            }
+
+            entry.evolutions.forEach { evo ->
+                if (evo == id) {
+                    out += "$id: lists itself as an evolution"
+                    return@forEach
+                }
+                val evoEntry = props.classes[evo]
+                if (evoEntry == null) {
+                    out += "$id: evolutions reference $evo which has no entry"
+                    return@forEach
+                }
+                if (evoEntry.parentClass != id) {
+                    out += "$id: lists $evo as an evolution but $evo's parent-class is ${evoEntry.parentClass ?: "null (base class)"}"
+                }
+                // Spec mechanics-reference §4.1: hard restrictions don't auto-inherit
+                // from the parent — the YAML must restate them. The validator catches
+                // a missing parent forbid as a startup failure rather than letting it
+                // slip into combat (e.g. a Researcher evolution that drops the FIREARMS
+                // ban would silently let scholars wield rifles).
+                val parentForbids = entry.forbiddenCombatSkills.toSet()
+                val evoForbids = evoEntry.forbiddenCombatSkills.toSet()
+                val missing = parentForbids - evoForbids
+                if (missing.isNotEmpty()) {
+                    out += "$evo: missing parent-class $id's forbidden-combat-skills: ${missing.sorted()}"
+                }
             }
         }
     }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
@@ -13,14 +13,17 @@ import dev.gvart.genesara.player.AgentRegistrar
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AllocateAttributesOutcome
 import dev.gvart.genesara.player.AssignClassOutcome
+import dev.gvart.genesara.player.AssignEvolutionOutcome
 import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.AttributeDerivation
 import dev.gvart.genesara.player.AttributeMilestoneCrossing
 import dev.gvart.genesara.player.AttributePointLoss
+import dev.gvart.genesara.player.ClassLookup
 import dev.gvart.genesara.player.ClassOffer
 import dev.gvart.genesara.player.DeathPenaltyOutcome
 import dev.gvart.genesara.player.RaceId
 import dev.gvart.genesara.player.RecordClassOfferOutcome
+import dev.gvart.genesara.player.RecordEvolutionOfferOutcome
 import dev.gvart.genesara.player.internal.jooq.tables.records.AgentsRecord
 import dev.gvart.genesara.player.internal.jooq.tables.references.AGENTS
 import dev.gvart.genesara.player.internal.race.RaceAssigner
@@ -37,6 +40,7 @@ internal class JooqAgentRegistry(
     private val dsl: DSLContext,
     private val profiles: AgentProfileRepository,
     private val raceAssigner: RaceAssigner,
+    private val classes: ClassLookup,
 ) : AgentRegistry, AgentRegistrar, AgentLastActiveStore {
 
     override fun find(id: AgentId): Agent? =
@@ -218,7 +222,7 @@ internal class JooqAgentRegistry(
         val record = lockAgentRow(agentId) ?: return null
 
         val previousLevel = record[AGENTS.LEVEL]!!
-        val previousClassId = record[AGENTS.CLASS_ID]
+        val previousClassId = record[AGENTS.CLASS_ID]?.let(AgentClass::valueOf)
         val previousXpCurrent = record[AGENTS.XP_CURRENT]!!
         val previousXpToNext = record[AGENTS.XP_TO_NEXT]!!
         val previousUnspent = record[AGENTS.UNSPENT_ATTRIBUTE_POINTS]!!
@@ -231,8 +235,11 @@ internal class JooqAgentRegistry(
                 xpToNext = previousXpToNext,
                 unspentAttributePoints = previousUnspent,
                 cappedAtPendingClassChoice = false,
+                cappedAtPendingEvolutionChoice = false,
             )
         }
+
+        val capLevel = computeCapLevel(previousClassId)
 
         var level = previousLevel
         var xpCurrent = previousXpCurrent + delta
@@ -241,7 +248,7 @@ internal class JooqAgentRegistry(
         var capped = false
 
         while (xpCurrent >= xpToNext) {
-            if (level >= LEVEL_TEN_PENDING_CHOICE_CAP && previousClassId == null) {
+            if (level >= capLevel) {
                 xpCurrent = xpToNext
                 capped = true
                 break
@@ -266,8 +273,29 @@ internal class JooqAgentRegistry(
             xpCurrent = xpCurrent,
             xpToNext = xpToNext,
             unspentAttributePoints = unspent,
-            cappedAtPendingClassChoice = capped,
+            cappedAtPendingClassChoice = capped && capLevel == LEVEL_TEN_PENDING_CHOICE_CAP,
+            cappedAtPendingEvolutionChoice = capped && capLevel == LEVEL_FIFTY_EVOLUTION_CAP,
         )
+    }
+
+    /**
+     * Decides which level boundary halts XP cascade for this agent:
+     *  - **Pre-L10** (no class): cap at level 10 — the agent must call `select_class`.
+     *  - **On a base class** (catalog `parentClass == null`) with declared
+     *    evolutions: cap at level 50 — the agent must call `select_evolution`.
+     *    The evolutions check defends against a YAML edit that empties a base
+     *    class's evolution list; without a candidate to offer the cap would
+     *    strand the agent at L50 forever.
+     *  - **On an evolution class**: no cap. L100 stays deferred per `mechanics-reference.md` §4.1.
+     */
+    private fun computeCapLevel(previousClassId: AgentClass?): Int {
+        if (previousClassId == null) return LEVEL_TEN_PENDING_CHOICE_CAP
+        val def = classes.byId(previousClassId) ?: return Int.MAX_VALUE
+        return if (def.parentClass == null && def.evolutions.size >= 2) {
+            LEVEL_FIFTY_EVOLUTION_CAP
+        } else {
+            Int.MAX_VALUE
+        }
     }
 
     @Transactional
@@ -308,6 +336,77 @@ internal class JooqAgentRegistry(
         val b = this[AGENTS.OFFERED_CLASS_B]?.let(AgentClass::valueOf) ?: return null
         // V207 enforces a != b at the DB layer; this guard keeps reads alive on a
         // corrupt row instead of throwing through every find()/get_status call.
+        if (a == b) return null
+        return ClassOffer(a, b)
+    }
+
+    @Transactional
+    override fun recordPendingEvolutionChoice(agentId: AgentId, offer: ClassOffer): RecordEvolutionOfferOutcome {
+        val record = lockAgentRow(agentId) ?: return RecordEvolutionOfferOutcome.UnknownAgent
+        val classId = record[AGENTS.CLASS_ID]?.let(AgentClass::valueOf)
+            ?: return RecordEvolutionOfferOutcome.NoClassAssigned
+        val def = classes.byId(classId)
+        if (def?.parentClass != null) {
+            return RecordEvolutionOfferOutcome.AlreadyEvolved(classId)
+        }
+        for (candidate in offer.toList()) {
+            val candidateDef = classes.byId(candidate)
+            if (candidateDef?.parentClass != classId) {
+                return RecordEvolutionOfferOutcome.InvalidCandidate(candidate, classId)
+            }
+        }
+        val existing = record.toEvolutionOfferOrNull()
+        if (existing != null) return RecordEvolutionOfferOutcome.AlreadyOffered(existing)
+
+        dsl.update(AGENTS)
+            .set(AGENTS.OFFERED_EVOLUTION_A, offer.first.name)
+            .set(AGENTS.OFFERED_EVOLUTION_B, offer.second.name)
+            .where(AGENTS.ID.eq(agentId.id))
+            .execute()
+        return RecordEvolutionOfferOutcome.Recorded
+    }
+
+    @Transactional
+    override fun assignEvolution(agentId: AgentId, evolutionId: AgentClass): AssignEvolutionOutcome {
+        val record = lockAgentRow(agentId) ?: return AssignEvolutionOutcome.UnknownAgent
+        val classId = record[AGENTS.CLASS_ID]?.let(AgentClass::valueOf)
+            ?: return AssignEvolutionOutcome.NoClassAssigned
+        val def = classes.byId(classId)
+        if (def?.parentClass != null) {
+            return AssignEvolutionOutcome.AlreadyEvolved(classId)
+        }
+        val pending = record.toEvolutionOfferOrNull() ?: return AssignEvolutionOutcome.NoPendingOffer
+        if (!pending.contains(evolutionId)) return AssignEvolutionOutcome.NotInOffer(pending)
+        // Spec mechanics-reference §4.1: select_evolution validates BOTH offer
+        // membership AND that the chosen class's parentClass equals the agent's
+        // current class. The membership check above is a transitive guarantee
+        // (the offer was scored from evolutionsOf(parent)), but a corrupt row
+        // or a future caller bypassing the emitter could violate it; the
+        // catalog re-check is the load-bearing guard.
+        val targetParent = classes.byId(evolutionId)?.parentClass
+        if (targetParent != classId) {
+            return AssignEvolutionOutcome.WrongParent(expectedParent = classId, actualParent = targetParent)
+        }
+
+        dsl.update(AGENTS)
+            .set(AGENTS.CLASS_ID, evolutionId.name)
+            .setNull(AGENTS.OFFERED_EVOLUTION_A)
+            .setNull(AGENTS.OFFERED_EVOLUTION_B)
+            .where(AGENTS.ID.eq(agentId.id))
+            .execute()
+        // TODO(post-#34, equipment-revalidation): when a future evolution introduces
+        // a forbidden-combat-skill the parent doesn't have (today only the
+        // RESEARCHER family forbids FIREARMS, and ClassValidator enforces parent
+        // forbid inheritance — so no L10→L50 transition can break an existing equip),
+        // wire an EventListener<ClassEvolved> in :world that auto-unequips the
+        // affected items and emits a CLASS_FORBIDDEN_BY_EVOLUTION rejection so the
+        // agent finds out about it.
+        return AssignEvolutionOutcome.Assigned(from = classId, to = evolutionId)
+    }
+
+    private fun AgentsRecord.toEvolutionOfferOrNull(): ClassOffer? {
+        val a = this[AGENTS.OFFERED_EVOLUTION_A]?.let(AgentClass::valueOf) ?: return null
+        val b = this[AGENTS.OFFERED_EVOLUTION_B]?.let(AgentClass::valueOf) ?: return null
         if (a == b) return null
         return ClassOffer(a, b)
     }
@@ -429,6 +528,7 @@ internal class JooqAgentRegistry(
             luck = this[AGENTS.LUCK]!!,
         ),
         offeredClasses = toClassOfferOrNull(),
+        offeredEvolutions = toEvolutionOfferOrNull(),
     )
 
     private companion object {
@@ -439,6 +539,7 @@ internal class JooqAgentRegistry(
         const val XP_PER_LEVEL = 100
         const val UNSPENT_PER_LEVEL_UP = 5
         const val LEVEL_TEN_PENDING_CHOICE_CAP = 10
+        const val LEVEL_FIFTY_EVOLUTION_CAP = 50
         val ATTRIBUTE_MILESTONES = listOf(50, 100, 200)
     }
 }

--- a/player/src/main/resources/db/migration/player/V208__agent_evolution_offers.sql
+++ b/player/src/main/resources/db/migration/player/V208__agent_evolution_offers.sql
@@ -1,0 +1,20 @@
+-- Skill-feature step 8 (issue #34): persists the L50 evolution offer in the
+-- same shape V207 used for the L10 class offer. Both columns are NULL when
+-- there is no pending evolution offer (pre-L50, mid-L50-pending, or already
+-- evolved); set together when the L50 emitter fires; cleared together when
+-- the agent commits via `select_evolution`.
+--
+-- Two scalar columns rather than a JSONB list: top-2 cardinality is fixed by
+-- the design (mirrors L10), and two columns keep the read on the hot status
+-- projection cheap. No second `evolution_class_id` column — `select_evolution`
+-- overwrites `class_id` with the evolution class, and the catalog
+-- (`ClassDefinition.parentClass`) carries the link back to the base class.
+ALTER TABLE agents
+    ADD COLUMN offered_evolution_a VARCHAR(32),
+    ADD COLUMN offered_evolution_b VARCHAR(32),
+    ADD CONSTRAINT agents_evolution_offer_paired_check CHECK (
+        (offered_evolution_a IS NULL AND offered_evolution_b IS NULL)
+        OR (offered_evolution_a IS NOT NULL
+            AND offered_evolution_b IS NOT NULL
+            AND offered_evolution_a <> offered_evolution_b)
+    );

--- a/player/src/main/resources/player-definition/classes.yaml
+++ b/player/src/main/resources/player-definition/classes.yaml
@@ -32,6 +32,7 @@ player:
         EXPLORE: 0.2
         MEDICAL: 0.0
         TRADE: 0.0
+      evolutions: [HEAVY_SOLDIER, STEALTH_SOLDIER, COMMANDER]
 
     SCOUT:
       display-name: Scout
@@ -59,6 +60,7 @@ player:
         EXPLORE: 1.0
         MEDICAL: 0.0
         TRADE: 0.1
+      evolutions: [RANGER, SNIPER, PATHFINDER]
 
     HUNTER:
       display-name: Hunter
@@ -87,6 +89,7 @@ player:
         EXPLORE: 0.7
         MEDICAL: 0.1
         TRADE: 0.2
+      evolutions: [BEASTMASTER, TRAPPER, POACHER]
 
     ARTISAN:
       display-name: Artisan
@@ -115,6 +118,7 @@ player:
         EXPLORE: 0.1
         MEDICAL: 0.1
         TRADE: 0.4
+      evolutions: [SMITH, CHEF, JEWELER]
 
     ENGINEER:
       display-name: Engineer
@@ -143,6 +147,7 @@ player:
         EXPLORE: 0.2
         MEDICAL: 0.0
         TRADE: 0.2
+      evolutions: [TECHNICIAN, ARTILLERIST, ARCHITECT]
 
     MEDIC:
       display-name: Medic
@@ -171,6 +176,7 @@ player:
         EXPLORE: 0.1
         MEDICAL: 1.0
         TRADE: 0.2
+      evolutions: [SURGEON, APOTHECARY, FIELD_MEDIC]
 
     MERCHANT:
       display-name: Merchant
@@ -199,6 +205,7 @@ player:
         EXPLORE: 0.3
         MEDICAL: 0.0
         TRADE: 1.0
+      evolutions: [NEGOTIATOR, SMUGGLER, CARAVAN_MASTER]
 
     RESEARCHER:
       display-name: Researcher
@@ -226,4 +233,654 @@ player:
         SOCIAL: 0.3
         EXPLORE: 0.6
         MEDICAL: 0.5
+        TRADE: 0.2
+      evolutions: [SCHOLAR, ALCHEMIST, NATURALIST]
+
+    # ─────────────── Evolution branches (level 50, #34) ────────────────
+    # Each evolution carries its own primary/neutral/forbidden/damage/fingerprint
+    # data. There is no automatic inheritance from the parent — RESEARCHER's
+    # FIREARMS forbid is restated explicitly on every Researcher evolution.
+    # `parent-class` is the back-link the L50 emitter uses to validate that the
+    # picked class is a legal evolution of the agent's current class.
+
+    HEAVY_SOLDIER:
+      display-name: Heavy Soldier
+      description: >-
+        Armoured frontline tank. Shield, two-handed weapons, and the soldier
+        evolution that absorbs hits while the rest of the party manoeuvres.
+      parent-class: SOLDIER
+      sight-range: 3
+      primary-skills: [SHIELD, AXE, CLUB, POLEARM, SWORD, ATHLETICS, INTIMIDATION]
+      neutral-skills: [DUAL_WIELD, SPEAR, ANATOMY, LEADERSHIP]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        BLUNT: 1.2
+        SLASH: 1.15
+        PIERCE: 1.0
+        ENERGY: 0.9
+        MAGICAL: 0.85
+      behavior-fingerprint:
+        COMBAT: 1.4
+        GATHER: 0.0
+        CRAFT: 0.0
+        BUILD: 0.2
+        SOCIAL: 0.2
+        EXPLORE: 0.1
+        MEDICAL: 0.0
+        TRADE: 0.0
+
+    STEALTH_SOLDIER:
+      display-name: Stealth Soldier
+      description: >-
+        Light infantry skirmisher. Dual blades, tumbling, and quiet approach —
+        the soldier branch for agents whose post-class fights skewed toward
+        stealth and acrobatics.
+      parent-class: SOLDIER
+      sight-range: 3
+      primary-skills: [DAGGER, DUAL_WIELD, SWORD, ACROBATICS, STEALTH, ATHLETICS]
+      neutral-skills: [SHIELD, BOW, CROSSBOW, INTIMIDATION]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        PIERCE: 1.2
+        SLASH: 1.1
+        BLUNT: 0.9
+        ENERGY: 0.95
+        MAGICAL: 0.85
+      behavior-fingerprint:
+        COMBAT: 1.2
+        GATHER: 0.1
+        CRAFT: 0.0
+        BUILD: 0.0
+        SOCIAL: 0.1
+        EXPLORE: 0.5
+        MEDICAL: 0.0
+        TRADE: 0.0
+
+    COMMANDER:
+      display-name: Commander
+      description: >-
+        Battlefield orchestrator. Polearm, shield, and the voice that holds a
+        line — the soldier branch for agents who paired combat with a steady
+        diet of leadership and persuasion verbs.
+      parent-class: SOLDIER
+      sight-range: 3
+      primary-skills: [LEADERSHIP, INTIMIDATION, SWORD, POLEARM, SHIELD, ATHLETICS, PERSUASION]
+      neutral-skills: [ANATOMY, BOW, AXE, SURVIVAL]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        SLASH: 1.05
+        BLUNT: 1.05
+        PIERCE: 1.0
+        ENERGY: 0.95
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 1.0
+        GATHER: 0.0
+        CRAFT: 0.0
+        BUILD: 0.1
+        SOCIAL: 0.8
+        EXPLORE: 0.2
+        MEDICAL: 0.0
+        TRADE: 0.1
+
+    RANGER:
+      display-name: Ranger
+      description: >-
+        Long-range woodsman. Bow, climbing, and fire-craft; the scout branch
+        for agents who lived in the wild between settlements.
+      parent-class: SCOUT
+      sight-range: 4
+      primary-skills: [BOW, CROSSBOW, ACROBATICS, CLIMBING, SURVIVAL, TRACKING, STEALTH, FIRECRAFT]
+      neutral-skills: [DAGGER, SPEAR, ATHLETICS, BEAST_LORE]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        PIERCE: 1.15
+        SLASH: 1.0
+        BLUNT: 0.85
+        ENERGY: 1.0
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 0.7
+        GATHER: 0.4
+        CRAFT: 0.0
+        BUILD: 0.0
+        SOCIAL: 0.1
+        EXPLORE: 1.2
+        MEDICAL: 0.0
+        TRADE: 0.1
+
+    SNIPER:
+      display-name: Sniper
+      description: >-
+        Precision shooter. Long-range engagement with bow, crossbow, and
+        firearm — the scout branch for an agent whose level-10-to-50 stretch
+        was a high-COMBAT explorer.
+      parent-class: SCOUT
+      sight-range: 5
+      primary-skills: [BOW, CROSSBOW, FIREARMS, STEALTH, ACROBATICS, ATHLETICS]
+      neutral-skills: [DAGGER, CARTOGRAPHY, SURVIVAL, INTIMIDATION]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        PIERCE: 1.3
+        SLASH: 0.85
+        BLUNT: 0.85
+        ENERGY: 1.05
+        MAGICAL: 0.85
+      behavior-fingerprint:
+        COMBAT: 1.0
+        GATHER: 0.1
+        CRAFT: 0.0
+        BUILD: 0.0
+        SOCIAL: 0.1
+        EXPLORE: 0.9
+        MEDICAL: 0.0
+        TRADE: 0.0
+
+    PATHFINDER:
+      display-name: Pathfinder
+      description: >-
+        Map-maker and terrain expert. Cartography, tracking, and the long
+        roads — the scout branch for agents who pivoted away from combat
+        toward pure exploration.
+      parent-class: SCOUT
+      sight-range: 5
+      primary-skills: [CARTOGRAPHY, TRACKING, CLIMBING, SURVIVAL, ACROBATICS, BEAST_LORE]
+      neutral-skills: [BOW, DAGGER, ATHLETICS, FIRECRAFT, FORAGING]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        PIERCE: 1.05
+        SLASH: 0.95
+        BLUNT: 0.9
+        ENERGY: 1.0
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 0.4
+        GATHER: 0.5
+        CRAFT: 0.0
+        BUILD: 0.0
+        SOCIAL: 0.1
+        EXPLORE: 1.5
+        MEDICAL: 0.0
+        TRADE: 0.2
+
+    BEASTMASTER:
+      display-name: Beastmaster
+      description: >-
+        Animal handler and mount specialist. Reads beasts; rides, herds, and
+        commands them — the hunter branch for agents who paired hunting with
+        animal-handling verbs.
+      parent-class: HUNTER
+      sight-range: 4
+      primary-skills: [ANIMAL_HANDLING, BEAST_LORE, BOW, SPEAR, HUNTING, TRACKING, SURVIVAL]
+      neutral-skills: [TRAPS, FIRECRAFT, LEATHERWORKING, ACROBATICS]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        PIERCE: 1.1
+        SLASH: 1.05
+        BLUNT: 0.9
+        ENERGY: 0.9
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 0.7
+        GATHER: 0.7
+        CRAFT: 0.1
+        BUILD: 0.0
+        SOCIAL: 0.2
+        EXPLORE: 0.7
+        MEDICAL: 0.2
+        TRADE: 0.2
+
+    TRAPPER:
+      display-name: Trapper
+      description: >-
+        Snare and pitfall specialist. The hunter branch for agents whose
+        windowed counters skewed toward placed traps and harvested kills
+        rather than direct engagement.
+      parent-class: HUNTER
+      sight-range: 3
+      primary-skills: [TRAPS, HUNTING, TRACKING, SURVIVAL, FIRECRAFT, LEATHERWORKING]
+      neutral-skills: [BOW, SPEAR, DAGGER, COOKING, BEAST_LORE]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        PIERCE: 1.1
+        SLASH: 1.0
+        BLUNT: 1.0
+        ENERGY: 0.9
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 0.5
+        GATHER: 1.0
+        CRAFT: 0.3
+        BUILD: 0.1
+        SOCIAL: 0.1
+        EXPLORE: 0.7
+        MEDICAL: 0.1
+        TRADE: 0.2
+
+    POACHER:
+      display-name: Poacher
+      description: >-
+        Quiet, illicit hunter. Stealth and pickpocket alongside hunting and
+        leather-work — the hunter branch for agents who learned to avoid
+        settlements as much as track their prey.
+      parent-class: HUNTER
+      sight-range: 3
+      primary-skills: [STEALTH, HUNTING, BOW, DAGGER, TRACKING, LEATHERWORKING, PICKPOCKET]
+      neutral-skills: [SURVIVAL, TRAPS, COOKING, ACROBATICS, LOCKPICKING]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        PIERCE: 1.15
+        SLASH: 1.05
+        BLUNT: 0.85
+        ENERGY: 0.9
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 0.7
+        GATHER: 0.7
+        CRAFT: 0.1
+        BUILD: 0.0
+        SOCIAL: 0.2
+        EXPLORE: 0.5
+        MEDICAL: 0.0
+        TRADE: 0.4
+
+    SMITH:
+      display-name: Smith
+      description: >-
+        Forge specialist. Weapons, armour, and the metalwork that supplies
+        them — the artisan branch for agents whose post-class crafts leaned
+        on smithing and the gathering chain that feeds it.
+      parent-class: ARTISAN
+      sight-range: 3
+      primary-skills: [SMITHING, MINING, LUMBERJACKING, CARPENTRY, LEATHERWORKING, TAILORING]
+      neutral-skills: [ALCHEMY, JEWELRYCRAFTING, ATHLETICS, AXE]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        BLUNT: 1.15
+        SLASH: 1.05
+        PIERCE: 1.0
+        ENERGY: 0.9
+        MAGICAL: 0.85
+      behavior-fingerprint:
+        COMBAT: 0.1
+        GATHER: 0.5
+        CRAFT: 1.4
+        BUILD: 0.6
+        SOCIAL: 0.1
+        EXPLORE: 0.0
+        MEDICAL: 0.0
+        TRADE: 0.4
+
+    CHEF:
+      display-name: Chef
+      description: >-
+        Cook and brewer. Feeds settlements and serves the table; the artisan
+        branch for agents whose level-10-to-50 stretch was kitchens, gardens,
+        and storerooms.
+      parent-class: ARTISAN
+      sight-range: 3
+      primary-skills: [COOKING, BREWING, ALCHEMY, FORAGING, FISHING, HERBALISM]
+      neutral-skills: [ATHLETICS, ANIMAL_HANDLING, PERSUASION, HUNTING]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        BLUNT: 1.0
+        SLASH: 0.95
+        PIERCE: 0.9
+        ENERGY: 0.9
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 0.0
+        GATHER: 0.7
+        CRAFT: 1.3
+        BUILD: 0.0
+        SOCIAL: 0.3
+        EXPLORE: 0.0
+        MEDICAL: 0.2
+        TRADE: 0.5
+
+    JEWELER:
+      display-name: Jeweler
+      description: >-
+        Precious-metals and gem-cutting craft. Trade-facing artisan branch —
+        the choice the system surfaces when crafts paired with persuasion and
+        social verbs.
+      parent-class: ARTISAN
+      sight-range: 3
+      primary-skills: [JEWELRYCRAFTING, MINING, ALCHEMY, SMITHING, PERSUASION]
+      neutral-skills: [TAILORING, LEATHERWORKING, INTIMIDATION]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        SLASH: 1.0
+        PIERCE: 1.0
+        BLUNT: 1.0
+        ENERGY: 0.95
+        MAGICAL: 1.0
+      behavior-fingerprint:
+        COMBAT: 0.0
+        GATHER: 0.5
+        CRAFT: 1.3
+        BUILD: 0.2
+        SOCIAL: 0.4
+        EXPLORE: 0.0
+        MEDICAL: 0.0
+        TRADE: 0.7
+
+    TECHNICIAN:
+      display-name: Technician
+      description: >-
+        Drone- and machine-handler. The engineer branch for agents whose
+        builds and repairs leaned on electronics and powered tools. Coordinate
+        naming with #38 (drones) when that lands.
+      parent-class: ENGINEER
+      sight-range: 3
+      primary-skills: [ENGINEERING, ELECTRONICS, SMITHING, FIREARMS, CROSSBOW, MINING]
+      neutral-skills: [CARPENTRY, ALCHEMY, ATHLETICS]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        ENERGY: 1.25
+        PIERCE: 1.05
+        BLUNT: 1.0
+        SLASH: 0.9
+        MAGICAL: 0.85
+      behavior-fingerprint:
+        COMBAT: 0.3
+        GATHER: 0.4
+        CRAFT: 0.9
+        BUILD: 1.3
+        SOCIAL: 0.1
+        EXPLORE: 0.2
+        MEDICAL: 0.0
+        TRADE: 0.2
+
+    ARTILLERIST:
+      display-name: Artillerist
+      description: >-
+        Heavy-ranged-weapons specialist. The engineer branch for agents who
+        paired construction skills with sustained firearm and crossbow combat.
+      parent-class: ENGINEER
+      sight-range: 4
+      primary-skills: [FIREARMS, CROSSBOW, ENGINEERING, ELECTRONICS, ATHLETICS, INTIMIDATION]
+      neutral-skills: [SMITHING, MINING, ALCHEMY]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        ENERGY: 1.2
+        PIERCE: 1.2
+        BLUNT: 1.0
+        SLASH: 0.85
+        MAGICAL: 0.85
+      behavior-fingerprint:
+        COMBAT: 1.0
+        GATHER: 0.2
+        CRAFT: 0.5
+        BUILD: 0.7
+        SOCIAL: 0.1
+        EXPLORE: 0.2
+        MEDICAL: 0.0
+        TRADE: 0.1
+
+    ARCHITECT:
+      display-name: Architect
+      description: >-
+        Buildings and large-scale structure specialist. The engineer branch
+        for agents who pivoted away from machinery toward settlement-scale
+        construction and leadership.
+      parent-class: ENGINEER
+      sight-range: 3
+      primary-skills: [CARPENTRY, SMITHING, ENGINEERING, MINING, LUMBERJACKING, LEADERSHIP]
+      neutral-skills: [ELECTRONICS, ATHLETICS, FIREARMS]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        BLUNT: 1.05
+        SLASH: 0.95
+        PIERCE: 0.95
+        ENERGY: 1.0
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 0.2
+        GATHER: 0.6
+        CRAFT: 0.9
+        BUILD: 1.5
+        SOCIAL: 0.2
+        EXPLORE: 0.1
+        MEDICAL: 0.0
+        TRADE: 0.2
+
+    SURGEON:
+      display-name: Surgeon
+      description: >-
+        Trauma specialist. Emergency healing, anatomy, and the focused-actives
+        roster — the medic branch for agents who treated wounded between
+        crafts and brews.
+      parent-class: MEDIC
+      sight-range: 3
+      primary-skills: [MEDICINE, ANATOMY, ALCHEMY, HERBALISM, COOKING, PERSUASION]
+      neutral-skills: [DAGGER, UNARMED, ACROBATICS, ATHLETICS]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        SLASH: 0.85
+        PIERCE: 0.9
+        BLUNT: 0.85
+        ENERGY: 0.95
+        MAGICAL: 1.0
+      behavior-fingerprint:
+        COMBAT: 0.0
+        GATHER: 0.2
+        CRAFT: 0.4
+        BUILD: 0.0
+        SOCIAL: 0.4
+        EXPLORE: 0.0
+        MEDICAL: 1.5
+        TRADE: 0.1
+
+    APOTHECARY:
+      display-name: Apothecary
+      description: >-
+        Herbalist and potion-maker. The medic branch for agents whose
+        windowed counters skewed toward gathering and brewing rather than
+        bedside care.
+      parent-class: MEDIC
+      sight-range: 3
+      primary-skills: [ALCHEMY, HERBALISM, FORAGING, MEDICINE, ANATOMY, BREWING]
+      neutral-skills: [COOKING, PERSUASION, BEAST_LORE]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        SLASH: 0.85
+        PIERCE: 0.9
+        BLUNT: 0.85
+        ENERGY: 0.95
+        MAGICAL: 1.05
+      behavior-fingerprint:
+        COMBAT: 0.0
+        GATHER: 0.7
+        CRAFT: 0.9
+        BUILD: 0.1
+        SOCIAL: 0.2
+        EXPLORE: 0.1
+        MEDICAL: 1.3
+        TRADE: 0.3
+
+    FIELD_MEDIC:
+      display-name: Field Medic
+      description: >-
+        Combat-zone healer. Light blades, athletics, and triage — the medic
+        branch for agents who followed parties into fights instead of waiting
+        in the infirmary.
+      parent-class: MEDIC
+      sight-range: 3
+      primary-skills: [MEDICINE, ANATOMY, ATHLETICS, SURVIVAL, ACROBATICS, DAGGER, UNARMED]
+      neutral-skills: [HERBALISM, ALCHEMY, INTIMIDATION, LEADERSHIP]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        SLASH: 0.95
+        PIERCE: 0.95
+        BLUNT: 0.9
+        ENERGY: 1.0
+        MAGICAL: 0.95
+      behavior-fingerprint:
+        COMBAT: 0.5
+        GATHER: 0.2
+        CRAFT: 0.2
+        BUILD: 0.0
+        SOCIAL: 0.3
+        EXPLORE: 0.4
+        MEDICAL: 1.3
+        TRADE: 0.1
+
+    NEGOTIATOR:
+      display-name: Negotiator
+      description: >-
+        Diplomat and broker. The merchant branch for agents whose social
+        verbs leaned on persuasion and leadership over haggling.
+      parent-class: MERCHANT
+      sight-range: 3
+      primary-skills: [PERSUASION, LEADERSHIP, INTIMIDATION, COOKING, BREWING]
+      neutral-skills: [SWORD, DAGGER, JEWELRYCRAFTING, ATHLETICS]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        SLASH: 1.0
+        PIERCE: 1.0
+        BLUNT: 1.0
+        ENERGY: 0.95
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 0.1
+        GATHER: 0.1
+        CRAFT: 0.2
+        BUILD: 0.1
+        SOCIAL: 1.5
+        EXPLORE: 0.2
+        MEDICAL: 0.0
+        TRADE: 1.0
+
+    SMUGGLER:
+      display-name: Smuggler
+      description: >-
+        Discreet trade and forced-entry specialist. The merchant branch for
+        agents who paired trade with stealth, lock-picking, and pickpocket
+        verbs.
+      parent-class: MERCHANT
+      sight-range: 3
+      primary-skills: [STEALTH, LOCKPICKING, PICKPOCKET, DAGGER, PERSUASION, ACROBATICS]
+      neutral-skills: [SWORD, ATHLETICS, INTIMIDATION, FORAGING]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        SLASH: 1.05
+        PIERCE: 1.1
+        BLUNT: 0.9
+        ENERGY: 0.9
+        MAGICAL: 0.85
+      behavior-fingerprint:
+        COMBAT: 0.3
+        GATHER: 0.2
+        CRAFT: 0.2
+        BUILD: 0.0
+        SOCIAL: 0.7
+        EXPLORE: 0.6
+        MEDICAL: 0.0
+        TRADE: 1.2
+
+    CARAVAN_MASTER:
+      display-name: Caravan Master
+      description: >-
+        Long-distance trade-route runner. The merchant branch for agents who
+        paired trade with sustained travel, pack handling, and party
+        leadership.
+      parent-class: MERCHANT
+      sight-range: 4
+      primary-skills: [ANIMAL_HANDLING, LEADERSHIP, ATHLETICS, SURVIVAL, PERSUASION, CARTOGRAPHY]
+      neutral-skills: [COOKING, FORAGING, INTIMIDATION, SWORD]
+      forbidden-combat-skills: []
+      damage-multipliers:
+        SLASH: 1.05
+        PIERCE: 1.0
+        BLUNT: 1.05
+        ENERGY: 0.95
+        MAGICAL: 0.9
+      behavior-fingerprint:
+        COMBAT: 0.2
+        GATHER: 0.3
+        CRAFT: 0.2
+        BUILD: 0.1
+        SOCIAL: 0.8
+        EXPLORE: 0.9
+        MEDICAL: 0.0
+        TRADE: 1.2
+
+    SCHOLAR:
+      display-name: Scholar
+      description: >-
+        Pure-knowledge researcher. Scanning and electronics-led inquiry —
+        carries the parent's auto-firearm ban (RESEARCHER hard restriction).
+      parent-class: RESEARCHER
+      sight-range: 5
+      primary-skills: [SCANNING, ANATOMY, ELECTRONICS, MEDICINE, CARTOGRAPHY, ALCHEMY]
+      neutral-skills: [ENGINEERING, HERBALISM, PERSUASION, JEWELRYCRAFTING]
+      forbidden-combat-skills: [FIREARMS]
+      damage-multipliers:
+        ENERGY: 1.2
+        MAGICAL: 1.2
+        SLASH: 0.8
+        PIERCE: 0.85
+        BLUNT: 0.8
+      behavior-fingerprint:
+        COMBAT: 0.0
+        GATHER: 0.3
+        CRAFT: 0.4
+        BUILD: 0.1
+        SOCIAL: 0.3
+        EXPLORE: 0.8
+        MEDICAL: 0.6
+        TRADE: 0.2
+
+    ALCHEMIST:
+      display-name: Alchemist
+      description: >-
+        Reagent and mutagen researcher. Carries the parent's auto-firearm
+        ban; pairs alchemy with sustained gathering and brewing.
+      parent-class: RESEARCHER
+      sight-range: 4
+      primary-skills: [ALCHEMY, BREWING, HERBALISM, FORAGING, SCANNING, ANATOMY]
+      neutral-skills: [MEDICINE, COOKING, PERSUASION, MINING]
+      forbidden-combat-skills: [FIREARMS]
+      damage-multipliers:
+        ENERGY: 1.15
+        MAGICAL: 1.2
+        SLASH: 0.85
+        PIERCE: 0.9
+        BLUNT: 0.85
+      behavior-fingerprint:
+        COMBAT: 0.0
+        GATHER: 0.7
+        CRAFT: 0.9
+        BUILD: 0.1
+        SOCIAL: 0.2
+        EXPLORE: 0.4
+        MEDICAL: 0.6
+        TRADE: 0.3
+
+    NATURALIST:
+      display-name: Naturalist
+      description: >-
+        Beast-lore and herbalism researcher. Carries the parent's
+        auto-firearm ban; the researcher branch for agents who scanned the
+        wild more than the workbench.
+      parent-class: RESEARCHER
+      sight-range: 5
+      primary-skills: [BEAST_LORE, HERBALISM, FORAGING, SCANNING, ANATOMY, TRACKING, SURVIVAL]
+      neutral-skills: [ALCHEMY, ANIMAL_HANDLING, BOW, MEDICINE]
+      forbidden-combat-skills: [FIREARMS]
+      damage-multipliers:
+        ENERGY: 1.05
+        MAGICAL: 1.1
+        SLASH: 0.9
+        PIERCE: 0.95
+        BLUNT: 0.85
+      behavior-fingerprint:
+        COMBAT: 0.1
+        GATHER: 0.8
+        CRAFT: 0.4
+        BUILD: 0.1
+        SOCIAL: 0.2
+        EXPLORE: 1.0
+        MEDICAL: 0.7
         TRADE: 0.2

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/ClassValidatorTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/ClassValidatorTest.kt
@@ -81,6 +81,88 @@ class ClassValidatorTest {
         assertTrue(ex.message!!.contains("appear in both primary and neutral lists"))
     }
 
+    @Test
+    fun `evolution declaring an unknown parent is rejected`() {
+        val orphanEvolution = soldierShape().copy(parentClass = AgentClass.MERCHANT)
+        val classes = allClasses(soldierShape()).toMutableMap().apply {
+            this[AgentClass.HEAVY_SOLDIER] = orphanEvolution
+        }
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassValidator(props(classes), fakeSkills()).validate()
+        }
+        assertTrue(
+            ex.message!!.contains("HEAVY_SOLDIER: parent-class MERCHANT does not list HEAVY_SOLDIER"),
+            "unexpected message: ${ex.message}",
+        )
+    }
+
+    @Test
+    fun `parent listing a non-matching evolution is rejected`() {
+        val parent = soldierShape().copy(evolutions = listOf(AgentClass.RANGER))
+        val notMyParent = soldierShape().copy(parentClass = AgentClass.SCOUT)
+        val classes = allClasses(soldierShape()).toMutableMap().apply {
+            this[AgentClass.SOLDIER] = parent
+            this[AgentClass.RANGER] = notMyParent
+        }
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassValidator(props(classes), fakeSkills()).validate()
+        }
+        assertTrue(ex.message!!.contains("RANGER's parent-class is SCOUT"))
+    }
+
+    @Test
+    fun `chained evolution (parent itself is an evolution) is rejected`() {
+        val baseSoldier = soldierShape().copy(evolutions = listOf(AgentClass.HEAVY_SOLDIER))
+        val midEvolution = soldierShape().copy(
+            parentClass = AgentClass.SOLDIER,
+            evolutions = listOf(AgentClass.SNIPER),
+        )
+        val grandchild = soldierShape().copy(parentClass = AgentClass.HEAVY_SOLDIER)
+        val classes = allClasses(soldierShape()).toMutableMap().apply {
+            this[AgentClass.SOLDIER] = baseSoldier
+            this[AgentClass.HEAVY_SOLDIER] = midEvolution
+            this[AgentClass.SNIPER] = grandchild
+        }
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassValidator(props(classes), fakeSkills()).validate()
+        }
+        assertTrue(ex.message!!.contains("chained evolutions are out of scope"))
+    }
+
+    @Test
+    fun `self-listing as evolution is rejected`() {
+        val brokenSelf = soldierShape().copy(evolutions = listOf(AgentClass.SOLDIER))
+        val classes = allClasses(soldierShape()).toMutableMap().apply {
+            this[AgentClass.SOLDIER] = brokenSelf
+        }
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassValidator(props(classes), fakeSkills()).validate()
+        }
+        assertTrue(ex.message!!.contains("SOLDIER: lists itself as an evolution"))
+    }
+
+    @Test
+    fun `evolution missing a parent forbid is rejected`() {
+        val researcher = soldierShape().copy(
+            forbiddenCombatSkills = listOf("FIREARMS"),
+            evolutions = listOf(AgentClass.SCHOLAR),
+        )
+        val scholar = soldierShape().copy(
+            parentClass = AgentClass.RESEARCHER,
+            // Forgets to inherit FIREARMS — would silently let scholars wield rifles.
+            forbiddenCombatSkills = emptyList(),
+        )
+        val classes = allClasses(soldierShape()).toMutableMap().apply {
+            this[AgentClass.RESEARCHER] = researcher
+            this[AgentClass.SCHOLAR] = scholar
+        }
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassValidator(props(classes), fakeSkills()).validate()
+        }
+        assertTrue(ex.message!!.contains("SCHOLAR: missing parent-class RESEARCHER's forbidden-combat-skills"))
+        assertTrue(ex.message!!.contains("FIREARMS"))
+    }
+
     private fun soldierShape() = ClassProperties(
         displayName = "Soldier",
         description = "Frontline pro.",

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/ClassesYamlLoadingTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/balance/ClassesYamlLoadingTest.kt
@@ -41,10 +41,35 @@ class ClassesYamlLoadingTest {
     }
 
     @Test
-    fun `classes_yaml binds the eight v1 base classes`() {
+    fun `classes_yaml binds every AgentClass entry (8 base + 24 evolutions)`() {
         val all = lookup.all()
-        assertEquals(8, all.size)
+        assertEquals(AgentClass.entries.size, all.size)
         assertEquals(AgentClass.entries.toSet(), all.map { it.id }.toSet())
+    }
+
+    @Test
+    fun `baseClasses returns exactly the 8 v1 base classes`() {
+        val bases = lookup.baseClasses()
+        assertEquals(8, bases.size)
+        assertTrue(bases.all { it.parentClass == null })
+        assertEquals(
+            setOf(
+                AgentClass.SOLDIER, AgentClass.SCOUT, AgentClass.HUNTER, AgentClass.ARTISAN,
+                AgentClass.ENGINEER, AgentClass.MEDIC, AgentClass.MERCHANT, AgentClass.RESEARCHER,
+            ),
+            bases.map { it.id }.toSet(),
+        )
+    }
+
+    @Test
+    fun `every base class declares exactly 3 evolutions and they all back-link`() {
+        for (base in lookup.baseClasses()) {
+            assertEquals(3, base.evolutions.size, "${base.id} must declare 3 evolutions")
+            for (evo in base.evolutions) {
+                val def = assertNotNull(lookup.byId(evo), "$evo missing from catalog")
+                assertEquals(base.id, def.parentClass, "$evo must back-link to ${base.id}")
+            }
+        }
     }
 
     @Test
@@ -60,16 +85,22 @@ class ClassesYamlLoadingTest {
     }
 
     @Test
-    fun `RESEARCHER hard-bans FIREARMS — the only v1 hard restriction`() {
-        val researcher = assertNotNull(lookup.byId(AgentClass.RESEARCHER))
-        assertTrue(SkillId("FIREARMS") in researcher.forbiddenCombatSkills)
+    fun `FIREARMS hard-ban is carried by RESEARCHER and all its evolutions, nothing else`() {
+        val researcherFamily = setOf(
+            AgentClass.RESEARCHER, AgentClass.SCHOLAR, AgentClass.ALCHEMIST, AgentClass.NATURALIST,
+        )
+
+        for (id in researcherFamily) {
+            val def = assertNotNull(lookup.byId(id))
+            assertTrue(SkillId("FIREARMS") in def.forbiddenCombatSkills, "$id must carry FIREARMS forbid")
+        }
 
         for (id in AgentClass.entries) {
-            if (id == AgentClass.RESEARCHER) continue
+            if (id in researcherFamily) continue
             val def = assertNotNull(lookup.byId(id))
             assertTrue(
                 def.forbiddenCombatSkills.isEmpty(),
-                "$id should not declare hard restrictions in v1 (only RESEARCHER does)",
+                "$id should not declare hard restrictions in v1 (only the Researcher family does)",
             )
         }
     }

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/progression/SkillProgressionImplTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/progression/SkillProgressionImplTest.kt
@@ -286,6 +286,8 @@ class SkillProgressionImplTest {
     ) : ClassLookup {
         override fun byId(classId: AgentClass): ClassDefinition? = null
         override fun all(): List<ClassDefinition> = emptyList()
+        override fun baseClasses(): List<ClassDefinition> = emptyList()
+        override fun evolutionsOf(parent: AgentClass): List<ClassDefinition> = emptyList()
         override fun sightRange(classId: AgentClass?): Int = 3
         override fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double {
             if (classId == null) return 1.0

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryAddCharacterXpIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryAddCharacterXpIntegrationTest.kt
@@ -5,9 +5,12 @@ import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AddCharacterXpOutcome
 import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.NoOpClassLookup
 import dev.gvart.genesara.player.AgentProfile
 import dev.gvart.genesara.player.AgentProfileRepository
 import dev.gvart.genesara.player.AttributeMods
+import dev.gvart.genesara.player.ClassDefinition
+import dev.gvart.genesara.player.ClassLookup
 import dev.gvart.genesara.player.Race
 import dev.gvart.genesara.player.RaceId
 import dev.gvart.genesara.player.RaceLookup
@@ -143,6 +146,37 @@ class JooqAgentRegistryAddCharacterXpIntegrationTest {
     }
 
     @Test
+    fun `base-class agent caps at level 50 with full bar even when surplus xp would push further`() {
+        val registry = registry(SoldierEvolutionLookup)
+        val agent = registry.register(owner, "Forty-niner")
+        seed(agent.id, level = 49, xpCurrent = 0, xpToNext = 4900, classId = AgentClass.SOLDIER)
+
+        val outcome = registry.addCharacterXp(agent.id, 4900 + 5000 + 6000)
+
+        val granted = assertIs<AddCharacterXpOutcome.Granted>(outcome)
+        assertEquals(50, granted.currentLevel)
+        assertEquals(granted.xpToNext, granted.xpCurrent, "bar capped at full")
+        assertEquals(false, granted.cappedAtPendingClassChoice)
+        assertEquals(true, granted.cappedAtPendingEvolutionChoice)
+    }
+
+    @Test
+    fun `evolved agent levels past 50 with no cap`() {
+        val registry = registry(SoldierEvolutionLookup)
+        val agent = registry.register(owner, "Heavy")
+        seed(agent.id, level = 50, xpCurrent = 0, xpToNext = 5000, classId = AgentClass.HEAVY_SOLDIER)
+
+        val outcome = registry.addCharacterXp(agent.id, 5500)
+
+        val granted = assertIs<AddCharacterXpOutcome.Granted>(outcome)
+        assertEquals(51, granted.currentLevel)
+        assertEquals(500, granted.xpCurrent)
+        assertEquals(5100, granted.xpToNext)
+        assertEquals(false, granted.cappedAtPendingClassChoice)
+        assertEquals(false, granted.cappedAtPendingEvolutionChoice)
+    }
+
+    @Test
     fun `classed agent at level 10 levels past the cap`() {
         val registry = registry()
         val agent = registry.register(owner, "Veteran")
@@ -205,7 +239,7 @@ class JooqAgentRegistryAddCharacterXpIntegrationTest {
         update.where(AGENTS.ID.eq(id.id)).execute()
     }
 
-    private fun registry(): JooqAgentRegistry {
+    private fun registry(classes: ClassLookup = NoOpClassLookup): JooqAgentRegistry {
         val race = Race(
             id = RaceId("test_race"),
             displayName = "Test",
@@ -216,7 +250,7 @@ class JooqAgentRegistryAddCharacterXpIntegrationTest {
         val lookup = SingleRaceLookup(race)
         val props = RaceDefinitionProperties(defaultId = race.id.value)
         val assigner = RaceAssigner(lookup, props, FixedRandom)
-        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner)
+        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner, classes)
     }
 
     private fun readAgent(id: AgentId) =
@@ -229,6 +263,42 @@ class JooqAgentRegistryAddCharacterXpIntegrationTest {
 
     private object FixedRandom : RandomSource {
         override fun nextInt(boundExclusive: Int): Int = 0
+    }
+
+    /** Catalog stub: SOLDIER is a base class with 3 evolutions; the rest are evolutions. */
+    private object SoldierEvolutionLookup : ClassLookup {
+        private val byId: Map<AgentClass, ClassDefinition> = mapOf(
+            AgentClass.SOLDIER to baseClass(AgentClass.SOLDIER, listOf(
+                AgentClass.HEAVY_SOLDIER, AgentClass.STEALTH_SOLDIER, AgentClass.COMMANDER,
+            )),
+            AgentClass.HEAVY_SOLDIER to evolutionClass(AgentClass.HEAVY_SOLDIER, AgentClass.SOLDIER),
+            AgentClass.STEALTH_SOLDIER to evolutionClass(AgentClass.STEALTH_SOLDIER, AgentClass.SOLDIER),
+            AgentClass.COMMANDER to evolutionClass(AgentClass.COMMANDER, AgentClass.SOLDIER),
+        )
+
+        override fun byId(classId: AgentClass): ClassDefinition? = byId[classId]
+        override fun all(): List<ClassDefinition> = byId.values.toList()
+        override fun baseClasses(): List<ClassDefinition> = listOf(byId[AgentClass.SOLDIER]!!)
+        override fun evolutionsOf(parent: AgentClass): List<ClassDefinition> =
+            byId[parent]?.evolutions?.mapNotNull { byId[it] } ?: emptyList()
+        override fun sightRange(classId: AgentClass?): Int = 3
+        override fun skillXpMultiplier(classId: AgentClass?, skill: dev.gvart.genesara.player.SkillId): Double = 1.0
+        override fun damageMultiplier(classId: AgentClass?, damageType: String): Double = 1.0
+        override fun forbidsCombatSkill(classId: AgentClass?, combatSkill: dev.gvart.genesara.player.SkillId): Boolean = false
+
+        private fun baseClass(id: AgentClass, evolutions: List<AgentClass>) = ClassDefinition(
+            id = id, displayName = id.name, description = "", sightRange = 3,
+            primarySkills = emptySet(), neutralSkills = emptySet(),
+            forbiddenCombatSkills = emptySet(), damageMultipliers = emptyMap(),
+            behaviorFingerprint = emptyMap(), parentClass = null, evolutions = evolutions,
+        )
+
+        private fun evolutionClass(id: AgentClass, parent: AgentClass) = ClassDefinition(
+            id = id, displayName = id.name, description = "", sightRange = 3,
+            primarySkills = emptySet(), neutralSkills = emptySet(),
+            forbiddenCombatSkills = emptySet(), damageMultipliers = emptyMap(),
+            behaviorFingerprint = emptyMap(), parentClass = parent,
+        )
     }
 
     private class JooqProfileRepository(private val dsl: DSLContext) : AgentProfileRepository {

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryAllocateAttributesIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryAllocateAttributesIntegrationTest.kt
@@ -9,6 +9,7 @@ import dev.gvart.genesara.player.AllocateAttributesOutcome
 import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.AttributeMilestoneCrossing
 import dev.gvart.genesara.player.AttributeMods
+import dev.gvart.genesara.player.NoOpClassLookup
 import dev.gvart.genesara.player.Race
 import dev.gvart.genesara.player.RaceId
 import dev.gvart.genesara.player.RaceLookup
@@ -259,7 +260,7 @@ class JooqAgentRegistryAllocateAttributesIntegrationTest {
         val lookup = SingleRaceLookup(race)
         val props = RaceDefinitionProperties(defaultId = race.id.value)
         val assigner = RaceAssigner(lookup, props, FixedRandom)
-        return JooqAgentRegistry(dsl, UpsertingProfileRepository(dsl), assigner)
+        return JooqAgentRegistry(dsl, UpsertingProfileRepository(dsl), assigner, NoOpClassLookup)
     }
 
     private fun readAgent(id: AgentId) =

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryClassChoiceIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryClassChoiceIntegrationTest.kt
@@ -7,12 +7,18 @@ import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentProfile
 import dev.gvart.genesara.player.AgentProfileRepository
 import dev.gvart.genesara.player.AssignClassOutcome
+import dev.gvart.genesara.player.AssignEvolutionOutcome
 import dev.gvart.genesara.player.AttributeMods
+import dev.gvart.genesara.player.ClassDefinition
+import dev.gvart.genesara.player.ClassLookup
 import dev.gvart.genesara.player.ClassOffer
+import dev.gvart.genesara.player.NoOpClassLookup
 import dev.gvart.genesara.player.Race
 import dev.gvart.genesara.player.RaceId
 import dev.gvart.genesara.player.RaceLookup
 import dev.gvart.genesara.player.RecordClassOfferOutcome
+import dev.gvart.genesara.player.RecordEvolutionOfferOutcome
+import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.internal.jooq.tables.references.AGENTS
 import dev.gvart.genesara.player.internal.jooq.tables.references.AGENT_PROFILES
 import dev.gvart.genesara.player.internal.race.RaceAssigner
@@ -198,6 +204,243 @@ class JooqAgentRegistryClassChoiceIntegrationTest {
         assertEquals(AssignClassOutcome.UnknownAgent, outcome)
     }
 
+    // ─────────────────────── L50 evolution flow (#34) ───────────────────────
+
+    private val evoOffer = ClassOffer(AgentClass.HEAVY_SOLDIER, AgentClass.STEALTH_SOLDIER)
+
+    @Test
+    fun `recordPendingEvolutionChoice writes both columns and is reflected on find`() {
+        val registry = registryWithSoldierEvolutions()
+        val agent = registry.register(owner, "Veteran")
+        seedClass(agent.id, AgentClass.SOLDIER)
+
+        val outcome = registry.recordPendingEvolutionChoice(agent.id, evoOffer)
+
+        assertEquals(RecordEvolutionOfferOutcome.Recorded, outcome)
+        val row = readAgent(agent.id)
+        assertEquals("HEAVY_SOLDIER", row[AGENTS.OFFERED_EVOLUTION_A])
+        assertEquals("STEALTH_SOLDIER", row[AGENTS.OFFERED_EVOLUTION_B])
+        assertEquals("SOLDIER", row[AGENTS.CLASS_ID])
+        val refreshed = registry.find(agent.id)
+        assertEquals(evoOffer, refreshed?.offeredEvolutions)
+    }
+
+    @Test
+    fun `recordPendingEvolutionChoice rejects when the agent has no class`() {
+        val registry = registryWithSoldierEvolutions()
+        val agent = registry.register(owner, "Pre-class")
+
+        val outcome = registry.recordPendingEvolutionChoice(agent.id, evoOffer)
+
+        assertEquals(RecordEvolutionOfferOutcome.NoClassAssigned, outcome)
+        val row = readAgent(agent.id)
+        assertNull(row[AGENTS.OFFERED_EVOLUTION_A])
+    }
+
+    @Test
+    fun `recordPendingEvolutionChoice rejects when the agent is already evolved`() {
+        val registry = registryWithSoldierEvolutions()
+        val agent = registry.register(owner, "Already")
+        seedClass(agent.id, AgentClass.HEAVY_SOLDIER)
+
+        val outcome = registry.recordPendingEvolutionChoice(agent.id, evoOffer)
+
+        val rejection = assertIs<RecordEvolutionOfferOutcome.AlreadyEvolved>(outcome)
+        assertEquals(AgentClass.HEAVY_SOLDIER, rejection.existing)
+    }
+
+    @Test
+    fun `recordPendingEvolutionChoice rejects when an offer is already pending`() {
+        val registry = registryWithSoldierEvolutions()
+        val agent = registry.register(owner, "Doubler")
+        seedClass(agent.id, AgentClass.SOLDIER)
+        registry.recordPendingEvolutionChoice(agent.id, evoOffer)
+
+        val outcome = registry.recordPendingEvolutionChoice(
+            agent.id,
+            ClassOffer(AgentClass.STEALTH_SOLDIER, AgentClass.COMMANDER),
+        )
+
+        val rejection = assertIs<RecordEvolutionOfferOutcome.AlreadyOffered>(outcome)
+        assertEquals(evoOffer, rejection.existing)
+    }
+
+    @Test
+    fun `assignEvolution overwrites class_id and clears the offer columns`() {
+        val registry = registryWithSoldierEvolutions()
+        val agent = registry.register(owner, "Picker")
+        seedClass(agent.id, AgentClass.SOLDIER)
+        registry.recordPendingEvolutionChoice(agent.id, evoOffer)
+
+        val outcome = registry.assignEvolution(agent.id, AgentClass.STEALTH_SOLDIER)
+
+        val assigned = assertIs<AssignEvolutionOutcome.Assigned>(outcome)
+        assertEquals(AgentClass.SOLDIER, assigned.from)
+        assertEquals(AgentClass.STEALTH_SOLDIER, assigned.to)
+        val row = readAgent(agent.id)
+        assertEquals("STEALTH_SOLDIER", row[AGENTS.CLASS_ID])
+        assertNull(row[AGENTS.OFFERED_EVOLUTION_A])
+        assertNull(row[AGENTS.OFFERED_EVOLUTION_B])
+    }
+
+    @Test
+    fun `assignEvolution rejects when the chosen class is not in the offer`() {
+        val registry = registryWithSoldierEvolutions()
+        val agent = registry.register(owner, "Stray")
+        seedClass(agent.id, AgentClass.SOLDIER)
+        registry.recordPendingEvolutionChoice(agent.id, evoOffer)
+
+        val outcome = registry.assignEvolution(agent.id, AgentClass.COMMANDER)
+
+        val rejection = assertIs<AssignEvolutionOutcome.NotInOffer>(outcome)
+        assertEquals(evoOffer, rejection.pending)
+        val row = readAgent(agent.id)
+        assertEquals("SOLDIER", row[AGENTS.CLASS_ID], "no DB mutation on rejection")
+        assertEquals("HEAVY_SOLDIER", row[AGENTS.OFFERED_EVOLUTION_A])
+    }
+
+    @Test
+    fun `assignEvolution rejects when no offer is pending`() {
+        val registry = registryWithSoldierEvolutions()
+        val agent = registry.register(owner, "Eager")
+        seedClass(agent.id, AgentClass.SOLDIER)
+
+        val outcome = registry.assignEvolution(agent.id, AgentClass.HEAVY_SOLDIER)
+
+        assertEquals(AssignEvolutionOutcome.NoPendingOffer, outcome)
+    }
+
+    @Test
+    fun `assignEvolution rejects when the agent has no class`() {
+        val registry = registryWithSoldierEvolutions()
+        val agent = registry.register(owner, "Pre-class")
+
+        val outcome = registry.assignEvolution(agent.id, AgentClass.HEAVY_SOLDIER)
+
+        assertEquals(AssignEvolutionOutcome.NoClassAssigned, outcome)
+    }
+
+    @Test
+    fun `assignEvolution rejects when the agent is already evolved`() {
+        val registry = registryWithSoldierEvolutions()
+        val agent = registry.register(owner, "Locked")
+        seedClass(agent.id, AgentClass.HEAVY_SOLDIER)
+
+        val outcome = registry.assignEvolution(agent.id, AgentClass.STEALTH_SOLDIER)
+
+        val rejection = assertIs<AssignEvolutionOutcome.AlreadyEvolved>(outcome)
+        assertEquals(AgentClass.HEAVY_SOLDIER, rejection.existing)
+    }
+
+    @Test
+    fun `assignEvolution rejects a cross-tree pick even if it leaks into the offer columns`() {
+        val registry = registryWithSoldierEvolutions()
+        val agent = registry.register(owner, "Pivoter")
+        seedClass(agent.id, AgentClass.SOLDIER)
+        // Hand-tampered offer that bypasses the L50 emitter's catalog scope.
+        // The HEAVY_SOLDIER half is legit; SCHOLAR is a Researcher evolution and
+        // must not be assignable to a Soldier even though it's in the offer.
+        dsl.update(AGENTS)
+            .set(AGENTS.OFFERED_EVOLUTION_A, AgentClass.HEAVY_SOLDIER.name)
+            .set(AGENTS.OFFERED_EVOLUTION_B, AgentClass.SCHOLAR.name)
+            .where(AGENTS.ID.eq(agent.id.id))
+            .execute()
+        val rogueLookup = LookupWithSoldierAndScholar
+        val rogueRegistry = JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assignerStub(), rogueLookup)
+
+        val outcome = rogueRegistry.assignEvolution(agent.id, AgentClass.SCHOLAR)
+
+        val rejection = assertIs<AssignEvolutionOutcome.WrongParent>(outcome)
+        assertEquals(AgentClass.SOLDIER, rejection.expectedParent)
+        assertEquals(AgentClass.RESEARCHER, rejection.actualParent)
+        val row = readAgent(agent.id)
+        assertEquals("SOLDIER", row[AGENTS.CLASS_ID], "no DB mutation on cross-tree rejection")
+    }
+
+    @Test
+    fun `recordPendingEvolutionChoice rejects an offer that includes a non-evolution candidate`() {
+        val registry = registryWithSoldierEvolutions()
+        val agent = registry.register(owner, "BadOffer")
+        seedClass(agent.id, AgentClass.SOLDIER)
+
+        val outcome = registry.recordPendingEvolutionChoice(
+            agent.id,
+            ClassOffer(AgentClass.HEAVY_SOLDIER, AgentClass.SCOUT),
+        )
+
+        val rejection = assertIs<RecordEvolutionOfferOutcome.InvalidCandidate>(outcome)
+        assertEquals(AgentClass.SCOUT, rejection.candidate)
+        assertEquals(AgentClass.SOLDIER, rejection.expectedParent)
+        val row = readAgent(agent.id)
+        assertNull(row[AGENTS.OFFERED_EVOLUTION_A], "no DB mutation on rejection")
+    }
+
+    private fun assignerStub(): RaceAssigner {
+        val race = Race(
+            id = RaceId("test_race"),
+            displayName = "Test",
+            weight = 1,
+            attributeMods = AttributeMods.NONE,
+            description = "",
+        )
+        val lookup = SingleRaceLookup(race)
+        val props = RaceDefinitionProperties(defaultId = race.id.value)
+        return RaceAssigner(lookup, props, FixedRandom)
+    }
+
+    /** Catalog where SOLDIER is base + SCHOLAR is a RESEARCHER evolution. */
+    private object LookupWithSoldierAndScholar : ClassLookup {
+        private val byId: Map<AgentClass, ClassDefinition> = mapOf(
+            AgentClass.SOLDIER to baseClass(AgentClass.SOLDIER, listOf(AgentClass.HEAVY_SOLDIER)),
+            AgentClass.HEAVY_SOLDIER to evolutionClass(AgentClass.HEAVY_SOLDIER, AgentClass.SOLDIER),
+            AgentClass.RESEARCHER to baseClass(AgentClass.RESEARCHER, listOf(AgentClass.SCHOLAR)),
+            AgentClass.SCHOLAR to evolutionClass(AgentClass.SCHOLAR, AgentClass.RESEARCHER),
+        )
+        override fun byId(classId: AgentClass): ClassDefinition? = byId[classId]
+        override fun all(): List<ClassDefinition> = byId.values.toList()
+        override fun baseClasses(): List<ClassDefinition> = byId.values.filter { it.parentClass == null }
+        override fun evolutionsOf(parent: AgentClass): List<ClassDefinition> =
+            byId[parent]?.evolutions?.mapNotNull { byId[it] } ?: emptyList()
+        override fun sightRange(classId: AgentClass?): Int = 3
+        override fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double = 1.0
+        override fun damageMultiplier(classId: AgentClass?, damageType: String): Double = 1.0
+        override fun forbidsCombatSkill(classId: AgentClass?, combatSkill: SkillId): Boolean = false
+
+        private fun baseClass(id: AgentClass, evolutions: List<AgentClass>) = ClassDefinition(
+            id = id, displayName = id.name, description = "", sightRange = 3,
+            primarySkills = emptySet(), neutralSkills = emptySet(),
+            forbiddenCombatSkills = emptySet(), damageMultipliers = emptyMap(),
+            behaviorFingerprint = emptyMap(), parentClass = null, evolutions = evolutions,
+        )
+        private fun evolutionClass(id: AgentClass, parent: AgentClass) = ClassDefinition(
+            id = id, displayName = id.name, description = "", sightRange = 3,
+            primarySkills = emptySet(), neutralSkills = emptySet(),
+            forbiddenCombatSkills = emptySet(), damageMultipliers = emptyMap(),
+            behaviorFingerprint = emptyMap(), parentClass = parent,
+        )
+    }
+
+    private fun seedClass(agentId: AgentId, classId: AgentClass) {
+        dsl.update(AGENTS)
+            .set(AGENTS.CLASS_ID, classId.name)
+            .where(AGENTS.ID.eq(agentId.id))
+            .execute()
+    }
+
+    private fun registryWithSoldierEvolutions(): JooqAgentRegistry {
+        val race = Race(
+            id = RaceId("test_race"),
+            displayName = "Test",
+            weight = 1,
+            attributeMods = AttributeMods.NONE,
+            description = "",
+        )
+        val lookup = SingleRaceLookup(race)
+        val props = RaceDefinitionProperties(defaultId = race.id.value)
+        val assigner = RaceAssigner(lookup, props, FixedRandom)
+        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner, SoldierEvolutionLookup)
+    }
+
     private fun registry(): JooqAgentRegistry {
         val race = Race(
             id = RaceId("test_race"),
@@ -209,7 +452,7 @@ class JooqAgentRegistryClassChoiceIntegrationTest {
         val lookup = SingleRaceLookup(race)
         val props = RaceDefinitionProperties(defaultId = race.id.value)
         val assigner = RaceAssigner(lookup, props, FixedRandom)
-        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner)
+        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner, NoOpClassLookup)
     }
 
     private fun readAgent(id: AgentId) =
@@ -233,5 +476,45 @@ class JooqAgentRegistryClassChoiceIntegrationTest {
                 .set(AGENT_PROFILES.MAX_MANA, profile.maxMana)
                 .execute()
         }
+    }
+
+    /**
+     * Catalog stub that knows SOLDIER → {HEAVY_SOLDIER, STEALTH_SOLDIER, COMMANDER}.
+     * Mirrors enough of the production catalog for the L50 evolution tests to
+     * exercise the parent-class check that gates `recordPendingEvolutionChoice`
+     * and `assignEvolution`.
+     */
+    private object SoldierEvolutionLookup : ClassLookup {
+        private val soldier = baseClass(AgentClass.SOLDIER, listOf(
+            AgentClass.HEAVY_SOLDIER, AgentClass.STEALTH_SOLDIER, AgentClass.COMMANDER,
+        ))
+        private val evolutions = listOf(AgentClass.HEAVY_SOLDIER, AgentClass.STEALTH_SOLDIER, AgentClass.COMMANDER)
+            .map { evolutionClass(it, AgentClass.SOLDIER) }
+        private val byId: Map<AgentClass, ClassDefinition> =
+            (listOf(soldier) + evolutions).associateBy { it.id }
+
+        override fun byId(classId: AgentClass): ClassDefinition? = byId[classId]
+        override fun all(): List<ClassDefinition> = byId.values.toList()
+        override fun baseClasses(): List<ClassDefinition> = listOf(soldier)
+        override fun evolutionsOf(parent: AgentClass): List<ClassDefinition> =
+            byId[parent]?.evolutions?.mapNotNull { byId[it] } ?: emptyList()
+        override fun sightRange(classId: AgentClass?): Int = 3
+        override fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double = 1.0
+        override fun damageMultiplier(classId: AgentClass?, damageType: String): Double = 1.0
+        override fun forbidsCombatSkill(classId: AgentClass?, combatSkill: SkillId): Boolean = false
+
+        private fun baseClass(id: AgentClass, evolutions: List<AgentClass>) = ClassDefinition(
+            id = id, displayName = id.name, description = "", sightRange = 3,
+            primarySkills = emptySet<SkillId>(), neutralSkills = emptySet(),
+            forbiddenCombatSkills = emptySet(), damageMultipliers = emptyMap(),
+            behaviorFingerprint = emptyMap(), parentClass = null, evolutions = evolutions,
+        )
+
+        private fun evolutionClass(id: AgentClass, parent: AgentClass) = ClassDefinition(
+            id = id, displayName = id.name, description = "", sightRange = 3,
+            primarySkills = emptySet<SkillId>(), neutralSkills = emptySet(),
+            forbiddenCombatSkills = emptySet(), damageMultipliers = emptyMap(),
+            behaviorFingerprint = emptyMap(), parentClass = parent,
+        )
     }
 }

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryDeathPenaltyIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryDeathPenaltyIntegrationTest.kt
@@ -8,6 +8,7 @@ import dev.gvart.genesara.player.AgentProfileRepository
 import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.AttributeMods
 import dev.gvart.genesara.player.AttributePointLoss
+import dev.gvart.genesara.player.NoOpClassLookup
 import dev.gvart.genesara.player.Race
 import dev.gvart.genesara.player.RaceId
 import dev.gvart.genesara.player.RaceLookup
@@ -258,7 +259,7 @@ class JooqAgentRegistryDeathPenaltyIntegrationTest {
         val lookup = SingleRaceLookup(race)
         val props = RaceDefinitionProperties(defaultId = race.id.value)
         val assigner = RaceAssigner(lookup, props, FixedRandom)
-        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner)
+        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner, NoOpClassLookup)
     }
 
     private fun readAgent(id: AgentId) =

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryIntegrationTest.kt
@@ -8,6 +8,7 @@ import dev.gvart.genesara.player.AgentProfile
 import dev.gvart.genesara.player.AgentProfileRepository
 import dev.gvart.genesara.player.AttributeDerivation
 import dev.gvart.genesara.player.AttributeMods
+import dev.gvart.genesara.player.NoOpClassLookup
 import dev.gvart.genesara.player.Race
 import dev.gvart.genesara.player.RaceId
 import dev.gvart.genesara.player.RaceLookup
@@ -188,7 +189,7 @@ class JooqAgentRegistryIntegrationTest {
         val props = RaceDefinitionProperties(defaultId = race.id.value)
         val assigner = RaceAssigner(lookup, props, FixedRandom)
         val profileRepo = JooqProfileRepository(dsl)
-        return JooqAgentRegistry(dsl, profileRepo, assigner)
+        return JooqAgentRegistry(dsl, profileRepo, assigner, NoOpClassLookup)
     }
 
     private class SingleRaceLookup(private val race: Race) : RaceLookup {

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryLastActiveIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryLastActiveIntegrationTest.kt
@@ -5,6 +5,7 @@ import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AgentProfile
 import dev.gvart.genesara.player.AgentProfileRepository
 import dev.gvart.genesara.player.AttributeMods
+import dev.gvart.genesara.player.NoOpClassLookup
 import dev.gvart.genesara.player.Race
 import dev.gvart.genesara.player.RaceId
 import dev.gvart.genesara.player.RaceLookup
@@ -136,7 +137,7 @@ class JooqAgentRegistryLastActiveIntegrationTest {
         val lookup = SingleRaceLookup(race)
         val props = RaceDefinitionProperties(defaultId = race.id.value)
         val assigner = RaceAssigner(lookup, props, FixedRandom)
-        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner)
+        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner, NoOpClassLookup)
     }
 
     private class SingleRaceLookup(private val race: Race) : RaceLookup {

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ClassCatalogConsistencyValidator.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ClassCatalogConsistencyValidator.kt
@@ -34,6 +34,17 @@ internal class ClassCatalogConsistencyValidator(
                 .forEach { problems += "${def.id}: behavior-fingerprint.$it does not match any ActionCategory (known: ${axisNames.sorted()})" }
         }
 
+        // Skill-feature step 8 (#34): the L50 emitter and the addCharacterXp
+        // L50 cap are coupled to "every base class has ≥2 evolutions". Without
+        // 2 candidates the emitter can't offer; the cap would still strand the
+        // agent at L50 with no way out. Fail boot rather than runtime-warn.
+        classes.baseClasses().forEach { base ->
+            if (base.evolutions.size < 2) {
+                problems += "${base.id}: base classes must declare >= 2 evolutions for the L50 event " +
+                    "(found ${base.evolutions.size}: ${base.evolutions})"
+            }
+        }
+
         require(problems.isEmpty()) {
             buildString {
                 append("Class catalog cross-module validation failed:\n")

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/behavior/BehaviorTracker.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/behavior/BehaviorTracker.kt
@@ -16,4 +16,23 @@ internal interface BehaviorTracker {
 
     /** Cumulative count per category; categories the agent has never touched are absent. */
     fun snapshotFor(agent: AgentId): Map<ActionCategory, Int>
+
+    /**
+     * Snapshot the current cumulative counters as the per-category baseline for
+     * windowed reads. Called from the `ClassChosen` listener so the L50 evolution
+     * scorer (#34) sees only the agent's post-L10 behaviour. Idempotent and safe
+     * to re-run; the DB-side CHECK clamps `baseline_count <= action_count`.
+     *
+     * Categories the agent first touches after this call implicitly land with
+     * `baseline_count = 0`, so `snapshotForWindow` returns the full count for
+     * those — exactly the right answer.
+     */
+    fun markBaseline(agent: AgentId)
+
+    /**
+     * Per-category counts since the last [markBaseline] (i.e. since the agent
+     * picked their L10 class). Returns an empty map when the agent has no rows
+     * yet. Categories with `action_count == baseline_count` are dropped.
+     */
+    fun snapshotForWindow(agent: AgentId): Map<ActionCategory, Int>
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/behavior/JooqBehaviorTracker.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/behavior/JooqBehaviorTracker.kt
@@ -30,7 +30,29 @@ internal class JooqBehaviorTracker(
 
     @Transactional(readOnly = true)
     override fun snapshotFor(agent: AgentId): Map<ActionCategory, Int> =
-        dsl.select(AGENT_ACTION_COUNTERS.CATEGORY, AGENT_ACTION_COUNTERS.ACTION_COUNT)
+        readSnapshot(agent) { actionCount, _ -> actionCount }
+
+    @Transactional
+    override fun markBaseline(agent: AgentId) {
+        dsl.update(AGENT_ACTION_COUNTERS)
+            .set(AGENT_ACTION_COUNTERS.BASELINE_COUNT, AGENT_ACTION_COUNTERS.ACTION_COUNT)
+            .where(AGENT_ACTION_COUNTERS.AGENT_ID.eq(agent.id))
+            .execute()
+    }
+
+    @Transactional(readOnly = true)
+    override fun snapshotForWindow(agent: AgentId): Map<ActionCategory, Int> =
+        readSnapshot(agent) { actionCount, baseline -> actionCount - baseline }
+
+    private fun readSnapshot(
+        agent: AgentId,
+        project: (actionCount: Int, baseline: Int) -> Int,
+    ): Map<ActionCategory, Int> =
+        dsl.select(
+            AGENT_ACTION_COUNTERS.CATEGORY,
+            AGENT_ACTION_COUNTERS.ACTION_COUNT,
+            AGENT_ACTION_COUNTERS.BASELINE_COUNT,
+        )
             .from(AGENT_ACTION_COUNTERS)
             .where(AGENT_ACTION_COUNTERS.AGENT_ID.eq(agent.id))
             .fetch()
@@ -45,7 +67,9 @@ internal class JooqBehaviorTracker(
                     return@mapNotNull null
                 }
                 val count = row[AGENT_ACTION_COUNTERS.ACTION_COUNT] ?: 0
-                category to count
+                val baseline = row[AGENT_ACTION_COUNTERS.BASELINE_COUNT] ?: 0
+                val projected = project(count, baseline)
+                if (projected <= 0) null else category to projected
             }
             .toMap()
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/BehaviorBaselineListener.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/BehaviorBaselineListener.kt
@@ -1,0 +1,42 @@
+package dev.gvart.genesara.world.internal.classes
+
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+/**
+ * Snapshots the agent's cumulative action counters into the per-row baseline
+ * once the agent has committed a class via `select_class`. The L50 evolution
+ * scorer (#34) reads `snapshotForWindow` which subtracts this baseline, so the
+ * score sees only the agent's post-class behaviour. See
+ * `mechanics-reference.md` §4.1 for the windowing rationale.
+ *
+ * Runs in [TransactionPhase.AFTER_COMMIT] so a `markBaseline` failure does NOT
+ * roll back the original `select_class` write — the agent stays classed, the
+ * baseline write retries on the next event or stays at zero. Counter logic
+ * tolerates a missing baseline as "every action since L1 counts in the
+ * window," which is a degraded but non-broken score; the explicit log here
+ * surfaces the gap so a sweep can fix it post-incident.
+ */
+@Component
+internal class BehaviorBaselineListener(
+    private val behavior: BehaviorTracker,
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun on(event: AgentEvent.ClassChosen) {
+        try {
+            behavior.markBaseline(event.agent)
+        } catch (e: RuntimeException) {
+            log.warn(
+                "markBaseline failed for {} after select_class commit; L50 window will include pre-class actions until reseeded",
+                event.agent.id, e,
+            )
+        }
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgression.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgression.kt
@@ -8,34 +8,39 @@ import org.springframework.stereotype.Component
 
 /**
  * Canonical character-XP grant entry point. Wraps the atomic
- * [AgentRegistry.addCharacterXp] mutation and routes any 9 → 10 transition
- * through [Level10ChoiceEmitter] so future XP-source slices (quest rewards,
- * NPC kills) only need to call this method.
+ * [AgentRegistry.addCharacterXp] mutation and routes level-milestone
+ * transitions through the matching emitter so future XP-source slices
+ * (quest rewards, NPC kills) only need to call this method.
  *
  * Currently no reducer wires up to this class — Phase-1 verbs only grant
- * skill XP via `SkillProgression`. The component exists so the level-10 flow
- * is end-to-end exercisable from integration tests, and so the wiring point
- * is fixed for the first XP-source slice that lands.
+ * skill XP via `SkillProgression`. The component exists so the L10 / L50
+ * flows are end-to-end exercisable from integration tests, and so the wiring
+ * point is fixed for the first XP-source slice that lands.
  */
 @Component
 internal class CharacterXpProgression(
     private val agents: AgentRegistry,
     private val level10: Level10ChoiceEmitter,
+    private val level50: Level50EvolutionEmitter,
     private val tickClock: TickClock,
 ) {
 
     fun grant(agentId: AgentId, delta: Int): AddCharacterXpOutcome? {
         val outcome = agents.addCharacterXp(agentId, delta) ?: return null
-        if (outcome is AddCharacterXpOutcome.Granted &&
-            outcome.previousLevel < LEVEL_TEN_THRESHOLD &&
-            outcome.currentLevel >= LEVEL_TEN_THRESHOLD
-        ) {
-            level10.tryEmitFor(agentId, tickClock.currentTick())
+        if (outcome is AddCharacterXpOutcome.Granted) {
+            val tick = tickClock.currentTick()
+            if (outcome.previousLevel < LEVEL_TEN_THRESHOLD && outcome.currentLevel >= LEVEL_TEN_THRESHOLD) {
+                level10.tryEmitFor(agentId, tick)
+            }
+            if (outcome.previousLevel < LEVEL_FIFTY_THRESHOLD && outcome.currentLevel >= LEVEL_FIFTY_THRESHOLD) {
+                level50.tryEmitFor(agentId, tick)
+            }
         }
         return outcome
     }
 
     private companion object {
         const val LEVEL_TEN_THRESHOLD = 10
+        const val LEVEL_FIFTY_THRESHOLD = 50
     }
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/Level10ChoiceEmitter.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/Level10ChoiceEmitter.kt
@@ -47,7 +47,7 @@ internal class Level10ChoiceEmitter(
         if (agent.level < LEVEL_TEN_THRESHOLD) return
 
         val snapshot = behavior.snapshotFor(agentId).mapKeys { it.key.name }
-        val topTwo = ClassFingerprintScorer.scoreTopTwo(snapshot, classes.all())
+        val topTwo = ClassFingerprintScorer.scoreTopTwo(snapshot, classes.baseClasses())
         if (topTwo.size < 2) {
             log.warn(
                 "Level-10 emitter aborted for {}: catalog produced {} candidates",

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/Level50EvolutionEmitter.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/Level50EvolutionEmitter.kt
@@ -1,0 +1,100 @@
+package dev.gvart.genesara.world.internal.classes
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.ClassLookup
+import dev.gvart.genesara.player.ClassOffer
+import dev.gvart.genesara.player.RecordEvolutionOfferOutcome
+import dev.gvart.genesara.player.classes.ClassFingerprintScorer
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+/**
+ * Mirror of [Level10ChoiceEmitter] for the L50 evolution event (#34). Reads
+ * the agent's *windowed* behavior snapshot (counters since `select_class`
+ * committed — see `mechanics-reference.md` §4.1), scores it against the
+ * parent class's evolution branches, persists the top-2 as the agent's
+ * pending evolution offer, and publishes [AgentEvent.EvolutionChoiceOffered].
+ *
+ * Idempotency lives in [AgentRegistry.recordPendingEvolutionChoice]: the DB
+ * write rejects when the agent has no class, is already on an evolution, or
+ * already has a pending evolution offer. A duplicate fire is a no-op for
+ * both persistence and the event.
+ */
+@Component
+internal class Level50EvolutionEmitter(
+    private val agents: AgentRegistry,
+    private val classes: ClassLookup,
+    private val behavior: BehaviorTracker,
+    private val publisher: ApplicationEventPublisher,
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun tryEmitFor(agentId: AgentId, tick: Long) {
+        val agent = agents.find(agentId)
+        if (agent == null) {
+            log.warn("L50 evolution emit skipped for {}: agent row missing", agentId.id)
+            return
+        }
+        val classId = agent.classId ?: return
+        if (agent.offeredEvolutions != null) return
+        if (agent.level < LEVEL_FIFTY_THRESHOLD) return
+
+        val def = classes.byId(classId) ?: run {
+            log.warn("L50 evolution emit skipped for {}: catalog has no entry for {}", agentId.id, classId)
+            return
+        }
+        if (def.parentClass != null) return
+
+        val candidates = classes.evolutionsOf(classId)
+        if (candidates.size < 2) {
+            log.warn(
+                "L50 evolution emit aborted for {}: catalog produced {} evolution candidate(s) for {}",
+                agentId.id, candidates.size, classId,
+            )
+            return
+        }
+        val snapshot = behavior.snapshotForWindow(agentId).mapKeys { it.key.name }
+        val topTwo = ClassFingerprintScorer.scoreTopTwo(snapshot, candidates)
+        if (topTwo.size < 2) {
+            log.warn(
+                "L50 evolution emit aborted for {}: scorer returned {} candidate(s)",
+                agentId.id, topTwo.size,
+            )
+            return
+        }
+        val offer = ClassOffer(topTwo[0], topTwo[1])
+
+        when (val outcome = agents.recordPendingEvolutionChoice(agentId, offer)) {
+            RecordEvolutionOfferOutcome.Recorded ->
+                publisher.publishEvent(
+                    AgentEvent.EvolutionChoiceOffered(
+                        agent = agentId,
+                        fromClass = classId,
+                        candidates = offer.toList(),
+                        tick = tick,
+                    )
+                )
+
+            RecordEvolutionOfferOutcome.NoClassAssigned,
+            is RecordEvolutionOfferOutcome.AlreadyEvolved,
+            is RecordEvolutionOfferOutcome.AlreadyOffered,
+            RecordEvolutionOfferOutcome.UnknownAgent ->
+                log.debug("L50 evolution emit skipped for {}: {}", agentId.id, outcome)
+
+            is RecordEvolutionOfferOutcome.InvalidCandidate ->
+                log.error(
+                    "L50 evolution emit produced an invalid candidate for {}: {} is not an evolution of {}",
+                    agentId.id, outcome.candidate, outcome.expectedParent,
+                )
+        }
+    }
+
+    private companion object {
+        const val LEVEL_FIFTY_THRESHOLD = 50
+    }
+}

--- a/world/src/main/resources/db/migration/world/V19__agent_action_counter_baseline.sql
+++ b/world/src/main/resources/db/migration/world/V19__agent_action_counter_baseline.sql
@@ -1,0 +1,25 @@
+-- Skill-feature step 8 (issue #34): the L50 evolution scorer needs a "windowed"
+-- behavior snapshot — only counters from the recent post-class-choice stretch
+-- count, so an agent that pivoted playstyle after L10 can evolve down a new
+-- branch.
+--
+-- Cheapest faithful implementation given the existing cumulative-only counter
+-- shape: add a per-row baseline. When `select_class` commits the L10 pick we
+-- copy `action_count` → `baseline_count` for every existing row of the agent;
+-- categories the agent first touches AFTER classing implicitly start at
+-- baseline 0 (default below), so the read `action_count - baseline_count` is
+-- exactly the post-classing count without a tick-bucketed history table.
+--
+-- Concurrency invariant for `baseline <= action_count`:
+--   `record()` is the only writer of `action_count`, and it ONLY increments
+--   (no decrement, no reset). So any value of `action_count` observed by a
+--   `markBaseline` UPDATE is a lower-bound for every subsequent observation
+--   in another transaction. Postgres takes a row-level lock on the UPDATE,
+--   so the listener's `SET baseline_count = action_count` is atomic with the
+--   read of `action_count`. The CHECK is a belt-and-braces guard against
+--   future schema edits that break monotonicity (e.g. a "decay" job that
+--   shrinks counters); break it loudly rather than letting `snapshotForWindow`
+--   return negative numbers downstream.
+ALTER TABLE agent_action_counters
+    ADD COLUMN baseline_count INT NOT NULL DEFAULT 0
+        CHECK (baseline_count >= 0 AND baseline_count <= action_count);

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/ClassCatalogConsistencyValidatorTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/ClassCatalogConsistencyValidatorTest.kt
@@ -33,6 +33,15 @@ class ClassCatalogConsistencyValidatorTest {
         ClassCatalogConsistencyValidator(StubClasses(listOf(soldier()))).validate()
     }
 
+    @Test
+    fun `base class with fewer than 2 evolutions is rejected (L50 emitter prerequisite)`() {
+        val onlyOne = soldier().copy(evolutions = listOf(AgentClass.HEAVY_SOLDIER))
+        val ex = assertFailsWith<IllegalArgumentException> {
+            ClassCatalogConsistencyValidator(StubClasses(listOf(onlyOne))).validate()
+        }
+        assertTrue(ex.message!!.contains("must declare >= 2 evolutions"))
+    }
+
     private fun soldier() = ClassDefinition(
         id = AgentClass.SOLDIER,
         displayName = "Soldier",
@@ -43,11 +52,14 @@ class ClassCatalogConsistencyValidatorTest {
         forbiddenCombatSkills = emptySet(),
         damageMultipliers = mapOf("SLASH" to 1.1),
         behaviorFingerprint = mapOf("COMBAT" to 1.0),
+        evolutions = listOf(AgentClass.HEAVY_SOLDIER, AgentClass.STEALTH_SOLDIER),
     )
 
     private class StubClasses(private val defs: List<ClassDefinition>) : ClassLookup {
         override fun byId(classId: AgentClass): ClassDefinition? = defs.firstOrNull { it.id == classId }
         override fun all(): List<ClassDefinition> = defs
+        override fun baseClasses(): List<ClassDefinition> = defs.filter { it.parentClass == null }
+        override fun evolutionsOf(parent: AgentClass): List<ClassDefinition> = emptyList()
         override fun sightRange(classId: AgentClass?): Int = 3
         override fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double = 1.0
         override fun damageMultiplier(classId: AgentClass?, damageType: String): Double = 1.0

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/behavior/JooqBehaviorTrackerIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/behavior/JooqBehaviorTrackerIntegrationTest.kt
@@ -122,4 +122,76 @@ class JooqBehaviorTrackerIntegrationTest {
 
         assertEquals(mapOf(ActionCategory.COMBAT to 1), tracker.snapshotFor(agent))
     }
+
+    // ─────────────────────── L50 windowed read (#34) ───────────────────────
+
+    @Test
+    fun `markBaseline copies action_count into baseline_count for every category of the agent`() {
+        repeat(3) { _ -> tracker.record(agent, ActionCategory.COMBAT, tick = 1L) }
+        repeat(7) { _ -> tracker.record(agent, ActionCategory.GATHER, tick = 1L) }
+
+        tracker.markBaseline(agent)
+
+        val rows: Map<String, Int> = dsl.select(AGENT_ACTION_COUNTERS.CATEGORY, AGENT_ACTION_COUNTERS.BASELINE_COUNT)
+            .from(AGENT_ACTION_COUNTERS)
+            .where(AGENT_ACTION_COUNTERS.AGENT_ID.eq(agent.id))
+            .fetch()
+            .associate { it[AGENT_ACTION_COUNTERS.CATEGORY]!! to it[AGENT_ACTION_COUNTERS.BASELINE_COUNT]!! }
+        assertEquals(mapOf("COMBAT" to 3, "GATHER" to 7), rows)
+    }
+
+    @Test
+    fun `snapshotForWindow returns empty immediately after markBaseline`() {
+        repeat(5) { _ -> tracker.record(agent, ActionCategory.COMBAT, tick = 1L) }
+        tracker.markBaseline(agent)
+
+        assertEquals(emptyMap<ActionCategory, Int>(), tracker.snapshotForWindow(agent))
+        // Cumulative read still sees the pre-baseline counts.
+        assertEquals(mapOf(ActionCategory.COMBAT to 5), tracker.snapshotFor(agent))
+    }
+
+    @Test
+    fun `snapshotForWindow returns post-baseline increments only`() {
+        repeat(10) { _ -> tracker.record(agent, ActionCategory.COMBAT, tick = 1L) }
+        tracker.markBaseline(agent)
+        repeat(4) { _ -> tracker.record(agent, ActionCategory.COMBAT, tick = 2L) }
+
+        assertEquals(mapOf(ActionCategory.COMBAT to 4), tracker.snapshotForWindow(agent))
+    }
+
+    @Test
+    fun `categories first touched after markBaseline contribute their full count to the window`() {
+        repeat(5) { _ -> tracker.record(agent, ActionCategory.GATHER, tick = 1L) }
+        tracker.markBaseline(agent)
+        // EXPLORE row didn't exist at markBaseline, so its baseline defaults to 0
+        // (CHECK constraint allows it because `baseline = 0 <= action_count`).
+        repeat(3) { _ -> tracker.record(agent, ActionCategory.EXPLORE, tick = 2L) }
+
+        assertEquals(mapOf(ActionCategory.EXPLORE to 3), tracker.snapshotForWindow(agent))
+    }
+
+    @Test
+    fun `markBaseline scopes to one agent and leaves others untouched`() {
+        tracker.record(agent, ActionCategory.COMBAT, tick = 1L)
+        tracker.record(other, ActionCategory.COMBAT, tick = 1L)
+
+        tracker.markBaseline(agent)
+
+        // Other agent's baseline stays at 0; their windowed read returns the full count.
+        assertEquals(mapOf(ActionCategory.COMBAT to 1), tracker.snapshotForWindow(other))
+        assertEquals(emptyMap(), tracker.snapshotForWindow(agent))
+    }
+
+    @Test
+    fun `CHECK constraint rejects manual writes that put baseline above action_count`() {
+        tracker.record(agent, ActionCategory.COMBAT, tick = 1L)
+        val ex = runCatching {
+            dsl.update(AGENT_ACTION_COUNTERS)
+                .set(AGENT_ACTION_COUNTERS.BASELINE_COUNT, 99)
+                .where(AGENT_ACTION_COUNTERS.AGENT_ID.eq(agent.id))
+                .and(AGENT_ACTION_COUNTERS.CATEGORY.eq(ActionCategory.COMBAT.name))
+                .execute()
+        }.exceptionOrNull()
+        kotlin.test.assertNotNull(ex, "expected CHECK violation when baseline > action_count")
+    }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/BehaviorBaselineListenerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/BehaviorBaselineListenerTest.kt
@@ -1,0 +1,37 @@
+package dev.gvart.genesara.world.internal.classes
+
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class BehaviorBaselineListenerTest {
+
+    @Test
+    fun `marks the baseline so post-classing window starts at zero`() {
+        val tracker = InMemoryBehaviorTracker()
+        val agentId = AgentId(UUID.randomUUID())
+        repeat(10) { _ -> tracker.record(agentId, ActionCategory.COMBAT, tick = 1L) }
+        repeat(3) { _ -> tracker.record(agentId, ActionCategory.GATHER, tick = 1L) }
+        val listener = BehaviorBaselineListener(tracker)
+
+        listener.on(AgentEvent.ClassChosen(agent = agentId, classId = AgentClass.SOLDIER, tick = 5L))
+
+        // Cumulative read still sees the pre-classing counters.
+        assertEquals(mapOf(ActionCategory.COMBAT to 10, ActionCategory.GATHER to 3), tracker.snapshotFor(agentId))
+        // Windowed read returns nothing right after baseline.
+        assertEquals(emptyMap<ActionCategory, Int>(), tracker.snapshotForWindow(agentId))
+
+        // Post-classing actions accrue into the windowed read; baseline stays put.
+        repeat(4) { _ -> tracker.record(agentId, ActionCategory.COMBAT, tick = 6L) }
+        repeat(2) { _ -> tracker.record(agentId, ActionCategory.EXPLORE, tick = 7L) }
+        assertEquals(
+            mapOf(ActionCategory.COMBAT to 4, ActionCategory.EXPLORE to 2),
+            tracker.snapshotForWindow(agentId),
+        )
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgressionTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgressionTest.kt
@@ -38,13 +38,15 @@ class CharacterXpProgressionTest {
             // which would happen on the no-op catalog's empty list).
             stateAfter = level10Unclassed(),
         )
-        val emitter = RecordingEmitter(agents)
-        val progression = CharacterXpProgression(agents, emitter, FixedTickClock(tick))
+        val l10 = RecordingL10Emitter(agents)
+        val l50 = RecordingL50Emitter(agents)
+        val progression = CharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
 
         progression.grant(agentId, 100)
 
-        assertEquals(1, emitter.invocations)
-        assertEquals(tick, emitter.lastTick)
+        assertEquals(1, l10.invocations)
+        assertEquals(tick, l10.lastTick)
+        assertEquals(0, l50.invocations)
     }
 
     @Test
@@ -60,12 +62,14 @@ class CharacterXpProgressionTest {
             ),
             stateAfter = level10Unclassed().copy(level = 6),
         )
-        val emitter = RecordingEmitter(agents)
-        val progression = CharacterXpProgression(agents, emitter, FixedTickClock(tick))
+        val l10 = RecordingL10Emitter(agents)
+        val l50 = RecordingL50Emitter(agents)
+        val progression = CharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
 
         progression.grant(agentId, 100)
 
-        assertEquals(0, emitter.invocations)
+        assertEquals(0, l10.invocations)
+        assertEquals(0, l50.invocations)
     }
 
     @Test
@@ -81,36 +85,67 @@ class CharacterXpProgressionTest {
             ),
             stateAfter = level10Unclassed().copy(level = 11),
         )
-        val emitter = RecordingEmitter(agents)
-        val progression = CharacterXpProgression(agents, emitter, FixedTickClock(tick))
+        val l10 = RecordingL10Emitter(agents)
+        val l50 = RecordingL50Emitter(agents)
+        val progression = CharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
 
         progression.grant(agentId, 1100)
 
-        assertEquals(0, emitter.invocations, "the offer fires only once, on the 9→10 boundary")
+        assertEquals(0, l10.invocations, "the offer fires only once, on the 9→10 boundary")
+        assertEquals(0, l50.invocations)
     }
 
     @Test
-    fun `passes through a NegativeDelta outcome without touching the emitter`() {
+    fun `routes a 49-to-50 transition through the level-50 emitter`() {
+        val agents = SequencedRegistry(
+            grant = AddCharacterXpOutcome.Granted(
+                previousLevel = 49,
+                currentLevel = 50,
+                xpCurrent = 0,
+                xpToNext = 5000,
+                unspentAttributePoints = 250,
+                cappedAtPendingClassChoice = false,
+                cappedAtPendingEvolutionChoice = false,
+            ),
+            stateAfter = level10Unclassed().copy(level = 50),
+        )
+        val l10 = RecordingL10Emitter(agents)
+        val l50 = RecordingL50Emitter(agents)
+        val progression = CharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
+
+        progression.grant(agentId, 100)
+
+        assertEquals(0, l10.invocations, "L10 emitter only fires on the 9→10 boundary")
+        assertEquals(1, l50.invocations)
+        assertEquals(tick, l50.lastTick)
+    }
+
+    @Test
+    fun `passes through a NegativeDelta outcome without touching the emitters`() {
         val agents = SequencedRegistry(grant = AddCharacterXpOutcome.NegativeDelta, stateAfter = level10Unclassed())
-        val emitter = RecordingEmitter(agents)
-        val progression = CharacterXpProgression(agents, emitter, FixedTickClock(tick))
+        val l10 = RecordingL10Emitter(agents)
+        val l50 = RecordingL50Emitter(agents)
+        val progression = CharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
 
         val outcome = progression.grant(agentId, -5)
 
         assertEquals(AddCharacterXpOutcome.NegativeDelta, outcome)
-        assertEquals(0, emitter.invocations)
+        assertEquals(0, l10.invocations)
+        assertEquals(0, l50.invocations)
     }
 
     @Test
     fun `unknown agent (null) is propagated and the emitter is not invoked`() {
         val agents = SequencedRegistry(grant = null, stateAfter = level10Unclassed())
-        val emitter = RecordingEmitter(agents)
-        val progression = CharacterXpProgression(agents, emitter, FixedTickClock(tick))
+        val l10 = RecordingL10Emitter(agents)
+        val l50 = RecordingL50Emitter(agents)
+        val progression = CharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
 
         val outcome = progression.grant(agentId, 100)
 
         assertNull(outcome)
-        assertEquals(0, emitter.invocations)
+        assertEquals(0, l10.invocations)
+        assertEquals(0, l50.invocations)
     }
 
     private fun level10Unclassed() = Agent(
@@ -121,7 +156,22 @@ class CharacterXpProgressionTest {
         level = 10,
     )
 
-    private inner class RecordingEmitter(agents: AgentRegistry) : Level10ChoiceEmitter(
+    private inner class RecordingL10Emitter(agents: AgentRegistry) : Level10ChoiceEmitter(
+        agents = agents,
+        classes = NoOpClassLookup,
+        behavior = InMemoryBehaviorTracker(),
+        publisher = SilentPublisher,
+    ) {
+        var invocations = 0
+        var lastTick: Long = -1
+
+        override fun tryEmitFor(agentId: AgentId, tick: Long) {
+            invocations += 1
+            lastTick = tick
+        }
+    }
+
+    private inner class RecordingL50Emitter(agents: AgentRegistry) : Level50EvolutionEmitter(
         agents = agents,
         classes = NoOpClassLookup,
         behavior = InMemoryBehaviorTracker(),

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/Level10ChoiceEmitterTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/Level10ChoiceEmitterTest.kt
@@ -153,6 +153,11 @@ class Level10ChoiceEmitterTest {
         private val list = defs.toList()
         override fun byId(classId: AgentClass): ClassDefinition? = list.firstOrNull { it.id == classId }
         override fun all(): List<ClassDefinition> = list
+        override fun baseClasses(): List<ClassDefinition> = list.filter { it.parentClass == null }
+        override fun evolutionsOf(parent: AgentClass): List<ClassDefinition> {
+            val def = byId(parent) ?: return emptyList()
+            return def.evolutions.mapNotNull(::byId)
+        }
         override fun sightRange(classId: AgentClass?): Int = 3
         override fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double = 1.0
         override fun damageMultiplier(classId: AgentClass?, damageType: String): Double = 1.0

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/Level50EvolutionEmitterTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/Level50EvolutionEmitterTest.kt
@@ -1,0 +1,246 @@
+package dev.gvart.genesara.world.internal.classes
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.ClassDefinition
+import dev.gvart.genesara.player.ClassLookup
+import dev.gvart.genesara.player.ClassOffer
+import dev.gvart.genesara.player.NoOpClassLookup
+import dev.gvart.genesara.player.RecordEvolutionOfferOutcome
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class Level50EvolutionEmitterTest {
+
+    private val agentId = AgentId(UUID.randomUUID())
+    private val owner = PlayerId(UUID.randomUUID())
+    private val tick = 9_000L
+
+    @Test
+    fun `emits EvolutionChoiceOffered with the windowed top-2 evolutions of the parent`() {
+        val behavior = InMemoryBehaviorTracker().also {
+            // Pre-class history that should NOT count once we mark the baseline.
+            repeat(50) { _ -> it.record(agentId, ActionCategory.GATHER, tick) }
+            it.markBaseline(agentId)
+            // Post-class window: 20 COMBAT + 5 EXPLORE — should beat HEAVY_SOLDIER's
+            // tank fingerprint and pick STEALTH_SOLDIER over COMMANDER.
+            repeat(20) { _ -> it.record(agentId, ActionCategory.COMBAT, tick) }
+            repeat(5) { _ -> it.record(agentId, ActionCategory.EXPLORE, tick) }
+        }
+        val classes = StubClassLookup(
+            soldierWith(
+                evolutions = listOf(
+                    AgentClass.HEAVY_SOLDIER,
+                    AgentClass.STEALTH_SOLDIER,
+                    AgentClass.COMMANDER,
+                ),
+            ),
+            evolutionFor(AgentClass.HEAVY_SOLDIER, AgentClass.SOLDIER, mapOf("COMBAT" to 1.4)),
+            evolutionFor(AgentClass.STEALTH_SOLDIER, AgentClass.SOLDIER, mapOf("COMBAT" to 1.2, "EXPLORE" to 0.5)),
+            evolutionFor(AgentClass.COMMANDER, AgentClass.SOLDIER, mapOf("COMBAT" to 1.0, "SOCIAL" to 0.8)),
+        )
+        val agents = StubAgentRegistry(initial = soldierAt(level = 50))
+        val publisher = RecordingPublisher()
+        val emitter = Level50EvolutionEmitter(agents, classes, behavior, publisher)
+
+        emitter.tryEmitFor(agentId, tick)
+
+        val event = publisher.events.filterIsInstance<AgentEvent.EvolutionChoiceOffered>().single()
+        assertEquals(agentId, event.agent)
+        assertEquals(AgentClass.SOLDIER, event.fromClass)
+        assertEquals(listOf(AgentClass.HEAVY_SOLDIER, AgentClass.STEALTH_SOLDIER), event.candidates)
+        assertEquals(tick, event.tick)
+        assertEquals(ClassOffer(AgentClass.HEAVY_SOLDIER, AgentClass.STEALTH_SOLDIER), agents.recordedOffer)
+    }
+
+    @Test
+    fun `is a no-op when the agent is below level 50`() {
+        val classes = StubClassLookup(
+            soldierWith(evolutions = listOf(AgentClass.HEAVY_SOLDIER, AgentClass.STEALTH_SOLDIER)),
+            evolutionFor(AgentClass.HEAVY_SOLDIER, AgentClass.SOLDIER, mapOf("COMBAT" to 1.0)),
+            evolutionFor(AgentClass.STEALTH_SOLDIER, AgentClass.SOLDIER, mapOf("COMBAT" to 0.9)),
+        )
+        val agents = StubAgentRegistry(initial = soldierAt(level = 49))
+        val publisher = RecordingPublisher()
+        val emitter = Level50EvolutionEmitter(agents, classes, InMemoryBehaviorTracker(), publisher)
+
+        emitter.tryEmitFor(agentId, tick)
+
+        assertEquals(0, agents.recordCalls)
+        assertTrue(publisher.events.isEmpty())
+    }
+
+    @Test
+    fun `is a no-op when the agent has no class assigned`() {
+        val agents = StubAgentRegistry(initial = soldierAt(level = 50).copy(classId = null))
+        val publisher = RecordingPublisher()
+        val emitter = Level50EvolutionEmitter(agents, NoOpClassLookup, InMemoryBehaviorTracker(), publisher)
+
+        emitter.tryEmitFor(agentId, tick)
+
+        assertEquals(0, agents.recordCalls)
+        assertTrue(publisher.events.isEmpty())
+    }
+
+    @Test
+    fun `is a no-op when the agent is already on an evolution class`() {
+        val classes = StubClassLookup(
+            evolutionFor(AgentClass.HEAVY_SOLDIER, AgentClass.SOLDIER, mapOf("COMBAT" to 1.0)),
+        )
+        val agents = StubAgentRegistry(initial = soldierAt(level = 50).copy(classId = AgentClass.HEAVY_SOLDIER))
+        val publisher = RecordingPublisher()
+        val emitter = Level50EvolutionEmitter(agents, classes, InMemoryBehaviorTracker(), publisher)
+
+        emitter.tryEmitFor(agentId, tick)
+
+        assertEquals(0, agents.recordCalls)
+        assertTrue(publisher.events.isEmpty())
+    }
+
+    @Test
+    fun `is a no-op when an evolution offer is already pending`() {
+        val classes = StubClassLookup(
+            soldierWith(evolutions = listOf(AgentClass.HEAVY_SOLDIER, AgentClass.STEALTH_SOLDIER)),
+            evolutionFor(AgentClass.HEAVY_SOLDIER, AgentClass.SOLDIER, mapOf("COMBAT" to 1.0)),
+            evolutionFor(AgentClass.STEALTH_SOLDIER, AgentClass.SOLDIER, mapOf("COMBAT" to 0.9)),
+        )
+        val agents = StubAgentRegistry(
+            initial = soldierAt(level = 50).copy(
+                offeredEvolutions = ClassOffer(AgentClass.HEAVY_SOLDIER, AgentClass.STEALTH_SOLDIER),
+            ),
+        )
+        val publisher = RecordingPublisher()
+        val emitter = Level50EvolutionEmitter(agents, classes, InMemoryBehaviorTracker(), publisher)
+
+        emitter.tryEmitFor(agentId, tick)
+
+        assertEquals(0, agents.recordCalls)
+        assertTrue(publisher.events.isEmpty())
+    }
+
+    @Test
+    fun `aborts when the parent class declares fewer than 2 evolutions`() {
+        val classes = StubClassLookup(
+            soldierWith(evolutions = listOf(AgentClass.HEAVY_SOLDIER)),
+            evolutionFor(AgentClass.HEAVY_SOLDIER, AgentClass.SOLDIER, mapOf("COMBAT" to 1.0)),
+        )
+        val agents = StubAgentRegistry(initial = soldierAt(level = 50))
+        val publisher = RecordingPublisher()
+        val emitter = Level50EvolutionEmitter(agents, classes, InMemoryBehaviorTracker(), publisher)
+
+        emitter.tryEmitFor(agentId, tick)
+
+        assertEquals(0, agents.recordCalls)
+        assertTrue(publisher.events.isEmpty())
+    }
+
+    @Test
+    fun `suppresses the event when the registry rejects the offer write`() {
+        val classes = StubClassLookup(
+            soldierWith(evolutions = listOf(AgentClass.HEAVY_SOLDIER, AgentClass.STEALTH_SOLDIER)),
+            evolutionFor(AgentClass.HEAVY_SOLDIER, AgentClass.SOLDIER, mapOf("COMBAT" to 1.0)),
+            evolutionFor(AgentClass.STEALTH_SOLDIER, AgentClass.SOLDIER, mapOf("COMBAT" to 0.9)),
+        )
+        val agents = StubAgentRegistry(
+            initial = soldierAt(level = 50),
+            recordResult = RecordEvolutionOfferOutcome.AlreadyEvolved(AgentClass.HEAVY_SOLDIER),
+        )
+        val publisher = RecordingPublisher()
+        val emitter = Level50EvolutionEmitter(agents, classes, InMemoryBehaviorTracker(), publisher)
+
+        emitter.tryEmitFor(agentId, tick)
+
+        assertEquals(1, agents.recordCalls)
+        assertTrue(publisher.events.none { it is AgentEvent.EvolutionChoiceOffered })
+    }
+
+    private fun soldierAt(level: Int) = Agent(
+        id = agentId,
+        owner = owner,
+        name = "Veteran",
+        classId = AgentClass.SOLDIER,
+        level = level,
+        offeredClasses = null,
+        offeredEvolutions = null,
+    )
+
+    private fun soldierWith(evolutions: List<AgentClass>) = ClassDefinition(
+        id = AgentClass.SOLDIER,
+        displayName = "Soldier",
+        description = "",
+        sightRange = 3,
+        primarySkills = emptySet<SkillId>(),
+        neutralSkills = emptySet(),
+        forbiddenCombatSkills = emptySet(),
+        damageMultipliers = emptyMap(),
+        behaviorFingerprint = mapOf("COMBAT" to 1.0),
+        parentClass = null,
+        evolutions = evolutions,
+    )
+
+    private fun evolutionFor(id: AgentClass, parent: AgentClass, fingerprint: Map<String, Double>) =
+        ClassDefinition(
+            id = id,
+            displayName = id.name,
+            description = "",
+            sightRange = 3,
+            primarySkills = emptySet(),
+            neutralSkills = emptySet(),
+            forbiddenCombatSkills = emptySet(),
+            damageMultipliers = emptyMap(),
+            behaviorFingerprint = fingerprint,
+            parentClass = parent,
+        )
+
+    private class StubClassLookup(vararg defs: ClassDefinition) : ClassLookup {
+        private val list = defs.toList()
+        override fun byId(classId: AgentClass): ClassDefinition? = list.firstOrNull { it.id == classId }
+        override fun all(): List<ClassDefinition> = list
+        override fun baseClasses(): List<ClassDefinition> = list.filter { it.parentClass == null }
+        override fun evolutionsOf(parent: AgentClass): List<ClassDefinition> {
+            val def = byId(parent) ?: return emptyList()
+            return def.evolutions.mapNotNull(::byId)
+        }
+        override fun sightRange(classId: AgentClass?): Int = 3
+        override fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double = 1.0
+        override fun damageMultiplier(classId: AgentClass?, damageType: String): Double = 1.0
+        override fun forbidsCombatSkill(classId: AgentClass?, combatSkill: SkillId): Boolean = false
+    }
+
+    private class StubAgentRegistry(
+        initial: Agent,
+        private val recordResult: RecordEvolutionOfferOutcome = RecordEvolutionOfferOutcome.Recorded,
+    ) : AgentRegistry {
+        private var current: Agent = initial
+        var recordedOffer: ClassOffer? = null
+        var recordCalls = 0
+
+        override fun find(id: AgentId): Agent? = if (id == current.id) current else null
+        override fun listForOwner(owner: PlayerId): List<Agent> = listOf(current)
+        override fun recordPendingEvolutionChoice(
+            agentId: AgentId,
+            offer: ClassOffer,
+        ): RecordEvolutionOfferOutcome {
+            recordCalls += 1
+            if (recordResult == RecordEvolutionOfferOutcome.Recorded) recordedOffer = offer
+            return recordResult
+        }
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
@@ -98,6 +98,8 @@ class AttackReducerTest {
         val classes = object : dev.gvart.genesara.player.ClassLookup {
             override fun byId(classId: dev.gvart.genesara.player.AgentClass): dev.gvart.genesara.player.ClassDefinition? = null
             override fun all(): List<dev.gvart.genesara.player.ClassDefinition> = emptyList()
+            override fun baseClasses(): List<dev.gvart.genesara.player.ClassDefinition> = emptyList()
+            override fun evolutionsOf(parent: dev.gvart.genesara.player.AgentClass): List<dev.gvart.genesara.player.ClassDefinition> = emptyList()
             override fun sightRange(classId: dev.gvart.genesara.player.AgentClass?): Int = 3
             override fun skillXpMultiplier(classId: dev.gvart.genesara.player.AgentClass?, skill: SkillId): Double = 1.0
             override fun damageMultiplier(classId: dev.gvart.genesara.player.AgentClass?, damageType: String): Double = 2.0
@@ -137,6 +139,8 @@ class AttackReducerTest {
         val classes = object : dev.gvart.genesara.player.ClassLookup {
             override fun byId(classId: dev.gvart.genesara.player.AgentClass): dev.gvart.genesara.player.ClassDefinition? = null
             override fun all(): List<dev.gvart.genesara.player.ClassDefinition> = emptyList()
+            override fun baseClasses(): List<dev.gvart.genesara.player.ClassDefinition> = emptyList()
+            override fun evolutionsOf(parent: dev.gvart.genesara.player.AgentClass): List<dev.gvart.genesara.player.ClassDefinition> = emptyList()
             override fun sightRange(classId: dev.gvart.genesara.player.AgentClass?): Int = 3
             override fun skillXpMultiplier(classId: dev.gvart.genesara.player.AgentClass?, skill: SkillId): Double = 1.0
             override fun damageMultiplier(classId: dev.gvart.genesara.player.AgentClass?, damageType: String): Double =

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentServiceImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentServiceImplTest.kt
@@ -553,6 +553,8 @@ class EquipmentServiceImplTest {
     private object StubBannedFirearmsLookup : dev.gvart.genesara.player.ClassLookup {
         override fun byId(classId: dev.gvart.genesara.player.AgentClass): dev.gvart.genesara.player.ClassDefinition? = null
         override fun all(): List<dev.gvart.genesara.player.ClassDefinition> = emptyList()
+        override fun baseClasses(): List<dev.gvart.genesara.player.ClassDefinition> = emptyList()
+        override fun evolutionsOf(parent: dev.gvart.genesara.player.AgentClass): List<dev.gvart.genesara.player.ClassDefinition> = emptyList()
         override fun sightRange(classId: dev.gvart.genesara.player.AgentClass?): Int = 3
         override fun skillXpMultiplier(classId: dev.gvart.genesara.player.AgentClass?, skill: SkillId): Double = 1.0
         override fun damageMultiplier(classId: dev.gvart.genesara.player.AgentClass?, damageType: String): Double = 1.0

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/InMemoryBehaviorTracker.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/InMemoryBehaviorTracker.kt
@@ -8,6 +8,7 @@ import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
 // a lock if a future test fans out parallel reducers against a shared instance.
 internal class InMemoryBehaviorTracker : BehaviorTracker {
     private val counts = mutableMapOf<Pair<AgentId, ActionCategory>, Int>()
+    private val baselines = mutableMapOf<Pair<AgentId, ActionCategory>, Int>()
     private val lastTicks = mutableMapOf<Pair<AgentId, ActionCategory>, Long>()
 
     override fun record(agent: AgentId, category: ActionCategory, tick: Long) {
@@ -20,6 +21,18 @@ internal class InMemoryBehaviorTracker : BehaviorTracker {
         counts.entries
             .filter { it.key.first == agent }
             .associate { it.key.second to it.value }
+
+    override fun markBaseline(agent: AgentId) {
+        counts.entries
+            .filter { it.key.first == agent }
+            .forEach { baselines[it.key] = it.value }
+    }
+
+    override fun snapshotForWindow(agent: AgentId): Map<ActionCategory, Int> =
+        counts.entries
+            .filter { it.key.first == agent }
+            .associate { it.key.second to (it.value - (baselines[it.key] ?: 0)) }
+            .filterValues { it > 0 }
 
     fun lastTickFor(agent: AgentId, category: ActionCategory): Long? =
         lastTicks[agent to category]

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImplTest.kt
@@ -104,6 +104,8 @@ class VisionRadiusImplTest {
     private fun constantBase(base: Int) = object : ClassLookup {
         override fun byId(classId: AgentClass): ClassDefinition? = null
         override fun all(): List<ClassDefinition> = emptyList()
+        override fun baseClasses(): List<ClassDefinition> = emptyList()
+        override fun evolutionsOf(parent: AgentClass): List<ClassDefinition> = emptyList()
         override fun sightRange(classId: AgentClass?): Int = base
         override fun skillXpMultiplier(classId: AgentClass?, skill: SkillId): Double = 1.0
         override fun damageMultiplier(classId: AgentClass?, damageType: String): Double = 1.0


### PR DESCRIPTION
## Summary

Post-merge tick of the #34 → #38 cross-issue coordination line in [`docs/skill-feature-sequence.md`](../blob/main/docs/skill-feature-sequence.md). PR #103 (the L50 evolution slice) shipped TECHNICIAN as one of ENGINEER's three L50 branches, so I left a coordination note on #38 explaining that drone craft recipes should key off ENGINEER + TECHNICIAN.

See https://github.com/Genesara/genesara-engine/issues/38#issuecomment-4416495094.

## Test plan

- [x] One-line tick + parenthetical note. No code change.