### PR TITLE
fix: bump move stamina cost, rename look_around adjacent, register select_perk

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
@@ -23,6 +23,7 @@ import dev.gvart.genesara.api.internal.mcp.tools.inspect.InspectTool
 import dev.gvart.genesara.api.internal.mcp.tools.loadout.GetLoadoutTool
 import dev.gvart.genesara.api.internal.mcp.tools.lookaround.LookAroundTool
 import dev.gvart.genesara.api.internal.mcp.tools.move.MoveTool
+import dev.gvart.genesara.api.internal.mcp.tools.perks.SelectPerkTool
 import dev.gvart.genesara.api.internal.mcp.tools.pickup.PickupTool
 import dev.gvart.genesara.api.internal.mcp.tools.respawn.RespawnTool
 import dev.gvart.genesara.api.internal.mcp.tools.safenode.SetSafeNodeTool
@@ -67,6 +68,7 @@ internal class McpServerConfiguration {
         useAbility: UseAbilityTool,
         selectClass: SelectClassTool,
         selectEvolution: SelectEvolutionTool,
+        selectPerk: SelectPerkTool,
     ): ToolCallbackProvider {
         val methodProvider = MethodToolCallbackProvider.builder()
             .toolObjects(
@@ -74,7 +76,7 @@ internal class McpServerConfiguration {
                 consume, drink, equipSkill, allocatePoints, inspect, getMap,
                 equipItem, unequipSlot,
                 setSafeNode, respawn, build, depositToChest, withdrawFromChest, craft, pickup, attack,
-                useAbility, selectClass, selectEvolution,
+                useAbility, selectClass, selectEvolution, selectPerk,
             )
             .build()
         return EnumCaseInsensitiveToolCallbackProvider(methodProvider)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
@@ -38,9 +38,11 @@ internal class LookAroundTool(
 
     @Tool(
         name = "look_around",
-        description = "Return the agent's current node and visible adjacent nodes within sight range. " +
-            "The current node carries full resource counts and full per-building summaries; adjacent " +
-            "nodes carry only item ids and a fog-of-war building summary (type + status, no instance ids).",
+        description = "Return the agent's current node, every node within sight range (`visible`), and " +
+            "the ids of the hex-adjacent one-step `move` targets (`neighbours`). The current node " +
+            "carries full resource counts and full per-building summaries; visible non-current nodes " +
+            "carry only item ids and a fog-of-war building summary (type + status, no instance ids). " +
+            "`neighbours` is the canonical input for `move`; not every entry in `visible` is move-legal.",
     )
     fun invoke(toolContext: ToolContext): LookAroundResponse {
         touchActivity(toolContext, activity, "look_around")
@@ -57,13 +59,13 @@ internal class LookAroundTool(
         val currentTick = tick.currentTick()
         val currentResources = world.resourcesAt(current.id, currentTick)
         val currentGroundItems = world.groundItemsAt(current.id)
-        val adjacent = adjacentVisibleNodes(nodeId, sight, currentTick)
+        val visible = adjacentVisibleNodes(nodeId, sight, currentTick)
 
         // Single round-trip for every visible node's buildings — never call `byNode` in a loop.
-        val visibleNodeIds = (adjacent.map { it.first.id } + current.id).toSet()
+        val visibleNodeIds = (visible.map { it.first.id } + current.id).toSet()
         val buildingsByNode = buildings.byNodes(visibleNodeIds)
 
-        journalVisibleNodes(agentId, current, region, adjacent, currentTick)
+        journalVisibleNodes(agentId, current, region, visible, currentTick)
 
         return LookAroundResponse(
             currentNode = current.toView(region, currentResources, buildingsByNode[current.id].orEmpty(), fogOfWar = false),
@@ -75,9 +77,10 @@ internal class LookAroundTool(
                 )
             },
             groundItems = currentGroundItems.map { it.toView() },
-            adjacent = adjacent.map { (n, r, res) ->
+            visible = visible.map { (n, r, res) ->
                 n.toView(r, res, buildingsByNode[n.id].orEmpty(), fogOfWar = true)
             },
+            neighbours = current.adjacency.map { it.value }.sorted(),
         )
     }
 

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolIo.kt
@@ -7,12 +7,15 @@ data class LookAroundResponse(
     val currentResources: List<ResourceView>,
     /**
      * Drops sitting on the agent's current tile, ready to be picked up via the
-     * `pickup` MCP tool. Empty when nothing has been dropped here. Adjacent
+     * `pickup` MCP tool. Empty when nothing has been dropped here. Non-current
      * nodes intentionally do not surface ground items (fog-of-war parity with
-     * adjacent resources).
+     * resources).
      */
     val groundItems: List<GroundItemView> = emptyList(),
-    val adjacent: List<NodeView>,
+    /** Every node within the agent's sight radius (current node excluded). Fog-of-war. */
+    val visible: List<NodeView>,
+    /** Ids of the hex-adjacent neighbours — the legal one-step `move` targets from the current node. */
+    val neighbours: List<Long>,
 )
 
 data class NodeView(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeController.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeController.kt
@@ -93,7 +93,8 @@ internal class AgentRuntimeController(
                         initialQuantity = it.initialQuantity,
                     )
                 },
-                adjacent = visible.map { (n, r, res) -> n.toView(r, res) },
+                visible = visible.map { (n, r, res) -> n.toView(r, res) },
+                neighbours = current.adjacency.map { it.value }.sorted(),
             ),
         )
     }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
@@ -95,8 +95,25 @@ class LookAroundToolTest {
         assertEquals(Biome.FOREST.name, response.currentNode.biome)
         assertEquals(Terrain.FOREST.name, response.currentNode.terrain)
         assertTrue(response.currentNode.pvpEnabled)
-        assertEquals(listOf(northNodeId.value), response.adjacent.map { it.id })
-        assertTrue(response.adjacent.none { it.id == farNodeId.value })
+        assertEquals(listOf(northNodeId.value), response.visible.map { it.id })
+        assertTrue(response.visible.none { it.id == farNodeId.value })
+    }
+
+    @Test
+    fun `neighbours lists only the hex-adjacent move-legal targets, not the wider vision radius`() {
+        val world = StubQuery(
+            location = currentNodeId,
+            nodes = mapOf(currentNodeId to current, northNodeId to north, farNodeId to far),
+            regions = mapOf(regionId to region),
+            // Sight 2 surfaces `far` in `visible` but it is not move-adjacent to the current node.
+            within = mapOf((currentNodeId to 2) to setOf(currentNodeId, northNodeId, farNodeId)),
+        )
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 2), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+
+        val response = tool.invoke(toolContext)
+
+        assertEquals(listOf(northNodeId.value, farNodeId.value).sorted(), response.visible.map { it.id }.sorted())
+        assertEquals(listOf(northNodeId.value), response.neighbours)
     }
 
     @Test
@@ -114,7 +131,7 @@ class LookAroundToolTest {
 
         assertEquals(false, response.currentNode.pvpEnabled)
         // Non-safe adjacent node still defaults to true.
-        assertTrue(response.adjacent.single().pvpEnabled)
+        assertTrue(response.visible.single().pvpEnabled)
     }
 
     @Test
@@ -176,7 +193,7 @@ class LookAroundToolTest {
 
         val response = tool.invoke(toolContext)
 
-        assertTrue(response.adjacent.none { it.id == currentNodeId.value })
+        assertTrue(response.visible.none { it.id == currentNodeId.value })
     }
 
     @Test
@@ -217,8 +234,8 @@ class LookAroundToolTest {
 
         val response = tool.invoke(toolContext)
 
-        val adjacent = response.adjacent.single { it.id == northNodeId.value }
-        val view = adjacent.buildings.single()
+        val visible = response.visible.single { it.id == northNodeId.value }
+        val view = visible.buildings.single()
         assertEquals("WORKBENCH", view.type)
         assertEquals("ACTIVE", view.status)
         assertEquals(null, view.instanceId)

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeControllerTest.kt
@@ -97,7 +97,7 @@ class AgentRuntimeControllerTest {
         assertEquals(HttpStatus.OK, response.statusCode)
         val body = assertNotNull(response.body)
         assertEquals(currentNodeId.value, body.currentNode.id)
-        assertEquals(listOf(northNodeId.value), body.adjacent.map { it.id })
+        assertEquals(listOf(northNodeId.value), body.visible.map { it.id })
     }
 
     @Test

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -273,7 +273,10 @@ internal class WorldDefinitionBalanceLookup(
     override fun roadStaminaMultiplier(): Double = ROAD_STAMINA_MULTIPLIER
 
     private companion object {
-        const val BASE_MOVE_COST = 1
+        // Must exceed BASE_REGEN_PER_TICK so the spend is observable across the
+        // agent's move-then-get-status loop; at parity the regen tick refills the
+        // spend before the agent can read it, masking the stamina-driven travel loop.
+        const val BASE_MOVE_COST = 3
         const val BASE_REGEN_PER_TICK = 1.0
         const val BASE_HARVEST_COST = 5
         const val BASE_HARVEST_YIELD = 1


### PR DESCRIPTION
## Summary

Three small E2E-finding fixes that don't share a surface, batched into one PR.

### #105 — `move` now visibly costs stamina

`BASE_MOVE_COST = 1` and `BASE_REGEN_PER_TICK = 1.0` net out to zero across the agent's move-then-`get_status` window: the spend was happening but the next regen tick refilled it before the agent could read it. Bump `BASE_MOVE_COST` to **3** so the spend survives one regen tick. Reducer code path was correct all along; only the constant was wrong.

### #108 — `look_around` `adjacent` → `visible` + `neighbours`

The field named `adjacent` actually returned the full vision radius (up to 36 entries at sight 5), which agents reasonably interpreted as one-step move targets. Renamed to `visible`. Added a dedicated `neighbours: List<Long>` that carries only the hex-adjacent ids = the canonical input for `move`. REST endpoint shape mirrored.

### #119 — `select_perk` now visible to MCP clients

`SelectPerkTool` was fully implemented and unit-tested, but missing from the `MethodToolCallbackProvider.toolObjects` list in `McpServerConfiguration`. Wired in.

## Test plan

- [x] `:world:test` green — no test relied on the old `BASE_MOVE_COST` value (all reducer tests use stub balance lookups)
- [x] `:api:test` green — `LookAroundToolTest` + `AgentRuntimeControllerTest` updated for the rename; new test asserts `neighbours` is restricted to hex-adjacency while `visible` carries the wider sight radius
- [ ] Manual: rerun E2E sweep against this branch to confirm stamina is observable after move, `look_around` lists move-legal `neighbours`, and `select_perk` shows up in the ToolSearch index