### PR TITLE
fix(api): wire missing WorldEvent dispatchers onto the agent event stream

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -96,6 +96,47 @@ internal class AgentEventDispatcher(
     @EventListener
     fun on(event: WorldEvent.AgentDied) = publish(event.agent, "agent.died", event)
 
+    @EventListener
+    fun on(event: WorldEvent.AgentRespawned) = publish(event.agent, "agent.respawned", event)
+
+    @EventListener
+    fun on(event: WorldEvent.SafeNodeSet) = publish(event.agent, "agent.safe_node_set", event)
+
+    @EventListener
+    fun on(event: WorldEvent.BuildingPlaced) = publish(event.building.builtByAgentId, "building.placed", event)
+
+    @EventListener
+    fun on(event: WorldEvent.BuildingProgressed) = publish(event.building.builtByAgentId, "building.progressed", event)
+
+    @EventListener
+    fun on(event: WorldEvent.BuildingCompleted) = publish(event.building.builtByAgentId, "building.completed", event)
+
+    @EventListener
+    fun on(event: WorldEvent.ItemDeposited) = publish(event.agent, "item.deposited", event)
+
+    @EventListener
+    fun on(event: WorldEvent.ItemWithdrawn) = publish(event.agent, "item.withdrawn", event)
+
+    @EventListener
+    fun on(event: WorldEvent.ItemPickedUp) = publish(event.agent, "item.pickedUp", event)
+
+    @EventListener
+    fun on(event: WorldEvent.ItemDroppedOnGround) = publish(event.byAgent, "item.droppedOnGround", event)
+
+    @EventListener
+    fun on(event: WorldEvent.AbilityUsed) {
+        publish(event.agent, "ability.used", event)
+        val target = event.target
+        if (target != null && target != event.agent) publish(target, "ability.used", event)
+    }
+
+    @EventListener
+    fun on(event: WorldEvent.PerkTriggered) {
+        publish(event.agent, "perk.triggered", event)
+        val target = event.target
+        if (target != null && target != event.agent) publish(target, "perk.triggered", event)
+    }
+
     private fun publish(agent: AgentId, type: String, payload: Any) {
         val tick = (payload as? WorldEvent)?.tick
             ?: (payload as? AgentEvent)?.tick

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
@@ -227,6 +227,38 @@ class AgentEventDispatcherTest {
     }
 
     @Test
+    fun `SafeNodeSet reaches the agent stream`() {
+        val cmdId = UUID.randomUUID()
+        dispatcher.on(WorldEvent.SafeNodeSet(agent, NodeId(525L), tick = 4L, causedBy = cmdId))
+
+        val entry = log.since(agent, 0).single()
+        assertEquals("agent.safe_node_set", entry.type)
+        assertEquals(4L, entry.tick)
+        assertEquals(cmdId.toString(), entry.payload.get("causedBy").asString())
+    }
+
+    @Test
+    fun `AgentRespawned reaches the agent stream`() {
+        val cmdId = UUID.randomUUID()
+        dispatcher.on(WorldEvent.AgentRespawned(agent, NodeId(1L), fromCheckpoint = true, tick = 9L, causedBy = cmdId))
+
+        val entry = log.since(agent, 0).single()
+        assertEquals("agent.respawned", entry.type)
+    }
+
+    @Test
+    fun `chest transfer events reach the agent stream`() {
+        val deposit = UUID.randomUUID()
+        val withdraw = UUID.randomUUID()
+        val chest = UUID.randomUUID()
+        dispatcher.on(WorldEvent.ItemDeposited(agent, chest, ItemId("WOOD"), quantity = 3, tick = 1L, causedBy = deposit))
+        dispatcher.on(WorldEvent.ItemWithdrawn(agent, chest, ItemId("WOOD"), quantity = 2, tick = 2L, causedBy = withdraw))
+
+        val types = log.since(agent, 0).map { it.type }
+        assertEquals(listOf("item.deposited", "item.withdrawn"), types)
+    }
+
+    @Test
     fun `PassivesApplied fans out one envelope per affected agent`() {
         val a1 = AgentId(UUID.randomUUID())
         val a2 = AgentId(UUID.randomUUID())


### PR DESCRIPTION
## Summary

`AgentEventDispatcher` had `@EventListener` methods for some `WorldEvent` subtypes but not all. **Eleven** subtypes fired correctly in the reducer pipeline but were never routed to the per-agent event log — so the agent saw no ack for several verbs. The most load-bearing example is `set_safe_node`: the reducer correctly emits `WorldEvent.SafeNodeSet`, but no dispatcher routed it onto the stream, so the `SafeNodeSet` event "promised" in the tool description never materialised. From the playtest server-log analysis, this is why "set_safe_node command dispatched but no event ever delivered" was reported as a P0.

## Newly-dispatched events

- `SafeNodeSet` → `agent.safe_node_set`
- `AgentRespawned` → `agent.respawned`
- `BuildingPlaced` / `BuildingProgressed` / `BuildingCompleted` → routed by `builtByAgentId`
- `ItemDeposited` / `ItemWithdrawn` → `item.deposited` / `item.withdrawn`
- `ItemPickedUp` → `item.pickedUp`
- `ItemDroppedOnGround` → routed by `byAgent`
- `AbilityUsed` / `PerkTriggered` → fan out to caster + non-self target

## Notes

- `DerivedPoolsRefreshed` is also missing today but it's introduced in PR #136 (allocate_points pool maxima) and wired there. This PR doesn't touch that event.
- An audit script confirms the dispatcher now covers every `WorldEvent` subtype with an agent-identifiable owner.

## Test plan

- [x] `:api:test` green
- [x] New `AgentEventDispatcherTest` cases for `SafeNodeSet`, `AgentRespawned`, and the chest transfer pair lock in the routing; remaining wiring is symmetric to existing pattern asserts.
- [ ] Manual E2E: spawn → `set_safe_node` → wait one tick → `agent://{id}/events` contains an `agent.safe_node_set` envelope with the original `commandId` as `causedBy`.

Closes #109, closes #112, closes #125.