### PR TITLE
fix: align move/unspawn rejection with NotInWorld, add NO_OP for allocate_points

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsTool.kt
@@ -34,6 +34,13 @@ internal class AllocatePointsTool(
         touchActivity(toolContext, activity, "allocate_points")
         val agent = AgentContextHolder.current()
 
+        if (deltas.isEmpty() || deltas.values.all { it == 0 }) {
+            return AllocatePointsResponse.rejected(
+                reason = AllocatePointsRejectionReason.NO_OP,
+                detail = "deltas are empty or every entry is zero — nothing to allocate",
+            )
+        }
+
         return when (val outcome = registry.allocateAttributes(agent, deltas)) {
             null -> AllocatePointsResponse.rejected(
                 reason = AllocatePointsRejectionReason.AGENT_MISSING,

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolIo.kt
@@ -10,6 +10,7 @@ enum class AllocatePointsRejectionReason {
     NEGATIVE_DELTA,
     INSUFFICIENT_POINTS,
     AGENT_MISSING,
+    NO_OP,
 }
 
 data class AllocatePointsResponse(

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolTest.kt
@@ -100,6 +100,30 @@ class AllocatePointsToolTest {
     }
 
     @Test
+    fun `empty deltas short-circuits to NO_OP without touching the registry`() {
+        val registry = RecordingRegistry(returns = AllocateAttributesOutcome.NegativeDelta)
+
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+            .invoke(emptyMap(), toolContext)
+
+        assertEquals(AllocatePointsKind.REJECTED, response.kind)
+        assertEquals(AllocatePointsRejectionReason.NO_OP, response.reason)
+        assertTrue(registry.calls.isEmpty())
+    }
+
+    @Test
+    fun `all-zero deltas short-circuits to NO_OP without touching the registry`() {
+        val registry = RecordingRegistry(returns = AllocateAttributesOutcome.NegativeDelta)
+
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+            .invoke(mapOf(Attribute.STRENGTH to 0, Attribute.DEXTERITY to 0), toolContext)
+
+        assertEquals(AllocatePointsKind.REJECTED, response.kind)
+        assertEquals(AllocatePointsRejectionReason.NO_OP, response.reason)
+        assertTrue(registry.calls.isEmpty())
+    }
+
+    @Test
     fun `null registry result becomes AGENT_MISSING`() {
         val registry = RecordingRegistry(returns = null)
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
@@ -7,7 +7,6 @@ import dev.gvart.genesara.player.AgentId
 import java.util.UUID
 
 sealed interface WorldRejection {
-    data class UnknownAgent(val agent: AgentId) : WorldRejection
     data class UnknownRegion(val region: RegionId) : WorldRejection
     data class UnknownNode(val node: NodeId) : WorldRejection
     data class UnknownProfile(val agent: AgentId) : WorldRejection

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
@@ -26,7 +26,7 @@ internal fun reduceMove(
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val from = ensureNotNull(state.positions[command.agent]) {
-        WorldRejection.UnknownAgent(command.agent)
+        WorldRejection.NotInWorld(command.agent)
     }
     val toNode = ensureNotNull(state.nodes[command.to]) {
         WorldRejection.UnknownNode(command.to)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/spawn/UnspawnReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/spawn/UnspawnReducer.kt
@@ -14,7 +14,7 @@ internal fun reduceUnspawn(
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     val from = ensureNotNull(state.positions[command.agent]) {
-        WorldRejection.UnknownAgent(command.agent)
+        WorldRejection.NotInWorld(command.agent)
     }
     val next = state.copy(positions = state.positions - command.agent)
     val event = WorldEvent.AgentDespawned(command.agent, from, tick, causedBy = command.commandId)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
@@ -82,12 +82,12 @@ class MovementReducerTest {
     }
 
     @Test
-    fun `rejects move when agent is unknown`() {
+    fun `rejects move when agent is not in the world`() {
         val unknown = AgentId(UUID.randomUUID())
         val result = reduceMove(world, WorldCommand.MoveAgent(unknown, b), flatCost, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         assertTrue(result.isLeft())
-        assertEquals(WorldRejection.UnknownAgent(unknown), result.leftOrNull())
+        assertEquals(WorldRejection.NotInWorld(unknown), result.leftOrNull())
     }
 
     @Test

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/UnspawnReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/UnspawnReducerTest.kt
@@ -67,6 +67,6 @@ class UnspawnReducerTest {
         val empty = baseWorld.copy(positions = emptyMap())
         val result = reduceUnspawn(empty, WorldCommand.UnspawnAgent(agent), tick = 1)
 
-        assertEquals(WorldRejection.UnknownAgent(agent), result.leftOrNull())
+        assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
     }
 }


### PR DESCRIPTION
## Summary

Two small rejection-lexicon nits surfaced by the autonomous E2E sweep.

### `move`/`unspawn` rejection — closes #131

`MovementReducer` and `UnspawnReducer` returned `WorldRejection.UnknownAgent` when `state.positions[agent]` was null. Eleven other reducers (build, chest, attack, harvest, drink, ability, …) already use `WorldRejection.NotInWorld` for the same "registered but not in `state.positions`" condition. The agent reading `UnknownAgent` reasonably interpreted it as auth failure on its own session id.

Aligned both outlier reducers with `NotInWorld`. `WorldRejection.UnknownAgent` had zero call sites after the change, so removed it from the sealed interface.

### `allocate_points` zero/empty deltas — closes #128

`allocate_points(deltas={})` and `allocate_points(deltas={STRENGTH: 0})` both silently returned `kind=OK`, encouraging retry-loop spam on transient agent errors. Short-circuit both to `REJECTED { reason: NO_OP }` before touching the registry. `NEGATIVE_DELTA` stays reachable for any mixed-sign input (the check is `deltas.isEmpty() || deltas.values.all { it == 0 }`).

## Test plan

- [x] `:world:test` and `:api:test` green
- [x] Tests updated: `MovementReducerTest` and `UnspawnReducerTest` now assert `NotInWorld`
- [x] New tests for empty-map and all-zero-map paths assert the registry is not invoked