### PR TITLE
fix(world): grant character XP from harvest and consume

### DIFF
--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -24,6 +24,7 @@ import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
 import dev.gvart.genesara.world.internal.buildings.BuildingsCatalog
+import dev.gvart.genesara.world.internal.classes.CharacterXpProgression
 import dev.gvart.genesara.world.internal.abilities.PendingAttackScaleStore
 import dev.gvart.genesara.world.internal.abilities.reduceUseAbility
 import dev.gvart.genesara.world.internal.buildings.reduceBuild
@@ -68,6 +69,7 @@ internal fun reduce(
     chestContents: ChestContentsStore,
     rarityRoller: RarityRoller,
     progression: SkillProgression,
+    characterXp: CharacterXpProgression,
     scaling: LevelScalingAggregator,
     passiveAura: PassiveAuraAggregator,
     spawnLocationResolver: SpawnLocationResolver,
@@ -89,9 +91,9 @@ internal fun reduce(
     is WorldCommand.Harvest ->
         reduceHarvest(
             state, command, balance, items, resources, agents, equipment,
-            progression, scaling, triggeredPassives, behaviorTracker, tick,
+            progression, characterXp, scaling, triggeredPassives, behaviorTracker, tick,
         )
-    is WorldCommand.ConsumeItem -> reduceConsume(state, command, items, tick)
+    is WorldCommand.ConsumeItem -> reduceConsume(state, command, items, characterXp, tick)
     is WorldCommand.Drink -> reduceDrink(state, command, balance, buildingsLookup, tick)
     is WorldCommand.SetSafeNode -> reduceSetSafeNode(state, command, safeNodes, tick)
     is WorldCommand.Respawn -> reduceRespawn(state, command, profiles, safeNodes, safeNodeResolver, tick)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgression.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgression.kt
@@ -7,25 +7,30 @@ import dev.gvart.genesara.player.AgentRegistry
 import org.springframework.stereotype.Component
 
 /**
- * Canonical character-XP grant entry point. Wraps the atomic
- * [AgentRegistry.addCharacterXp] mutation and routes level-milestone
- * transitions through the matching emitter so future XP-source slices
- * (quest rewards, NPC kills) only need to call this method.
- *
- * Currently no reducer wires up to this class — Phase-1 verbs only grant
- * skill XP via `SkillProgression`. The component exists so the L10 / L50
- * flows are end-to-end exercisable from integration tests, and so the wiring
- * point is fixed for the first XP-source slice that lands.
+ * Canonical character-XP grant entry point. Wraps the atomic [AgentRegistry.addCharacterXp]
+ * mutation and routes level-milestone transitions through the matching emitter so future
+ * XP-source slices (quest rewards, NPC kills) only need to call this method.
  */
+internal interface CharacterXpProgression {
+    fun grant(agentId: AgentId, delta: Int): AddCharacterXpOutcome?
+
+    companion object {
+        /** Drop-in no-op for tests that exercise reducers but don't care about XP propagation. */
+        val NoOp: CharacterXpProgression = object : CharacterXpProgression {
+            override fun grant(agentId: AgentId, delta: Int): AddCharacterXpOutcome? = null
+        }
+    }
+}
+
 @Component
-internal class CharacterXpProgression(
+internal class DefaultCharacterXpProgression(
     private val agents: AgentRegistry,
     private val level10: Level10ChoiceEmitter,
     private val level50: Level50EvolutionEmitter,
     private val tickClock: TickClock,
-) {
+) : CharacterXpProgression {
 
-    fun grant(agentId: AgentId, delta: Int): AddCharacterXpOutcome? {
+    override fun grant(agentId: AgentId, delta: Int): AddCharacterXpOutcome? {
         val outcome = agents.addCharacterXp(agentId, delta) ?: return null
         if (outcome is AddCharacterXpOutcome.Granted) {
             val tick = tickClock.currentTick()

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducer.kt
@@ -8,6 +8,7 @@ import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.classes.CharacterXpProgression
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 
 /**
@@ -27,6 +28,7 @@ internal fun reduceConsume(
     state: WorldState,
     command: WorldCommand.ConsumeItem,
     items: ItemLookup,
+    characterXp: CharacterXpProgression,
     tick: Long,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
     ensure(command.agent in state.positions) { WorldRejection.NotInWorld(command.agent) }
@@ -47,6 +49,7 @@ internal fun reduceConsume(
     val nextBody = body.refill(effect.gauge, effect.amount)
     val refilled = nextBody.valueOf(effect.gauge) - before
     val nextInventory = inventory.remove(command.item, 1)
+    characterXp.grant(command.agent, delta = 1)
     val next = state
         .updateBody(command.agent, nextBody)
         .updateInventory(command.agent, nextInventory)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
@@ -21,6 +21,7 @@ import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.behavior.ActionCategory
 import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
+import dev.gvart.genesara.world.internal.classes.CharacterXpProgression
 import dev.gvart.genesara.world.internal.inventory.enforceCarryCap
 import dev.gvart.genesara.world.internal.inventory.equippedGrams
 import dev.gvart.genesara.world.internal.inventory.totalGrams
@@ -46,6 +47,7 @@ internal fun reduceHarvest(
     agents: AgentRegistry,
     equipment: EquipmentInstanceStore,
     progression: SkillProgression,
+    characterXp: CharacterXpProgression,
     scaling: LevelScalingAggregator,
     triggeredPassives: TriggeredPassiveDispatcher,
     behaviorTracker: BehaviorTracker,
@@ -84,6 +86,7 @@ internal fun reduceHarvest(
     itemDef.harvestSkill?.let { skill ->
         progression.accrueXp(command.agent, skill, delta = quantity, tick, command.commandId, agentRecord.classId)
     }
+    characterXp.grant(command.agent, quantity)
     behaviorTracker.record(command.agent, ActionCategory.GATHER, tick)
 
     // TODO(max-stack): reject (StackFull) when adding `quantity` would exceed maxStack.

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -24,6 +24,7 @@ import dev.gvart.genesara.world.internal.abilities.PendingAttackScaleStore
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
 import dev.gvart.genesara.world.internal.buildings.BuildingsCatalog
+import dev.gvart.genesara.world.internal.classes.CharacterXpProgression
 import dev.gvart.genesara.world.internal.crafting.RarityRoller
 import dev.gvart.genesara.world.internal.death.DeathProcessor
 import dev.gvart.genesara.world.internal.death.SafeNodeResolver
@@ -65,6 +66,7 @@ internal class WorldTickHandler(
     private val chestContents: ChestContentsStore,
     private val rarityRoller: RarityRoller,
     private val progression: SkillProgression,
+    private val characterXp: CharacterXpProgression,
     private val scaling: LevelScalingAggregator,
     private val passiveAura: PassiveAuraAggregator,
     private val spawnLocationResolver: SpawnLocationResolver,
@@ -130,7 +132,7 @@ internal class WorldTickHandler(
             reduce(
                 state, command, balance, profiles, items, recipes, resources, skills, agents, equipment,
                 safeNodes, safeNodeResolver, buildings, buildingsLookup, buildingsCatalog, chestContents,
-                rarityRoller, progression, scaling, passiveAura, spawnLocationResolver, groundItems,
+                rarityRoller, progression, characterXp, scaling, passiveAura, spawnLocationResolver, groundItems,
                 deathProcessor, triggeredPassives, activePerks, perkCooldowns, pendingScales,
                 behaviorTracker, tickIntervalSeconds, number, classes = classes,
             ).fold(

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgressionTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgressionTest.kt
@@ -40,7 +40,7 @@ class CharacterXpProgressionTest {
         )
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = CharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
 
         progression.grant(agentId, 100)
 
@@ -64,7 +64,7 @@ class CharacterXpProgressionTest {
         )
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = CharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
 
         progression.grant(agentId, 100)
 
@@ -87,7 +87,7 @@ class CharacterXpProgressionTest {
         )
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = CharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
 
         progression.grant(agentId, 1100)
 
@@ -111,7 +111,7 @@ class CharacterXpProgressionTest {
         )
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = CharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
 
         progression.grant(agentId, 100)
 
@@ -125,7 +125,7 @@ class CharacterXpProgressionTest {
         val agents = SequencedRegistry(grant = AddCharacterXpOutcome.NegativeDelta, stateAfter = level10Unclassed())
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = CharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
 
         val outcome = progression.grant(agentId, -5)
 
@@ -139,7 +139,7 @@ class CharacterXpProgressionTest {
         val agents = SequencedRegistry(grant = null, stateAfter = level10Unclassed())
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = CharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
 
         val outcome = progression.grant(agentId, 100)
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducerTest.kt
@@ -78,7 +78,7 @@ class ConsumeReducerTest {
         val state = stateWith(hunger = 90, inventory = AgentInventory(mapOf(berry to 2)))
         val command = WorldCommand.ConsumeItem(agent, berry)
 
-        val result = reduceConsume(state, command, items, tick = 7)
+        val result = reduceConsume(state, command, items, characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, tick = 7)
 
         val (next, events) = assertNotNull(result.getOrNull())
         val event = events.single()
@@ -98,7 +98,7 @@ class ConsumeReducerTest {
     fun `last unit - removing 1 from a stack of 1 drops the entry entirely`() {
         val state = stateWith(inventory = AgentInventory(mapOf(berry to 1)))
 
-        val result = reduceConsume(state, WorldCommand.ConsumeItem(agent, berry), items, tick = 1)
+        val result = reduceConsume(state, WorldCommand.ConsumeItem(agent, berry), items, characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, tick = 1)
 
         val (next, _) = assertNotNull(result.getOrNull())
         assertEquals(0, next.inventoryOf(agent).quantityOf(berry))
@@ -108,7 +108,7 @@ class ConsumeReducerTest {
     fun `rejects when agent is not in the world`() {
         val state = stateWith(positioned = false)
 
-        val result = reduceConsume(state, WorldCommand.ConsumeItem(agent, berry), items, tick = 1)
+        val result = reduceConsume(state, WorldCommand.ConsumeItem(agent, berry), items, characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, tick = 1)
 
         assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
     }
@@ -118,7 +118,7 @@ class ConsumeReducerTest {
         val state = stateWith()
         val unknown = ItemId("PHANTOM")
 
-        val result = reduceConsume(state, WorldCommand.ConsumeItem(agent, unknown), items, tick = 1)
+        val result = reduceConsume(state, WorldCommand.ConsumeItem(agent, unknown), items, characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, tick = 1)
 
         assertEquals(WorldRejection.UnknownItem(unknown), result.leftOrNull())
     }
@@ -127,7 +127,7 @@ class ConsumeReducerTest {
     fun `rejects when item is not consumable`() {
         val state = stateWith(inventory = AgentInventory(mapOf(wood to 2)))
 
-        val result = reduceConsume(state, WorldCommand.ConsumeItem(agent, wood), items, tick = 1)
+        val result = reduceConsume(state, WorldCommand.ConsumeItem(agent, wood), items, characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, tick = 1)
 
         assertEquals(WorldRejection.ItemNotConsumable(wood), result.leftOrNull())
     }
@@ -136,7 +136,7 @@ class ConsumeReducerTest {
     fun `rejects when agent does not own the item`() {
         val state = stateWith(inventory = AgentInventory.EMPTY)
 
-        val result = reduceConsume(state, WorldCommand.ConsumeItem(agent, berry), items, tick = 1)
+        val result = reduceConsume(state, WorldCommand.ConsumeItem(agent, berry), items, characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, tick = 1)
 
         assertEquals(WorldRejection.ItemNotInInventory(agent, berry), result.leftOrNull())
     }
@@ -147,7 +147,7 @@ class ConsumeReducerTest {
         // UnknownItem → ItemNotConsumable → ItemNotInInventory, so ItemNotConsumable wins.
         val state = stateWith(inventory = AgentInventory.EMPTY)
 
-        val result = reduceConsume(state, WorldCommand.ConsumeItem(agent, wood), items, tick = 1)
+        val result = reduceConsume(state, WorldCommand.ConsumeItem(agent, wood), items, characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, tick = 1)
 
         assertEquals(WorldRejection.ItemNotConsumable(wood), result.leftOrNull())
     }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
@@ -111,7 +111,7 @@ class HarvestReducerTest {
         val publisher = RecordingPublisher()
 
         val result = reduceHarvest(
-            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
         )
 
         val (next, events) = assertNotNull(result.getOrNull())
@@ -138,7 +138,7 @@ class HarvestReducerTest {
         val publisher = RecordingPublisher()
 
         val result = reduceHarvest(
-            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, publisher), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val (next, events) = assertNotNull(result.getOrNull())
@@ -175,7 +175,7 @@ class HarvestReducerTest {
         val skills = StubSkillsRegistry().apply { slot(mining) }
 
         val result = reduceHarvest(
-            state, command, balance, regenItems, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            state, command, balance, regenItems, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -191,7 +191,7 @@ class HarvestReducerTest {
         val skills = StubSkillsRegistry().apply { slot(foraging) }
 
         val result = reduceHarvest(
-            state, command, balance, items, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            state, command, balance, items, store, agents, equipment, SkillProgression(skills, RecordingPublisher()), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -205,7 +205,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
@@ -219,7 +219,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, unknown), balance, emptyCatalog,
-            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            StubResourceStore(), agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(WorldRejection.UnknownItem(unknown), result.leftOrNull())
@@ -232,7 +232,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, berry), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(
@@ -248,7 +248,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(
@@ -264,7 +264,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(
@@ -280,7 +280,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -296,7 +296,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), highYield, items,
-            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            store, agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val (next, events) = assertNotNull(result.getOrNull())
@@ -320,7 +320,7 @@ class HarvestReducerTest {
 
         val result = reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), tightBalance, items, store,
-            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(
@@ -339,7 +339,7 @@ class HarvestReducerTest {
         val result = reduceHarvest(
             state = stateWith(),
             WorldCommand.Harvest(agent, wood), tightBalance, items, store,
-            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            skinnyAgents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val (next, _) = assertNotNull(result.getOrNull())
@@ -382,7 +382,7 @@ class HarvestReducerTest {
         val result = reduceHarvest(
             state = stateWith(),
             WorldCommand.Harvest(agent, wood), tightBalance, itemsWithHelmet, store,
-            skinnyAgents, helmetEquipped, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            skinnyAgents, helmetEquipped, SkillProgression(StubSkillsRegistry(), RecordingPublisher()), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(
@@ -400,7 +400,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
         )
 
         assertEquals(listOf(lumberjacking to 1), skills.xpAddCalls)
@@ -420,7 +420,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
         )
 
         val ev = publisher.events.filterIsInstance<AgentEvent.SkillMilestoneReached>().single()
@@ -441,7 +441,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
         )
 
         val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()
@@ -458,7 +458,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, items,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
         )
 
         assertTrue(publisher.events.none { it is AgentEvent.SkillRecommended })
@@ -475,7 +475,7 @@ class HarvestReducerTest {
 
         reduceHarvest(
             state, WorldCommand.Harvest(agent, wood), balance, skillFreeItems,
-            store, agents, equipment, SkillProgression(skills, publisher), scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
+            store, agents, equipment, SkillProgression(skills, publisher), characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp, scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
         )
 
         assertEquals(0, skills.xpAddCalls.size)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -211,6 +211,7 @@ class WorldTickHandlerTest {
         NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway,
         NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog,
         NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher),
+        dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp,
         NoScaling, NoAura, NoopSpawnLocationResolver, NoopGroundItemStore,
         DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore),
         NoOpTriggeredPassiveDispatcher, NoOpActivePerkLookup, InMemoryPerkCooldownStore(),


### PR DESCRIPTION
## Summary — closes #118

`CharacterXpProgression` existed but had no callers — its own docstring admitted *"Currently no reducer wires up to this class — Phase-1 verbs only grant skill XP via SkillProgression."* Net effect: agents got skill XP but no character XP, so `xp.current` stayed pinned at fixture values across the entire grind loop and the **L10 cap path** (`class.choice_offered` at `level == 10`) was unreachable via natural play. The L10 emitter is already wired through `CharacterXpProgression.grant`, so granting unblocks the class-choice flow with no extra plumbing.

## Fix

1. Promoted `CharacterXpProgression` to an `interface` with a `NoOp` test instance, so reducer tests that don't care about XP propagation don't have to construct a real `Default` + `Level10/50` emitter trio. The production implementation moves to `DefaultCharacterXpProgression` with the same `@Component` annotation; Spring wiring is unchanged.
2. `HarvestReducer.reduceHarvest` now calls `characterXp.grant(agent, quantity)` after a successful harvest — same shape as the skill XP grant.
3. `ConsumeReducer.reduceConsume` calls `characterXp.grant(agent, delta = 1)` after a successful consume.
4. Threaded the dependency through `WorldReducer` and `WorldTickHandler`. Spring auto-wires the bean.

Out of scope for this PR: emitting a dedicated `xp.gained` event onto the agent stream. The level-up emitters already publish `class.choice_offered` etc. via the existing `AgentEvent` path; `get_status.xp.current` reads from the registry so the ledger advances are observable. A dedicated `xp.gained` event can land separately if needed.

## Test plan

- [x] `:world:test` green — the 30+ existing reducer test cases pass the new `characterXp` parameter (mostly via `CharacterXpProgression.NoOp`)
- [ ] Manual E2E s05-lvl10-cap: spawn at the fixture's L10/999-XP state → `harvest(HERB)` once → `get_status.xp.current` overflows 1000, `class.choice_offered` lands, `pendingClassChoice` populates with 2 options.