### PR TITLE
fix(api): align get_status tick with event clock; surface safeNode

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusTool.kt
@@ -3,7 +3,6 @@ package dev.gvart.genesara.api.internal.mcp.tools.getstatus
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
-import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentPerksRegistry
 import dev.gvart.genesara.player.AgentRegistry
@@ -12,6 +11,7 @@ import dev.gvart.genesara.player.AgentSkillsSnapshot
 import dev.gvart.genesara.player.PerkLookup
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillLookup
+import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.WorldQueryGateway
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.annotation.Tool
@@ -21,20 +21,21 @@ import org.springframework.stereotype.Component
 internal class GetStatusTool(
     private val agents: AgentRegistry,
     private val world: WorldQueryGateway,
-    private val engine: TickClock,
     private val activity: AgentActivityTracker,
     private val skillsRegistry: AgentSkillsRegistry,
     private val skillCatalog: SkillLookup,
     private val perksRegistry: AgentPerksRegistry,
     private val perkCatalog: PerkLookup,
+    private val safeNodes: AgentSafeNodeGateway,
 ) {
 
     @Tool(
         name = "get_status",
         description = "Return the agent's full character snapshot: identity, race, level/XP, " +
             "attributes, HP/Stamina/Mana, survival pools (Hunger/Thirst/Sleep), current location, " +
-            "current tick, and discovered skills. The skills view lists every slot 0..slotCount-1 " +
-            "(skill = null when empty) plus discovered-but-unslotted skills. Read-only — no command queued.",
+            "bound safe-node id, current tick, and discovered skills. The skills view lists every " +
+            "slot 0..slotCount-1 (skill = null when empty) plus discovered-but-unslotted skills. " +
+            "Read-only — no command queued.",
     )
     fun invoke(toolContext: ToolContext): GetStatusResponse {
         touchActivity(toolContext, activity, "get_status")
@@ -67,7 +68,8 @@ internal class GetStatusTool(
             thirst = PoolView(current = body?.thirst ?: 0, max = body?.maxThirst ?: 0),
             sleep = PoolView(current = body?.sleep ?: 0, max = body?.maxSleep ?: 0),
             location = location?.value,
-            tick = engine.currentTick(),
+            safeNode = safeNodes.find(agentId)?.value,
+            tick = world.currentTickFor(agentId),
             skills = buildSkillsView(agentId),
             pendingClassChoice = agent.offeredClasses?.toList() ?: emptyList(),
             pendingEvolutionChoice = agent.offeredEvolutions?.toList() ?: emptyList(),

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolIo.kt
@@ -19,6 +19,8 @@ data class GetStatusResponse(
     val thirst: PoolView,
     val sleep: PoolView,
     val location: Long?,
+    /** Node id of the agent's currently-bound safe node, or `null` if none is set. */
+    val safeNode: Long? = null,
     val tick: Long,
     val activeEffects: List<String> = emptyList(),
     val skills: SkillsView,

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
@@ -4,7 +4,6 @@ import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.api.internal.mcp.projection.vitalBand
-import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.world.AgentMapMemoryGateway
@@ -30,7 +29,6 @@ internal class LookAroundTool(
     private val agents: AgentRegistry,
     private val vision: VisionRadius,
     private val activity: AgentActivityTracker,
-    private val tick: TickClock,
     private val mapMemory: AgentMapMemoryGateway,
     private val buildings: BuildingsLookup,
 ) {
@@ -56,7 +54,7 @@ internal class LookAroundTool(
         val region = world.region(current.regionId)
             ?: error("Current region not found: ${current.regionId}")
 
-        val currentTick = tick.currentTick()
+        val currentTick = world.currentTickFor(agentId)
         val currentResources = world.resourcesAt(current.id, currentTick)
         val currentGroundItems = world.groundItemsAt(current.id)
         val visible = adjacentVisibleNodes(nodeId, sight, currentTick)

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/presence/PresenceReaperTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/presence/PresenceReaperTest.kt
@@ -92,6 +92,7 @@ class PresenceReaperTest {
         override fun resourcesAt(nodeId: NodeId, tick: Long): dev.gvart.genesara.world.NodeResources =
             dev.gvart.genesara.world.NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
+        override fun currentTickFor(agent: AgentId): Long = 0L
     }
 
     private class StubTickClock(private val currentTick: Long) : TickClock {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolTest.kt
@@ -2,7 +2,6 @@ package dev.gvart.genesara.api.internal.mcp.tools.getstatus
 
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
-import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.Agent
@@ -28,6 +27,7 @@ import dev.gvart.genesara.player.SkillCategory
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillLookup
 import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.BodyView
 import dev.gvart.genesara.world.Node
 import dev.gvart.genesara.world.NodeId
@@ -93,7 +93,6 @@ class GetStatusToolTest {
 
     private val clock = MutableTestClock(Instant.parse("2026-01-01T00:00:00Z"))
     private val activity = AgentActivityRegistry(clock)
-    private val tickClock = StubTickClock(currentTick = 200L)
     private val toolContext = ToolContext(emptyMap())
 
     @BeforeEach fun setUp() = AgentContextHolder.set(agentId)
@@ -104,12 +103,12 @@ class GetStatusToolTest {
         val tool = GetStatusTool(
             agents = StubRegistry(agent),
             world = StubQuery(active = node, body = body),
-            engine = tickClock,
             activity = activity,
             skillsRegistry = emptySkills,
             skillCatalog = skillCatalog,
             perksRegistry = StubPerksRegistry(),
             perkCatalog = StubPerkLookup(),
+            safeNodes = StubSafeNodes(),
         )
 
         val res = tool.invoke(toolContext)
@@ -144,12 +143,12 @@ class GetStatusToolTest {
         val tool = GetStatusTool(
             agents = StubRegistry(agent),
             world = StubQuery(active = null, lastLocation = node, body = body),
-            engine = tickClock,
             activity = activity,
             skillsRegistry = emptySkills,
             skillCatalog = skillCatalog,
             perksRegistry = StubPerksRegistry(),
             perkCatalog = StubPerkLookup(),
+            safeNodes = StubSafeNodes(),
         )
 
         val res = tool.invoke(toolContext)
@@ -162,12 +161,12 @@ class GetStatusToolTest {
         val tool = GetStatusTool(
             agents = StubRegistry(agent),
             world = StubQuery(active = null, lastLocation = null, body = null),
-            engine = tickClock,
             activity = activity,
             skillsRegistry = emptySkills,
             skillCatalog = skillCatalog,
             perksRegistry = StubPerksRegistry(),
             perkCatalog = StubPerkLookup(),
+            safeNodes = StubSafeNodes(),
         )
 
         val res = tool.invoke(toolContext)
@@ -179,16 +178,71 @@ class GetStatusToolTest {
     }
 
     @Test
-    fun `errors when the agent is not registered`() {
+    fun `surfaces the bound safe node id when the agent has set one`() {
+        val safe = NodeId(4242L)
         val tool = GetStatusTool(
-            agents = StubRegistry(null),
-            world = StubQuery(),
-            engine = tickClock,
+            agents = StubRegistry(agent),
+            world = StubQuery(active = node, body = body),
             activity = activity,
             skillsRegistry = emptySkills,
             skillCatalog = skillCatalog,
             perksRegistry = StubPerksRegistry(),
             perkCatalog = StubPerkLookup(),
+            safeNodes = StubSafeNodes(node = safe),
+        )
+
+        val res = tool.invoke(toolContext)
+
+        assertEquals(safe.value, res.safeNode)
+    }
+
+    @Test
+    fun `safeNode is null when the agent has never set one`() {
+        val tool = GetStatusTool(
+            agents = StubRegistry(agent),
+            world = StubQuery(active = node, body = body),
+            activity = activity,
+            skillsRegistry = emptySkills,
+            skillCatalog = skillCatalog,
+            perksRegistry = StubPerksRegistry(),
+            perkCatalog = StubPerkLookup(),
+            safeNodes = StubSafeNodes(node = null),
+        )
+
+        val res = tool.invoke(toolContext)
+
+        assertNull(res.safeNode)
+    }
+
+    @Test
+    fun `tick is read from the per-world counter so it correlates with the event stream`() {
+        val tool = GetStatusTool(
+            agents = StubRegistry(agent),
+            world = StubQuery(active = node, body = body, tick = 17_500L),
+            activity = activity,
+            skillsRegistry = emptySkills,
+            skillCatalog = skillCatalog,
+            perksRegistry = StubPerksRegistry(),
+            perkCatalog = StubPerkLookup(),
+            safeNodes = StubSafeNodes(),
+        )
+
+        val res = tool.invoke(toolContext)
+
+        assertEquals(17_500L, res.tick)
+    }
+
+    @Test
+    fun `errors when the agent is not registered`() {
+        val tool = GetStatusTool(
+            agents = StubRegistry(null),
+            world = StubQuery(),
+            activity = activity,
+            skillsRegistry = emptySkills,
+            skillCatalog = skillCatalog,
+            perksRegistry = StubPerksRegistry(),
+            perkCatalog = StubPerkLookup(),
+            safeNodes = StubSafeNodes(),
         )
 
         assertThrows<IllegalStateException> { tool.invoke(toolContext) }
@@ -207,12 +261,12 @@ class GetStatusToolTest {
         val tool = GetStatusTool(
             agents = StubRegistry(agent),
             world = StubQuery(active = node, body = body),
-            engine = tickClock,
             activity = activity,
             skillsRegistry = StubSkillsRegistry(snapshot),
             skillCatalog = skillCatalog,
             perksRegistry = StubPerksRegistry(),
             perkCatalog = StubPerkLookup(),
+            safeNodes = StubSafeNodes(),
         )
 
         val skills = tool.invoke(toolContext).skills
@@ -241,12 +295,12 @@ class GetStatusToolTest {
         val tool = GetStatusTool(
             agents = StubRegistry(agent),
             world = StubQuery(active = node, body = body),
-            engine = tickClock,
             activity = activity,
             skillsRegistry = StubSkillsRegistry(snapshot),
             skillCatalog = skillCatalog,
             perksRegistry = StubPerksRegistry(),
             perkCatalog = StubPerkLookup(),
+            safeNodes = StubSafeNodes(),
         )
 
         val skills = tool.invoke(toolContext).skills
@@ -278,12 +332,12 @@ class GetStatusToolTest {
         val tool = GetStatusTool(
             agents = StubRegistry(agent),
             world = StubQuery(active = node, body = body),
-            engine = tickClock,
             activity = activity,
             skillsRegistry = StubSkillsRegistry(snapshot),
             skillCatalog = stubSkillLookupForPerks(),
             perksRegistry = perksRegistry,
             perkCatalog = StubPerkLookup(),
+            safeNodes = StubSafeNodes(),
         )
 
         val skills = tool.invoke(toolContext).skills
@@ -323,12 +377,12 @@ class GetStatusToolTest {
         val tool = GetStatusTool(
             agents = StubRegistry(agent),
             world = StubQuery(active = node, body = body),
-            engine = tickClock,
             activity = activity,
             skillsRegistry = StubSkillsRegistry(snapshot),
             skillCatalog = stubSkillLookupForPerks(),
             perksRegistry = perksRegistry,
             perkCatalog = perkCatalog,
+            safeNodes = StubSafeNodes(),
         )
 
         val skills = tool.invoke(toolContext).skills
@@ -361,12 +415,12 @@ class GetStatusToolTest {
         val tool = GetStatusTool(
             agents = StubRegistry(agent),
             world = StubQuery(active = node, body = body),
-            engine = tickClock,
             activity = activity,
             skillsRegistry = StubSkillsRegistry(snapshot),
             skillCatalog = stubSkillLookupForPerks(),
             perksRegistry = StubPerksRegistry(),
             perkCatalog = perkCatalog,
+            safeNodes = StubSafeNodes(),
         )
 
         val skills = tool.invoke(toolContext).skills
@@ -392,12 +446,12 @@ class GetStatusToolTest {
         val tool = GetStatusTool(
             agents = StubRegistry(agent),
             world = StubQuery(active = node, body = body),
-            engine = tickClock,
             activity = activity,
             skillsRegistry = StubSkillsRegistry(snapshot),
             skillCatalog = stubSkillLookupForPerks(),
             perksRegistry = StubPerksRegistry(),
             perkCatalog = perkCatalog,
+            safeNodes = StubSafeNodes(),
         )
 
         val skills = tool.invoke(toolContext).skills
@@ -419,12 +473,12 @@ class GetStatusToolTest {
         val tool = GetStatusTool(
             agents = StubRegistry(agent),
             world = StubQuery(active = node, body = body),
-            engine = tickClock,
             activity = activity,
             skillsRegistry = StubSkillsRegistry(snapshot),
             skillCatalog = stubSkillLookupForPerks(),
             perksRegistry = StubPerksRegistry(),
             perkCatalog = perkCatalog,
+            safeNodes = StubSafeNodes(),
         )
 
         val skills = tool.invoke(toolContext).skills
@@ -461,12 +515,12 @@ class GetStatusToolTest {
         val tool = GetStatusTool(
             agents = StubRegistry(agent),
             world = StubQuery(active = node, body = body),
-            engine = tickClock,
             activity = activity,
             skillsRegistry = StubSkillsRegistry(snapshot),
             skillCatalog = skillCatalog,
             perksRegistry = StubPerksRegistry(),
             perkCatalog = StubPerkLookup(),
+            safeNodes = StubSafeNodes(),
         )
 
         val skills = tool.invoke(toolContext).skills
@@ -485,6 +539,7 @@ class GetStatusToolTest {
         private val active: NodeId? = null,
         private val lastLocation: NodeId? = null,
         private val body: BodyView? = null,
+        private val tick: Long = 200L,
     ) : WorldQueryGateway {
         override fun locationOf(agent: AgentId): NodeId? = lastLocation
         override fun activePositionOf(agent: AgentId): NodeId? = active
@@ -499,6 +554,13 @@ class GetStatusToolTest {
         override fun resourcesAt(nodeId: NodeId, tick: Long): dev.gvart.genesara.world.NodeResources =
             dev.gvart.genesara.world.NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
+        override fun currentTickFor(agent: AgentId): Long = tick
+    }
+
+    private class StubSafeNodes(private val node: NodeId? = null) : AgentSafeNodeGateway {
+        override fun set(agentId: AgentId, nodeId: NodeId, tick: Long) = Unit
+        override fun find(agentId: AgentId): NodeId? = node
+        override fun clear(agentId: AgentId) = Unit
     }
 
     private class StubSkillsRegistry(private val snap: AgentSkillsSnapshot) : AgentSkillsRegistry {
@@ -533,10 +595,6 @@ class GetStatusToolTest {
                 .toSortedMap()
                 .map { (level, list) -> PerkChoice(skill, level, list) }
         override fun all(): List<Perk> = perks
-    }
-
-    private class StubTickClock(private val currentTick: Long) : TickClock {
-        override fun currentTick(): Long = currentTick
     }
 
     private class MutableTestClock(private var now: Instant) : Clock() {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
@@ -292,6 +292,7 @@ class InspectBuildingTest {
         override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
+        override fun currentTickFor(agent: AgentId): Long = 0L
     }
 
     private class StubBuildings(private val rows: List<Building>) : BuildingsLookup {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
@@ -454,6 +454,7 @@ class InspectToolTest {
         override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(inventory)
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
+        override fun currentTickFor(agent: AgentId): Long = 0L
     }
 
     private class MutableTestClock(private var now: Instant) : Clock() {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/loadout/GetLoadoutToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/loadout/GetLoadoutToolTest.kt
@@ -255,6 +255,7 @@ class GetLoadoutToolTest {
         override fun inventoryOf(agent: AgentId): InventoryView = inventory
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<GroundItemView> = emptyList()
+        override fun currentTickFor(agent: AgentId): Long = 0L
     }
 
     private class MutableTestClock(private var now: Instant) : Clock() {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
@@ -3,7 +3,6 @@ package dev.gvart.genesara.api.internal.mcp.tools.lookaround
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
 import dev.gvart.genesara.account.PlayerId
-import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
@@ -87,7 +86,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings)
 
         val response = tool.invoke(toolContext)
 
@@ -108,7 +107,7 @@ class LookAroundToolTest {
             // Sight 2 surfaces `far` in `visible` but it is not move-adjacent to the current node.
             within = mapOf((currentNodeId to 2) to setOf(currentNodeId, northNodeId, farNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 2), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 2), activity, RecordingMapMemory(), NoBuildings)
 
         val response = tool.invoke(toolContext)
 
@@ -125,7 +124,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings)
 
         val response = tool.invoke(toolContext)
 
@@ -135,17 +134,16 @@ class LookAroundToolTest {
     }
 
     @Test
-    fun `records every visible node into agent map memory at the current tick`() {
-        // Fog-of-war recall: look_around batches the current tile + every adjacent
-        // visible tile into the map-memory gateway so get_map can replay them later.
+    fun `records every visible node into agent map memory at the per-world tick`() {
         val world = StubQuery(
             location = currentNodeId,
             nodes = mapOf(currentNodeId to current, northNodeId to north),
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
+            currentTick = 7L,
         )
         val memory = RecordingMapMemory()
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(7L), memory, NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, memory, NoBuildings)
 
         tool.invoke(toolContext)
 
@@ -174,11 +172,28 @@ class LookAroundToolTest {
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
         val flaky = ThrowingMapMemory()
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), flaky, NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, flaky, NoBuildings)
 
         // Should NOT throw — the read still returns successfully.
         val response = tool.invoke(toolContext)
         assertEquals(currentNodeId.value, response.currentNode.id)
+    }
+
+    @Test
+    fun `resourcesAt is queried at the per-world tick so lazy-regen aligns with the event clock`() {
+        val world = StubQuery(
+            location = currentNodeId,
+            nodes = mapOf(currentNodeId to current, northNodeId to north),
+            regions = mapOf(regionId to region),
+            within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
+            currentTick = 9_999L,
+        )
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings)
+
+        tool.invoke(toolContext)
+
+        assertTrue(world.resourcesAtCalls.isNotEmpty())
+        assertTrue(world.resourcesAtCalls.all { it.second == 9_999L })
     }
 
     @Test
@@ -189,7 +204,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings)
 
         val response = tool.invoke(toolContext)
 
@@ -206,7 +221,7 @@ class LookAroundToolTest {
         )
         val campfire = activeBuilding(currentNodeId, dev.gvart.genesara.world.BuildingType.CAMPFIRE)
         val buildings = StubBuildingsLookup(byNode = mapOf(currentNodeId to listOf(campfire)))
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), buildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), buildings)
 
         val response = tool.invoke(toolContext)
 
@@ -230,7 +245,7 @@ class LookAroundToolTest {
         )
         val workbench = activeBuilding(northNodeId, dev.gvart.genesara.world.BuildingType.WORKBENCH)
         val buildings = StubBuildingsLookup(byNode = mapOf(northNodeId to listOf(workbench)))
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), buildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), buildings)
 
         val response = tool.invoke(toolContext)
 
@@ -255,7 +270,7 @@ class LookAroundToolTest {
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
         val recordingBuildings = RecordingBuildingsLookup()
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), recordingBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), recordingBuildings)
 
         tool.invoke(toolContext)
 
@@ -326,7 +341,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to unpainted),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings)
 
         val response = tool.invoke(toolContext)
 
@@ -342,7 +357,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = emptyMap(),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings)
 
         assertThrows<IllegalStateException> {
             tool.invoke(toolContext)
@@ -357,7 +372,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId)),
         )
-        val tool = LookAroundTool(world, EmptyRegistry, vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, EmptyRegistry, vision(sight = 1), activity, RecordingMapMemory(), NoBuildings)
 
         assertThrows<IllegalStateException> {
             tool.invoke(toolContext)
@@ -372,7 +387,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, FixedTickClock(0L), RecordingMapMemory(), NoBuildings)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings)
 
         tool.invoke(toolContext)
 
@@ -398,6 +413,8 @@ class LookAroundToolTest {
         private val nodes: Map<NodeId, Node>,
         private val regions: Map<RegionId, Region>,
         private val within: Map<Pair<NodeId, Int>, Set<NodeId>>,
+        private val currentTick: Long = 0L,
+        val resourcesAtCalls: MutableList<Pair<NodeId, Long>> = mutableListOf(),
     ) : WorldQueryGateway {
         override fun locationOf(agent: AgentId): NodeId? = location
         override fun activePositionOf(agent: AgentId): NodeId? = location
@@ -410,19 +427,18 @@ class LookAroundToolTest {
         override fun bodyOf(agent: AgentId): dev.gvart.genesara.world.BodyView? = null
         override fun inventoryOf(agent: AgentId): dev.gvart.genesara.world.InventoryView =
             dev.gvart.genesara.world.InventoryView(emptyList())
-        override fun resourcesAt(nodeId: NodeId, tick: Long): dev.gvart.genesara.world.NodeResources =
-            dev.gvart.genesara.world.NodeResources.EMPTY
+        override fun resourcesAt(nodeId: NodeId, tick: Long): dev.gvart.genesara.world.NodeResources {
+            resourcesAtCalls += nodeId to tick
+            return dev.gvart.genesara.world.NodeResources.EMPTY
+        }
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
+        override fun currentTickFor(agent: AgentId): Long = currentTick
     }
 
     private class MutableTestClock(private var now: Instant) : Clock() {
         override fun instant(): Instant = now
         override fun getZone(): ZoneId = ZoneOffset.UTC
         override fun withZone(zone: ZoneId?): Clock = this
-    }
-
-    private class FixedTickClock(private val current: Long) : TickClock {
-        override fun currentTick(): Long = current
     }
 
     private class RecordingMapMemory : dev.gvart.genesara.world.AgentMapMemoryGateway {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/AgentManagementControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/AgentManagementControllerTest.kt
@@ -161,6 +161,7 @@ class AgentManagementControllerTest {
         override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
+        override fun currentTickFor(agent: AgentId): Long = 0L
     }
 
     private class StubActivity(private val rows: Map<AgentId, Instant>) : AgentActivityTracker {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeControllerTest.kt
@@ -188,5 +188,6 @@ class AgentRuntimeControllerTest {
         override fun resourcesAt(nodeId: NodeId, tick: Long): dev.gvart.genesara.world.NodeResources =
             dev.gvart.genesara.world.NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
+        override fun currentTickFor(agent: AgentId): Long = 0L
     }
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldQueryGateway.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldQueryGateway.kt
@@ -65,4 +65,12 @@ interface WorldQueryGateway {
      * [GroundItemStore.take] via the reducer path; this gateway is read-only.
      */
     fun groundItemsAt(nodeId: NodeId): List<GroundItemView>
+
+    /**
+     * Per-world tick for the world [agent] is currently routed to — the same clock
+     * `WorldEvent.tick` carries. Returns `0` when no world is routable (no worlds
+     * configured), so read tools never NPE. Use this instead of the process-local
+     * `TickClock` whenever a value needs to correlate with the event stream.
+     */
+    fun currentTickFor(agent: AgentId): Long
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGateway.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGateway.kt
@@ -20,6 +20,8 @@ import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_BODIES
 import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_INVENTORY
 import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_POSITIONS
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
+import dev.gvart.genesara.world.internal.tick.AgentWorldRouter
+import dev.gvart.genesara.world.internal.tick.WorldTickCounter
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 import org.jooq.impl.SQLDataType
@@ -33,6 +35,8 @@ internal class WorldStateQueryGateway(
     private val resources: NodeResourceStore,
     private val balance: BalanceLookup,
     private val groundItems: GroundItemStore,
+    private val worldRouter: AgentWorldRouter,
+    private val tickCounter: WorldTickCounter,
 ) : WorldQueryGateway {
 
     override fun locationOf(agent: AgentId): NodeId? =
@@ -128,4 +132,7 @@ internal class WorldStateQueryGateway(
 
     override fun groundItemsAt(nodeId: NodeId): List<GroundItemView> =
         groundItems.atNode(nodeId)
+
+    override fun currentTickFor(agent: AgentId): Long =
+        worldRouter.routeFor(agent)?.let(tickCounter::currentTick) ?: 0L
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/editor/JooqWorldEditingGatewayCreateWorldIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/editor/JooqWorldEditingGatewayCreateWorldIntegrationTest.kt
@@ -204,6 +204,8 @@ class JooqWorldEditingGatewayCreateWorldIntegrationTest {
             resources = NoOpResourceStore,
             balance = OceanIsImpassable,
             groundItems = dev.gvart.genesara.world.internal.testsupport.NoOpGroundItemStore,
+            worldRouter = dev.gvart.genesara.world.internal.testsupport.NoOpAgentWorldRouter(),
+            tickCounter = dev.gvart.genesara.world.internal.testsupport.FixedWorldTickCounter(),
         )
 
         // 50 samples — chance of picking only PLAINS by luck if the filter were broken

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnLocationResolverTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnLocationResolverTest.kt
@@ -106,5 +106,6 @@ class SpawnLocationResolverTest {
         override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
+        override fun currentTickFor(agent: AgentId): Long = 0L
     }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/FixedWorldTickCounter.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/FixedWorldTickCounter.kt
@@ -1,0 +1,10 @@
+package dev.gvart.genesara.world.internal.testsupport
+
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.internal.tick.WorldTickCounter
+
+internal class FixedWorldTickCounter(private val tick: Long = 0L) : WorldTickCounter {
+    override fun incrementAndGet(worldId: WorldId): Long = tick
+    override fun currentTick(worldId: WorldId): Long = tick
+    override fun onLeaseAcquired(worldId: WorldId) = Unit
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/NoOpAgentWorldRouter.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/testsupport/NoOpAgentWorldRouter.kt
@@ -1,0 +1,9 @@
+package dev.gvart.genesara.world.internal.testsupport
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.internal.tick.AgentWorldRouter
+
+internal class NoOpAgentWorldRouter(private val worldId: WorldId? = null) : AgentWorldRouter {
+    override fun routeFor(agent: AgentId): WorldId? = worldId
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImplTest.kt
@@ -140,5 +140,6 @@ class VisionRadiusImplTest {
         override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
+        override fun currentTickFor(agent: AgentId): Long = 0L
     }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayCurrentTickIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayCurrentTickIntegrationTest.kt
@@ -3,17 +3,17 @@ package dev.gvart.genesara.world.internal.worldstate
 import com.zaxxer.hikari.HikariDataSource
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.RaceId
-import dev.gvart.genesara.world.BodyView
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.StarterNodeLookup
-import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_BODIES
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.internal.testsupport.FixedWorldTickCounter
+import dev.gvart.genesara.world.internal.testsupport.NoOpAgentWorldRouter
 import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
 import org.jooq.DSLContext
 import org.jooq.SQLDialect
 import org.jooq.impl.DSL
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
@@ -22,15 +22,9 @@ import tools.jackson.databind.json.JsonMapper
 import tools.jackson.module.kotlin.kotlinModule
 import java.util.UUID
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
-/**
- * Integration test for the new `bodyOf` query on [WorldStateQueryGateway].
- * Other gateway methods are covered by existing reducer / handler tests; this fills the
- * gap created by adding a public [BodyView] projection on top of the internal `AgentBody`.
- */
 @Testcontainers
-class WorldStateQueryGatewayBodyViewIntegrationTest {
+class WorldStateQueryGatewayCurrentTickIntegrationTest {
 
     companion object {
         @Container
@@ -58,65 +52,45 @@ class WorldStateQueryGatewayBodyViewIntegrationTest {
         }
     }
 
-    private lateinit var gateway: WorldStateQueryGateway
+    @Test
+    fun `currentTickFor returns the per-world tick from the counter for the agent's routed world`() {
+        val gateway = buildGateway(
+            NoOpAgentWorldRouter(WorldId(7L)),
+            FixedWorldTickCounter(tick = 4_242L),
+        )
 
-    @BeforeEach
-    fun resetBodies() {
-        dsl.truncate(AGENT_BODIES).cascade().execute()
-        // bodyOf does not touch static config or starter nodes; construct an empty static
-        // config and a no-op starter lookup just to satisfy the constructor.
+        assertEquals(4_242L, gateway.currentTickFor(AgentId(UUID.randomUUID())))
+    }
+
+    @Test
+    fun `currentTickFor falls back to zero when no world is routable for the agent`() {
+        val gateway = buildGateway(
+            NoOpAgentWorldRouter(worldId = null),
+            FixedWorldTickCounter(tick = 999L),
+        )
+
+        assertEquals(0L, gateway.currentTickFor(AgentId(UUID.randomUUID())))
+    }
+
+    private fun buildGateway(
+        router: NoOpAgentWorldRouter,
+        counter: FixedWorldTickCounter,
+    ): WorldStateQueryGateway {
         val staticConfig = WorldStaticConfig(dsl, JsonMapper.builder().addModule(kotlinModule()).build())
         staticConfig.reload()
-        gateway = WorldStateQueryGateway(
+        return WorldStateQueryGateway(
             dsl = dsl,
             staticConfig = staticConfig,
-            starterNodes = NoOpStarterNodes(),
+            starterNodes = NoOpStarterNodes,
             resources = EmptyResourceStore,
             balance = AlwaysTraversableBalance,
             groundItems = dev.gvart.genesara.world.internal.testsupport.NoOpGroundItemStore,
-            worldRouter = dev.gvart.genesara.world.internal.testsupport.NoOpAgentWorldRouter(),
-            tickCounter = dev.gvart.genesara.world.internal.testsupport.FixedWorldTickCounter(),
+            worldRouter = router,
+            tickCounter = counter,
         )
     }
 
-    @Test
-    fun `bodyOf projects every column from agent_bodies into a BodyView`() {
-        // Reminder: when adding a column to `agent_bodies` (e.g. armor_class for a future combat
-        // slice), update both the seed below AND `BodyView` + `WorldStateQueryGateway.bodyOf`,
-        // otherwise `BodyView` will silently drop the new column and this test will keep passing.
-        val agent = AgentId(UUID.randomUUID())
-        dsl.insertInto(AGENT_BODIES)
-            .set(AGENT_BODIES.AGENT_ID, agent.id)
-            .set(AGENT_BODIES.HP, 80).set(AGENT_BODIES.MAX_HP, 100)
-            .set(AGENT_BODIES.STAMINA, 25).set(AGENT_BODIES.MAX_STAMINA, 50)
-            .set(AGENT_BODIES.MANA, 5).set(AGENT_BODIES.MAX_MANA, 15)
-            .set(AGENT_BODIES.HUNGER, 90).set(AGENT_BODIES.MAX_HUNGER, 100)
-            .set(AGENT_BODIES.THIRST, 70).set(AGENT_BODIES.MAX_THIRST, 100)
-            .set(AGENT_BODIES.SLEEP, 40).set(AGENT_BODIES.MAX_SLEEP, 100)
-            .execute()
-
-        val body = gateway.bodyOf(agent)
-
-        assertEquals(
-            BodyView(
-                hp = 80, maxHp = 100,
-                stamina = 25, maxStamina = 50,
-                mana = 5, maxMana = 15,
-                hunger = 90, maxHunger = 100,
-                thirst = 70, maxThirst = 100,
-                sleep = 40, maxSleep = 100,
-            ),
-            body,
-        )
-    }
-
-    @Test
-    fun `bodyOf returns null when no row exists for the agent`() {
-        val ghost = AgentId(UUID.randomUUID())
-        assertNull(gateway.bodyOf(ghost))
-    }
-
-    private class NoOpStarterNodes : StarterNodeLookup {
+    private object NoOpStarterNodes : StarterNodeLookup {
         override fun byRace(race: RaceId): NodeId? = null
     }
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayInventoryIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayInventoryIntegrationTest.kt
@@ -72,6 +72,8 @@ class WorldStateQueryGatewayInventoryIntegrationTest {
             resources = EmptyResourceStore,
             balance = AlwaysTraversableBalance,
             groundItems = dev.gvart.genesara.world.internal.testsupport.NoOpGroundItemStore,
+            worldRouter = dev.gvart.genesara.world.internal.testsupport.NoOpAgentWorldRouter(),
+            tickCounter = dev.gvart.genesara.world.internal.testsupport.FixedWorldTickCounter(),
         )
     }
 


### PR DESCRIPTION
## Summary

- `GetStatusTool.tick` and `LookAroundTool` (both the map-memory journal write and the lazy-regen `resourcesAt` call) now read the per-world `WorldTickCounter` via a new `WorldQueryGateway.currentTickFor(agent)` method, so the value an agent sees lines up with the `WorldEvent.tick` carried on the event stream — even across pod restarts (which reset the in-memory `TickClock`).
- `GetStatusResponse` gains a `safeNode: Long?` field projected from `AgentSafeNodeGateway.find(agentId)`, so a respawning agent can pathfind back to their bound checkpoint without re-deriving it.
- New unit + integration tests cover the new gateway method, the safeNode projection, and the per-world tick wiring in both read tools.

Closes #115. Closes #117. Closes #130.

## Test plan

- [x] `./gradlew :api:test` — green, includes new `surfaces the bound safe node id`, `safeNode is null when the agent has never set one`, `tick is read from the per-world counter`, `records every visible node into agent map memory at the per-world tick`, `resourcesAt is queried at the per-world tick` cases.
- [x] `./gradlew :world:test` — green, includes new `WorldStateQueryGatewayCurrentTickIntegrationTest` (2 cases covering the router/counter happy path and the no-routable-world fallback to 0).
- [x] `./gradlew :app:test` — Spring context wiring of the changed `GetStatusTool` / `LookAroundTool` constructors verified.