### PR TITLE
fix(api): align MCP UUID @ToolParam binder, tighten playtest tick, fix redis listener lifecycle

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/CommandAckKind.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/CommandAckKind.kt
@@ -1,15 +1,3 @@
 package dev.gvart.genesara.api.internal.mcp.tools
 
-/**
- * Discriminator for queue-and-ack tool responses. The MCP `@Tool` returns
- * synchronously the moment the command is enqueued (before the tick has
- * resolved it), so the only outcome it can report in-band is "queued".
- * Reducer-level rejections surface later via `WorldEvent.CommandRejected`
- * on the agent's event stream, not on this response.
- *
- * Tools whose synchronous response itself carries success/failure semantics
- * (e.g. `equip_item`'s `equipped` / `rejected`, `allocate_points`'
- * `OK` / `REJECTED`) keep their own enums — they're describing a different
- * shape (in-band sync outcome, not an enqueue ack).
- */
-enum class CommandAckKind { QUEUED }
+enum class CommandAckKind { QUEUED, REJECTED }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/abilities/UseAbilityTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/abilities/UseAbilityTool.kt
@@ -34,17 +34,26 @@ internal class UseAbilityTool(
         @ToolParam(required = true, description = "Ability id (e.g. SWORD_POWER_STRIKE) granted by a chosen perk.")
         abilityId: String,
         @ToolParam(required = false, description = "Target agent id for SINGLE_AGENT abilities; omit for SELF / AREA_SELF_NODE.")
-        targetAgentId: UUID?,
+        targetAgentId: String?,
         toolContext: ToolContext,
     ): UseAbilityResponse {
         touchActivity(toolContext, activity, "use_ability")
+        val targetUuid = targetAgentId?.let {
+            runCatching { UUID.fromString(it) }.getOrNull()
+                ?: return UseAbilityResponse.rejected(
+                    abilityId = abilityId,
+                    targetAgentId = it,
+                    reason = "bad_target_agent_id",
+                    detail = "targetAgentId must be a UUID",
+                )
+        }
         val agent = AgentContextHolder.current()
         val command = WorldCommand.UseAbility(
             agent = agent,
             ability = AbilityId(abilityId),
-            target = targetAgentId?.let(::AgentId),
+            target = targetUuid?.let(::AgentId),
         )
         val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
-        return UseAbilityResponse.queued(command.commandId, appliesAtTick, abilityId, targetAgentId)
+        return UseAbilityResponse.queued(command.commandId, appliesAtTick, abilityId, targetUuid)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/abilities/UseAbilityToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/abilities/UseAbilityToolIo.kt
@@ -6,12 +6,29 @@ import java.util.UUID
 data class UseAbilityResponse(
     val kind: CommandAckKind,
     val abilityId: String,
-    val targetAgentId: UUID?,
-    val commandId: UUID,
-    val appliesAtTick: Long,
+    val targetAgentId: String?,
+    val commandId: UUID? = null,
+    val appliesAtTick: Long? = null,
+    val reason: String? = null,
+    val detail: String? = null,
 ) {
     companion object {
         fun queued(commandId: UUID, appliesAtTick: Long, abilityId: String, targetAgentId: UUID?) =
-            UseAbilityResponse(CommandAckKind.QUEUED, abilityId, targetAgentId, commandId, appliesAtTick)
+            UseAbilityResponse(
+                kind = CommandAckKind.QUEUED,
+                abilityId = abilityId,
+                targetAgentId = targetAgentId?.toString(),
+                commandId = commandId,
+                appliesAtTick = appliesAtTick,
+            )
+
+        fun rejected(abilityId: String, targetAgentId: String?, reason: String, detail: String) =
+            UseAbilityResponse(
+                kind = CommandAckKind.REJECTED,
+                abilityId = abilityId,
+                targetAgentId = targetAgentId,
+                reason = reason,
+                detail = detail,
+            )
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackTool.kt
@@ -30,13 +30,19 @@ internal class AttackTool(
     )
     fun invoke(
         @ToolParam(required = true, description = "Attack target — UUID of the agent to attack.")
-        targetAgentId: UUID,
+        targetAgentId: String,
         toolContext: ToolContext,
     ): AttackResponse {
         touchActivity(toolContext, activity, "attack")
+        val targetUuid = runCatching { UUID.fromString(targetAgentId) }.getOrNull()
+            ?: return AttackResponse.rejected(
+                targetAgentId = targetAgentId,
+                reason = "bad_target_agent_id",
+                detail = "targetAgentId must be a UUID",
+            )
         val agent = AgentContextHolder.current()
-        val command = WorldCommand.AttackTarget(agent = agent, target = AgentId(targetAgentId))
+        val command = WorldCommand.AttackTarget(agent = agent, target = AgentId(targetUuid))
         val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
-        return AttackResponse.queued(command.commandId, appliesAtTick, targetAgentId)
+        return AttackResponse.queued(command.commandId, appliesAtTick, targetUuid)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolIo.kt
@@ -5,12 +5,27 @@ import java.util.UUID
 
 data class AttackResponse(
     val kind: CommandAckKind,
-    val targetAgentId: UUID,
-    val commandId: UUID,
-    val appliesAtTick: Long,
+    val targetAgentId: String,
+    val commandId: UUID? = null,
+    val appliesAtTick: Long? = null,
+    val reason: String? = null,
+    val detail: String? = null,
 ) {
     companion object {
         fun queued(commandId: UUID, appliesAtTick: Long, targetAgentId: UUID) =
-            AttackResponse(CommandAckKind.QUEUED, targetAgentId, commandId, appliesAtTick)
+            AttackResponse(
+                kind = CommandAckKind.QUEUED,
+                targetAgentId = targetAgentId.toString(),
+                commandId = commandId,
+                appliesAtTick = appliesAtTick,
+            )
+
+        fun rejected(targetAgentId: String, reason: String, detail: String) =
+            AttackResponse(
+                kind = CommandAckKind.REJECTED,
+                targetAgentId = targetAgentId,
+                reason = reason,
+                detail = detail,
+            )
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/ChestToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/ChestToolIo.kt
@@ -1,17 +1,37 @@
 package dev.gvart.genesara.api.internal.mcp.tools.chest
 
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import java.util.UUID
 
-/**
- * Successful queue-and-ack response for chest transfers. The matching `ItemDeposited` /
- * `ItemWithdrawn` event lands on the agent's event stream once the tick resolves; the
- * reducer-level rejections (chest doesn't exist, capacity exceeded, etc.) surface via the
- * event stream as a rejection event, not in-band on this response.
- */
 data class ChestTransferResponse(
-    val commandId: UUID,
-    val appliesAtTick: Long,
-    val chestId: UUID,
+    val kind: CommandAckKind,
+    val chestId: String,
     val itemId: String,
     val quantity: Int,
-)
+    val commandId: UUID? = null,
+    val appliesAtTick: Long? = null,
+    val reason: String? = null,
+    val detail: String? = null,
+) {
+    companion object {
+        fun queued(commandId: UUID, appliesAtTick: Long, chestId: UUID, itemId: String, quantity: Int) =
+            ChestTransferResponse(
+                kind = CommandAckKind.QUEUED,
+                chestId = chestId.toString(),
+                itemId = itemId,
+                quantity = quantity,
+                commandId = commandId,
+                appliesAtTick = appliesAtTick,
+            )
+
+        fun rejected(chestId: String, itemId: String, quantity: Int, reason: String, detail: String) =
+            ChestTransferResponse(
+                kind = CommandAckKind.REJECTED,
+                chestId = chestId,
+                itemId = itemId,
+                quantity = quantity,
+                reason = reason,
+                detail = detail,
+            )
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/ChestTransferDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/ChestTransferDispatcher.kt
@@ -1,0 +1,36 @@
+package dev.gvart.genesara.api.internal.mcp.tools.chest
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import java.util.UUID
+
+internal inline fun dispatchChestTransfer(
+    chestId: String,
+    itemId: String,
+    quantity: Int,
+    world: WorldCommandGateway,
+    engine: TickClock,
+    buildCommand: (chestUuid: UUID, agent: AgentId) -> WorldCommand,
+): ChestTransferResponse {
+    val chestUuid = runCatching { UUID.fromString(chestId) }.getOrNull()
+        ?: return ChestTransferResponse.rejected(
+            chestId = chestId,
+            itemId = itemId,
+            quantity = quantity,
+            reason = "bad_chest_id",
+            detail = "chestId must be a UUID",
+        )
+    val agent = AgentContextHolder.current()
+    val command = buildCommand(chestUuid, agent)
+    val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
+    return ChestTransferResponse.queued(
+        commandId = command.commandId,
+        appliesAtTick = appliesAtTick,
+        chestId = chestUuid,
+        itemId = itemId,
+        quantity = quantity,
+    )
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/DepositToChestTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/DepositToChestTool.kt
@@ -1,6 +1,5 @@
 package dev.gvart.genesara.api.internal.mcp.tools.chest
 
-import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
@@ -11,7 +10,6 @@ import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.annotation.Tool
 import org.springframework.ai.tool.annotation.ToolParam
 import org.springframework.stereotype.Component
-import java.util.UUID
 
 @Component
 internal class DepositToChestTool(
@@ -36,28 +34,13 @@ internal class DepositToChestTool(
         toolContext: ToolContext,
     ): ChestTransferResponse {
         touchActivity(toolContext, activity, "deposit_to_chest")
-        val chestUuid = runCatching { UUID.fromString(chestId) }.getOrNull()
-            ?: return ChestTransferResponse.rejected(
-                chestId = chestId,
-                itemId = itemId,
+        return dispatchChestTransfer(chestId, itemId, quantity, world, engine) { chestUuid, agent ->
+            WorldCommand.DepositToChest(
+                agent = agent,
+                chestId = chestUuid,
+                item = ItemId(itemId),
                 quantity = quantity,
-                reason = "bad_chest_id",
-                detail = "chestId must be a UUID",
             )
-        val agent = AgentContextHolder.current()
-        val command = WorldCommand.DepositToChest(
-            agent = agent,
-            chestId = chestUuid,
-            item = ItemId(itemId),
-            quantity = quantity,
-        )
-        val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
-        return ChestTransferResponse.queued(
-            commandId = command.commandId,
-            appliesAtTick = appliesAtTick,
-            chestId = chestUuid,
-            itemId = itemId,
-            quantity = quantity,
-        )
+        }
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/DepositToChestTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/DepositToChestTool.kt
@@ -28,7 +28,7 @@ internal class DepositToChestTool(
     )
     fun invoke(
         @ToolParam(required = true, description = "Building instance UUID of the target chest (from look_around / inspect).")
-        chestId: UUID,
+        chestId: String,
         @ToolParam(required = true, description = "Item id to deposit (e.g. WOOD, STONE, BERRY).")
         itemId: String,
         @ToolParam(required = true, description = "Quantity to deposit. Must be > 0.")
@@ -36,18 +36,26 @@ internal class DepositToChestTool(
         toolContext: ToolContext,
     ): ChestTransferResponse {
         touchActivity(toolContext, activity, "deposit_to_chest")
+        val chestUuid = runCatching { UUID.fromString(chestId) }.getOrNull()
+            ?: return ChestTransferResponse.rejected(
+                chestId = chestId,
+                itemId = itemId,
+                quantity = quantity,
+                reason = "bad_chest_id",
+                detail = "chestId must be a UUID",
+            )
         val agent = AgentContextHolder.current()
         val command = WorldCommand.DepositToChest(
             agent = agent,
-            chestId = chestId,
+            chestId = chestUuid,
             item = ItemId(itemId),
             quantity = quantity,
         )
         val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
-        return ChestTransferResponse(
+        return ChestTransferResponse.queued(
             commandId = command.commandId,
             appliesAtTick = appliesAtTick,
-            chestId = chestId,
+            chestId = chestUuid,
             itemId = itemId,
             quantity = quantity,
         )

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/WithdrawFromChestTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/WithdrawFromChestTool.kt
@@ -1,6 +1,5 @@
 package dev.gvart.genesara.api.internal.mcp.tools.chest
 
-import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
@@ -11,7 +10,6 @@ import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.annotation.Tool
 import org.springframework.ai.tool.annotation.ToolParam
 import org.springframework.stereotype.Component
-import java.util.UUID
 
 @Component
 internal class WithdrawFromChestTool(
@@ -36,28 +34,13 @@ internal class WithdrawFromChestTool(
         toolContext: ToolContext,
     ): ChestTransferResponse {
         touchActivity(toolContext, activity, "withdraw_from_chest")
-        val chestUuid = runCatching { UUID.fromString(chestId) }.getOrNull()
-            ?: return ChestTransferResponse.rejected(
-                chestId = chestId,
-                itemId = itemId,
+        return dispatchChestTransfer(chestId, itemId, quantity, world, engine) { chestUuid, agent ->
+            WorldCommand.WithdrawFromChest(
+                agent = agent,
+                chestId = chestUuid,
+                item = ItemId(itemId),
                 quantity = quantity,
-                reason = "bad_chest_id",
-                detail = "chestId must be a UUID",
             )
-        val agent = AgentContextHolder.current()
-        val command = WorldCommand.WithdrawFromChest(
-            agent = agent,
-            chestId = chestUuid,
-            item = ItemId(itemId),
-            quantity = quantity,
-        )
-        val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
-        return ChestTransferResponse.queued(
-            commandId = command.commandId,
-            appliesAtTick = appliesAtTick,
-            chestId = chestUuid,
-            itemId = itemId,
-            quantity = quantity,
-        )
+        }
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/WithdrawFromChestTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/WithdrawFromChestTool.kt
@@ -28,7 +28,7 @@ internal class WithdrawFromChestTool(
     )
     fun invoke(
         @ToolParam(required = true, description = "Building instance UUID of the target chest (from look_around / inspect).")
-        chestId: UUID,
+        chestId: String,
         @ToolParam(required = true, description = "Item id to withdraw (e.g. WOOD, STONE, BERRY).")
         itemId: String,
         @ToolParam(required = true, description = "Quantity to withdraw. Must be > 0.")
@@ -36,18 +36,26 @@ internal class WithdrawFromChestTool(
         toolContext: ToolContext,
     ): ChestTransferResponse {
         touchActivity(toolContext, activity, "withdraw_from_chest")
+        val chestUuid = runCatching { UUID.fromString(chestId) }.getOrNull()
+            ?: return ChestTransferResponse.rejected(
+                chestId = chestId,
+                itemId = itemId,
+                quantity = quantity,
+                reason = "bad_chest_id",
+                detail = "chestId must be a UUID",
+            )
         val agent = AgentContextHolder.current()
         val command = WorldCommand.WithdrawFromChest(
             agent = agent,
-            chestId = chestId,
+            chestId = chestUuid,
             item = ItemId(itemId),
             quantity = quantity,
         )
         val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
-        return ChestTransferResponse(
+        return ChestTransferResponse.queued(
             commandId = command.commandId,
             appliesAtTick = appliesAtTick,
-            chestId = chestId,
+            chestId = chestUuid,
             itemId = itemId,
             quantity = quantity,
         )

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemTool.kt
@@ -30,21 +30,28 @@ internal class EquipItemTool(
     )
     fun invoke(
         @ToolParam(required = true, description = "Equipment instance UUID (from get_equipment / your event stream).")
-        instanceId: UUID,
+        instanceId: String,
         @ToolParam(required = true, description = "Target slot id (e.g. MAIN_HAND, HELMET, RING_LEFT).")
         slot: EquipSlot,
         toolContext: ToolContext,
     ): EquipItemResponse {
         touchActivity(toolContext, activity, "equip_item")
+        val instanceUuid = runCatching { UUID.fromString(instanceId) }.getOrNull()
+            ?: return EquipItemResponse.rejected(
+                instanceId = instanceId,
+                slot = slot,
+                reason = "bad_instance_id",
+                detail = "instanceId must be a UUID",
+            )
         val agent = AgentContextHolder.current()
 
-        return when (val result = equipment.equip(agent, instanceId, slot)) {
+        return when (val result = equipment.equip(agent, instanceUuid, slot)) {
             is EquipResult.Equipped -> EquipItemResponse.equipped(
                 instanceId = result.instance.instanceId,
                 slot = slot,
             )
             is EquipResult.Rejected -> EquipItemResponse.rejected(
-                instanceId = instanceId,
+                instanceId = instanceUuid.toString(),
                 slot = slot,
                 reason = result.reason.toReasonCode(),
                 detail = result.detail ?: result.reason.detailFor(slot),

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemToolIo.kt
@@ -3,26 +3,18 @@ package dev.gvart.genesara.api.internal.mcp.tools.equipment
 import dev.gvart.genesara.world.EquipSlot
 import java.util.UUID
 
-/**
- * Either:
- *  - `kind = "equipped"`: success; the instance is now in the named slot.
- *  - `kind = "rejected"`: validation failed; `reason` carries an enum-string code
- *    (`instance_not_found`, `not_your_instance`, `unknown_item`, `not_equipment`,
- *    `invalid_slot_for_item`, `two_handed_not_main_hand`, `already_equipped`,
- *    `off_hand_occupied`, `off_hand_blocked_by_two_handed`, `slot_occupied`).
- */
 data class EquipItemResponse(
     val kind: String,
-    val instanceId: UUID,
+    val instanceId: String,
     val slot: EquipSlot,
     val reason: String? = null,
     val detail: String? = null,
 ) {
     companion object {
         fun equipped(instanceId: UUID, slot: EquipSlot) =
-            EquipItemResponse("equipped", instanceId, slot)
+            EquipItemResponse("equipped", instanceId.toString(), slot)
 
-        fun rejected(instanceId: UUID, slot: EquipSlot, reason: String, detail: String) =
+        fun rejected(instanceId: String, slot: EquipSlot, reason: String, detail: String) =
             EquipItemResponse("rejected", instanceId, slot, reason, detail)
     }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/abilities/UseAbilityToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/abilities/UseAbilityToolTest.kt
@@ -39,11 +39,11 @@ class UseAbilityToolTest {
     fun `queues a UseAbility command at the next tick with target id`() {
         val tool = UseAbilityTool(gateway, tickClock, activity)
 
-        val response = tool.invoke("SWORD_POWER_STRIKE", target.id, toolContext)
+        val response = tool.invoke("SWORD_POWER_STRIKE", target.id.toString(), toolContext)
 
         assertEquals(CommandAckKind.QUEUED, response.kind)
         assertEquals("SWORD_POWER_STRIKE", response.abilityId)
-        assertEquals(target.id, response.targetAgentId)
+        assertEquals(target.id.toString(), response.targetAgentId)
         assertEquals(51L, response.appliesAtTick)
         val (cmd, appliesAt) = gateway.submissions.single()
         val use = assertNotNull(cmd as? WorldCommand.UseAbility)
@@ -66,12 +66,24 @@ class UseAbilityToolTest {
     }
 
     @Test
+    fun `malformed targetAgentId is rejected without queueing`() {
+        val tool = UseAbilityTool(gateway, tickClock, activity)
+
+        val response = tool.invoke("SWORD_POWER_STRIKE", "not-a-uuid", toolContext)
+
+        assertEquals(CommandAckKind.REJECTED, response.kind)
+        assertEquals("bad_target_agent_id", response.reason)
+        assertEquals("not-a-uuid", response.targetAgentId)
+        assertTrue(gateway.submissions.isEmpty())
+    }
+
+    @Test
     fun `touches activity registry on every successful invocation`() {
         val tool = UseAbilityTool(gateway, tickClock, activity)
 
         assertTrue(agent !in activity.staleAgents(clock.instant().minusSeconds(60)))
 
-        tool.invoke("SWORD_POWER_STRIKE", target.id, toolContext)
+        tool.invoke("SWORD_POWER_STRIKE", target.id.toString(), toolContext)
 
         assertTrue(agent in activity.staleAgents(clock.instant().plusSeconds(60)))
     }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attack/AttackToolTest.kt
@@ -18,6 +18,7 @@ import java.time.ZoneOffset
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class AttackToolTest {
@@ -37,10 +38,10 @@ class AttackToolTest {
     fun `queues an AttackTarget command at the next tick and returns the ack`() {
         val tool = AttackTool(gateway, tickClock, activity)
 
-        val response = tool.invoke(target.id, toolContext)
+        val response = tool.invoke(target.id.toString(), toolContext)
 
         assertEquals(CommandAckKind.QUEUED, response.kind)
-        assertEquals(target.id, response.targetAgentId)
+        assertEquals(target.id.toString(), response.targetAgentId)
         assertEquals(51L, response.appliesAtTick)
         val (cmd, appliesAt) = gateway.submissions.single()
         val attack = assertNotNull(cmd as? WorldCommand.AttackTarget)
@@ -51,12 +52,36 @@ class AttackToolTest {
     }
 
     @Test
+    fun `accepts the raw unquoted UUID form that MCP agents emit by default`() {
+        val tool = AttackTool(gateway, tickClock, activity)
+        val rawUuid = "c2da8aef-aeb1-466d-99fd-0e38ad9ed971"
+
+        val response = tool.invoke(rawUuid, toolContext)
+
+        assertEquals(CommandAckKind.QUEUED, response.kind)
+        assertEquals(rawUuid, response.targetAgentId)
+    }
+
+    @Test
+    fun `rejects a malformed targetAgentId without queueing`() {
+        val tool = AttackTool(gateway, tickClock, activity)
+
+        val response = tool.invoke("not-a-uuid", toolContext)
+
+        assertEquals(CommandAckKind.REJECTED, response.kind)
+        assertEquals("not-a-uuid", response.targetAgentId)
+        assertEquals("bad_target_agent_id", response.reason)
+        assertNull(response.commandId)
+        assertTrue(gateway.submissions.isEmpty())
+    }
+
+    @Test
     fun `touches activity registry on every successful invocation`() {
         val tool = AttackTool(gateway, tickClock, activity)
 
         assertTrue(attacker !in activity.staleAgents(clock.instant().minusSeconds(60)))
 
-        tool.invoke(target.id, toolContext)
+        tool.invoke(target.id.toString(), toolContext)
 
         assertTrue(attacker in activity.staleAgents(clock.instant().plusSeconds(60)))
     }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/ChestToolsTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/chest/ChestToolsTest.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.chest
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.world.ItemId
@@ -18,6 +19,7 @@ import java.time.ZoneOffset
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ChestToolsTest {
@@ -38,13 +40,14 @@ class ChestToolsTest {
         val tool = DepositToChestTool(gateway, tickClock, activity)
 
         val response = tool.invoke(
-            chestId = chest,
+            chestId = chest.toString(),
             itemId = "WOOD",
             quantity = 5,
             toolContext = toolContext,
         )
 
-        assertEquals(chest, response.chestId)
+        assertEquals(CommandAckKind.QUEUED, response.kind)
+        assertEquals(chest.toString(), response.chestId)
         assertEquals("WOOD", response.itemId)
         assertEquals(5, response.quantity)
         assertEquals(51L, response.appliesAtTick)
@@ -63,13 +66,14 @@ class ChestToolsTest {
         val tool = WithdrawFromChestTool(gateway, tickClock, activity)
 
         val response = tool.invoke(
-            chestId = chest,
+            chestId = chest.toString(),
             itemId = "STONE",
             quantity = 3,
             toolContext = toolContext,
         )
 
-        assertEquals(chest, response.chestId)
+        assertEquals(CommandAckKind.QUEUED, response.kind)
+        assertEquals(chest.toString(), response.chestId)
         assertEquals("STONE", response.itemId)
         assertEquals(3, response.quantity)
         val (cmd, _) = gateway.submissions.single()
@@ -82,14 +86,37 @@ class ChestToolsTest {
 
     @Test
     fun `non-positive quantity is forwarded to the reducer (not rejected at the tool boundary)`() {
-        // Strong-typed inputs delegate validation to the reducer's NonPositiveQuantity rejection,
-        // which surfaces on the agent's event stream. Tool layer just queues.
         val tool = DepositToChestTool(gateway, tickClock, activity)
 
-        tool.invoke(chestId = chest, itemId = "WOOD", quantity = 0, toolContext = toolContext)
+        tool.invoke(chestId = chest.toString(), itemId = "WOOD", quantity = 0, toolContext = toolContext)
 
         val cmd = assertNotNull(gateway.submissions.single().first as? WorldCommand.DepositToChest)
         assertEquals(0, cmd.quantity)
+    }
+
+    @Test
+    fun `deposit rejects malformed chestId without queueing`() {
+        val tool = DepositToChestTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(chestId = "not-a-uuid", itemId = "WOOD", quantity = 1, toolContext = toolContext)
+
+        assertEquals(CommandAckKind.REJECTED, response.kind)
+        assertEquals("not-a-uuid", response.chestId)
+        assertEquals("bad_chest_id", response.reason)
+        assertNull(response.commandId)
+        assertTrue(gateway.submissions.isEmpty())
+    }
+
+    @Test
+    fun `withdraw rejects malformed chestId without queueing`() {
+        val tool = WithdrawFromChestTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(chestId = "BERRY", itemId = "WOOD", quantity = 1, toolContext = toolContext)
+
+        assertEquals(CommandAckKind.REJECTED, response.kind)
+        assertEquals("BERRY", response.chestId)
+        assertEquals("bad_chest_id", response.reason)
+        assertTrue(gateway.submissions.isEmpty())
     }
 
     @Test
@@ -97,9 +124,9 @@ class ChestToolsTest {
         val deposit = DepositToChestTool(gateway, tickClock, activity)
         val withdraw = WithdrawFromChestTool(gateway, tickClock, activity)
 
-        deposit.invoke(chest, "WOOD", 1, toolContext)
+        deposit.invoke(chest.toString(), "WOOD", 1, toolContext)
         AgentContextHolder.set(agent)
-        withdraw.invoke(chest, "WOOD", 1, toolContext)
+        withdraw.invoke(chest.toString(), "WOOD", 1, toolContext)
 
         assertTrue(agent in activity.staleAgents(clock.instant().plusSeconds(60)))
     }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemToolTest.kt
@@ -21,6 +21,7 @@ import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class EquipItemToolTest {
 
@@ -40,11 +41,11 @@ class EquipItemToolTest {
         )
         val tool = EquipItemTool(service, activity)
 
-        val res = tool.invoke(instanceId, EquipSlot.MAIN_HAND, toolContext)
+        val res = tool.invoke(instanceId.toString(), EquipSlot.MAIN_HAND, toolContext)
 
         assertEquals("equipped", res.kind)
         assertEquals(EquipSlot.MAIN_HAND, res.slot)
-        assertEquals(instanceId, res.instanceId)
+        assertEquals(instanceId.toString(), res.instanceId)
         assertEquals(null, res.reason)
     }
 
@@ -55,7 +56,7 @@ class EquipItemToolTest {
         )
         val tool = EquipItemTool(service, activity)
 
-        val res = tool.invoke(UUID.randomUUID(), EquipSlot.OFF_HAND, toolContext)
+        val res = tool.invoke(UUID.randomUUID().toString(), EquipSlot.OFF_HAND, toolContext)
 
         assertEquals("rejected", res.kind)
         assertEquals("off_hand_blocked_by_two_handed", res.reason)
@@ -73,11 +74,24 @@ class EquipItemToolTest {
         )
         val tool = EquipItemTool(service, activity)
 
-        val res = tool.invoke(UUID.randomUUID(), EquipSlot.MAIN_HAND, toolContext)
+        val res = tool.invoke(UUID.randomUUID().toString(), EquipSlot.MAIN_HAND, toolContext)
 
         assertEquals("rejected", res.kind)
         assertEquals("insufficient_attributes", res.reason)
         assertEquals(customDetail, res.detail)
+    }
+
+    @Test
+    fun `malformed instanceId is rejected at the tool boundary without hitting the service`() {
+        val service = StubEquipmentService()
+        val tool = EquipItemTool(service, activity)
+
+        val res = tool.invoke("not-a-uuid", EquipSlot.MAIN_HAND, toolContext)
+
+        assertEquals("rejected", res.kind)
+        assertEquals("bad_instance_id", res.reason)
+        assertEquals("not-a-uuid", res.instanceId)
+        assertTrue(service.equipCalls.isEmpty())
     }
 
     private fun sampleInstance(id: UUID, slot: EquipSlot) = EquipmentInstance(

--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -45,7 +45,7 @@ application:
       secret: ${SECURITY_JWT_SECRET:dev-only-jwt-secret-change-me-please-32-bytes-min}
       ttl: PT24H
   tick:
-    interval: PT5S
+    interval: PT1S
   shard:
     # Stable identity for this JVM. Defaults to a fresh UUID per start.
     pod-id: ${POD_ID:${random.uuid}}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/invalidation/InvalidationListenerConfiguration.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/invalidation/InvalidationListenerConfiguration.kt
@@ -12,7 +12,5 @@ internal class InvalidationListenerConfiguration {
     fun invalidationListenerContainer(connectionFactory: RedisConnectionFactory): RedisMessageListenerContainer =
         RedisMessageListenerContainer().apply {
             setConnectionFactory(connectionFactory)
-            afterPropertiesSet()
-            start()
         }
 }


### PR DESCRIPTION
## Summary

Three small fixes surfaced by the autonomous E2E playtest sweep.

### 1. UUID `@ToolParam` binder — closes #114, #121, #123, #124

Five MCP `@ToolParam` arguments were typed `UUID`. Spring AI's argument binder reads those via Jackson `readValue`, which parses the raw input as a JSON token first — so unquoted UUIDs blow up at transport with `Unrecognized token 'c2da8aef'` / `Leading zeroes not allowed` / `Unexpected character '-'`. Net: `attack`, `deposit_to_chest`, `withdraw_from_chest`, `equip_item`, and `use_ability.targetAgentId` were 100% undispatchable from a naive agent. String-typed params (pickup, inspect, equip_skill, use_ability.abilityId, …) bypass Jackson and already accept raw input.

Switched the five params to `String`, parse with `runCatching { UUID.fromString(...) }` inside the tool, and return a structured rejection (`kind=REJECTED`, `reason="bad_*_id"`, raw input echoed back) on parse failure. Added `CommandAckKind.REJECTED` for the sync-rejection case. Every affected tool now has a uniform contract for malformed UUIDs and accepts the raw-string form MCP agents emit by default.

### 2. Tick interval — `PT5S` → `PT1S`

Playtest agents kept hitting 5-second waits to observe state changes within a single conversation turn. Drop to 1s so observed state is current by the next look.

### 3. Redis `InvalidationListenerContainer` lifecycle

Removed manual `afterPropertiesSet()` + `start()` from the `@Bean` factory — they race Spring's own `SmartLifecycle` handling and double-start under some refresh paths. Spring manages this via `InitializingBean` + `SmartLifecycle` already.

## Test plan

- [x] `:api:test` green — existing tool tests updated to use `UUID.toString()`, new bad-UUID rejection cases added for attack / chest / equip_item / use_ability
- [x] `:app:compileKotlin` clean
- [ ] Re-run the autonomous E2E sweep against this branch to confirm the four closed findings no longer reproduce