### PR TITLE
feat(api): expose co-located agents on look_around.currentNode

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
@@ -38,9 +38,11 @@ internal class LookAroundTool(
         name = "look_around",
         description = "Return the agent's current node, every node within sight range (`visible`), and " +
             "the ids of the hex-adjacent one-step `move` targets (`neighbours`). The current node " +
-            "carries full resource counts and full per-building summaries; visible non-current nodes " +
-            "carry only item ids and a fog-of-war building summary (type + status, no instance ids). " +
-            "`neighbours` is the canonical input for `move`; not every entry in `visible` is move-legal.",
+            "carries full resource counts, full per-building summaries, and `agents` — other agents " +
+            "present on the same tile (id/name/race/level/hpBand), suitable for `attack` targeting. " +
+            "Visible non-current nodes carry only item ids and a fog-of-war building summary " +
+            "(type + status, no instance ids, no agents). `neighbours` is the canonical input for " +
+            "`move`; not every entry in `visible` is move-legal.",
     )
     fun invoke(toolContext: ToolContext): LookAroundResponse {
         touchActivity(toolContext, activity, "look_around")
@@ -63,10 +65,18 @@ internal class LookAroundTool(
         val visibleNodeIds = (visible.map { it.first.id } + current.id).toSet()
         val buildingsByNode = buildings.byNodes(visibleNodeIds)
 
+        val currentNodeAgents = projectAgentsAt(current.id, excluding = agentId)
+
         journalVisibleNodes(agentId, current, region, visible, currentTick)
 
         return LookAroundResponse(
-            currentNode = current.toView(region, currentResources, buildingsByNode[current.id].orEmpty(), fogOfWar = false),
+            currentNode = current.toView(
+                region,
+                currentResources,
+                buildingsByNode[current.id].orEmpty(),
+                currentNodeAgents,
+                fogOfWar = false,
+            ),
             currentResources = currentResources.entries.values.map {
                 ResourceView(
                     itemId = it.itemId.value,
@@ -76,10 +86,30 @@ internal class LookAroundTool(
             },
             groundItems = currentGroundItems.map { it.toView() },
             visible = visible.map { (n, r, res) ->
-                n.toView(r, res, buildingsByNode[n.id].orEmpty(), fogOfWar = true)
+                n.toView(r, res, buildingsByNode[n.id].orEmpty(), emptyList(), fogOfWar = true)
             },
             neighbours = current.adjacency.map { it.value }.sorted(),
         )
+    }
+
+    private fun projectAgentsAt(nodeId: NodeId, excluding: AgentId): List<AgentPresenceView> {
+        val occupants = world.activeAgentsAtNodes(setOf(nodeId))[nodeId].orEmpty()
+        return occupants
+            .asSequence()
+            .filter { it != excluding }
+            .sortedBy { it.id }
+            .mapNotNull { otherId ->
+                val other = agents.find(otherId) ?: return@mapNotNull null
+                val body = world.bodyOf(otherId) ?: return@mapNotNull null
+                AgentPresenceView(
+                    id = other.id.id.toString(),
+                    name = other.name,
+                    race = other.race.value,
+                    level = other.level,
+                    hpBand = vitalBand(body.hp, body.maxHp, zeroLabel = "dead"),
+                )
+            }
+            .toList()
     }
 
     private fun adjacentVisibleNodes(
@@ -128,6 +158,7 @@ private fun Node.toView(
     region: Region,
     resources: NodeResources,
     buildings: List<Building>,
+    agents: List<AgentPresenceView>,
     fogOfWar: Boolean,
 ) = NodeView(
     id = id.value,
@@ -141,6 +172,7 @@ private fun Node.toView(
     buildings = buildings
         .sortedBy { it.instanceId }
         .map { it.toSummary(fogOfWar) },
+    agents = agents,
 )
 
 private fun DomainGroundItemView.toView(): GroundItemView = when (val payload = drop) {

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolIo.kt
@@ -39,6 +39,25 @@ data class NodeView(
      * only type + status + count (fog-of-war analogous to resources).
      */
     val buildings: List<BuildingSummaryView> = emptyList(),
+    /**
+     * Other active agents present at this node. Populated only on the current tile —
+     * adjacent tiles never carry agent presence (separate fog-of-war problem). The
+     * calling agent is excluded; self info is already on `get_status`.
+     */
+    val agents: List<AgentPresenceView> = emptyList(),
+)
+
+/**
+ * Discovery row for another agent in the same node. Carries enough to address the agent
+ * (`id` for `attack(targetAgentId=…)`) and assess them at a coarse band — `hpBand` is the
+ * shared low/mid/high projection from `vitalBand`; the raw HP is never exposed.
+ */
+data class AgentPresenceView(
+    val id: String,
+    val name: String,
+    val race: String,
+    val level: Int,
+    val hpBand: String,
 )
 
 data class ResourceView(

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/presence/PresenceReaperTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/presence/PresenceReaperTest.kt
@@ -93,6 +93,7 @@ class PresenceReaperTest {
             dev.gvart.genesara.world.NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
         override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> = emptyMap()
     }
 
     private class StubTickClock(private val currentTick: Long) : TickClock {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolTest.kt
@@ -555,6 +555,7 @@ class GetStatusToolTest {
             dev.gvart.genesara.world.NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
         override fun currentTickFor(agent: AgentId): Long = tick
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> = emptyMap()
     }
 
     private class StubSafeNodes(private val node: NodeId? = null) : AgentSafeNodeGateway {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
@@ -293,6 +293,7 @@ class InspectBuildingTest {
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
         override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> = emptyMap()
     }
 
     private class StubBuildings(private val rows: List<Building>) : BuildingsLookup {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
@@ -455,6 +455,7 @@ class InspectToolTest {
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
         override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> = emptyMap()
     }
 
     private class MutableTestClock(private var now: Instant) : Clock() {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/loadout/GetLoadoutToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/loadout/GetLoadoutToolTest.kt
@@ -256,6 +256,7 @@ class GetLoadoutToolTest {
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<GroundItemView> = emptyList()
         override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> = emptyMap()
     }
 
     private class MutableTestClock(private var now: Instant) : Clock() {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
@@ -279,6 +279,126 @@ class LookAroundToolTest {
         assertEquals(0, recordingBuildings.byNodeCalls.size, "must not fall back to per-node lookups")
     }
 
+    @Test
+    fun `currentNode agents lists co-located agents excluding self, sorted by id, with hpBand only`() {
+        val firstOtherId = AgentId(java.util.UUID.fromString("00000000-0000-0000-0000-000000000001"))
+        val secondOtherId = AgentId(java.util.UUID.fromString("00000000-0000-0000-0000-000000000002"))
+        val firstOther = scoutAgent.copy(
+            id = firstOtherId,
+            name = "alice",
+            race = dev.gvart.genesara.player.RaceId("human_warden"),
+            level = 4,
+        )
+        val secondOther = scoutAgent.copy(
+            id = secondOtherId,
+            name = "bob",
+            race = dev.gvart.genesara.player.RaceId("human_commoner"),
+            level = 7,
+        )
+        val world = StubQuery(
+            location = currentNodeId,
+            nodes = mapOf(currentNodeId to current, northNodeId to north),
+            regions = mapOf(regionId to region),
+            within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
+            occupants = mapOf(currentNodeId to listOf(secondOtherId, firstOtherId, agentId)),
+            bodies = mapOf(
+                firstOtherId to bodyAt(hp = 95, maxHp = 100),
+                secondOtherId to bodyAt(hp = 15, maxHp = 100),
+            ),
+        )
+        val tool = LookAroundTool(
+            world,
+            registryWith(scoutAgent, firstOther, secondOther),
+            vision(sight = 1),
+            activity,
+            FixedTickClock(0L),
+            RecordingMapMemory(),
+            NoBuildings,
+        )
+
+        val response = tool.invoke(toolContext)
+
+        val agents = response.currentNode.agents
+        assertEquals(2, agents.size)
+        assertEquals(firstOtherId.id.toString(), agents[0].id)
+        assertEquals("alice", agents[0].name)
+        assertEquals("human_warden", agents[0].race)
+        assertEquals(4, agents[0].level)
+        assertEquals("high", agents[0].hpBand)
+        assertEquals(secondOtherId.id.toString(), agents[1].id)
+        assertEquals("low", agents[1].hpBand)
+        assertTrue(agents.none { it.id == agentId.id.toString() })
+    }
+
+    @Test
+    fun `currentNode agents skips entries whose agent row or body is missing`() {
+        val knownOtherId = AgentId(java.util.UUID.fromString("00000000-0000-0000-0000-000000000010"))
+        val ghostId = AgentId(java.util.UUID.fromString("00000000-0000-0000-0000-000000000020"))
+        val bodylessId = AgentId(java.util.UUID.fromString("00000000-0000-0000-0000-000000000030"))
+        val knownOther = scoutAgent.copy(id = knownOtherId, name = "known", level = 2)
+        val bodyless = scoutAgent.copy(id = bodylessId, name = "bodyless", level = 5)
+        val world = StubQuery(
+            location = currentNodeId,
+            nodes = mapOf(currentNodeId to current),
+            regions = mapOf(regionId to region),
+            within = mapOf((currentNodeId to 1) to setOf(currentNodeId)),
+            occupants = mapOf(currentNodeId to listOf(knownOtherId, ghostId, bodylessId)),
+            bodies = mapOf(knownOtherId to bodyAt(hp = 50, maxHp = 100)),
+        )
+        val tool = LookAroundTool(
+            world,
+            registryWith(scoutAgent, knownOther, bodyless),
+            vision(sight = 1),
+            activity,
+            FixedTickClock(0L),
+            RecordingMapMemory(),
+            NoBuildings,
+        )
+
+        val response = tool.invoke(toolContext)
+
+        val agents = response.currentNode.agents
+        assertEquals(1, agents.size)
+        assertEquals(knownOtherId.id.toString(), agents.single().id)
+    }
+
+    @Test
+    fun `visible adjacent nodes never carry agent presence`() {
+        val otherId = AgentId(java.util.UUID.fromString("00000000-0000-0000-0000-0000000000aa"))
+        val other = scoutAgent.copy(id = otherId, name = "scout-north")
+        val world = StubQuery(
+            location = currentNodeId,
+            nodes = mapOf(currentNodeId to current, northNodeId to north),
+            regions = mapOf(regionId to region),
+            within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
+            occupants = mapOf(northNodeId to listOf(otherId)),
+            bodies = mapOf(otherId to bodyAt(hp = 100, maxHp = 100)),
+        )
+        val tool = LookAroundTool(
+            world,
+            registryWith(scoutAgent, other),
+            vision(sight = 1),
+            activity,
+            FixedTickClock(0L),
+            RecordingMapMemory(),
+            NoBuildings,
+        )
+
+        val response = tool.invoke(toolContext)
+
+        assertEquals(emptyList(), response.currentNode.agents)
+        assertTrue(response.visible.single().agents.isEmpty())
+    }
+
+    private fun bodyAt(hp: Int, maxHp: Int) = dev.gvart.genesara.world.BodyView(
+        hp = hp, maxHp = maxHp,
+        stamina = 0, maxStamina = 1,
+        mana = 0, maxMana = 1,
+        hunger = 0, maxHunger = 1,
+        thirst = 0, maxThirst = 1,
+        sleep = 0, maxSleep = 1,
+    )
+
     private fun activeBuilding(
         node: NodeId,
         type: dev.gvart.genesara.world.BuildingType,
@@ -394,9 +514,10 @@ class LookAroundToolTest {
         assertTrue(agentId in activity.staleAgents(clock.instant().plusSeconds(60)))
     }
 
-    private fun registryWith(agent: Agent) = object : AgentRegistry {
-        override fun find(id: AgentId): Agent? = if (id == agent.id) agent else null
-        override fun listForOwner(owner: PlayerId): List<Agent> = listOf(agent).filter { it.owner == owner }
+    private fun registryWith(vararg entries: Agent) = object : AgentRegistry {
+        private val byId = entries.associateBy { it.id }
+        override fun find(id: AgentId): Agent? = byId[id]
+        override fun listForOwner(owner: PlayerId): List<Agent> = entries.filter { it.owner == owner }
     }
 
     private fun vision(sight: Int) = object : VisionRadius {
@@ -415,6 +536,8 @@ class LookAroundToolTest {
         private val within: Map<Pair<NodeId, Int>, Set<NodeId>>,
         private val currentTick: Long = 0L,
         val resourcesAtCalls: MutableList<Pair<NodeId, Long>> = mutableListOf(),
+        private val occupants: Map<NodeId, List<AgentId>> = emptyMap(),
+        private val bodies: Map<AgentId, dev.gvart.genesara.world.BodyView> = emptyMap(),
     ) : WorldQueryGateway {
         override fun locationOf(agent: AgentId): NodeId? = location
         override fun activePositionOf(agent: AgentId): NodeId? = location
@@ -424,7 +547,7 @@ class LookAroundToolTest {
             within[origin to radius] ?: emptySet()
         override fun randomSpawnableNode(): NodeId? = null
         override fun starterNodeFor(race: dev.gvart.genesara.player.RaceId): NodeId? = null
-        override fun bodyOf(agent: AgentId): dev.gvart.genesara.world.BodyView? = null
+        override fun bodyOf(agent: AgentId): dev.gvart.genesara.world.BodyView? = bodies[agent]
         override fun inventoryOf(agent: AgentId): dev.gvart.genesara.world.InventoryView =
             dev.gvart.genesara.world.InventoryView(emptyList())
         override fun resourcesAt(nodeId: NodeId, tick: Long): dev.gvart.genesara.world.NodeResources {
@@ -433,6 +556,8 @@ class LookAroundToolTest {
         }
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
         override fun currentTickFor(agent: AgentId): Long = currentTick
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> =
+            nodeIds.associateWith { occupants[it].orEmpty() }.filterValues { it.isNotEmpty() }
     }
 
     private class MutableTestClock(private var now: Instant) : Clock() {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
@@ -311,7 +311,6 @@ class LookAroundToolTest {
             registryWith(scoutAgent, firstOther, secondOther),
             vision(sight = 1),
             activity,
-            FixedTickClock(0L),
             RecordingMapMemory(),
             NoBuildings,
         )
@@ -350,7 +349,6 @@ class LookAroundToolTest {
             registryWith(scoutAgent, knownOther, bodyless),
             vision(sight = 1),
             activity,
-            FixedTickClock(0L),
             RecordingMapMemory(),
             NoBuildings,
         )
@@ -379,7 +377,6 @@ class LookAroundToolTest {
             registryWith(scoutAgent, other),
             vision(sight = 1),
             activity,
-            FixedTickClock(0L),
             RecordingMapMemory(),
             NoBuildings,
         )

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/AgentManagementControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/AgentManagementControllerTest.kt
@@ -162,6 +162,7 @@ class AgentManagementControllerTest {
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
         override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> = emptyMap()
     }
 
     private class StubActivity(private val rows: Map<AgentId, Instant>) : AgentActivityTracker {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/agent/AgentRuntimeControllerTest.kt
@@ -189,5 +189,6 @@ class AgentRuntimeControllerTest {
             dev.gvart.genesara.world.NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
         override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> = emptyMap()
     }
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldQueryGateway.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldQueryGateway.kt
@@ -73,4 +73,11 @@ interface WorldQueryGateway {
      * `TickClock` whenever a value needs to correlate with the event stream.
      */
     fun currentTickFor(agent: AgentId): Long
+
+    /**
+     * Active agents present at any of [nodeIds], grouped by node. Nodes with no
+     * active occupants are absent from the map. Batched — never call in a loop
+     * over nodes. Empty input returns an empty map without touching the DB.
+     */
+    fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>>
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGateway.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGateway.kt
@@ -135,4 +135,16 @@ internal class WorldStateQueryGateway(
 
     override fun currentTickFor(agent: AgentId): Long =
         worldRouter.routeFor(agent)?.let(tickCounter::currentTick) ?: 0L
+
+    override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> {
+        if (nodeIds.isEmpty()) return emptyMap()
+        return dsl.select(AGENT_POSITIONS.NODE_ID, AGENT_POSITIONS.AGENT_ID)
+            .from(AGENT_POSITIONS)
+            .where(AGENT_POSITIONS.NODE_ID.`in`(nodeIds.map { it.value }))
+            .and(AGENT_POSITIONS.ACTIVE.isTrue)
+            .fetchGroups(
+                { NodeId(it[AGENT_POSITIONS.NODE_ID]!!) },
+                { AgentId(it[AGENT_POSITIONS.AGENT_ID]!!) },
+            )
+    }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnLocationResolverTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnLocationResolverTest.kt
@@ -107,5 +107,6 @@ class SpawnLocationResolverTest {
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
         override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> = emptyMap()
     }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/vision/VisionRadiusImplTest.kt
@@ -141,5 +141,6 @@ class VisionRadiusImplTest {
         override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
         override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
         override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> = emptyMap()
     }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayActiveAgentsAtNodesIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayActiveAgentsAtNodesIntegrationTest.kt
@@ -74,6 +74,8 @@ class WorldStateQueryGatewayActiveAgentsAtNodesIntegrationTest {
             resources = EmptyResourceStore,
             balance = AlwaysTraversableBalance,
             groundItems = dev.gvart.genesara.world.internal.testsupport.NoOpGroundItemStore,
+            worldRouter = dev.gvart.genesara.world.internal.testsupport.NoOpAgentWorldRouter(),
+            tickCounter = dev.gvart.genesara.world.internal.testsupport.FixedWorldTickCounter(),
         )
     }
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayActiveAgentsAtNodesIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/WorldStateQueryGatewayActiveAgentsAtNodesIntegrationTest.kt
@@ -1,0 +1,196 @@
+package dev.gvart.genesara.world.internal.worldstate
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.StarterNodeLookup
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_POSITIONS
+import dev.gvart.genesara.world.internal.jooq.tables.references.NODES
+import dev.gvart.genesara.world.internal.jooq.tables.references.REGIONS
+import dev.gvart.genesara.world.internal.jooq.tables.references.WORLDS
+import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
+import org.jooq.DSLContext
+import org.jooq.JSON
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Testcontainers
+class WorldStateQueryGatewayActiveAgentsAtNodesIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("world_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = WorldFlyway.pooledDataSource(postgres)
+            WorldFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private lateinit var gateway: WorldStateQueryGateway
+
+    @BeforeEach
+    fun resetState() {
+        dsl.truncate(AGENT_POSITIONS).cascade().execute()
+        dsl.truncate(NODES).cascade().execute()
+        dsl.truncate(REGIONS).cascade().execute()
+        dsl.truncate(WORLDS).cascade().execute()
+
+        val staticConfig = WorldStaticConfig(dsl, JsonMapper.builder().addModule(kotlinModule()).build())
+        staticConfig.reload()
+        gateway = WorldStateQueryGateway(
+            dsl = dsl,
+            staticConfig = staticConfig,
+            starterNodes = NoOpStarterNodes(),
+            resources = EmptyResourceStore,
+            balance = AlwaysTraversableBalance,
+            groundItems = dev.gvart.genesara.world.internal.testsupport.NoOpGroundItemStore,
+        )
+    }
+
+    @Test
+    fun `activeAgentsAtNodes groups active agents by node and filters out inactive rows`() {
+        val worldId = seedWorld()
+        val regionId = seedRegion(worldId, sphereIndex = 0)
+        val nodeA = seedNode(regionId, q = 0, r = 0)
+        val nodeB = seedNode(regionId, q = 1, r = 0)
+        val nodeUnqueried = seedNode(regionId, q = 2, r = 0)
+
+        val activeOnA1 = AgentId(UUID.randomUUID())
+        val activeOnA2 = AgentId(UUID.randomUUID())
+        val activeOnB = AgentId(UUID.randomUUID())
+        val inactiveOnA = AgentId(UUID.randomUUID())
+        val activeButNotQueried = AgentId(UUID.randomUUID())
+
+        insertPosition(activeOnA1, nodeA, worldId, active = true)
+        insertPosition(activeOnA2, nodeA, worldId, active = true)
+        insertPosition(activeOnB, nodeB, worldId, active = true)
+        insertPosition(inactiveOnA, nodeA, worldId, active = false)
+        insertPosition(activeButNotQueried, nodeUnqueried, worldId, active = true)
+
+        val grouped = gateway.activeAgentsAtNodes(setOf(NodeId(nodeA), NodeId(nodeB)))
+
+        assertEquals(setOf(activeOnA1, activeOnA2), grouped[NodeId(nodeA)]?.toSet())
+        assertEquals(listOf(activeOnB), grouped[NodeId(nodeB)])
+        assertTrue(grouped.values.flatten().none { it == inactiveOnA }, "inactive row must be filtered")
+        assertTrue(grouped.values.flatten().none { it == activeButNotQueried }, "node not in query must be absent")
+    }
+
+    @Test
+    fun `activeAgentsAtNodes returns an empty map for empty input without touching the DB`() {
+        assertEquals(emptyMap(), gateway.activeAgentsAtNodes(emptySet()))
+    }
+
+    @Test
+    fun `activeAgentsAtNodes omits nodes with no active occupants`() {
+        val worldId = seedWorld()
+        val regionId = seedRegion(worldId, sphereIndex = 0)
+        val populated = seedNode(regionId, q = 0, r = 0)
+        val empty = seedNode(regionId, q = 1, r = 0)
+
+        val agent = AgentId(UUID.randomUUID())
+        insertPosition(agent, populated, worldId, active = true)
+
+        val grouped = gateway.activeAgentsAtNodes(setOf(NodeId(populated), NodeId(empty)))
+
+        assertEquals(listOf(agent), grouped[NodeId(populated)])
+        assertTrue(NodeId(empty) !in grouped, "empty node must not appear in the result map")
+    }
+
+    private fun seedWorld(): Long = dsl.insertInto(WORLDS)
+        .set(WORLDS.NAME, "world-${UUID.randomUUID()}")
+        .set(WORLDS.NODE_COUNT, 1)
+        .set(WORLDS.NODE_SIZE, 1)
+        .set(WORLDS.FREQUENCY, 1)
+        .returningResult(WORLDS.ID)
+        .fetchOne()!!.value1()!!
+
+    private fun seedRegion(worldId: Long, sphereIndex: Int): Long = dsl.insertInto(REGIONS)
+        .set(REGIONS.WORLD_ID, worldId)
+        .set(REGIONS.SPHERE_INDEX, sphereIndex)
+        .set(REGIONS.BIOME, "PLAINS")
+        .set(REGIONS.CLIMATE, "OCEANIC")
+        .set(REGIONS.CENTROID_X, 0.0)
+        .set(REGIONS.CENTROID_Y, 0.0)
+        .set(REGIONS.CENTROID_Z, 1.0)
+        .set(REGIONS.FACE_VERTICES, JSON.valueOf("[]"))
+        .returningResult(REGIONS.ID)
+        .fetchOne()!!.value1()!!
+
+    private fun seedNode(regionId: Long, q: Int, r: Int): Long = dsl.insertInto(NODES)
+        .set(NODES.REGION_ID, regionId)
+        .set(NODES.Q, q)
+        .set(NODES.R, r)
+        .set(NODES.TERRAIN, "PLAINS")
+        .returningResult(NODES.ID)
+        .fetchOne()!!.value1()!!
+
+    private fun insertPosition(agent: AgentId, nodeId: Long, worldId: Long, active: Boolean) {
+        dsl.insertInto(AGENT_POSITIONS)
+            .set(AGENT_POSITIONS.AGENT_ID, agent.id)
+            .set(AGENT_POSITIONS.NODE_ID, nodeId)
+            .set(AGENT_POSITIONS.WORLD_ID, worldId)
+            .set(AGENT_POSITIONS.ACTIVE, active)
+            .execute()
+    }
+
+    private class NoOpStarterNodes : StarterNodeLookup {
+        override fun byRace(race: RaceId): NodeId? = null
+    }
+
+    private object EmptyResourceStore : dev.gvart.genesara.world.internal.resources.NodeResourceStore {
+        override fun read(nodeId: NodeId, tick: Long) = dev.gvart.genesara.world.NodeResources.EMPTY
+        override fun availability(nodeId: NodeId, item: dev.gvart.genesara.world.ItemId, tick: Long) = null
+        override fun decrement(nodeId: NodeId, item: dev.gvart.genesara.world.ItemId, amount: Int, tick: Long) {}
+        override fun seed(rows: Collection<dev.gvart.genesara.world.internal.resources.InitialResourceRow>, tick: Long) {}
+    }
+
+    private object AlwaysTraversableBalance : dev.gvart.genesara.world.internal.balance.BalanceLookup {
+        override fun moveStaminaCost(
+            biome: dev.gvart.genesara.world.Biome,
+            climate: dev.gvart.genesara.world.Climate,
+            terrain: dev.gvart.genesara.world.Terrain,
+        ): Int = 1
+        override fun staminaRegenPerTick(climate: dev.gvart.genesara.world.Climate): Int = 0
+        override fun resourceSpawnsFor(terrain: dev.gvart.genesara.world.Terrain): List<dev.gvart.genesara.world.ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: dev.gvart.genesara.world.ItemId): Int = 5
+        override fun harvestYield(item: dev.gvart.genesara.world.ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: dev.gvart.genesara.world.Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: dev.gvart.genesara.world.Terrain): Boolean = true
+    }
+}


### PR DESCRIPTION
## Summary
- Add `agents: [{id, name, race, level, hpBand}]` to `look_around.currentNode` so an agent can discover the UUIDs of other agents sharing its node — `attack(targetAgentId=…)` was previously unreachable from inside the engine.
- New batched gateway method `WorldQueryGateway.activeAgentsAtNodes(Set<NodeId>) → Map<NodeId, List<AgentId>>` reads from `agent_positions` where `active = true`. One round-trip; empty input fast-path.
- Self is excluded from the projection; raw HP is never exposed (`hpBand` only, via the existing `vitalBand` projection).

Out of scope (follow-up):
- `adjacent[i].agents` (ranged scouting) — separate fog-of-war problem.
- Pose / equipped weapon hints, aggression / threat projection.

Closes #122

## Test plan
- [x] `./gradlew :api:test :world:test` — green
- [x] Unit (`LookAroundToolTest`): co-located agents listed (sorted by id), self excluded, `hpBand` is the band string from `vitalBand`, partial rows skipped when `Agent` or `bodyOf` is null, adjacent nodes never carry agent presence.
- [x] Integration (`WorldStateQueryGatewayActiveAgentsAtNodesIntegrationTest`, Testcontainers): grouping by node, `active = false` filtered, empty input returns empty map without touching the DB.