### PR TITLE
fix(world): resume persisted body when spawning an offline agent

### DIFF
--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -123,11 +123,14 @@ internal class WorldTickHandler(
     @Transactional
     override fun tickOne(worldId: WorldId, number: Long) {
         val online = presence.onlineIn(worldId)
-        val initial = repository.load(worldId, online)
+        val commands = drainer.drainFor(worldId, number)
+        // Include pending-command agents so a spawning agent's persisted body
+        // is resumed by the reducer instead of overwritten with a fresh one.
+        val loadSet = if (commands.isEmpty()) online else online + commands.map { it.agent }
+        val initial = repository.load(worldId, loadSet)
         val (afterPassives, passivesEvent) = applyPassives(initial, balance, number)
         val (afterDeaths, deathEvents) = processDeaths(afterPassives, deathProcessor, number)
 
-        val commands = drainer.drainFor(worldId, number)
         val (next, commandEvents) = commands.fold(afterDeaths to emptyList<WorldEvent>()) { (state, acc), command ->
             reduce(
                 state, command, balance, profiles, items, recipes, resources, skills, agents, equipment,

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerSpawnResumeIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerSpawnResumeIntegrationTest.kt
@@ -1,0 +1,363 @@
+package dev.gvart.genesara.world.internal.tick
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentProfile
+import dev.gvart.genesara.player.AgentProfileLookup
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
+import dev.gvart.genesara.player.PassiveAuraAggregator.Companion.NoAura
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.world.AgentKillStreak
+import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsLookup
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.ChestContentsStore
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DroppedItemView
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.Gauge
+import dev.gvart.genesara.world.GroundItemStore
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NodeResources
+import dev.gvart.genesara.world.Recipe
+import dev.gvart.genesara.world.RecipeId
+import dev.gvart.genesara.world.RecipeLookup
+import dev.gvart.genesara.world.ResourceSpawnRule
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.buildings.BuildingDefinitionProperties
+import dev.gvart.genesara.world.internal.buildings.BuildingsCatalog
+import dev.gvart.genesara.world.internal.classes.CharacterXpProgression
+import dev.gvart.genesara.world.internal.crafting.RarityRoller
+import dev.gvart.genesara.world.internal.death.DeathProcessor
+import dev.gvart.genesara.world.internal.death.SafeNodeResolution
+import dev.gvart.genesara.world.internal.death.SafeNodeResolver
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_BODIES
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_INVENTORY
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_POSITIONS
+import dev.gvart.genesara.world.internal.jooq.tables.references.NODES
+import dev.gvart.genesara.world.internal.jooq.tables.references.REGIONS
+import dev.gvart.genesara.world.internal.jooq.tables.references.WORLDS
+import dev.gvart.genesara.world.internal.killstreaks.KillStreakStore
+import dev.gvart.genesara.world.internal.resources.InitialResourceRow
+import dev.gvart.genesara.world.internal.resources.NodeResourceStore
+import dev.gvart.genesara.world.internal.spawn.SpawnLocationResolver
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
+import dev.gvart.genesara.world.internal.testsupport.InMemoryPendingAttackScaleStore
+import dev.gvart.genesara.world.internal.testsupport.InMemoryPerkCooldownStore
+import dev.gvart.genesara.world.internal.testsupport.NoOpActivePerkLookup
+import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
+import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
+import dev.gvart.genesara.world.internal.tick.lease.WorldLeaseFence
+import dev.gvart.genesara.world.internal.worldstate.JooqWorldOnlinePresence
+import dev.gvart.genesara.world.internal.worldstate.JooqWorldStateRepository
+import dev.gvart.genesara.world.internal.worldstate.WorldStaticConfig
+import org.jooq.DSLContext
+import org.jooq.JSON
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import java.time.Duration
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@Testcontainers
+class WorldTickHandlerSpawnResumeIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("world_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = WorldFlyway.pooledDataSource(postgres)
+            WorldFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private lateinit var repository: JooqWorldStateRepository
+    private lateinit var staticConfig: WorldStaticConfig
+    private lateinit var presence: JooqWorldOnlinePresence
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+
+    @BeforeEach
+    fun resetState() {
+        dsl.truncate(AGENT_INVENTORY).cascade().execute()
+        dsl.truncate(AGENT_BODIES).cascade().execute()
+        dsl.truncate(AGENT_POSITIONS).cascade().execute()
+        dsl.truncate(NODES).cascade().execute()
+        dsl.truncate(REGIONS).cascade().execute()
+        dsl.truncate(WORLDS).cascade().execute()
+
+        staticConfig = WorldStaticConfig(dsl, mapper)
+        presence = JooqWorldOnlinePresence(dsl)
+        repository = JooqWorldStateRepository(dsl, staticConfig, NoopKillStreakStore)
+    }
+
+    @Test
+    fun `tickOne resumes a persisted body of an offline agent on spawn instead of overwriting it`() {
+        val (worldId, nodeId) = seedSingleNodeWorld("world-spawn-resume")
+        staticConfig.reload()
+
+        val agent = AgentId(UUID.randomUUID())
+        seedPersistedBody(agent, hp = 5, hunger = 1, thirst = 1)
+
+        assertEquals(emptySet(), presence.onlineIn(worldId), "agent has no active position before spawn")
+
+        val queue = InMemoryCommandQueue()
+        val publisher = RecordingPublisher()
+        queue.submitTo(worldId, WorldCommand.SpawnAgent(agent), appliesAtTick = 1)
+
+        val handler = newHandler(
+            queue = queue,
+            publisher = publisher,
+            spawnResolver = FixedSpawnResolver(nodeId),
+            profileFor = { id -> AgentProfile(id, maxHp = 100, maxStamina = 50, maxMana = 0) },
+        )
+
+        handler.tickOne(worldId, 1)
+
+        val reloaded = repository.load(worldId, presence.onlineIn(worldId))
+        val savedBody = assertNotNull(reloaded.bodies[agent], "spawn must persist a body for the agent")
+        assertEquals(5, savedBody.hp, "spawn must NOT overwrite persisted hp with maxHp (issue #116)")
+        assertEquals(1, savedBody.hunger, "persisted hunger survives spawn")
+        assertEquals(1, savedBody.thirst, "persisted thirst survives spawn")
+        assertEquals(nodeId, reloaded.positions[agent], "agent is positioned at the resolved spawn node")
+    }
+
+    private fun seedPersistedBody(agent: AgentId, hp: Int, hunger: Int, thirst: Int) {
+        dsl.insertInto(AGENT_BODIES)
+            .set(AGENT_BODIES.AGENT_ID, agent.id)
+            .set(AGENT_BODIES.HP, hp).set(AGENT_BODIES.MAX_HP, 100)
+            .set(AGENT_BODIES.STAMINA, 20).set(AGENT_BODIES.MAX_STAMINA, 50)
+            .set(AGENT_BODIES.MANA, 0).set(AGENT_BODIES.MAX_MANA, 0)
+            .set(AGENT_BODIES.HUNGER, hunger).set(AGENT_BODIES.MAX_HUNGER, 100)
+            .set(AGENT_BODIES.THIRST, thirst).set(AGENT_BODIES.MAX_THIRST, 100)
+            .set(AGENT_BODIES.SLEEP, 80).set(AGENT_BODIES.MAX_SLEEP, 100)
+            .execute()
+    }
+
+    private data class SeededWorld(val worldId: WorldId, val nodeId: NodeId)
+
+    private fun seedSingleNodeWorld(name: String): SeededWorld {
+        val worldIdValue = dsl.insertInto(WORLDS)
+            .set(WORLDS.NAME, name)
+            .set(WORLDS.NODE_COUNT, 1)
+            .set(WORLDS.NODE_SIZE, 1)
+            .set(WORLDS.FREQUENCY, 1)
+            .returningResult(WORLDS.ID).fetchOne()!!.value1()!!
+
+        val regionIdValue = dsl.insertInto(REGIONS)
+            .set(REGIONS.WORLD_ID, worldIdValue)
+            .set(REGIONS.SPHERE_INDEX, 0)
+            .set(REGIONS.BIOME, "PLAINS")
+            .set(REGIONS.CLIMATE, "OCEANIC")
+            .set(REGIONS.CENTROID_X, 0.0)
+            .set(REGIONS.CENTROID_Y, 0.0)
+            .set(REGIONS.CENTROID_Z, 1.0)
+            .set(REGIONS.FACE_VERTICES, JSON.valueOf("[]"))
+            .returningResult(REGIONS.ID).fetchOne()!!.value1()!!
+
+        val nodeIdValue = dsl.insertInto(NODES)
+            .set(NODES.REGION_ID, regionIdValue)
+            .set(NODES.Q, 0).set(NODES.R, 0)
+            .set(NODES.TERRAIN, "PLAINS")
+            .returningResult(NODES.ID).fetchOne()!!.value1()!!
+
+        return SeededWorld(WorldId(worldIdValue), NodeId(nodeIdValue))
+    }
+
+    private fun newHandler(
+        queue: InMemoryCommandQueue,
+        publisher: ApplicationEventPublisher,
+        spawnResolver: SpawnLocationResolver,
+        profileFor: (AgentId) -> AgentProfile,
+    ): WorldTickHandler {
+        val skills: AgentSkillsRegistry = NoopSkillsRegistry
+        val balance = ZeroBalanceLookup
+        val agents = NoopAgentRegistry
+        val equipment = NoopEquipmentStore
+        val groundItems = NoopGroundItemStore
+        val deathProcessor = DeathProcessor(balance, agents, equipment, groundItems)
+        val rarity = RarityRoller(kotlin.random.Random(0))
+        val buildingsCatalog = BuildingsCatalog(BuildingDefinitionProperties(catalog = emptyMap()))
+        val profiles = object : AgentProfileLookup {
+            override fun find(id: AgentId): AgentProfile = profileFor(id)
+        }
+        return WorldTickHandler(
+            queue, repository, presence, publisher, balance, profiles, NoopItemLookup,
+            NoopRecipeLookup, NoopResourceStore, skills, agents, equipment, NoopSafeNodeGateway,
+            NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, buildingsCatalog,
+            NoopChestContentsStore, rarity, SkillProgression(skills, publisher),
+            CharacterXpProgression.NoOp, NoScaling, NoAura, spawnResolver, groundItems,
+            deathProcessor, NoOpTriggeredPassiveDispatcher, NoOpActivePerkLookup,
+            InMemoryPerkCooldownStore(), InMemoryPendingAttackScaleStore(),
+            InMemoryBehaviorTracker(), AlwaysHeldLeaseFence, Duration.ofSeconds(5L),
+        )
+    }
+
+    private object AlwaysHeldLeaseFence : WorldLeaseFence {
+        override fun requireHeldAndRenew(worldId: WorldId, tick: Long) = Unit
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+
+    private class FixedSpawnResolver(private val node: NodeId) : SpawnLocationResolver {
+        override fun resolveFor(agentId: AgentId): NodeId = node
+    }
+
+    private object NoopKillStreakStore : KillStreakStore {
+        override fun byAgents(agents: Set<AgentId>): Map<AgentId, AgentKillStreak> = emptyMap()
+        override fun save(agent: AgentId, streak: AgentKillStreak) = Unit
+        override fun delete(agent: AgentId) = Unit
+    }
+
+    private object ZeroBalanceLookup : BalanceLookup {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
+        override fun staminaRegenPerTick(climate: Climate) = 0
+        override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+    }
+
+    private object NoopItemLookup : ItemLookup {
+        override fun byId(id: ItemId): Item? = null
+        override fun all(): List<Item> = emptyList()
+    }
+
+    private object NoopRecipeLookup : RecipeLookup {
+        override fun byId(id: RecipeId): Recipe? = null
+        override fun all(): List<Recipe> = emptyList()
+    }
+
+    private object NoopResourceStore : NodeResourceStore {
+        override fun read(nodeId: NodeId, tick: Long) = NodeResources.EMPTY
+        override fun availability(nodeId: NodeId, item: ItemId, tick: Long) = null
+        override fun decrement(nodeId: NodeId, item: ItemId, amount: Int, tick: Long) =
+            error("not used")
+        override fun seed(rows: Collection<InitialResourceRow>, tick: Long) {}
+    }
+
+    private object NoopSkillsRegistry : AgentSkillsRegistry {
+        override fun snapshot(agent: AgentId) = AgentSkillsSnapshot(
+            perSkill = emptyMap(), slotCount = 8, slotsFilled = 0,
+        )
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int) = AddXpResult.Unslotted
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? = null
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int) = null
+    }
+
+    private object NoopAgentRegistry : AgentRegistry {
+        override fun find(id: AgentId): Agent? = null
+        override fun listForOwner(owner: dev.gvart.genesara.account.PlayerId): List<Agent> = emptyList()
+    }
+
+    private object NoopEquipmentStore : EquipmentInstanceStore {
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> = emptyMap()
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = error("not used")
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? =
+            error("not used")
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = error("not used")
+        override fun delete(instanceId: UUID): Boolean = error("not used")
+    }
+
+    private object NoopSafeNodeGateway : AgentSafeNodeGateway {
+        override fun set(agentId: AgentId, nodeId: NodeId, tick: Long) {}
+        override fun find(agentId: AgentId): NodeId? = null
+        override fun clear(agentId: AgentId) {}
+    }
+
+    private object NoopSafeNodeResolver : SafeNodeResolver {
+        override fun resolveFor(agentId: AgentId): SafeNodeResolution? = null
+    }
+
+    private object NoopBuildingsStore : BuildingsStore {
+        override fun insert(building: Building) = error("not used")
+        override fun findById(id: UUID): Building? = null
+        override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? = null
+        override fun listAtNode(node: NodeId): List<Building> = emptyList()
+        override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = emptyMap()
+        override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = null
+        override fun complete(id: UUID, asOfTick: Long): Building? = null
+    }
+
+    private object NoopBuildingsLookup : BuildingsLookup {
+        override fun byId(id: UUID): Building? = null
+        override fun byNode(node: NodeId): List<Building> = emptyList()
+        override fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = emptyMap()
+        override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> = emptyList()
+    }
+
+    private object NoopChestContentsStore : ChestContentsStore {
+        override fun quantityOf(buildingId: UUID, item: ItemId): Int = 0
+        override fun contentsOf(buildingId: UUID): Map<ItemId, Int> = emptyMap()
+        override fun add(buildingId: UUID, item: ItemId, quantity: Int) = error("not used")
+        override fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean = error("not used")
+    }
+
+    private object NoopGroundItemStore : GroundItemStore {
+        override fun deposit(node: NodeId, drop: DroppedItemView, droppedAtTick: Long) = error("not used")
+        override fun atNode(node: NodeId): List<GroundItemView> = emptyList()
+        override fun take(node: NodeId, dropId: UUID): GroundItemView? = null
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -186,6 +186,49 @@ class WorldTickHandlerTest {
     }
 
     @Test
+    fun `spawn resumes the persisted body of an offline agent instead of overwriting with a fresh one`() {
+        val persistedBody = AgentBody(
+            hp = 5, maxHp = 100,
+            stamina = 20, maxStamina = 50,
+            mana = 0, maxMana = 0,
+            hunger = 80, maxHunger = 100,
+            thirst = 80, maxThirst = 100,
+            sleep = 80, maxSleep = 100,
+        )
+        val offlineState = WorldState(
+            regions = mapOf(regionId to region),
+            nodes = mapOf(homeId to home, northId to north),
+            positions = emptyMap(),
+            bodies = emptyMap(),
+            inventories = emptyMap(),
+        )
+        val repo = LoadSetAwareRepository(
+            base = offlineState,
+            persistedBodies = mapOf(agent to persistedBody),
+        )
+        val queue = InMemoryCommandQueue()
+        val publisher = RecordingPublisher()
+
+        queue.submit(WorldCommand.SpawnAgent(agent), appliesAtTick = 3)
+        val handler = newHandler(
+            queue, repo, FixedPresence(emptySet()), publisher, balance,
+            spawnResolver = FixedSpawnResolver(homeId),
+        )
+
+        handler.tickOne(worldId, 3)
+
+        val saved = assertNotNull(repo.lastSaved)
+        val savedBody = assertNotNull(saved.bodies[agent])
+        assertEquals(5, savedBody.hp, "spawn must not overwrite persisted hp with maxHp")
+        assertEquals(20, savedBody.stamina)
+        assertEquals(homeId, saved.positions[agent])
+        val spawned = publisher.events.filterIsInstance<WorldEvent.AgentSpawned>().single()
+        assertEquals(agent, spawned.agent)
+        assertEquals(homeId, spawned.at)
+        assertTrue(repo.lastLoadSet.contains(agent), "the spawning agent must be in the load set")
+    }
+
+    @Test
     fun `commands targeted at other ticks are not drained for this tick`() {
         val repo = RecordingRepository(initial = baseState)
         val queue = InMemoryCommandQueue()
@@ -206,13 +249,14 @@ class WorldTickHandlerTest {
         publisher: RecordingPublisher,
         balance: BalanceLookup,
         fence: WorldLeaseFence = AlwaysHeldLeaseFence,
+        spawnResolver: dev.gvart.genesara.world.internal.spawn.SpawnLocationResolver = NoopSpawnLocationResolver,
     ): WorldTickHandler = WorldTickHandler(
         queue, repo, presence, publisher, balance, profiles, items, NoopRecipeLookup, NoopResourceStore,
         NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway,
         NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup, EmptyBuildingsCatalog,
         NoopChestContentsStore, NoopRarityRoller, SkillProgression(NoopSkillsRegistry, publisher),
         dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp,
-        NoScaling, NoAura, NoopSpawnLocationResolver, NoopGroundItemStore,
+        NoScaling, NoAura, spawnResolver, NoopGroundItemStore,
         DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore),
         NoOpTriggeredPassiveDispatcher, NoOpActivePerkLookup, InMemoryPerkCooldownStore(),
         InMemoryPendingAttackScaleStore(), InMemoryBehaviorTracker(), fence, java.time.Duration.ofSeconds(5L),
@@ -233,6 +277,29 @@ class WorldTickHandlerTest {
         override fun save(worldId: WorldId, state: WorldState) {
             lastSaved = state
         }
+    }
+
+    private class LoadSetAwareRepository(
+        private val base: WorldState,
+        private val persistedBodies: Map<AgentId, AgentBody>,
+    ) : WorldStateRepository {
+        var lastSaved: WorldState? = null
+        var lastLoadSet: Set<AgentId> = emptySet()
+            private set
+
+        override fun load(worldId: WorldId, onlineAgentIds: Set<AgentId>): WorldState {
+            lastLoadSet = onlineAgentIds
+            val bodies = persistedBodies.filterKeys { it in onlineAgentIds }
+            return base.copy(bodies = base.bodies + bodies)
+        }
+
+        override fun save(worldId: WorldId, state: WorldState) {
+            lastSaved = state
+        }
+    }
+
+    private class FixedSpawnResolver(private val node: NodeId) : dev.gvart.genesara.world.internal.spawn.SpawnLocationResolver {
+        override fun resolveFor(agentId: AgentId): NodeId = node
     }
 
     private class FixedPresence(private val agents: Set<AgentId>) : WorldOnlinePresence {


### PR DESCRIPTION
## Summary

- **Root cause**: `WorldTickHandler.tickOne` loaded `agent_bodies` filtered by the online-presence set, so a spawning agent's persisted body row was never visible to the reducer. `SpawnReducer` fell through to `AgentBody.fromProfile` and `repository.save` overwrote the pre-seeded depleted body with full pools — defeating playtest fixtures like `04-low-hp.sql`.
- **Fix (Approach A)**: drain pending commands before loading state, then build `loadSet = online ∪ commands.map { it.agent }`. The spawning agent's body now reaches `state.bodies`, and `SpawnReducer` resumes from it instead of synthesising a fresh one. No new types or interfaces threaded through the reducer signature.
- The death sweep stays gated on `state.positions` (offline agents have no position, so it skips them). Passive drains on the briefly-loaded offline body match the documented intent on `gaugeDrainPassive` ("even logged-out agents grow hungry over real time").

Closes #116

## Test plan

- [x] Unit: `WorldTickHandlerTest.spawn resumes the persisted body of an offline agent instead of overwriting with a fresh one` — seeds an offline agent with a persisted `hp=5` body via a load-set-aware repository stub, queues `SpawnAgent`, and asserts the saved body retains `hp=5`.
- [x] Integration: `WorldTickHandlerSpawnResumeIntegrationTest.tickOne resumes a persisted body of an offline agent on spawn instead of overwriting it` — Testcontainers Postgres + real `JooqWorldStateRepository` + real `JooqWorldOnlinePresence` + real `WorldTickHandler`. Pre-seeds `agent_bodies` with `hp=5, hunger=1, thirst=1` for an unpositioned agent, queues `SpawnAgent`, ticks once, reloads and asserts the body still has `hp=5`.
- [x] `./gradlew :world:test` — green.
- [x] `./gradlew :api:test :app:test` — green.