### PR TITLE
fix(player,world,api): refresh body pool maxima after allocate_points

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -96,6 +96,9 @@ internal class AgentEventDispatcher(
     @EventListener
     fun on(event: WorldEvent.AgentDied) = publish(event.agent, "agent.died", event)
 
+    @EventListener
+    fun on(event: WorldEvent.DerivedPoolsRefreshed) = publish(event.agent, "pools.refreshed", event)
+
     private fun publish(agent: AgentId, type: String, payload: Any) {
         val tick = (payload as? WorldEvent)?.tick
             ?: (payload as? AgentEvent)?.tick

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsTool.kt
@@ -8,6 +8,8 @@ import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AllocateAttributesOutcome
 import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.annotation.Tool
 import org.springframework.ai.tool.annotation.ToolParam
@@ -20,6 +22,7 @@ internal class AllocatePointsTool(
     private val activity: AgentActivityTracker,
     private val publisher: ApplicationEventPublisher,
     private val tickClock: TickClock,
+    private val world: WorldCommandGateway,
 ) {
 
     @Tool(
@@ -66,6 +69,18 @@ internal class AllocatePointsTool(
                         ),
                     )
                 }
+                // Profile pools just changed in player-side storage; queue a body-cache refresh
+                // so the next get_status reflects the new maxHp/Stamina/Mana instead of the
+                // stale values copied from the profile at spawn time.
+                world.submit(
+                    WorldCommand.RefreshDerivedPools(
+                        agent = agent,
+                        maxHp = outcome.pools.maxHp,
+                        maxStamina = outcome.pools.maxStamina,
+                        maxMana = outcome.pools.maxMana,
+                    ),
+                    appliesAtTick = tick + 1,
+                )
                 AllocatePointsResponse.ok(
                     attrs = outcome.attributes,
                     remainingUnspent = outcome.remainingUnspent,

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolTest.kt
@@ -11,7 +11,10 @@ import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AllocateAttributesOutcome
 import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.AttributeMilestoneCrossing
+import dev.gvart.genesara.player.MaxPools
 import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -37,6 +40,18 @@ class AllocatePointsToolTest {
     @BeforeEach fun setUp() = AgentContextHolder.set(agent)
     @AfterEach fun tearDown() = AgentContextHolder.clear()
 
+    private fun allocated(
+        attrs: AgentAttributes,
+        remainingUnspent: Int = 0,
+        crossings: List<AttributeMilestoneCrossing> = emptyList(),
+        pools: MaxPools = MaxPools(maxHp = 60, maxStamina = 40, maxMana = 5),
+    ) = AllocateAttributesOutcome.Allocated(
+        attributes = attrs,
+        remainingUnspent = remainingUnspent,
+        crossedMilestones = crossings,
+        pools = pools,
+    )
+
     @Test
     fun `happy path returns ok and publishes one event per crossed milestone`() {
         val crossings = listOf(
@@ -44,9 +59,10 @@ class AllocatePointsToolTest {
             AttributeMilestoneCrossing(Attribute.INTELLIGENCE, 100),
         )
         val newAttrs = AgentAttributes(intelligence = 100)
-        val registry = RecordingRegistry(returns = AllocateAttributesOutcome.Allocated(newAttrs, remainingUnspent = 0, crossedMilestones = crossings))
+        val registry = RecordingRegistry(returns = allocated(newAttrs, crossings = crossings))
         val publisher = RecordingPublisher()
-        val tool = AllocatePointsTool(registry, activity, publisher, tickClock)
+        val gateway = RecordingGateway()
+        val tool = AllocatePointsTool(registry, activity, publisher, tickClock, gateway)
 
         val response = tool.invoke(mapOf(Attribute.INTELLIGENCE to 99), toolContext)
 
@@ -62,34 +78,57 @@ class AllocatePointsToolTest {
     }
 
     @Test
-    fun `no crossings means no events even on success`() {
+    fun `successful allocation queues a RefreshDerivedPools world command with the new pool maxima`() {
         val registry = RecordingRegistry(
-            returns = AllocateAttributesOutcome.Allocated(AgentAttributes(strength = 4), remainingUnspent = 2, crossedMilestones = emptyList()),
+            returns = allocated(
+                attrs = AgentAttributes(constitution = 5, intelligence = 3),
+                remainingUnspent = 0,
+                pools = MaxPools(maxHp = 100, maxStamina = 55, maxMana = 15),
+            ),
         )
+        val gateway = RecordingGateway()
+        val tool = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, gateway)
+
+        tool.invoke(mapOf(Attribute.CONSTITUTION to 4, Attribute.INTELLIGENCE to 2), toolContext)
+
+        val (cmd, appliesAt) = gateway.submissions.single()
+        val refresh = assertNotNull(cmd as? WorldCommand.RefreshDerivedPools)
+        assertEquals(agent, refresh.agent)
+        assertEquals(100, refresh.maxHp)
+        assertEquals(55, refresh.maxStamina)
+        assertEquals(15, refresh.maxMana)
+        assertEquals(43L, appliesAt)
+    }
+
+    @Test
+    fun `no crossings means no events even on success`() {
+        val registry = RecordingRegistry(returns = allocated(AgentAttributes(strength = 4), remainingUnspent = 2))
         val publisher = RecordingPublisher()
 
-        AllocatePointsTool(registry, activity, publisher, tickClock)
+        AllocatePointsTool(registry, activity, publisher, tickClock, RecordingGateway())
             .invoke(mapOf(Attribute.STRENGTH to 3), toolContext)
 
         assertTrue(publisher.events.isEmpty())
     }
 
     @Test
-    fun `negative delta from registry maps to NEGATIVE_DELTA reason`() {
+    fun `negative delta from registry maps to NEGATIVE_DELTA reason and skips the gateway`() {
         val registry = RecordingRegistry(returns = AllocateAttributesOutcome.NegativeDelta)
+        val gateway = RecordingGateway()
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, gateway)
             .invoke(mapOf(Attribute.STRENGTH to 1), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
         assertEquals(AllocatePointsRejectionReason.NEGATIVE_DELTA, response.reason)
+        assertTrue(gateway.submissions.isEmpty())
     }
 
     @Test
     fun `insufficient points reports unspent and requested in detail`() {
         val registry = RecordingRegistry(returns = AllocateAttributesOutcome.InsufficientPoints(unspent = 2, requested = 5L))
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingGateway())
             .invoke(mapOf(Attribute.STRENGTH to 5), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
@@ -102,32 +141,36 @@ class AllocatePointsToolTest {
     @Test
     fun `empty deltas short-circuits to NO_OP without touching the registry`() {
         val registry = RecordingRegistry(returns = AllocateAttributesOutcome.NegativeDelta)
+        val gateway = RecordingGateway()
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, gateway)
             .invoke(emptyMap(), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
         assertEquals(AllocatePointsRejectionReason.NO_OP, response.reason)
         assertTrue(registry.calls.isEmpty())
+        assertTrue(gateway.submissions.isEmpty())
     }
 
     @Test
     fun `all-zero deltas short-circuits to NO_OP without touching the registry`() {
         val registry = RecordingRegistry(returns = AllocateAttributesOutcome.NegativeDelta)
+        val gateway = RecordingGateway()
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, gateway)
             .invoke(mapOf(Attribute.STRENGTH to 0, Attribute.DEXTERITY to 0), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
         assertEquals(AllocatePointsRejectionReason.NO_OP, response.reason)
         assertTrue(registry.calls.isEmpty())
+        assertTrue(gateway.submissions.isEmpty())
     }
 
     @Test
     fun `null registry result becomes AGENT_MISSING`() {
         val registry = RecordingRegistry(returns = null)
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingGateway())
             .invoke(mapOf(Attribute.STRENGTH to 1), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
@@ -136,11 +179,9 @@ class AllocatePointsToolTest {
 
     @Test
     fun `touchActivity records the agent on every entry`() {
-        val registry = RecordingRegistry(
-            returns = AllocateAttributesOutcome.Allocated(AgentAttributes(), remainingUnspent = 4, crossedMilestones = emptyList()),
-        )
+        val registry = RecordingRegistry(returns = allocated(AgentAttributes(), remainingUnspent = 4))
 
-        AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock)
+        AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingGateway())
             .invoke(mapOf(Attribute.STRENGTH to 1), toolContext)
 
         assertEquals(clock.instant(), activity.lastActiveAt(agent))
@@ -163,6 +204,14 @@ class AllocatePointsToolTest {
         val events = mutableListOf<Any>()
         override fun publishEvent(event: Any) {
             events += event
+        }
+    }
+
+    private class RecordingGateway : WorldCommandGateway {
+        val submissions = mutableListOf<Pair<WorldCommand, Long>>()
+        override fun submit(command: WorldCommand, appliesAtTick: Long): Long {
+            submissions += command to appliesAtTick
+            return appliesAtTick
         }
     }
 

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
@@ -161,11 +161,15 @@ sealed interface AttributePointLoss {
 
 /** Result of [AgentRegistry.allocateAttributes]. */
 sealed interface AllocateAttributesOutcome {
-    /** Successful allocation. Carries the post-allocation snapshot for the caller to surface. */
+    /** Successful allocation. Carries the post-allocation snapshot for the caller to surface,
+     *  including the freshly-derived pool maxima — the world-side body cache must be refreshed
+     *  with these numbers so `get_status` reads consistent values, since the body stores its
+     *  own (now-stale) `maxHp/maxStamina/maxMana` columns. */
     data class Allocated(
         val attributes: AgentAttributes,
         val remainingUnspent: Int,
         val crossedMilestones: List<AttributeMilestoneCrossing>,
+        val pools: MaxPools,
     ) : AllocateAttributesOutcome
 
     /** At least one delta was negative — rejected up-front before the DB round trip. */

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
@@ -150,10 +150,12 @@ internal class JooqAgentRegistry(
         }
         val requested = requestedLong.toInt()
         if (requested == 0) {
+            val attrs = record.toAttributes()
             return AllocateAttributesOutcome.Allocated(
-                attributes = record.toAttributes(),
+                attributes = attrs,
                 remainingUnspent = unspent,
                 crossedMilestones = emptyList(),
+                pools = AttributeDerivation.deriveMaxPools(attrs),
             )
         }
 
@@ -181,6 +183,7 @@ internal class JooqAgentRegistry(
             attributes = newAttrs,
             remainingUnspent = unspent - requested,
             crossedMilestones = crossings,
+            pools = pools,
         )
     }
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
@@ -36,6 +36,7 @@ import java.util.UUID
     JsonSubTypes.Type(value = WorldCommand.Pickup::class, name = "pickup"),
     JsonSubTypes.Type(value = WorldCommand.AttackTarget::class, name = "attack"),
     JsonSubTypes.Type(value = WorldCommand.UseAbility::class, name = "useAbility"),
+    JsonSubTypes.Type(value = WorldCommand.RefreshDerivedPools::class, name = "refreshDerivedPools"),
 )
 sealed interface WorldCommand {
     val agent: AgentId
@@ -191,6 +192,21 @@ sealed interface WorldCommand {
         override val agent: AgentId,
         val ability: AbilityId,
         val target: AgentId? = null,
+        override val commandId: UUID = UUID.randomUUID(),
+    ) : WorldCommand
+
+    /**
+     * Push a freshly-derived pool maxima triple onto the body cache after an
+     * out-of-tick mutation (e.g. `allocate_points`). The reducer copies the
+     * supplied maxima onto `state.bodies[agent]` and clamps current values to
+     * the new max so a max-reduction never leaves `current > max`. Currents
+     * are NOT auto-restored — per the spec, allocation does not heal.
+     */
+    data class RefreshDerivedPools(
+        override val agent: AgentId,
+        val maxHp: Int,
+        val maxStamina: Int,
+        val maxMana: Int,
         override val commandId: UUID = UUID.randomUUID(),
     ) : WorldCommand
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
@@ -307,4 +307,15 @@ sealed interface WorldEvent {
         override val tick: Long,
         val causedBy: UUID,
     ) : WorldEvent
+
+    /** Body cache caught up to attribute-derived pool maxima after an out-of-tick mutation
+     *  (`allocate_points` today). Current pool values clamp to the new max but are not refilled. */
+    data class DerivedPoolsRefreshed(
+        val agent: AgentId,
+        val maxHp: Int,
+        val maxStamina: Int,
+        val maxMana: Int,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : WorldEvent
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -23,6 +23,7 @@ import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
+import dev.gvart.genesara.world.internal.body.reduceRefreshDerivedPools
 import dev.gvart.genesara.world.internal.buildings.BuildingsCatalog
 import dev.gvart.genesara.world.internal.abilities.PendingAttackScaleStore
 import dev.gvart.genesara.world.internal.abilities.reduceUseAbility
@@ -122,4 +123,5 @@ internal fun reduce(
             state, command, activePerks, perkCooldowns, pendingScales,
             progression, balance, behaviorTracker, tickIntervalSeconds, tick,
         )
+    is WorldCommand.RefreshDerivedPools -> reduceRefreshDerivedPools(state, command, tick)
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/body/RefreshDerivedPoolsReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/body/RefreshDerivedPoolsReducer.kt
@@ -1,0 +1,37 @@
+package dev.gvart.genesara.world.internal.body
+
+import arrow.core.Either
+import arrow.core.raise.either
+import arrow.core.raise.ensureNotNull
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+
+internal fun reduceRefreshDerivedPools(
+    state: WorldState,
+    command: WorldCommand.RefreshDerivedPools,
+    tick: Long,
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
+    val body = ensureNotNull(state.bodyOf(command.agent)) {
+        WorldRejection.NotInWorld(command.agent)
+    }
+    val updated = body.copy(
+        hp = body.hp.coerceAtMost(command.maxHp),
+        maxHp = command.maxHp,
+        stamina = body.stamina.coerceAtMost(command.maxStamina),
+        maxStamina = command.maxStamina,
+        mana = body.mana.coerceAtMost(command.maxMana),
+        maxMana = command.maxMana,
+    )
+    val next = state.updateBody(command.agent, updated)
+    val event = WorldEvent.DerivedPoolsRefreshed(
+        agent = command.agent,
+        maxHp = command.maxHp,
+        maxStamina = command.maxStamina,
+        maxMana = command.maxMana,
+        tick = tick,
+        causedBy = command.commandId,
+    )
+    next to listOf(event)
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/body/RefreshDerivedPoolsReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/body/RefreshDerivedPoolsReducerTest.kt
@@ -1,0 +1,77 @@
+package dev.gvart.genesara.world.internal.body
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class RefreshDerivedPoolsReducerTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+
+    @Test
+    fun `updates the maxima on the body, leaving sub-max currents alone`() {
+        val state = stateWith(
+            AgentBody(
+                hp = 30, maxHp = 60,
+                stamina = 25, maxStamina = 40,
+                mana = 2, maxMana = 5,
+            ),
+        )
+        val command = WorldCommand.RefreshDerivedPools(agent, maxHp = 100, maxStamina = 60, maxMana = 15)
+
+        val (next, events) = reduceRefreshDerivedPools(state, command, tick = 7).getOrNull()!!
+
+        val body = next.bodyOf(agent)!!
+        assertEquals(100, body.maxHp)
+        assertEquals(60, body.maxStamina)
+        assertEquals(15, body.maxMana)
+        // Currents below the previous max stay where they were — allocation does not heal.
+        assertEquals(30, body.hp)
+        assertEquals(25, body.stamina)
+        assertEquals(2, body.mana)
+        val event = assertNotNull(events.single() as? WorldEvent.DerivedPoolsRefreshed)
+        assertEquals(agent, event.agent)
+        assertEquals(100, event.maxHp)
+        assertEquals(7L, event.tick)
+        assertEquals(command.commandId, event.causedBy)
+    }
+
+    @Test
+    fun `clamps currents down when the new maxima are lower than the previous currents`() {
+        val state = stateWith(
+            AgentBody(
+                hp = 80, maxHp = 100,
+                stamina = 50, maxStamina = 60,
+                mana = 12, maxMana = 15,
+            ),
+        )
+        val command = WorldCommand.RefreshDerivedPools(agent, maxHp = 50, maxStamina = 40, maxMana = 5)
+
+        val (next, _) = reduceRefreshDerivedPools(state, command, tick = 1).getOrNull()!!
+
+        val body = next.bodyOf(agent)!!
+        assertEquals(50, body.hp)
+        assertEquals(40, body.stamina)
+        assertEquals(5, body.mana)
+    }
+
+    @Test
+    fun `rejects with NotInWorld when the agent has no body row`() {
+        val state = WorldState.EMPTY
+        val command = WorldCommand.RefreshDerivedPools(agent, maxHp = 100, maxStamina = 60, maxMana = 15)
+
+        val rejection = reduceRefreshDerivedPools(state, command, tick = 1).leftOrNull()
+
+        assertEquals(WorldRejection.NotInWorld(agent), rejection)
+    }
+
+    private fun stateWith(body: AgentBody): WorldState = WorldState.EMPTY.copy(
+        bodies = mapOf(agent to body),
+    )
+}


### PR DESCRIPTION
## Summary — closes #110

After `allocate_points` raised an attribute, `JooqAgentRegistry` correctly recomputed `maxHp / maxStamina / maxMana` via `AttributeDerivation` and persisted them to `AGENT_PROFILES`. But the world-side body cache (`state.bodies` and `AGENT_BODIES.MAX_*`) was seeded from the profile only on the agent's first spawn. After allocation the body kept the old maxima, so `get_status` returned `hp:{60/60}` after a CON +2 bump that should have moved `maxHp` to 70+.

## Fix

1. `AllocateAttributesOutcome.Allocated` now carries the newly-derived `MaxPools` so callers don't need a follow-up profile lookup.
2. New `WorldCommand.RefreshDerivedPools(agent, maxHp, maxStamina, maxMana)` + reducer in `world.internal.body`. Updates `state.bodies[agent]` maxima and defensively clamps any current value that would exceed the new max (today the allocate path is monotonic upward, but the guard keeps the invariant local). Emits `WorldEvent.DerivedPoolsRefreshed` so the change is auditable on the agent stream.
3. `AllocatePointsTool` dispatches the command at `tick + 1` after a successful allocation. Current pool values are **not** auto-refilled — the spec requires a manual heal.

## Test plan

- [x] `:world:test` green — new `RefreshDerivedPoolsReducerTest` covers the happy path, current-clamp on max-reduction, and `NotInWorld` rejection when the body row is absent
- [x] `:api:test` green — new `AllocatePointsToolTest` case asserts the `RefreshDerivedPools` command is queued with the correct numbers at `tick + 1` and is **not** queued on rejection paths or the `NO_OP` short-circuit
- [x] `:player:test` green — existing integration test continues to assert the profile recompute; new `pools` field flows through transparently
- [ ] Manual E2E: spawn → `allocate_points(CON: 2, INT: 2)` → wait one tick → `get_status` reports updated `maxHp / maxStamina / maxMana`