### PR TITLE
fix(api): structured errors for missing required params and unknown enum values

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/EnumCaseInsensitiveToolCallback.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/EnumCaseInsensitiveToolCallback.kt
@@ -77,5 +77,7 @@ internal class EnumCaseInsensitiveToolCallbackProvider(
 ) : ToolCallbackProvider {
 
     override fun getToolCallbacks(): Array<ToolCallback> =
-        delegate.toolCallbacks.map { EnumCaseInsensitiveToolCallback(it) }.toTypedArray()
+        delegate.toolCallbacks.map {
+            EnumCaseInsensitiveToolCallback(McpToolInputValidationCallback(it))
+        }.toTypedArray()
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/McpToolInputValidationCallback.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/McpToolInputValidationCallback.kt
@@ -1,0 +1,129 @@
+package dev.gvart.genesara.api.internal.mcp.jackson
+
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.ToolCallback
+import org.springframework.ai.tool.definition.ToolDefinition
+import org.springframework.ai.tool.metadata.ToolMetadata
+import org.springframework.ai.util.json.JsonParser
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.node.ObjectNode
+
+/** Catches Spring AI [org.springframework.ai.tool.method.MethodToolCallback] binder errors
+ *  before they reach the reflective invocation — Kotlin NPE on a missing required param and
+ *  `IllegalArgumentException` on an unknown enum constant both leak fully-qualified internal
+ *  class names back to the agent. Pre-validates against the tool's own inputSchema and
+ *  returns a structured `{"kind":"error", ...}` JSON shape instead. Runs *inside*
+ *  [EnumCaseInsensitiveToolCallback], so any case-normalised enum value has already been
+ *  rewritten to its canonical form by the time we validate. */
+internal class McpToolInputValidationCallback(
+    private val delegate: ToolCallback,
+) : ToolCallback {
+
+    private val required: List<String>
+    private val enumValues: Map<String, List<String>>
+
+    init {
+        val (req, enums) = parseSchema(delegate.toolDefinition.inputSchema())
+        required = req
+        enumValues = enums
+    }
+
+    override fun getToolDefinition(): ToolDefinition = delegate.toolDefinition
+
+    override fun getToolMetadata(): ToolMetadata = delegate.toolMetadata
+
+    override fun call(toolInput: String): String = call(toolInput, null)
+
+    override fun call(toolInput: String, toolContext: ToolContext?): String {
+        if (required.isEmpty() && enumValues.isEmpty()) return delegate.call(toolInput, toolContext)
+        val mapper = JsonParser.getJsonMapper()
+        val node = runCatching { mapper.readTree(toolInput) }.getOrNull()
+        if (node !is ObjectNode) return delegate.call(toolInput, toolContext)
+
+        for (param in required) {
+            val value = node.get(param)
+            if (value == null || value.isNull) {
+                return missingParamError(mapper, param)
+            }
+            if (value.isString && value.asString().isBlank()) {
+                return blankParamError(mapper, param)
+            }
+        }
+
+        for ((param, allowed) in enumValues) {
+            val value = node.get(param) ?: continue
+            if (!value.isString) continue
+            val raw = value.asString()
+            if (raw !in allowed) {
+                return unknownEnumError(mapper, param, raw, allowed)
+            }
+        }
+
+        return delegate.call(toolInput, toolContext)
+    }
+
+    private fun missingParamError(mapper: ObjectMapper, parameter: String): String {
+        val error = mapper.createObjectNode()
+        error.put("code", "MISSING_REQUIRED_PARAMETER")
+        error.put("parameter", parameter)
+        error.put("message", "Required parameter '$parameter' is missing")
+        return wrap(mapper, error)
+    }
+
+    private fun blankParamError(mapper: ObjectMapper, parameter: String): String {
+        val error = mapper.createObjectNode()
+        error.put("code", "MISSING_REQUIRED_PARAMETER")
+        error.put("parameter", parameter)
+        error.put("message", "Required parameter '$parameter' must not be blank")
+        return wrap(mapper, error)
+    }
+
+    private fun unknownEnumError(
+        mapper: ObjectMapper,
+        parameter: String,
+        received: String,
+        validValues: List<String>,
+    ): String {
+        val error = mapper.createObjectNode()
+        error.put("code", "INVALID_ENUM_VALUE")
+        error.put("parameter", parameter)
+        error.put("received", received)
+        error.put(
+            "message",
+            "Unknown value '$received' for parameter '$parameter'. Valid values: ${validValues.joinToString()}",
+        )
+        val arr = error.putArray("validValues")
+        validValues.forEach { arr.add(it) }
+        return wrap(mapper, error)
+    }
+
+    private fun wrap(mapper: ObjectMapper, error: ObjectNode): String {
+        val root = mapper.createObjectNode()
+        root.put("kind", "error")
+        root.set("error", error)
+        return mapper.writeValueAsString(root)
+    }
+
+    private companion object {
+        fun parseSchema(schema: String): Pair<List<String>, Map<String, List<String>>> {
+            val tree = runCatching { JsonParser.getJsonMapper().readTree(schema) }.getOrNull()
+                ?: return emptyList<String>() to emptyMap()
+            val requiredNode = tree.get("required")
+            val required = if (requiredNode != null && requiredNode.isArray) {
+                val out = mutableListOf<String>()
+                requiredNode.forEach { it.asString().takeIf { v -> v.isNotEmpty() }?.let(out::add) }
+                out.toList()
+            } else emptyList()
+            val properties = tree.get("properties") as? ObjectNode ?: return required to emptyMap()
+            val enums = mutableMapOf<String, List<String>>()
+            for (entry in properties.properties()) {
+                val enumNode = entry.value.get("enum") ?: continue
+                if (!enumNode.isArray) continue
+                val values = mutableListOf<String>()
+                enumNode.forEach { it.asString().takeIf { v -> v.isNotEmpty() }?.let(values::add) }
+                if (values.isNotEmpty()) enums[entry.key] = values.toList()
+            }
+            return required to enums
+        }
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/McpToolInputValidationCallbackTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/McpToolInputValidationCallbackTest.kt
@@ -1,0 +1,156 @@
+package dev.gvart.genesara.api.internal.mcp.jackson
+
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.ToolCallback
+import org.springframework.ai.tool.definition.ToolDefinition
+import org.springframework.ai.tool.metadata.ToolMetadata
+import org.springframework.ai.util.json.JsonParser
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class McpToolInputValidationCallbackTest {
+
+    private val harvestSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "itemId": {"type": "string"}
+          },
+          "required": ["itemId"]
+        }
+    """.trimIndent()
+
+    private val buildSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "type": {"type": "string", "enum": ["CAMPFIRE", "WORKBENCH", "STORAGE_CHEST"]}
+          },
+          "required": ["type"]
+        }
+    """.trimIndent()
+
+    @Test
+    fun `missing required param returns structured error and does not call delegate`() {
+        val recorder = RecordingToolCallback(harvestSchema)
+        val wrapped = McpToolInputValidationCallback(recorder)
+
+        val result = wrapped.call("""{}""", ToolContext(emptyMap()))
+        val tree = JsonParser.getJsonMapper().readTree(result)
+
+        assertNull(recorder.lastInput, "delegate must not be invoked for invalid input")
+        assertEquals("error", tree.get("kind").asString())
+        assertEquals("MISSING_REQUIRED_PARAMETER", tree.path("error").path("code").asString())
+        assertEquals("itemId", tree.path("error").path("parameter").asString())
+    }
+
+    @Test
+    fun `explicit null for required param returns structured error`() {
+        val recorder = RecordingToolCallback(harvestSchema)
+        val wrapped = McpToolInputValidationCallback(recorder)
+
+        val result = wrapped.call("""{"itemId": null}""", ToolContext(emptyMap()))
+        val tree = JsonParser.getJsonMapper().readTree(result)
+
+        assertNull(recorder.lastInput)
+        assertEquals("MISSING_REQUIRED_PARAMETER", tree.path("error").path("code").asString())
+    }
+
+    @Test
+    fun `blank required string returns structured error`() {
+        val recorder = RecordingToolCallback(harvestSchema)
+        val wrapped = McpToolInputValidationCallback(recorder)
+
+        val result = wrapped.call("""{"itemId":"   "}""", ToolContext(emptyMap()))
+        val tree = JsonParser.getJsonMapper().readTree(result)
+
+        assertNull(recorder.lastInput)
+        assertEquals("MISSING_REQUIRED_PARAMETER", tree.path("error").path("code").asString())
+        assertTrue(tree.path("error").path("message").asString().contains("must not be blank"))
+    }
+
+    @Test
+    fun `unknown enum value returns structured error with validValues list`() {
+        val recorder = RecordingToolCallback(buildSchema)
+        val wrapped = McpToolInputValidationCallback(recorder)
+
+        val result = wrapped.call("""{"type":"CASTLE"}""", ToolContext(emptyMap()))
+        val tree = JsonParser.getJsonMapper().readTree(result)
+
+        assertNull(recorder.lastInput)
+        assertEquals("INVALID_ENUM_VALUE", tree.path("error").path("code").asString())
+        assertEquals("type", tree.path("error").path("parameter").asString())
+        assertEquals("CASTLE", tree.path("error").path("received").asString())
+        val valid = mutableListOf<String>()
+        tree.path("error").path("validValues").forEach { valid.add(it.asString()) }
+        assertEquals(listOf("CAMPFIRE", "WORKBENCH", "STORAGE_CHEST"), valid)
+    }
+
+    @Test
+    fun `valid enum value passes through and delegate is invoked`() {
+        val recorder = RecordingToolCallback(buildSchema)
+        val wrapped = McpToolInputValidationCallback(recorder)
+
+        wrapped.call("""{"type":"CAMPFIRE"}""", ToolContext(emptyMap()))
+
+        assertTrue(recorder.lastInput!!.contains("\"type\":\"CAMPFIRE\""))
+    }
+
+    @Test
+    fun `present required param passes through and delegate is invoked`() {
+        val recorder = RecordingToolCallback(harvestSchema)
+        val wrapped = McpToolInputValidationCallback(recorder)
+
+        wrapped.call("""{"itemId":"BERRY"}""", ToolContext(emptyMap()))
+
+        assertEquals("""{"itemId":"BERRY"}""", recorder.lastInput)
+    }
+
+    @Test
+    fun `schema with no required and no enum fields skips validation entirely`() {
+        val plainSchema = """{"type":"object","properties":{"nodeId":{"type":"integer"}}}"""
+        val recorder = RecordingToolCallback(plainSchema)
+        val wrapped = McpToolInputValidationCallback(recorder)
+        val input = """{}"""
+
+        wrapped.call(input, ToolContext(emptyMap()))
+
+        assertEquals(input, recorder.lastInput)
+    }
+
+    @Test
+    fun `composition with EnumCaseInsensitiveToolCallback canonicalises case before validation`() {
+        val recorder = RecordingToolCallback(buildSchema)
+        val wrapped = EnumCaseInsensitiveToolCallback(McpToolInputValidationCallback(recorder))
+
+        wrapped.call("""{"type":"campfire"}""", ToolContext(emptyMap()))
+
+        assertTrue(recorder.lastInput!!.contains("\"type\":\"CAMPFIRE\""))
+    }
+
+    @Test
+    fun `composition rejects unknown enum even with mixed casing`() {
+        val recorder = RecordingToolCallback(buildSchema)
+        val wrapped = EnumCaseInsensitiveToolCallback(McpToolInputValidationCallback(recorder))
+
+        val result = wrapped.call("""{"type":"CasTLE"}""", ToolContext(emptyMap()))
+        val tree = JsonParser.getJsonMapper().readTree(result)
+
+        assertNull(recorder.lastInput)
+        assertEquals("INVALID_ENUM_VALUE", tree.path("error").path("code").asString())
+    }
+
+    private class RecordingToolCallback(private val schema: String) : ToolCallback {
+        var lastInput: String? = null
+        override fun getToolDefinition(): ToolDefinition =
+            ToolDefinition.builder().name("test").description("test").inputSchema(schema).build()
+        override fun getToolMetadata(): ToolMetadata = ToolMetadata.builder().build()
+        override fun call(toolInput: String): String = call(toolInput, null)
+        override fun call(toolInput: String, toolContext: ToolContext?): String {
+            lastInput = toolInput
+            return "{}"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Pre-validates MCP tool input against the tool's own JSON inputSchema before Spring AI's reflective binder runs.
- Returns a structured `{"kind":"error", "error":{...}}` payload with `code`, `parameter`, optional `received` + `validValues` — replacing raw Kotlin NPE / `IllegalArgumentException` traces that previously leaked internal class names back to MCP clients.
- Composed inside the existing `EnumCaseInsensitiveToolCallback`, so case-normalisation runs first; the validator sees canonical enum values and rejects only the genuinely unknown ones.

Surfaced by the autonomous E2E playtest sweep: `inspect`, `harvest`, `pickup`, `build`, `consume`, and `allocate_points` were all leaking these binder errors. Today the agent sees:

```json
{"kind":"error","error":{"code":"INVALID_ENUM_VALUE","parameter":"type","received":"CASTLE","message":"Unknown value 'CASTLE' for parameter 'type'. Valid values: CAMPFIRE, WORKBENCH, STORAGE_CHEST","validValues":["CAMPFIRE","WORKBENCH","STORAGE_CHEST"]}}
```

Closes #106
Closes #129

## Test plan

- [x] New `McpToolInputValidationCallbackTest` — 9 cases (missing param, null, blank, unknown enum, valid pass-through, schemaless tools, composition with case-normaliser).
- [x] Existing `EnumCaseInsensitiveToolCallbackTest` still green.
- [x] Full `:api:test` passes.