### PR TITLE
fix(api): advertise event-stream resource via agent://self/events

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventResource.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventResource.kt
@@ -23,10 +23,12 @@ internal class AgentEventResource(
     fun read(exchange: McpSyncServerExchange, req: ReadResourceRequest): ReadResourceResult {
         val match = URI_PATTERN.matchEntire(req.uri())
             ?: throw IllegalArgumentException("Invalid agent-events URI: ${req.uri()}")
-        val uriAgent = AgentId(UUID.fromString(match.groupValues[1]))
+        val authedAgent = AgentContextHolder.current()
+        val identifier = match.groupValues[1]
+        val uriAgent =
+            if (identifier == SELF_ALIAS) authedAgent else AgentId(UUID.fromString(identifier))
         val after = match.groupValues[2].takeIf { it.isNotEmpty() }?.toLong() ?: 0L
 
-        val authedAgent = AgentContextHolder.current()
         require(uriAgent == authedAgent) {
             "Agent $authedAgent is not allowed to read events of $uriAgent"
         }
@@ -38,6 +40,8 @@ internal class AgentEventResource(
     }
 
     companion object {
-        private val URI_PATTERN = Regex("^agent://([0-9a-fA-F-]{36})/events(?:\\?after=(\\d+))?$")
+        const val SELF_ALIAS = "self"
+        const val SELF_URI = "agent://$SELF_ALIAS/events"
+        private val URI_PATTERN = Regex("^agent://($SELF_ALIAS|[0-9a-fA-F-]{36})/events(?:\\?after=(\\d+))?$")
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventResourceConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventResourceConfiguration.kt
@@ -1,6 +1,8 @@
 package dev.gvart.genesara.api.internal.mcp.events
 
+import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceSpecification
 import io.modelcontextprotocol.server.McpServerFeatures.SyncResourceTemplateSpecification
+import io.modelcontextprotocol.spec.McpSchema.Resource
 import io.modelcontextprotocol.spec.McpSchema.ResourceTemplate
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -29,6 +31,27 @@ internal class AgentEventResourceConfiguration {
                     "application/json",
                     null,
                 ),
+                handler::read,
+            ),
+        )
+
+    /** Surfaces the event-stream as a concrete resource so `resources/list` (and clients
+     *  like `ListMcpResourcesTool`) can discover it. The `self` literal resolves to the
+     *  calling agent at read time; the agent does not need to know its own UUID. Resume
+     *  paging is done via the templated form `agent://self/events?after={seq}`. */
+    @Bean
+    fun agentEventResource(handler: AgentEventResource): List<SyncResourceSpecification> =
+        listOf(
+            SyncResourceSpecification(
+                Resource.builder()
+                    .uri(AgentEventResource.SELF_URI)
+                    .name("agent-events")
+                    .description(
+                        "Your event log. Read with no cursor to drain pending events; " +
+                            "resume after a known sequence number via `agent://self/events?after={seq}`.",
+                    )
+                    .mimeType("application/json")
+                    .build(),
                 handler::read,
             ),
         )

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventResourceConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventResourceConfiguration.kt
@@ -40,7 +40,7 @@ internal class AgentEventResourceConfiguration {
      *  calling agent at read time; the agent does not need to know its own UUID. Resume
      *  paging is done via the templated form `agent://self/events?after={seq}`. */
     @Bean
-    fun agentEventResource(handler: AgentEventResource): List<SyncResourceSpecification> =
+    fun agentEventSelfResource(handler: AgentEventResource): List<SyncResourceSpecification> =
         listOf(
             SyncResourceSpecification(
                 Resource.builder()

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventResourceTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventResourceTest.kt
@@ -105,6 +105,38 @@ class AgentEventResourceTest {
     }
 
     @Test
+    fun `read resolves self alias to the authenticated agent`() {
+        val log = FakeAgentEventLog()
+        log.append(agent, "agent.moved", 7L, mapper.createObjectNode())
+
+        AgentContextHolder.set(agent)
+        val resource = AgentEventResource(log, mapper)
+        val result = resource.read(exchange, ReadResourceRequest("agent://self/events"))
+
+        val parsed = mapper.readTree((result.contents().single() as TextResourceContents).text())
+        assertEquals(1, parsed.size())
+        assertEquals("agent.moved", parsed.get(0).get("type").asString())
+    }
+
+    @Test
+    fun `read accepts self alias with after cursor`() {
+        val log = FakeAgentEventLog()
+        val first = log.append(agent, "agent.moved", 1L, mapper.createObjectNode())
+        log.append(agent, "agent.moved", 2L, mapper.createObjectNode())
+
+        AgentContextHolder.set(agent)
+        val resource = AgentEventResource(log, mapper)
+        val result = resource.read(
+            exchange,
+            ReadResourceRequest("agent://self/events?after=${first.seq}"),
+        )
+
+        val parsed = mapper.readTree((result.contents().single() as TextResourceContents).text())
+        assertEquals(1, parsed.size())
+        assertEquals(2L, parsed.get(0).get("seq").asLong())
+    }
+
+    @Test
     fun `read refuses to access another agent's log`() {
         val intruder = AgentId(UUID.randomUUID())
         val log = FakeAgentEventLog()

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -101,6 +101,8 @@ Read parameters:
 
 - `after` — the highest `seq` the agent has already consumed. The resource returns every entry with `seq > after`. Default `0` returns the entire visible window.
 
+The resource is also advertised under the alias URI `agent://self/events`, which `resources/list` (and `ListMcpResourcesTool`) returns. `self` resolves to the calling agent — an agent does not need to know its own UUID to consume the stream. The same resume-after-seq mechanism applies (`agent://self/events?after={seq}`).
+
 The log is bounded by **TTL + entry-count cap** (`application.events.ttl` / `application.events.backlog-cap`, defaults `PT1H` / `500`). If an agent disconnects long enough for the log to roll, on next read it should treat the response as a snapshot, not a continuation. Authorization is per-agent: the log resource validates that the requesting agent matches the URI's `{id}` — agents cannot read each other's logs.
 
 ## Presence


### PR DESCRIPTION
## Summary

- The per-agent event-stream was registered only as a resource *template* (`agent://{agentId}/events`). Clients calling `resources/list` (including Claude's `ListMcpResourcesTool`) never see templates — only `resources/templates/list` returns those. An agent that didn't already know the URI shape had no way to discover it.
- Register a concrete `SyncResourceSpecification` at `agent://self/events`. `self` resolves to the calling agent at read time via `AgentContextHolder`, so a static resource list works regardless of which agent owns the session. Resume paging continues to work via `agent://self/events?after={seq}`.
- Documented the alias in `docs/mcp-api.md`.

Closes #126

## Test plan

- [x] New tests: `read resolves self alias to the authenticated agent`, `read accepts self alias with after cursor`.
- [x] Existing access-control tests still green (`read refuses to access another agent's log`).
- [x] Full `:api:test` passes.