### PR TITLE
fix(playtest): shrink 02-stocked inventory to fit Str=1 carry capacity

### DIFF
--- a/docs/playtest/fixtures/02-stocked.sql
+++ b/docs/playtest/fixtures/02-stocked.sql
@@ -1,0 +1,28 @@
+-- Session 2 fixture: agent with crafting materials and unspent attribute points.
+-- Targets: allocate_points, equip_skill (after a recommendation), craft, build,
+-- set_safe_node. Equipment slice (equip_item / unequip_slot) needs an item
+-- instance in agent_equipment_instances — none seeded here because the
+-- catalog has no equippable weapons/armor yet (world-definition/items.yaml).
+--
+-- WHY these quantities fit Str=1 capacity (5000 g; 5 kg per Str point,
+-- balance/Lookup.kt CARRY_GRAMS_PER_STRENGTH_POINT):
+--   WOOD  2 × 800  g = 1600 g
+--   STONE 1 × 1500 g = 1500 g
+--   BERRY 5 × 50   g =  250 g
+--   HERB  5 × 30   g =  150 g
+--   FIBER 5 × 100  g =  500 g
+--   HIDE  1 × 600  g =  600 g
+--                     ------
+--                      4600 g (≈92% of capacity; ~400 g harvest headroom)
+-- Covers Phase-1 reachable crafts (FIBER_BASIC: WOOD 1, CLOTH_BASIC: FIBER 3).
+-- LEATHER_BASIC (HIDE 2) stays dormant in v1 — HIDE is non-harvestable.
+
+\i 00-base.sql
+
+INSERT INTO agent_inventory (agent_id, item_id, quantity) VALUES
+    (:'agent_id', 'WOOD',   2),
+    (:'agent_id', 'STONE',  1),
+    (:'agent_id', 'BERRY',  5),
+    (:'agent_id', 'HERB',   5),
+    (:'agent_id', 'FIBER',  5),
+    (:'agent_id', 'HIDE',   1);


### PR DESCRIPTION
## Summary

Issue #111 surfaced that the `02-stocked` E2E fixture seeded ~94.6 kg of inventory into a fresh agent whose Str=1 carry capacity is 5 kg. Every `harvest` / `pickup` rejected with `OverEncumbered{ requested:94600, capacity:10000 }` (where the 10000 reading is for a Str=2 agent — even spending the 5 starter points doesn't fit the inventory).

The carry-weight ruleset (`CARRY_GRAMS_PER_STRENGTH_POINT = 5_000` in `world/internal/balance/Lookup.kt`) and the per-item weights in `world-definition/items.yaml` are canonical per `docs/lore/mechanics-reference.md` §8 — only the fixture changes.

## Numbers

Old quantities (~94.3 kg, far over 5 kg capacity):

| Item  | Qty | Weight |
|-------|----:|-------:|
| WOOD  |  50 | 40 000 g |
| STONE |  30 | 45 000 g |
| BERRY |  20 |  1 000 g |
| HERB  |  10 |    300 g |
| FIBER |  20 |  2 000 g |
| HIDE  |  10 |  6 000 g |
| **Total** | | **94 300 g** |

New quantities (4 600 g, ≈92% of Str=1 capacity):

| Item  | Qty | Weight |
|-------|----:|-------:|
| WOOD  |   2 |  1 600 g |
| STONE |   1 |  1 500 g |
| BERRY |   5 |    250 g |
| HERB  |   5 |    150 g |
| FIBER |   5 |    500 g |
| HIDE  |   1 |    600 g |
| **Total** | | **4 600 g** |

Leaves ~400 g headroom for the agent to test the harvest path on purpose without immediate `OverEncumbered`. Still covers the reachable Phase-1 craft recipes: `FIBER_BASIC` (WOOD 1) and `CLOTH_BASIC` (FIBER 3). `LEATHER_BASIC` (HIDE 2) stays dormant in v1 — HIDE is non-harvestable until the hunting verb lands, so a fixture HIDE of 1 doesn't block any reachable craft.

Note: this PR introduces `docs/playtest/fixtures/02-stocked.sql` as a tracked file — it was previously an untracked playtest artefact in the working tree.

Closes #111

## Test plan

- [x] `./gradlew :world:check` — green (no Kotlin / YAML / SQL touched aside from the fixture data).
- [ ] Run `scripts/playtest-reset.sh` against fixture `02-stocked.sql` and confirm `get_loadout` reports inventory weight 4 600 g and `harvest(itemId=BERRY)` (or any small item) succeeds at a forest node.
- [ ] Confirm Str=1 agent can still issue at least one `craft(FIBER_BASIC)` and one `craft(CLOTH_BASIC)` once stations are reachable.