### PR TITLE
fix(api): case-insensitive enum binding on @ToolParam input

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp
 
 import dev.gvart.genesara.api.internal.mcp.events.EventLogProperties
+import dev.gvart.genesara.api.internal.mcp.jackson.EnumCaseInsensitiveToolCallbackProvider
 import dev.gvart.genesara.api.internal.mcp.presence.PresenceProperties
 import dev.gvart.genesara.api.internal.mcp.tools.abilities.UseAbilityTool
 import dev.gvart.genesara.api.internal.mcp.tools.attack.AttackTool
@@ -66,8 +67,8 @@ internal class McpServerConfiguration {
         useAbility: UseAbilityTool,
         selectClass: SelectClassTool,
         selectEvolution: SelectEvolutionTool,
-    ): ToolCallbackProvider =
-        MethodToolCallbackProvider.builder()
+    ): ToolCallbackProvider {
+        val methodProvider = MethodToolCallbackProvider.builder()
             .toolObjects(
                 spawn, move, lookAround, unspawn, getStatus, harvest, getLoadout,
                 consume, drink, equipSkill, allocatePoints, inspect, getMap,
@@ -76,4 +77,6 @@ internal class McpServerConfiguration {
                 useAbility, selectClass, selectEvolution,
             )
             .build()
+        return EnumCaseInsensitiveToolCallbackProvider(methodProvider)
+    }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/CaseInsensitiveEnumModule.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/CaseInsensitiveEnumModule.kt
@@ -1,0 +1,44 @@
+package dev.gvart.genesara.api.internal.mcp.jackson
+
+import tools.jackson.core.Version
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JacksonModule
+import tools.jackson.databind.deser.DeserializationProblemHandler
+
+/** Picked up via SPI by Spring AI's static [tools.jackson.databind.json.JsonMapper] — fixes
+ *  case-sensitive enum binding on Jackson-routed paths (e.g. map keys in `allocate_points`). */
+class CaseInsensitiveEnumModule : JacksonModule() {
+
+    override fun getModuleName(): String = "genesara-case-insensitive-enum"
+
+    override fun version(): Version = Version.unknownVersion()
+
+    override fun setupModule(context: SetupContext) {
+        context.addHandler(Handler)
+    }
+
+    private object Handler : DeserializationProblemHandler() {
+
+        override fun handleWeirdStringValue(
+            ctx: DeserializationContext,
+            targetType: Class<*>,
+            valueToConvert: String,
+            failureMsg: String?,
+        ): Any = matchEnum(targetType, valueToConvert) ?: NOT_HANDLED
+
+        override fun handleWeirdKey(
+            ctx: DeserializationContext,
+            rawKeyType: Class<*>,
+            keyValue: String,
+            failureMsg: String?,
+        ): Any = matchEnum(rawKeyType, keyValue) ?: NOT_HANDLED
+
+        private fun matchEnum(targetType: Class<*>, raw: String): Enum<*>? {
+            if (!targetType.isEnum) return null
+            val trimmed = raw.trim()
+            @Suppress("UNCHECKED_CAST")
+            val constants = (targetType as Class<out Enum<*>>).enumConstants ?: return null
+            return constants.firstOrNull { it.name.equals(trimmed, ignoreCase = true) }
+        }
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/EnumCaseInsensitiveToolCallback.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/EnumCaseInsensitiveToolCallback.kt
@@ -1,0 +1,81 @@
+package dev.gvart.genesara.api.internal.mcp.jackson
+
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.ToolCallback
+import org.springframework.ai.tool.ToolCallbackProvider
+import org.springframework.ai.tool.definition.ToolDefinition
+import org.springframework.ai.tool.metadata.ToolMetadata
+import org.springframework.ai.util.json.JsonParser
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.ObjectNode
+
+/** Spring AI's [org.springframework.ai.tool.method.MethodToolCallback] binds top-level
+ *  enum-typed `@ToolParam` values via raw [java.lang.Enum.valueOf], bypassing Jackson —
+ *  so [CaseInsensitiveEnumModule] never sees them. This wrapper rewrites the agent's JSON
+ *  to canonical casing using the tool's own inputSchema as the source of truth. */
+internal class EnumCaseInsensitiveToolCallback(
+    private val delegate: ToolCallback,
+) : ToolCallback {
+
+    private val enumNormalizers: Map<String, EnumNormalizer> =
+        parseEnumNormalizers(delegate.toolDefinition.inputSchema())
+
+    override fun getToolDefinition(): ToolDefinition = delegate.toolDefinition
+
+    override fun getToolMetadata(): ToolMetadata = delegate.toolMetadata
+
+    override fun call(toolInput: String): String = call(toolInput, null)
+
+    override fun call(toolInput: String, toolContext: ToolContext?): String {
+        if (enumNormalizers.isEmpty()) return delegate.call(toolInput, toolContext)
+        val rewritten = rewriteEnumFields(toolInput) ?: toolInput
+        return delegate.call(rewritten, toolContext)
+    }
+
+    private fun rewriteEnumFields(toolInput: String): String? {
+        val mapper = JsonParser.getJsonMapper()
+        val node = runCatching { mapper.readTree(toolInput) }.getOrNull() ?: return null
+        if (node !is ObjectNode) return null
+        var changed = false
+        for ((field, normalizer) in enumNormalizers) {
+            val current = node.get(field) ?: continue
+            if (!current.isString) continue
+            val raw = current.asString()
+            val canonical = normalizer.canonicalFor(raw) ?: continue
+            if (canonical == raw) continue
+            node.put(field, canonical)
+            changed = true
+        }
+        return if (changed) mapper.writeValueAsString(node) else null
+    }
+
+    private class EnumNormalizer(values: List<String>) {
+        private val byLowercase: Map<String, String> = values.associateBy { it.lowercase() }
+
+        fun canonicalFor(raw: String): String? = byLowercase[raw.trim().lowercase()]
+    }
+
+    private companion object {
+        fun parseEnumNormalizers(schema: String): Map<String, EnumNormalizer> {
+            val tree = runCatching { JsonParser.getJsonMapper().readTree(schema) }.getOrNull()
+                ?: return emptyMap()
+            val properties = tree.get("properties") as? ObjectNode ?: return emptyMap()
+            val result = mutableMapOf<String, EnumNormalizer>()
+            for (entry in properties.properties()) {
+                val enumNode: JsonNode = entry.value.get("enum") ?: continue
+                if (!enumNode.isArray) continue
+                val values = enumNode.mapNotNull { it.asString().takeIf { v -> v.isNotEmpty() } }
+                if (values.isNotEmpty()) result[entry.key] = EnumNormalizer(values)
+            }
+            return result
+        }
+    }
+}
+
+internal class EnumCaseInsensitiveToolCallbackProvider(
+    private val delegate: ToolCallbackProvider,
+) : ToolCallbackProvider {
+
+    override fun getToolCallbacks(): Array<ToolCallback> =
+        delegate.toolCallbacks.map { EnumCaseInsensitiveToolCallback(it) }.toTypedArray()
+}

--- a/api/src/main/resources/META-INF/services/tools.jackson.databind.JacksonModule
+++ b/api/src/main/resources/META-INF/services/tools.jackson.databind.JacksonModule
@@ -1,0 +1,1 @@
+dev.gvart.genesara.api.internal.mcp.jackson.CaseInsensitiveEnumModule

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/CaseInsensitiveEnumModuleTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/CaseInsensitiveEnumModuleTest.kt
@@ -1,0 +1,56 @@
+package dev.gvart.genesara.api.internal.mcp.jackson
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.ai.util.JacksonUtils
+import tools.jackson.databind.exc.InvalidFormatException
+import tools.jackson.databind.json.JsonMapper
+import kotlin.test.assertEquals
+
+class CaseInsensitiveEnumModuleTest {
+
+    private enum class Colour { RED, GREEN, BLUE }
+
+    private val mapper: JsonMapper = JsonMapper.builder()
+        .addModules(JacksonUtils.instantiateAvailableModules())
+        .build()
+
+    @Test
+    fun `lowercase enum literal binds to the matching constant`() {
+        assertEquals(Colour.RED, mapper.readValue("\"red\"", Colour::class.java))
+    }
+
+    @Test
+    fun `mixed-case enum literal binds to the matching constant`() {
+        assertEquals(Colour.GREEN, mapper.readValue("\"Green\"", Colour::class.java))
+    }
+
+    @Test
+    fun `exact-match upper-case continues to work`() {
+        assertEquals(Colour.BLUE, mapper.readValue("\"BLUE\"", Colour::class.java))
+    }
+
+    @Test
+    fun `lowercase enum-typed map key binds`() {
+        val parsed: Map<Colour, Int> = mapper.readValue(
+            "{\"red\": 1, \"Green\": 2}",
+            mapper.typeFactory.constructMapType(Map::class.java, Colour::class.java, Integer::class.java),
+        )
+        assertEquals(mapOf(Colour.RED to 1, Colour.GREEN to 2), parsed)
+    }
+
+    @Test
+    fun `unknown enum literal still throws — handler defers to default error path`() {
+        assertThrows<InvalidFormatException> {
+            mapper.readValue("\"PURPLE\"", Colour::class.java)
+        }
+    }
+
+    @Test
+    fun `module is discovered via SPI`() {
+        val moduleNames = JacksonUtils.instantiateAvailableModules().map { it.moduleName }
+        assert(moduleNames.contains("genesara-case-insensitive-enum")) {
+            "expected genesara-case-insensitive-enum in modules, got: $moduleNames"
+        }
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/EnumCaseInsensitiveToolCallbackTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/EnumCaseInsensitiveToolCallbackTest.kt
@@ -1,0 +1,88 @@
+package dev.gvart.genesara.api.internal.mcp.jackson
+
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.ToolCallback
+import org.springframework.ai.tool.definition.ToolDefinition
+import org.springframework.ai.tool.metadata.ToolMetadata
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EnumCaseInsensitiveToolCallbackTest {
+
+    private val inspectSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "targetType": {"type": "string", "enum": ["NODE", "AGENT", "ITEM", "BUILDING"]},
+            "targetId":   {"type": "string"}
+          }
+        }
+    """.trimIndent()
+
+    @Test
+    fun `lowercase enum value is rewritten to its canonical case`() {
+        val recorder = RecordingToolCallback(inspectSchema)
+        val wrapped = EnumCaseInsensitiveToolCallback(recorder)
+
+        wrapped.call("""{"targetType": "node", "targetId": "525"}""", ToolContext(emptyMap()))
+
+        val seen = recorder.lastInput!!
+        assertTrue(seen.contains("\"targetType\":\"NODE\""), "expected NODE in delegated input, got: $seen")
+        assertTrue(seen.contains("\"targetId\":\"525\""))
+    }
+
+    @Test
+    fun `mixed-case enum value is rewritten to its canonical case`() {
+        val recorder = RecordingToolCallback(inspectSchema)
+        val wrapped = EnumCaseInsensitiveToolCallback(recorder)
+
+        wrapped.call("""{"targetType": "Agent", "targetId": "x"}""", ToolContext(emptyMap()))
+
+        assertTrue(recorder.lastInput!!.contains("\"targetType\":\"AGENT\""))
+    }
+
+    @Test
+    fun `exact-case enum value passes through without rewriting`() {
+        val recorder = RecordingToolCallback(inspectSchema)
+        val wrapped = EnumCaseInsensitiveToolCallback(recorder)
+
+        wrapped.call("""{"targetType":"NODE","targetId":"525"}""", ToolContext(emptyMap()))
+
+        assertEquals("""{"targetType":"NODE","targetId":"525"}""", recorder.lastInput)
+    }
+
+    @Test
+    fun `unknown enum value passes through untouched and lets the delegate raise`() {
+        val recorder = RecordingToolCallback(inspectSchema)
+        val wrapped = EnumCaseInsensitiveToolCallback(recorder)
+
+        wrapped.call("""{"targetType":"CASTLE","targetId":"x"}""", ToolContext(emptyMap()))
+
+        assertTrue(recorder.lastInput!!.contains("\"targetType\":\"CASTLE\""))
+    }
+
+    @Test
+    fun `tool with no enum fields skips rewrite entirely`() {
+        val plainSchema = """{"type":"object","properties":{"nodeId":{"type":"integer"}}}"""
+        val recorder = RecordingToolCallback(plainSchema)
+        val wrapped = EnumCaseInsensitiveToolCallback(recorder)
+        val input = """{"nodeId":525}"""
+
+        wrapped.call(input, ToolContext(emptyMap()))
+
+        assertEquals(input, recorder.lastInput)
+    }
+
+    private class RecordingToolCallback(private val schema: String) : ToolCallback {
+        var lastInput: String? = null
+        override fun getToolDefinition(): ToolDefinition =
+            ToolDefinition.builder().name("test").description("test").inputSchema(schema).build()
+        override fun getToolMetadata(): ToolMetadata = ToolMetadata.builder().build()
+        override fun call(toolInput: String): String = call(toolInput, null)
+        override fun call(toolInput: String, toolContext: ToolContext?): String {
+            lastInput = toolInput
+            return "{}"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two-channel fix that makes MCP enum-typed `@ToolParam` arguments case-insensitive without changing any param types to `String`. Closes #107 and #127; partially relevant to #129.

### Why two channels

Spring AI 2.0.0-M5's `MethodToolCallback` binds top-level enum-typed parameters via raw `Enum.valueOf` — case-sensitive and **bypassing Jackson entirely**. Map-keyed enums (`allocate_points.deltas`) route through Jackson but fail the same way without explicit configuration. So a single Jackson module isn't enough.

### Channel 1 — `CaseInsensitiveEnumModule` (Jackson SPI)

A Jackson 3 `JacksonModule` registered via `META-INF/services/tools.jackson.databind.JacksonModule`. Spring AI's static `JsonMapper` discovers it via `MapperBuilder.findModules`. Adds a `DeserializationProblemHandler` that does case-insensitive enum lookup on both string values and map keys. Truly unknown values fall through to Jackson's default `InvalidFormatException` (which lists valid values).

Fixes the Jackson-routed paths — most importantly `allocate_points(deltas={"strength": 1})`.

### Channel 2 — `EnumCaseInsensitiveToolCallbackProvider` (wrapper)

Wraps the existing `MethodToolCallbackProvider`. Each wrapped `ToolCallback` reads its own inputSchema once at construction to identify enum-typed properties and build case-insensitive lookup tables. At call time it parses the agent's JSON, rewrites enum-typed fields to canonical case, and delegates. Tools with no enum fields incur **zero overhead** (early-return).

Fixes the `Enum.valueOf` paths — most importantly `inspect(targetType="node")`.

### Scope note on #129

#129 reports unknown enum values (`build(type=CASTLE)`) leaking raw exceptions. This PR makes that path case-insensitive but `CASTLE` is still genuinely unknown, so the Jackson `InvalidFormatException` still surfaces. The error message **does** list valid building types (Jackson's default behavior), which is an improvement. A fully structured rejection would require per-tool catching and is a separate decision.

## Test plan

- [x] `:api:test` green — six new tests covering: lowercase, mixed-case, exact-case, unknown-value pass-through, no-enum-fields short-circuit, SPI discovery
- [ ] Manual: re-run autonomous E2E sweep for s01 (`inspect(targetType="node")`) and s08 (`allocate_points(deltas={"strength": ...})`)