### PR TITLE
feat(world): equipment set bonuses with average-rarity scaling (Slice 2 of #147)

### DIFF
--- a/docs/adr/0002-equipment-set-bonuses.md
+++ b/docs/adr/0002-equipment-set-bonuses.md
@@ -31,6 +31,8 @@ sets:
 
 A startup `EquipmentSetReferentialValidator` enforces: every id in `pieces` resolves in `ItemLookup` AND has `category: EQUIPMENT`. An item can appear in multiple sets.
 
+**Threshold stacking.** Tiers stack additively — wearing 4 IRON pieces grants the 2-piece bonus AND the 4-piece bonus (Diablo / WoW convention). Each threshold defines the bonuses *added at that tier*, not the total for that tier.
+
 ### Rarity scaling
 
 Item rarity is per-instance (`EquipmentInstance.rarity`, rolled at craft). With mismatched-rarity loadouts (3 Legendary IRON + 1 Common IRON), the set magnitude scales by the **average rarity** of the equipped pieces from that set:

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSet.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSet.kt
@@ -1,0 +1,51 @@
+package dev.gvart.genesara.world
+
+@JvmInline
+value class EquipmentSetId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "EquipmentSetId must not be blank" }
+    }
+
+    override fun toString(): String = value
+}
+
+/**
+ * A named group of equipment items granting threshold bonuses when an agent
+ * has N pieces equipped. Pieces are declared in [pieces]; items stay
+ * agnostic of which sets they belong to (an item can appear in multiple
+ * sets). See ADR-0002.
+ */
+data class EquipmentSet(
+    val id: EquipmentSetId,
+    val pieces: Set<ItemId>,
+    /** Tier count (must be ≥1) → bonuses granted while the agent has that many pieces equipped. */
+    val thresholds: Map<Int, EquipmentSetThreshold>,
+) {
+    init {
+        require(pieces.isNotEmpty()) { "$id: pieces must not be empty" }
+        require(thresholds.isNotEmpty()) { "$id: thresholds must not be empty" }
+        thresholds.keys.forEach { tier ->
+            require(tier in 1..pieces.size) {
+                "$id: threshold tier $tier must be in 1..${pieces.size} (pieces in set)"
+            }
+        }
+    }
+
+    /**
+     * Bonuses granted by every threshold whose tier ≤ [equippedCount]. Tiers
+     * stack additively — wearing 4 IRON pieces grants the 2-piece bonus AND
+     * the 4-piece bonus (matches the WoW/Diablo convention).
+     */
+    fun activeBonuses(equippedCount: Int): List<EquippedBonus> =
+        thresholds.entries
+            .filter { (tier, _) -> tier <= equippedCount }
+            .flatMap { it.value.bonuses }
+}
+
+data class EquipmentSetThreshold(
+    val bonuses: List<EquippedBonus>,
+) {
+    init {
+        require(bonuses.isNotEmpty()) { "EquipmentSetThreshold.bonuses must not be empty" }
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSetLookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSetLookup.kt
@@ -1,0 +1,16 @@
+package dev.gvart.genesara.world
+
+/** Catalog-level read surface for the [EquipmentSet] registry (ADR-0002). */
+interface EquipmentSetLookup {
+
+    fun byId(id: EquipmentSetId): EquipmentSet?
+
+    fun all(): List<EquipmentSet>
+
+    /**
+     * Sets that contain [itemId] in their `pieces` list. Used by the bonus
+     * aggregator to discover which sets an agent's equipped item contributes
+     * to without walking every catalog entry per call.
+     */
+    fun setsContaining(itemId: ItemId): List<EquipmentSet>
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/EquippedBonusBinder.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/EquippedBonusBinder.kt
@@ -1,0 +1,20 @@
+package dev.gvart.genesara.world.internal.balance
+
+import dev.gvart.genesara.player.Attribute
+import dev.gvart.genesara.player.ScalingEffect
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.EquippedBonus
+
+/**
+ * Dispatches a YAML `{ target, magnitude }` bonus entry into the typed
+ * [EquippedBonus] variant by checking [target] against three enum lists.
+ * Throws on unknown targets — the calling context names the source
+ * ([sourceId]: item id, set id, etc.) for the error message.
+ */
+internal fun EquippedBonusProperties.bindToDomain(sourceId: String): EquippedBonus {
+    val raw = target
+    DamageType.entries.firstOrNull { it.name == raw }?.let { return EquippedBonus.ArmorDef(it, magnitude) }
+    Attribute.entries.firstOrNull { it.name == raw }?.let { return EquippedBonus.AttributeBonus(it, magnitude) }
+    ScalingEffect.entries.firstOrNull { it.name == raw }?.let { return EquippedBonus.PassiveBuff(it, magnitude) }
+    error("$sourceId: unknown bonus target '$raw' (expected one of DamageType, Attribute, or ScalingEffect)")
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemLookupImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemLookupImpl.kt
@@ -1,11 +1,7 @@
 package dev.gvart.genesara.world.internal.balance
 
-import dev.gvart.genesara.player.Attribute
-import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.world.ConsumableEffect
-import dev.gvart.genesara.world.DamageType
-import dev.gvart.genesara.world.EquippedBonus
 import dev.gvart.genesara.world.Item
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.ItemLookup
@@ -50,14 +46,6 @@ internal class ItemLookupImpl(
         weaponPower = weaponPower,
         combatSkill = combatSkill?.let(::SkillId),
         range = range,
-        bonuses = bonuses.map { it.toDomain(id) },
+        bonuses = bonuses.map { it.bindToDomain(id.value) },
     )
-
-    private fun EquippedBonusProperties.toDomain(itemId: ItemId): EquippedBonus {
-        val raw = target
-        DamageType.entries.firstOrNull { it.name == raw }?.let { return EquippedBonus.ArmorDef(it, magnitude) }
-        Attribute.entries.firstOrNull { it.name == raw }?.let { return EquippedBonus.AttributeBonus(it, magnitude) }
-        ScalingEffect.entries.firstOrNull { it.name == raw }?.let { return EquippedBonus.PassiveBuff(it, magnitude) }
-        error("${itemId.value}: unknown bonus target '$raw' (expected one of DamageType, Attribute, or ScalingEffect)")
-    }
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -7,6 +7,7 @@ import dev.gvart.genesara.world.Climate
 import dev.gvart.genesara.world.DamageType
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.Rarity
 import dev.gvart.genesara.world.ResourceSpawnRule
 import dev.gvart.genesara.world.Terrain
 import org.springframework.stereotype.Component
@@ -188,6 +189,20 @@ internal interface BalanceLookup {
     fun combatStatFor(skill: SkillId): Attribute = when (skill.value) {
         "BOW" -> Attribute.DEXTERITY
         else -> Attribute.STRENGTH
+    }
+
+    /**
+     * Magnitude scaler for equipment-set bonuses, keyed by the average rarity
+     * ordinal of the equipped set pieces (rounded to the nearest tier). Curve
+     * is `{COMMON: 1.0, UNCOMMON: 1.25, RARE: 1.5, EPIC: 1.75, LEGENDARY: 2.0}`
+     * per ADR-0002. Tunable from one place.
+     */
+    fun rarityMultiplier(avgRarity: Rarity): Double = when (avgRarity) {
+        Rarity.COMMON -> 1.0
+        Rarity.UNCOMMON -> 1.25
+        Rarity.RARE -> 1.5
+        Rarity.EPIC -> 1.75
+        Rarity.LEGENDARY -> 2.0
     }
 
     /** XP delta granted to the weapon's combat-skill per successful attack. Mirrors craft/build at 1. */

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImpl.kt
@@ -5,36 +5,92 @@ import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.world.DamageType
 import dev.gvart.genesara.world.EquipmentBonusAggregator
+import dev.gvart.genesara.world.EquipmentInstance
 import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.EquipmentSet
+import dev.gvart.genesara.world.EquipmentSetLookup
 import dev.gvart.genesara.world.EquippedBonus
+import dev.gvart.genesara.world.EquipSlot
 import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.Rarity
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import org.springframework.stereotype.Component
+import kotlin.math.roundToInt
 
 @Component
 internal class EquipmentBonusAggregatorImpl(
     private val equipment: EquipmentInstanceStore,
     private val items: ItemLookup,
+    private val sets: EquipmentSetLookup,
+    private val balance: BalanceLookup,
 ) : EquipmentBonusAggregator {
 
     override fun armorDef(agent: AgentId, damageType: DamageType): Int =
-        sum(agent) { it is EquippedBonus.ArmorDef && it.damageType == damageType }
+        total(agent) { it is EquippedBonus.ArmorDef && it.damageType == damageType }
 
     override fun attributeBonus(agent: AgentId, attribute: Attribute): Int =
-        sum(agent) { it is EquippedBonus.AttributeBonus && it.attribute == attribute }
+        total(agent) { it is EquippedBonus.AttributeBonus && it.attribute == attribute }
 
     override fun passiveBuff(agent: AgentId, effect: ScalingEffect): Int =
-        sum(agent) { it is EquippedBonus.PassiveBuff && it.effect == effect }
+        total(agent) { it is EquippedBonus.PassiveBuff && it.effect == effect }
 
-    private inline fun sum(agent: AgentId, match: (EquippedBonus) -> Boolean): Int {
+    private inline fun total(agent: AgentId, match: (EquippedBonus) -> Boolean): Int {
         val equipped = equipment.equippedFor(agent)
         if (equipped.isEmpty()) return 0
+        return perPieceSum(equipped, match) + setBonusSum(equipped, match)
+    }
+
+    private inline fun perPieceSum(
+        equipped: Map<EquipSlot, EquipmentInstance>,
+        match: (EquippedBonus) -> Boolean,
+    ): Int {
         var acc = 0
         for ((_, instance) in equipped) {
             val item = items.byId(instance.itemId) ?: continue
-            for (bonus in item.bonuses) {
-                if (match(bonus)) acc += bonus.magnitude
+            for (bonus in item.bonuses) if (match(bonus)) acc += bonus.magnitude
+        }
+        return acc
+    }
+
+    private inline fun setBonusSum(
+        equipped: Map<EquipSlot, EquipmentInstance>,
+        match: (EquippedBonus) -> Boolean,
+    ): Int {
+        // Walk instances once, grouping by set membership. An item can belong
+        // to multiple sets (ADR-0002), so a single instance may push multiple
+        // counts and rarity contributions.
+        val contributions = mutableMapOf<EquipmentSet, MutableList<Rarity>>()
+        for ((_, instance) in equipped) {
+            for (set in sets.setsContaining(instance.itemId)) {
+                contributions.getOrPut(set) { mutableListOf() }.add(instance.rarity)
+            }
+        }
+        if (contributions.isEmpty()) return 0
+        var acc = 0
+        for ((set, rarities) in contributions) {
+            val activeBonuses = set.activeBonuses(rarities.size)
+            if (activeBonuses.isEmpty()) continue
+            val avgRarity = averageRarity(rarities)
+            val multiplier = balance.rarityMultiplier(avgRarity)
+            for (bonus in activeBonuses) {
+                if (match(bonus)) {
+                    acc += (bonus.magnitude * multiplier).roundToInt()
+                }
             }
         }
         return acc
+    }
+
+    /**
+     * Average ordinal across [rarities], rounded **half-up** (Kotlin
+     * `Double.roundToInt` is half-away-from-zero; all ordinals are
+     * non-negative so it collapses to half-up here). Mean 2.5 rounds to
+     * 3 (EPIC), not 2 (RARE). Mixed loadouts smooth through the rarity
+     * multiplier curve in [BalanceLookup] — see ADR-0002.
+     */
+    private fun averageRarity(rarities: List<Rarity>): Rarity {
+        val mean = rarities.sumOf { it.ordinal }.toDouble() / rarities.size
+        val rounded = mean.roundToInt().coerceIn(0, Rarity.entries.lastIndex)
+        return Rarity.entries[rounded]
     }
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetConfiguration.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetConfiguration.kt
@@ -1,0 +1,14 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.world.internal.balance.YamlPropertySourceFactory
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.PropertySource
+
+@Configuration
+@PropertySource(
+    value = ["classpath:world-definition/equipment-sets.yaml"],
+    factory = YamlPropertySourceFactory::class,
+)
+@EnableConfigurationProperties(EquipmentSetDefinitionProperties::class)
+internal class EquipmentSetConfiguration

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetDefinitionProperties.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetDefinitionProperties.kt
@@ -1,0 +1,8 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "sets")
+internal data class EquipmentSetDefinitionProperties(
+    val catalog: Map<String, EquipmentSetProperties> = emptyMap(),
+)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetLookupImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetLookupImpl.kt
@@ -1,0 +1,40 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.world.EquipmentSet
+import dev.gvart.genesara.world.EquipmentSetId
+import dev.gvart.genesara.world.EquipmentSetLookup
+import dev.gvart.genesara.world.EquipmentSetThreshold
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.internal.balance.bindToDomain
+import org.springframework.stereotype.Component
+
+@Component
+internal class EquipmentSetLookupImpl(
+    props: EquipmentSetDefinitionProperties,
+) : EquipmentSetLookup {
+
+    private val byId: Map<EquipmentSetId, EquipmentSet> = props.catalog.entries.associate { (key, properties) ->
+        val id = EquipmentSetId(key)
+        id to properties.toDomain(id)
+    }
+
+    private val byItem: Map<ItemId, List<EquipmentSet>> = byId.values
+        .flatMap { set -> set.pieces.map { it to set } }
+        .groupBy({ it.first }, { it.second })
+
+    override fun byId(id: EquipmentSetId): EquipmentSet? = byId[id]
+
+    override fun all(): List<EquipmentSet> = byId.values.toList()
+
+    override fun setsContaining(itemId: ItemId): List<EquipmentSet> = byItem[itemId].orEmpty()
+
+    private fun EquipmentSetProperties.toDomain(id: EquipmentSetId): EquipmentSet = EquipmentSet(
+        id = id,
+        pieces = pieces.map(::ItemId).toSet(),
+        thresholds = thresholds.mapValues { (tier, threshold) ->
+            EquipmentSetThreshold(
+                bonuses = threshold.bonuses.map { it.bindToDomain("${id.value}@$tier") },
+            )
+        },
+    )
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetProperties.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetProperties.kt
@@ -1,0 +1,11 @@
+package dev.gvart.genesara.world.internal.equipment
+
+internal data class EquipmentSetProperties(
+    val pieces: List<String>,
+    /** Map<tierCount, threshold> — tier 2/4/6/etc → bonuses added at that tier. */
+    val thresholds: Map<Int, EquipmentSetThresholdProperties>,
+)
+
+internal data class EquipmentSetThresholdProperties(
+    val bonuses: List<dev.gvart.genesara.world.internal.balance.EquippedBonusProperties> = emptyList(),
+)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetReferentialValidator.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetReferentialValidator.kt
@@ -1,0 +1,40 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.world.EquipmentSetLookup
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemLookup
+import jakarta.annotation.PostConstruct
+import org.springframework.stereotype.Component
+
+/**
+ * Boot-time check that every set piece resolves in [ItemLookup] AND has
+ * `category: EQUIPMENT`. Set bonuses only make sense on items that can be
+ * equipped — a typo or accidental RESOURCE inclusion silently dies otherwise.
+ */
+@Component
+internal class EquipmentSetReferentialValidator(
+    private val sets: EquipmentSetLookup,
+    private val items: ItemLookup,
+) {
+
+    @PostConstruct
+    fun validate() {
+        val problems = mutableListOf<String>()
+        for (set in sets.all()) {
+            for (piece in set.pieces) {
+                val item = items.byId(piece)
+                if (item == null) {
+                    problems += "${set.id}: piece '${piece.value}' is not in the items catalog"
+                } else if (item.category != ItemCategory.EQUIPMENT) {
+                    problems += "${set.id}: piece '${piece.value}' is ${item.category} — must be EQUIPMENT"
+                }
+            }
+        }
+        require(problems.isEmpty()) {
+            buildString {
+                append("Equipment-set referential validation failed:\n")
+                problems.forEach { append("  - $it\n") }
+            }
+        }
+    }
+}

--- a/world/src/main/resources/world-definition/equipment-sets.yaml
+++ b/world/src/main/resources/world-definition/equipment-sets.yaml
@@ -1,0 +1,12 @@
+# Equipment set bonuses. Pieces declared per-set; items themselves stay agnostic
+# of which sets they belong to (an item can appear in multiple sets). Threshold
+# tiers stack additively — wearing 4 IRON pieces grants 2-piece AND 4-piece bonuses.
+#
+# Magnitudes scale by average rarity of equipped set pieces via the rarityMultiplier
+# curve in BalanceLookup. See ADR-0002.
+#
+# Slice 2 ships the infrastructure with an empty catalog; Slice 3 populates the
+# first IRON set after equipment items grow their `bonuses:` blocks.
+
+sets:
+  catalog: {}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImplTest.kt
@@ -86,13 +86,121 @@ class EquipmentBonusAggregatorImplTest {
     }
 
     @Test
+    fun `set bonus stacks on top of per-piece bonus when threshold is met`() {
+        val helmet = itemWithBonuses("IRON_HELMET", EquipSlot.HELMET, listOf(
+            EquippedBonus.ArmorDef(DamageType.SLASH, 2),
+        ))
+        val chest = itemWithBonuses("IRON_CHEST", EquipSlot.CHEST, listOf(
+            EquippedBonus.ArmorDef(DamageType.SLASH, 3),
+        ))
+        val ironSet = dev.gvart.genesara.world.EquipmentSet(
+            id = dev.gvart.genesara.world.EquipmentSetId("IRON"),
+            pieces = setOf(helmet.id, chest.id),
+            thresholds = mapOf(
+                2 to dev.gvart.genesara.world.EquipmentSetThreshold(
+                    bonuses = listOf(EquippedBonus.ArmorDef(DamageType.SLASH, 4)),
+                ),
+            ),
+        )
+        val store = InMemoryStore(mapOf(agent to mapOf(
+            EquipSlot.HELMET to instanceOf(helmet),
+            EquipSlot.CHEST to instanceOf(chest),
+        )))
+        val items = StubItems(listOf(helmet, chest))
+        val sets = SingleSetLookup(ironSet)
+        val aggregator = EquipmentBonusAggregatorImpl(store, items, sets, NoOpBalance)
+
+        // per-piece SLASH = 2 + 3 = 5; set 2-piece SLASH = 4 × 1.0 (COMMON avg) = 4; total = 9.
+        assertEquals(9, aggregator.armorDef(agent, DamageType.SLASH))
+    }
+
+    @Test
+    fun `set bonus tiers stack additively when count crosses multiple thresholds`() {
+        val pieceIds = (1..4).map { ItemId("IRON_$it") }
+        val pieces = pieceIds.map { id ->
+            Item(
+                id = id, displayName = id.value, description = "",
+                category = ItemCategory.EQUIPMENT, weightPerUnit = 0, maxStack = 1,
+                validSlots = setOf(EquipSlot.CHEST), maxDurability = 100,
+            )
+        }
+        val ironSet = dev.gvart.genesara.world.EquipmentSet(
+            id = dev.gvart.genesara.world.EquipmentSetId("IRON"),
+            pieces = pieceIds.toSet(),
+            thresholds = mapOf(
+                2 to dev.gvart.genesara.world.EquipmentSetThreshold(
+                    bonuses = listOf(EquippedBonus.AttributeBonus(Attribute.CONSTITUTION, 1)),
+                ),
+                4 to dev.gvart.genesara.world.EquipmentSetThreshold(
+                    bonuses = listOf(EquippedBonus.AttributeBonus(Attribute.CONSTITUTION, 3)),
+                ),
+            ),
+        )
+        // Equipping all 4 pieces — but only one slot can hold each; for the aggregator test
+        // we just need any 4 instances in any slots since the aggregator counts membership, not slot.
+        val instances = listOf(EquipSlot.HELMET, EquipSlot.CHEST, EquipSlot.PANTS, EquipSlot.BOOTS)
+            .zip(pieces).associate { (slot, item) -> slot to instanceOf(item) }
+        val store = InMemoryStore(mapOf(agent to instances))
+        val items = StubItems(pieces)
+        val aggregator = EquipmentBonusAggregatorImpl(store, items, SingleSetLookup(ironSet), NoOpBalance)
+
+        // 4 pieces equipped → 2-piece tier (+1) + 4-piece tier (+3) = +4 CON.
+        assertEquals(4, aggregator.attributeBonus(agent, Attribute.CONSTITUTION))
+    }
+
+    @Test
+    fun `set bonus uses average-rarity multiplier from BalanceLookup`() {
+        val helmet = itemWithBonuses("IRON_HELMET", EquipSlot.HELMET, emptyList())
+        val chest = itemWithBonuses("IRON_CHEST", EquipSlot.CHEST, emptyList())
+        val ironSet = dev.gvart.genesara.world.EquipmentSet(
+            id = dev.gvart.genesara.world.EquipmentSetId("IRON"),
+            pieces = setOf(helmet.id, chest.id),
+            thresholds = mapOf(
+                2 to dev.gvart.genesara.world.EquipmentSetThreshold(
+                    bonuses = listOf(EquippedBonus.ArmorDef(DamageType.SLASH, 10)),
+                ),
+            ),
+        )
+        // Two pieces with rarities RARE (ordinal 2) and EPIC (ordinal 3) — mean 2.5 → rounds
+        // to 3 (EPIC). Multiplier per default curve: 1.75. Expected armorDef = 10 × 1.75 = 17.5 → 18.
+        val rareHelmet = instanceOf(helmet).copy(rarity = Rarity.RARE)
+        val epicChest = instanceOf(chest).copy(rarity = Rarity.EPIC)
+        val store = InMemoryStore(mapOf(agent to mapOf(
+            EquipSlot.HELMET to rareHelmet,
+            EquipSlot.CHEST to epicChest,
+        )))
+        val items = StubItems(listOf(helmet, chest))
+        val aggregator = EquipmentBonusAggregatorImpl(store, items, SingleSetLookup(ironSet), NoOpBalance)
+
+        assertEquals(18, aggregator.armorDef(agent, DamageType.SLASH))
+    }
+
+    @Test
+    fun `equipping only one piece below the lowest threshold yields no set bonus`() {
+        val helmet = itemWithBonuses("IRON_HELMET", EquipSlot.HELMET, emptyList())
+        val chest = itemWithBonuses("IRON_CHEST", EquipSlot.CHEST, emptyList())
+        val ironSet = dev.gvart.genesara.world.EquipmentSet(
+            id = dev.gvart.genesara.world.EquipmentSetId("IRON"),
+            pieces = setOf(helmet.id, chest.id),
+            thresholds = mapOf(2 to dev.gvart.genesara.world.EquipmentSetThreshold(
+                bonuses = listOf(EquippedBonus.ArmorDef(DamageType.SLASH, 5)),
+            )),
+        )
+        val store = InMemoryStore(mapOf(agent to mapOf(EquipSlot.HELMET to instanceOf(helmet))))
+        val items = StubItems(listOf(helmet, chest))
+        val aggregator = EquipmentBonusAggregatorImpl(store, items, SingleSetLookup(ironSet), NoOpBalance)
+
+        assertEquals(0, aggregator.armorDef(agent, DamageType.SLASH))
+    }
+
+    @Test
     fun `bonuses scoped to the queried agent — other agents' gear is invisible`() {
         val chest = itemWithBonuses("CHEST", EquipSlot.CHEST, listOf(
             EquippedBonus.ArmorDef(DamageType.SLASH, 8),
         ))
         val store = InMemoryStore(mapOf(agent to mapOf(EquipSlot.CHEST to instanceOf(chest))))
         val items = StubItems(listOf(chest))
-        val aggregator = EquipmentBonusAggregatorImpl(store, items)
+        val aggregator = EquipmentBonusAggregatorImpl(store, items, EmptySetLookup, NoOpBalance)
 
         assertEquals(8, aggregator.armorDef(agent, DamageType.SLASH))
         assertEquals(0, aggregator.armorDef(other, DamageType.SLASH))
@@ -120,7 +228,7 @@ class EquipmentBonusAggregatorImplTest {
         val store = InMemoryStore(mapOf(agent to instances))
         // Mystery item NOT in items catalog → aggregator skips its bonuses.
         val items = StubItems(listOf(chest))
-        val aggregator = EquipmentBonusAggregatorImpl(store, items)
+        val aggregator = EquipmentBonusAggregatorImpl(store, items, EmptySetLookup, NoOpBalance)
 
         assertEquals(5, aggregator.armorDef(agent, DamageType.SLASH))
     }
@@ -141,7 +249,7 @@ class EquipmentBonusAggregatorImplTest {
         val instances = equipped.mapValues { (_, item) -> instanceOf(item) }
         val store = InMemoryStore(mapOf(agent to instances))
         val items = StubItems(equipped.values.toList())
-        return EquipmentBonusAggregatorImpl(store, items)
+        return EquipmentBonusAggregatorImpl(store, items, EmptySetLookup, NoOpBalance)
     }
 
     private fun instanceOf(item: Item): EquipmentInstance = EquipmentInstance(
@@ -160,6 +268,38 @@ class EquipmentBonusAggregatorImplTest {
         private val byId = items.associateBy { it.id }
         override fun byId(id: ItemId): Item? = byId[id]
         override fun all(): List<Item> = byId.values.toList()
+    }
+
+    private object EmptySetLookup : dev.gvart.genesara.world.EquipmentSetLookup {
+        override fun byId(id: dev.gvart.genesara.world.EquipmentSetId): dev.gvart.genesara.world.EquipmentSet? = null
+        override fun all(): List<dev.gvart.genesara.world.EquipmentSet> = emptyList()
+        override fun setsContaining(itemId: ItemId): List<dev.gvart.genesara.world.EquipmentSet> = emptyList()
+    }
+
+    private class SingleSetLookup(private val set: dev.gvart.genesara.world.EquipmentSet) : dev.gvart.genesara.world.EquipmentSetLookup {
+        override fun byId(id: dev.gvart.genesara.world.EquipmentSetId): dev.gvart.genesara.world.EquipmentSet? =
+            set.takeIf { it.id == id }
+
+        override fun all(): List<dev.gvart.genesara.world.EquipmentSet> = listOf(set)
+
+        override fun setsContaining(itemId: ItemId): List<dev.gvart.genesara.world.EquipmentSet> =
+            if (itemId in set.pieces) listOf(set) else emptyList()
+    }
+
+    private object NoOpBalance : dev.gvart.genesara.world.internal.balance.BalanceLookup {
+        override fun moveStaminaCost(biome: dev.gvart.genesara.world.Biome, climate: dev.gvart.genesara.world.Climate, terrain: dev.gvart.genesara.world.Terrain): Int = 1
+        override fun staminaRegenPerTick(climate: dev.gvart.genesara.world.Climate): Int = 0
+        override fun resourceSpawnsFor(terrain: dev.gvart.genesara.world.Terrain): List<dev.gvart.genesara.world.ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = 1
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: dev.gvart.genesara.world.Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: dev.gvart.genesara.world.Terrain): Boolean = true
     }
 
     private class InMemoryStore(

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetLookupImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetLookupImplTest.kt
@@ -1,0 +1,78 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.world.EquipmentSetId
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.internal.balance.EquippedBonusProperties
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class EquipmentSetLookupImplTest {
+
+    @Test
+    fun `byId returns the bound set or null`() {
+        val lookup = lookupOf(
+            "IRON" to setProps(
+                pieces = listOf("IRON_HELMET", "IRON_CHEST"),
+                thresholds = mapOf(2 to listOf(EquippedBonusProperties("SLASH", 3))),
+            ),
+        )
+        assertNotNull(lookup.byId(EquipmentSetId("IRON")))
+        assertNull(lookup.byId(EquipmentSetId("PHANTOM")))
+    }
+
+    @Test
+    fun `setsContaining reverse-indexes items to their containing sets`() {
+        val lookup = lookupOf(
+            "IRON" to setProps(
+                pieces = listOf("IRON_HELMET", "IRON_CHEST"),
+                thresholds = mapOf(2 to listOf(EquippedBonusProperties("SLASH", 3))),
+            ),
+            "STEEL" to setProps(
+                pieces = listOf("STEEL_HELMET", "IRON_CHEST"),
+                thresholds = mapOf(2 to listOf(EquippedBonusProperties("PIERCE", 2))),
+            ),
+        )
+        val sharedItem = ItemId("IRON_CHEST")
+        val sets = lookup.setsContaining(sharedItem).map { it.id.value }.toSet()
+        assertEquals(setOf("IRON", "STEEL"), sets)
+    }
+
+    @Test
+    fun `unknown bonus target in a threshold fails at construction time`() {
+        val ex = assertFailsWith<IllegalStateException> {
+            lookupOf(
+                "IRON" to setProps(
+                    pieces = listOf("IRON_HELMET"),
+                    thresholds = mapOf(1 to listOf(EquippedBonusProperties("PHANTOM_TARGET", 1))),
+                ),
+            )
+        }
+        kotlin.test.assertTrue("PHANTOM_TARGET" in ex.message!!)
+    }
+
+    @Test
+    fun `threshold tier above piece count fails the EquipmentSet require`() {
+        // tier 3 on a 2-piece set is invalid per EquipmentSet.init
+        val ex = assertFailsWith<IllegalArgumentException> {
+            lookupOf(
+                "IRON" to setProps(
+                    pieces = listOf("A", "B"),
+                    thresholds = mapOf(3 to listOf(EquippedBonusProperties("SLASH", 1))),
+                ),
+            )
+        }
+        kotlin.test.assertTrue("threshold tier 3" in ex.message!!)
+    }
+
+    private fun setProps(pieces: List<String>, thresholds: Map<Int, List<EquippedBonusProperties>>): EquipmentSetProperties =
+        EquipmentSetProperties(
+            pieces = pieces,
+            thresholds = thresholds.mapValues { (_, bonuses) -> EquipmentSetThresholdProperties(bonuses) },
+        )
+
+    private fun lookupOf(vararg sets: Pair<String, EquipmentSetProperties>): EquipmentSetLookupImpl =
+        EquipmentSetLookupImpl(EquipmentSetDefinitionProperties(catalog = sets.toMap()))
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetReferentialValidatorTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetReferentialValidatorTest.kt
@@ -1,0 +1,90 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentSet
+import dev.gvart.genesara.world.EquipmentSetId
+import dev.gvart.genesara.world.EquipmentSetLookup
+import dev.gvart.genesara.world.EquipmentSetThreshold
+import dev.gvart.genesara.world.EquippedBonus
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class EquipmentSetReferentialValidatorTest {
+
+    @Test
+    fun `passes when every piece is an EQUIPMENT-category item in the catalog`() {
+        val helmet = equipmentItem("IRON_HELMET")
+        val chest = equipmentItem("IRON_CHEST")
+        val validator = EquipmentSetReferentialValidator(
+            sets = StubSets(setOf(setOf(helmet.id, chest.id))),
+            items = StubItems(listOf(helmet, chest)),
+        )
+        validator.validate()
+    }
+
+    @Test
+    fun `fails when a piece is missing from the items catalog`() {
+        val helmet = equipmentItem("IRON_HELMET")
+        val validator = EquipmentSetReferentialValidator(
+            sets = StubSets(setOf(setOf(helmet.id, ItemId("PHANTOM_PIECE")))),
+            items = StubItems(listOf(helmet)),
+        )
+        val ex = assertFailsWith<IllegalArgumentException> { validator.validate() }
+        assertTrue("PHANTOM_PIECE" in ex.message!!)
+    }
+
+    @Test
+    fun `fails when a piece is RESOURCE category instead of EQUIPMENT`() {
+        val helmet = equipmentItem("IRON_HELMET")
+        val woodId = ItemId("WOOD")
+        val wood = Item(
+            id = woodId, displayName = "Wood", description = "",
+            category = ItemCategory.RESOURCE, weightPerUnit = 100, maxStack = 99,
+        )
+        val validator = EquipmentSetReferentialValidator(
+            sets = StubSets(setOf(setOf(helmet.id, woodId))),
+            items = StubItems(listOf(helmet, wood)),
+        )
+        val ex = assertFailsWith<IllegalArgumentException> { validator.validate() }
+        assertTrue("WOOD" in ex.message!! && "RESOURCE" in ex.message!!)
+    }
+
+    private fun equipmentItem(id: String) = Item(
+        id = ItemId(id),
+        displayName = id,
+        description = "",
+        category = ItemCategory.EQUIPMENT,
+        weightPerUnit = 0,
+        maxStack = 1,
+        validSlots = setOf(EquipSlot.HELMET),
+        maxDurability = 100,
+    )
+
+    private class StubItems(items: List<Item>) : ItemLookup {
+        private val byId = items.associateBy { it.id }
+        override fun byId(id: ItemId): Item? = byId[id]
+        override fun all(): List<Item> = byId.values.toList()
+    }
+
+    private class StubSets(private val setsAsPieces: Set<Set<ItemId>>) : EquipmentSetLookup {
+        private val builtSets: List<EquipmentSet> = setsAsPieces.mapIndexed { idx, pieces ->
+            EquipmentSet(
+                id = EquipmentSetId("SET_$idx"),
+                pieces = pieces,
+                thresholds = mapOf(1 to EquipmentSetThreshold(
+                    bonuses = listOf(EquippedBonus.ArmorDef(DamageType.SLASH, 1)),
+                )),
+            )
+        }
+        override fun byId(id: EquipmentSetId): EquipmentSet? = builtSets.firstOrNull { it.id == id }
+        override fun all(): List<EquipmentSet> = builtSets
+        override fun setsContaining(itemId: ItemId): List<EquipmentSet> =
+            builtSets.filter { itemId in it.pieces }
+    }
+}


### PR DESCRIPTION
## Summary

Second slice of three implementing #147 — set bonus pipeline per ADR-0002. **Depends on #150 (Slice 1)** so this PR is targeted at \`feat/equipment-bonuses\`. Re-target to \`main\` after Slice 1 merges.

- \`EquipmentSet\` domain — pieces, tier-keyed thresholds, \`activeBonuses(equippedCount)\` returns bonuses from every tier ≤ count (additive stacking, WoW convention).
- \`EquipmentSetLookup\` with reverse \`item → containing sets\` index built once at startup.
- \`EquipmentSetReferentialValidator\` — fails app boot on missing piece or non-\`EQUIPMENT\` piece.
- \`BalanceLookup.rarityMultiplier(Rarity): Double\` — tunable curve \`{1.0, 1.25, 1.5, 1.75, 2.0}\`.
- \`EquipmentBonusAggregatorImpl\` composes per-piece + set contributions; set magnitudes scale by average rarity of equipped set pieces (rounded half-up).
- \`EquippedBonusBinder.bindToDomain(sourceId)\` extracted; both \`ItemLookupImpl\` and \`EquipmentSetLookupImpl\` share the target-dispatch logic.
- \`equipment-sets.yaml\` ships empty — Slice 3 populates the first IRON set after equipment items grow their \`bonuses:\` blocks.

## What's not in this slice

- **Triggered-passive dispatch at set thresholds** — ADR-0002 mentions this; deferred to a follow-up. Lookup API is additive-compatible with a future triggered-passive lookup.
- **Catalog migration** — Slice 3.
- **Derived-pool wiring for attribute bonuses** — Slice 3.

## Test plan

- [x] \`EquipmentSetLookupImplTest\` — byId / reverse index / unknown target / invalid threshold tier.
- [x] \`EquipmentSetReferentialValidatorTest\` — passes / missing piece / RESOURCE-category piece.
- [x] \`EquipmentBonusAggregatorImplTest\` 4 new cases:
  - \`set bonus stacks on top of per-piece bonus when threshold is met\`
  - \`set bonus tiers stack additively when count crosses multiple thresholds\`
  - \`set bonus uses average-rarity multiplier from BalanceLookup\`
  - \`equipping only one piece below the lowest threshold yields no set bonus\`
- [x] \`./gradlew :world:test\` — all green.

## Review feedback addressed

- Documented half-up rounding behavior in \`averageRarity\`.
- Added \`require(bonuses.isNotEmpty())\` to \`EquipmentSetThreshold\` to catch empty-threshold typos at boot.
- Per-call \`mutableMapOf\` allocation in \`setBonusSum\` flagged as acceptable for now; not pre-optimizing.