### PR TITLE
docs: pin equipment-definition design decisions for #147

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,29 @@
+# Genesara Engine — Domain Context
+
+A glossary of domain terms whose meaning a future contributor (or an AI agent reading the code) cannot derive from the code alone. Code-level structure is documented in `docs/architecture.md`; lore-canon is in `docs/lore/mechanics-reference.md`. This file is the **short, semantic** index — what each term means in this engine, not how it's wired.
+
+## Equipment, slots, bonuses
+
+- **Equipment slot** — one of the 12 canonical body-positioned slots (`HELMET`, `CHEST`, `PANTS`, `BOOTS`, `GLOVES`, `MAIN_HAND`, `OFF_HAND`, `RING_LEFT`, `RING_RIGHT`, `BRACELET_LEFT`, `BRACELET_RIGHT`, `AMULET`). Two-handed weapons occupy MAIN_HAND and block OFF_HAND.
+- **`valid-slots`** — declared per equipment item, the set of slots the item may occupy. A ring lists both `RING_LEFT` and `RING_RIGHT`; the equip reducer picks the empty one.
+- **Equipment instance** — a per-agent row tracking a specific crafted/looted piece. Distinct from the catalog `Item`: instance carries the rolled rarity, current durability, creator signature.
+- **`bonuses:` field** — single heterogeneous list on equipment items. Each entry is `{ target: <enum>, magnitude: Int }` where `target` is one of `DamageType` (→ armor defense), `Attribute` (→ attribute bonus), or `ScalingEffect` (→ passive buff). Dispatched into typed sealed-class variants at YAML bind time. See [ADR-0001](docs/adr/0001-equipment-bonus-unified-list.md).
+- **Armor defense** — `(SLASH_DEFENSE | PIERCE_DEFENSE | BLUNT_DEFENSE | ENERGY_DEFENSE | MAGICAL_DEFENSE)`, the right-hand term in the combat formula `(attackerStat × weaponPow) - (targetStat × armorDef) × typeModifier`. Targets the wearer's defense stat.
+- **Attribute bonus** — `+N` to one of `STRENGTH/DEXTERITY/CONSTITUTION/PERCEPTION/INTELLIGENCE/LUCK`. Feeds *effective* attributes used by derived-pool calculations (max HP from CON, etc.). Does **not** feed `required-attributes` equip checks — those always read **base** attributes to prevent recursive bootstrap.
+- **Passive buff** — magnitude added to an existing `ScalingEffect` target (`STAMINA_REGEN`, `BLOCK_CHANCE`, `MOVEMENT_SPEED`, …). Sums into the same aggregator that perk passive auras feed.
+- **`required-attributes`** — per-item minimum base attribute thresholds. The `equip_item` reducer rejects with `AttributeRequirementUnmet` on shortfall. An agent who *drops* below a requirement (de-leveling on death) keeps the item equipped — gear is never auto-unequipped on stat changes.
+- **Block roll** — defensive roll layered between dodge and hit. Triggers when the agent has aggregated `BLOCK_CHANCE > 0`. On success, damage is reduced by `blockMitigationPct` (in `BalanceLookup`). Mirrors the existing dodge roll structure.
+
+## Sets
+
+- **Equipment set** — a named group of equipment items (e.g. `IRON`) that grants threshold bonuses when the agent has 2 / 4 / 6 / … pieces equipped. Membership lives in `equipment-sets.yaml`; items themselves carry no set metadata. See [ADR-0002](docs/adr/0002-equipment-set-bonuses.md).
+- **Set threshold** — count of equipped pieces from a set that unlocks a tier of bonuses. Each threshold grants stat bonuses (same `{target, magnitude}` shape as item bonuses) and may grant triggered passives.
+- **Average-rarity scaling** — set bonus magnitudes scale by the mean ordinal rarity of the agent's equipped pieces from that set, mapped through a `rarityMultiplier` curve in `BalanceLookup`. So a 4-piece IRON set with 3 RARE + 1 COMMON pieces averages to ordinal 1.5 → UNCOMMON multiplier 1.25×.
+- **Set-only active abilities** — deferred to a follow-up. v1 set thresholds can grant stat bonuses + triggered passives only.
+
+## Recipes (#146-related)
+
+- **Recipe unlock mode** — `Open | ClassPerk(perkId) | ItemLearned(itemId)`. Open recipes are universally visible (subject to skill-level gate); ClassPerk and ItemLearned recipes require a row in `agent_known_recipes` for the agent.
+- **`agent_known_recipes` ledger** — per-agent persistent record of recipes unlocked through gameplay (perk pick or scroll consume). Never rolls back on de-level or perk-loss. Idempotent inserts via `onConflictDoNothing`.
+- **`RecipeLearned` event** — `AgentEvent.RecipeLearned`, emitted only on a genuinely-new ledger row write. Routed by `AgentEventDispatcher` to the `recipe.learned` topic on the agent's event stream.
+- **`UnknownRecipe` collapse** — when an agent tries to craft a locked recipe they haven't unlocked, the craft reducer raises `WorldRejection.UnknownRecipe` rather than a distinct `RecipeNotLearned`. Preserves information asymmetry (design principle #7) — agents can't probe the locked-recipe namespace.

--- a/docs/adr/0001-equipment-bonus-unified-list.md
+++ b/docs/adr/0001-equipment-bonus-unified-list.md
@@ -1,0 +1,54 @@
+# ADR 0001: Equipment bonuses are a single heterogeneous list
+
+**Status:** Accepted — 2026-05-12
+
+## Context
+
+Issue #147 enriches `Item` with first-class equipment metadata (armor defense, attribute bonuses, passive buffs, set bonuses). The combat formula `(attackerStat × weaponPow) - (targetStat × armorDef) × typeModifier` already assumes a `targetStat × armorDef` term on the defender side, but no field on `Item` carries `armorDef` today. Armor pieces currently exist as catalog entries with `category: EQUIPMENT` but no defensive value — they're inert in combat.
+
+Three distinct bonus kinds need a home on equipment:
+
+1. **Defensive value per damage type** — `(SLASH_DEFENSE, magnitude)`, fed into the combat formula.
+2. **Attribute bonuses** — `(CONSTITUTION, +5)`, modifying derived pools (max HP, max stamina, etc.) but **not** input to `required-attributes` equip checks (otherwise gear is recursively bootstrap-able).
+3. **Passive buffs** — re-uses existing `ScalingEffect` targets (STAMINA_REGEN, BLOCK_CHANCE, MOVEMENT_SPEED, …).
+
+## Decision
+
+A single optional `bonuses:` field on each equipment item carrying a heterogeneous list of `{ target, magnitude }` entries. The binder dispatches on `target` enum membership:
+
+- `target ∈ DamageType` → `EquippedBonus.ArmorDef(damageType, magnitude)`
+- `target ∈ Attribute` → `EquippedBonus.AttributeBonus(attribute, magnitude)`
+- `target ∈ ScalingEffect` → `EquippedBonus.PassiveBuff(effect, magnitude)`
+
+Validator rejects unknown targets at app boot.
+
+```yaml
+IRON_CHEST_PLATE:
+  category: EQUIPMENT
+  valid-slots: [CHEST]
+  max-durability: 200
+  required-attributes:
+    strength: 20    # checked against BASE attributes only
+  bonuses:
+    - { target: SLASH_DEFENSE,   magnitude: 8 }
+    - { target: PIERCE_DEFENSE,  magnitude: 6 }
+    - { target: CONSTITUTION,    magnitude: 5 }
+    - { target: STAMINA_REGEN,   magnitude: 2 }
+```
+
+At runtime, an `EquipmentBonusAggregator` walks equipped instances and produces three bucketed views (`ArmorDefByDamageType`, `AttributeBonuses`, `PassiveBuffs`) for downstream consumers.
+
+`required-attributes` checks query the agent's **base** attributes only — never the effective (base + equipped) attribute view. Otherwise wearing a +CON ring qualifies the agent for a +CON breastplate, recursively. Effective attributes feed derived-pool calculations (max HP from CON), not gating logic.
+
+## Consequences
+
+- **Pro:** YAML is uniform across all equipment items — authors learn one `bonuses:` syntax, not three section-specific shapes.
+- **Pro:** Kotlin model remains type-safe via the sealed `EquippedBonus`; consumers can `when (bonus)` exhaustively.
+- **Pro:** New bonus kinds (e.g. resistances, on-hit triggers) extend the sealed type without touching unrelated equipment.
+- **Con:** YAML readers can't tell at a glance that `SLASH_DEFENSE` is a defense vs `CONSTITUTION` is an attribute — they must consult the enum lists. Mitigated by the validator rejecting unknown targets with a clear error pointing at the offending line.
+- **Con:** Authors could write nonsense like `{ target: SLASH_DEFENSE, magnitude: 8 }` on a weapon. Mitigated by an optional category-aware validator pass (out of scope for the initial slice).
+
+## Alternatives considered
+
+- **Typed sub-sections** (`armor-def:`, `attribute-bonuses:`, `passive-buffs:`). Tighter schema but YAML becomes verbose and authors duplicate magnitude semantics across sections. Rejected.
+- **Defer attribute and buff fields**, ship armor-def only in v1. Rejected: catalog churn is high once items exist; better to land the unified shape once.

--- a/docs/adr/0002-equipment-set-bonuses.md
+++ b/docs/adr/0002-equipment-set-bonuses.md
@@ -1,0 +1,63 @@
+# ADR 0002: Set bonuses — pieces declared in set catalog, average-rarity scaling, triggered passives at threshold
+
+**Status:** Accepted — 2026-05-12
+
+## Context
+
+Set bonuses (full Iron armor → +X) need three shape decisions: (1) how set membership is declared; (2) how per-instance rarity affects the bonus magnitude given mismatched-rarity loadouts; (3) what kinds of behavior a set threshold can grant.
+
+## Decision
+
+### Membership
+
+Set membership lives in a new top-level catalog `world-definition/equipment-sets.yaml`. Items stay agnostic of set systems — no `set-id` field on `Item`.
+
+```yaml
+sets:
+  catalog:
+    IRON:
+      pieces: [IRON_HELMET, IRON_CHEST_PLATE, IRON_PANTS, IRON_BOOTS, IRON_GLOVES]
+      thresholds:
+        2:
+          bonuses: [{ target: SLASH_DEFENSE, magnitude: 2 }]
+        4:
+          bonuses: [{ target: CONSTITUTION, magnitude: 3 }]
+          triggered-passives:
+            - trigger: ON_HIT_TAKEN
+              effect-kind: REFLECT_DAMAGE
+              params: { multiplierPct: "10" }
+              internal-cooldown-ticks: 5
+```
+
+A startup `EquipmentSetReferentialValidator` enforces: every id in `pieces` resolves in `ItemLookup` AND has `category: EQUIPMENT`. An item can appear in multiple sets.
+
+### Rarity scaling
+
+Item rarity is per-instance (`EquipmentInstance.rarity`, rolled at craft). With mismatched-rarity loadouts (3 Legendary IRON + 1 Common IRON), the set magnitude scales by the **average rarity** of the equipped pieces from that set:
+
+```
+multiplier(avgOrdinal) where avgOrdinal = mean(rarity.ordinal across equipped set pieces)
+rarityMultiplier = {COMMON: 1.0, UNCOMMON: 1.25, RARE: 1.5, EPIC: 1.75, LEGENDARY: 2.0}
+```
+
+Average ordinal is rounded to the nearest tier for the multiplier table lookup. Configurable in `BalanceLookup` so the curve is tunable without a code change.
+
+### Threshold behavior shapes
+
+A set threshold can grant **stat bonuses + triggered passives** but **not active abilities** in v1. Triggered passives re-use the existing `TriggeredPassiveDispatcher` plumbing — set membership is treated as another firing source alongside chosen perks.
+
+Active abilities (`use_ability(SET_BONUS_ID)`) are out of scope: they introduce a parallel ability namespace, a new cooldown store, and a validator path to dedupe set-ability ids against perk-ability ids. Deferrable; can land later without breaking this shape.
+
+## Consequences
+
+- **Pro:** Items stay clean of cross-cutting metadata. Adding a new set is a single file change.
+- **Pro:** Mismatched-rarity loadouts feel gradient-y rather than cliff-y — agents are encouraged to upgrade pieces incrementally.
+- **Pro:** No new behavior pipeline — set triggered passives ride the existing `TriggeredPassiveDispatcher`.
+- **Con:** Reverse-index on item → containing sets has to be built at startup (cheap; analogous to `RecipeUnlockIndex` from #146).
+- **Con:** Average-rarity rounding has edge cases (3 Common + 2 Legendary averages to ordinal 1.6 → UNCOMMON, not RARE). Documented; tunable curve absorbs the rough edges.
+
+## Alternatives considered
+
+- **`set-id: IRON` on each item.** Rejected — items end up with set-specific cross-cutting metadata, and an item can't easily belong to multiple sets.
+- **Lowest-rarity scaling.** Rejected — creates a perverse incentive (keep an old Common piece to preserve set bonus tier instead of upgrading to a higher-rarity non-set piece).
+- **Active abilities at set thresholds.** Deferred — adds three new infra pieces (lookup, cooldown store, validator) for limited v1 design value. Can land later as a follow-up without breaking this ADR.


### PR DESCRIPTION
## Summary

- **ADR-0001**: Equipment bonuses are a single heterogeneous \`bonuses:\` list. YAML \`{ target, magnitude }\` entries dispatch on the \`target\` enum into \`EquippedBonus.ArmorDef | AttributeBonus | PassiveBuff\`. \`required-attributes\` always checks against base attributes (never effective) to prevent recursive bootstrap.
- **ADR-0002**: Set bonuses with average-rarity scaling. Pieces declared in \`equipment-sets.yaml\`; items stay agnostic. v1 thresholds grant stat bonuses + triggered passives only — active abilities deferred.
- **CONTEXT.md**: domain glossary entries for equipment slots, bonuses, set thresholds, recipe ledger.

Lands the locked decisions from the grilling session on #147 so the follow-up implementation slice(s) reference a stable spec. Implementation will follow in separate PRs (likely 2-3 slices: core bonuses, set system, catalog migration).

## Test plan

- [x] No code changes — docs-only PR.
- [ ] Reviewers eyeball the ADRs against #147's open questions and the existing \`docs/lore/mechanics-reference.md\`.