### PR TITLE
feat(world): populate sample equipment bonuses + first IRON set (Slice 3 of #147)

### DIFF
--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
@@ -143,12 +143,16 @@ internal fun reduceAttack(
     // Dodge rolls FIRST so a successful dodge short-circuits the crit roll. Otherwise a crit
     // followed by a dodge would burn the RNG cursor on a discarded crit and shift downstream
     // rolls — keeping order matters for reproducible seeds.
-    val dodgeChance = balance.dodgeChancePercent(defender.attributes.dexterity)
+    val dodgeChance = balance.dodgeChancePercent(defender.attributes.dexterity) +
+        equipmentBonuses.passiveBuff(command.target, ScalingEffect.DODGE_CHANCE)
     val isDodged = rng.nextInt(100) < dodgeChance
     val (hpLost, isCrit) = if (isDodged) {
         0 to false
     } else {
-        val critChance = balance.critChancePercent(attacker.attributes.luck)
+        // Equipped CRIT_CHANCE bonuses (e.g. GEM_RING) add percentage points on top
+        // of the LUCK-derived base. Same shape as DODGE_CHANCE on the defender side.
+        val critChance = balance.critChancePercent(attacker.attributes.luck) +
+            equipmentBonuses.passiveBuff(command.agent, ScalingEffect.CRIT_CHANCE)
         val crit = rng.nextInt(100) < critChance
         val landed = if (crit) scaledDamage * balance.critMultiplier() else scaledDamage
         landed to crit

--- a/world/src/main/resources/world-definition/equipment-armor.yaml
+++ b/world/src/main/resources/world-definition/equipment-armor.yaml
@@ -1,3 +1,13 @@
+# Armor catalog. The `bonuses:` list under each item carries wearer-bonuses while
+# the item is equipped. On armor pieces, bonus `target` values that name a damage
+# type (SLASH/PIERCE/BLUNT/ENERGY/MAGICAL) are interpreted as defensive bonuses
+# against that type — the binder dispatches to EquippedBonus.ArmorDef and the
+# combat reducer multiplies armor-def by defender CON to get mitigation per lore §9.
+#
+# Magnitudes are tuned small (single digits per piece) because the combat formula
+# already amplifies them by defender CON. A full iron set + CON 12 should yield
+# meaningful but non-immune mitigation against an iron-tier weapon swing.
+
 items:
   catalog:
 
@@ -14,6 +24,8 @@ items:
       max-durability: 60
       valid-slots: [HELMET]
       two-handed: false
+      bonuses:
+        - { target: SLASH, magnitude: 1 }
 
     LEATHER_TUNIC:
       display-name: Leather Tunic
@@ -27,6 +39,9 @@ items:
       max-durability: 80
       valid-slots: [CHEST]
       two-handed: false
+      bonuses:
+        - { target: SLASH, magnitude: 2 }
+        - { target: PIERCE, magnitude: 1 }
 
     LEATHER_PANTS:
       display-name: Leather Pants
@@ -40,6 +55,9 @@ items:
       max-durability: 70
       valid-slots: [PANTS]
       two-handed: false
+      bonuses:
+        - { target: SLASH, magnitude: 1 }
+        - { target: PIERCE, magnitude: 1 }
 
     LEATHER_BOOTS:
       display-name: Leather Boots
@@ -53,6 +71,8 @@ items:
       max-durability: 60
       valid-slots: [BOOTS]
       two-handed: false
+      bonuses:
+        - { target: BLUNT, magnitude: 1 }
 
     LEATHER_GLOVES:
       display-name: Leather Gloves
@@ -65,6 +85,8 @@ items:
       max-durability: 50
       valid-slots: [GLOVES]
       two-handed: false
+      bonuses:
+        - { target: SLASH, magnitude: 1 }
 
     # ───────────────────── T2 armor: iron (forge) ─────────────────────
 
@@ -82,6 +104,10 @@ items:
       two-handed: false
       required-attributes:
         STRENGTH: 8
+      bonuses:
+        - { target: SLASH, magnitude: 1 }
+        - { target: BLUNT, magnitude: 1 }
+        - { target: CONSTITUTION, magnitude: 1 }
 
     IRON_CHESTPLATE:
       display-name: Iron Chestplate
@@ -97,6 +123,11 @@ items:
       two-handed: false
       required-attributes:
         STRENGTH: 12
+      bonuses:
+        - { target: SLASH, magnitude: 2 }
+        - { target: PIERCE, magnitude: 1 }
+        - { target: BLUNT, magnitude: 1 }
+        - { target: CONSTITUTION, magnitude: 1 }
 
     IRON_GREAVES:
       display-name: Iron Greaves
@@ -112,6 +143,9 @@ items:
       two-handed: false
       required-attributes:
         STRENGTH: 10
+      bonuses:
+        - { target: SLASH, magnitude: 1 }
+        - { target: PIERCE, magnitude: 1 }
 
     IRON_BOOTS:
       display-name: Iron Boots
@@ -127,6 +161,8 @@ items:
       two-handed: false
       required-attributes:
         STRENGTH: 8
+      bonuses:
+        - { target: BLUNT, magnitude: 1 }
 
     IRON_GAUNTLETS:
       display-name: Iron Gauntlets
@@ -142,6 +178,8 @@ items:
       two-handed: false
       required-attributes:
         STRENGTH: 8
+      bonuses:
+        - { target: BLUNT, magnitude: 1 }
 
     # ───────────────────── T2 armor: cloth (workbench, magic-flavored) ─────────────────────
 
@@ -157,6 +195,10 @@ items:
       max-durability: 40
       valid-slots: [HELMET]
       two-handed: false
+      bonuses:
+        - { target: ENERGY, magnitude: 2 }
+        - { target: MAGICAL, magnitude: 2 }
+        - { target: INTELLIGENCE, magnitude: 1 }
 
     CLOTH_ROBE:
       display-name: Cloth Robe
@@ -170,3 +212,7 @@ items:
       max-durability: 60
       valid-slots: [CHEST]
       two-handed: false
+      bonuses:
+        - { target: ENERGY, magnitude: 3 }
+        - { target: MAGICAL, magnitude: 3 }
+        - { target: INTELLIGENCE, magnitude: 2 }

--- a/world/src/main/resources/world-definition/equipment-jewelry.yaml
+++ b/world/src/main/resources/world-definition/equipment-jewelry.yaml
@@ -6,8 +6,8 @@ items:
     GEM_AMULET:
       display-name: Gem Amulet
       description: >-
-        Polished gemstone set in an iron mounting. The forge-tier amulet —
-        future perks will hang attribute bonuses off this slot.
+        Polished gemstone set in an iron mounting. Boosts the wearer's
+        constitution.
       category: EQUIPMENT
       weight-per-unit: 200
       max-stack: 1
@@ -15,6 +15,8 @@ items:
       max-durability: 80
       valid-slots: [AMULET]
       two-handed: false
+      bonuses:
+        - { target: CONSTITUTION, magnitude: 2 }
 
     # ──────────────────────── Rings ────────────────────────
 
@@ -30,12 +32,14 @@ items:
       max-durability: 100
       valid-slots: [RING_LEFT, RING_RIGHT]
       two-handed: false
+      bonuses:
+        - { target: STRENGTH, magnitude: 1 }
 
     GEM_RING:
       display-name: Gem Ring
       description: >-
-        Gemstone-set ring on an iron band. T2 equivalent of the iron ring;
-        future perk surface for crit / Luck bonuses.
+        Gemstone-set ring on an iron band. Sharpens the wearer's edge in
+        combat — a small but reliable luck and crit nudge.
       category: EQUIPMENT
       weight-per-unit: 120
       max-stack: 1
@@ -43,6 +47,9 @@ items:
       max-durability: 90
       valid-slots: [RING_LEFT, RING_RIGHT]
       two-handed: false
+      bonuses:
+        - { target: LUCK, magnitude: 1 }
+        - { target: CRIT_CHANCE, magnitude: 2 }
 
     # ──────────────────────── Bracelets ────────────────────────
 
@@ -57,6 +64,8 @@ items:
       max-durability: 60
       valid-slots: [BRACELET_LEFT, BRACELET_RIGHT]
       two-handed: false
+      bonuses:
+        - { target: DEXTERITY, magnitude: 1 }
 
     IRON_BRACELET:
       display-name: Iron Bracelet
@@ -69,3 +78,6 @@ items:
       max-durability: 100
       valid-slots: [BRACELET_LEFT, BRACELET_RIGHT]
       two-handed: false
+      bonuses:
+        - { target: SLASH, magnitude: 1 }
+        - { target: PIERCE, magnitude: 1 }

--- a/world/src/main/resources/world-definition/equipment-sets.yaml
+++ b/world/src/main/resources/world-definition/equipment-sets.yaml
@@ -5,8 +5,29 @@
 # Magnitudes scale by average rarity of equipped set pieces via the rarityMultiplier
 # curve in BalanceLookup. See ADR-0002.
 #
-# Slice 2 ships the infrastructure with an empty catalog; Slice 3 populates the
-# first IRON set after equipment items grow their `bonuses:` blocks.
+# Bonus `target` values that name a DamageType (SLASH/PIERCE/BLUNT/ENERGY/MAGICAL)
+# are interpreted as defensive bonuses against that type — the binder dispatches to
+# EquippedBonus.ArmorDef. The combat reducer multiplies armor-def by defender CON
+# per lore §9; keep magnitudes single-digit accordingly.
 
 sets:
-  catalog: {}
+  catalog:
+
+    IRON:
+      pieces:
+        - IRON_HELM
+        - IRON_CHESTPLATE
+        - IRON_GREAVES
+        - IRON_BOOTS
+        - IRON_GAUNTLETS
+      thresholds:
+        2:
+          bonuses:
+            - { target: SLASH, magnitude: 1 }
+        4:
+          bonuses:
+            - { target: PIERCE, magnitude: 1 }
+        5:
+          bonuses:
+            - { target: CONSTITUTION, magnitude: 2 }
+            - { target: BLUNT, magnitude: 1 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
@@ -737,6 +737,36 @@ class AttackReducerTest {
     }
 
     @Test
+    fun `attacker's CRIT_CHANCE passive buff stacks on top of LUCK-derived crit chance`() {
+        // Without the buff (LUCK=0), crit chance is 0% and the crit roll cannot succeed.
+        // With +90 CRIT_CHANCE from equipment, the same RNG sequence lifts into crit territory.
+        val state = battleState(targetHp = 999)
+        val skills = StubSkillsRegistry()
+        val critBoost = object : dev.gvart.genesara.world.EquipmentBonusAggregator {
+            override fun armorDef(agent: AgentId, damageType: dev.gvart.genesara.world.DamageType): Int = 0
+            override fun attributeBonus(agent: AgentId, attribute: dev.gvart.genesara.player.Attribute): Int = 0
+            override fun passiveBuff(agent: AgentId, effect: dev.gvart.genesara.player.ScalingEffect): Int =
+                if (effect == dev.gvart.genesara.player.ScalingEffect.CRIT_CHANCE) 90 else 0
+        }
+
+        val (_, events) = assertNotNull(
+            reduceAttack(
+                state, WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
+                SkillProgression(skills, RecordingPublisher()),
+                equipmentBonuses = critBoost,
+                deathProcessor = stubDeathProcessor(skills, RecordingPublisher()),
+                rng = Random(seed = 1L),
+                scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher,
+                pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
+            ).getOrNull(),
+        )
+
+        val attacked = events.filterIsInstance<WorldEvent.AgentAttacked>().single()
+        assertEquals(true, attacked.isCrit, "equipment CRIT_CHANCE buff must lift the roll into crit territory")
+    }
+
+    @Test
     fun `armor-def sums across multiple equipped pieces matching the damage type`() {
         // End-to-end: chest + helmet both grant SLASH armor — total armorDef enters the
         // formula once after the aggregator sums them.

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetsYamlLoadingTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetsYamlLoadingTest.kt
@@ -1,0 +1,92 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.world.EquipmentSetId
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.internal.balance.ItemBalanceConfiguration
+import dev.gvart.genesara.world.internal.balance.ItemDefinitionProperties
+import dev.gvart.genesara.world.internal.balance.ItemLookupImpl
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class EquipmentSetsYamlLoadingTest {
+
+    @Test
+    fun `shipped equipment-sets_yaml binds into the catalog`() {
+        AnnotationConfigApplicationContext().use { ctx ->
+            ConfigurationPropertiesBindingPostProcessor.register(ctx)
+            ctx.register(EquipmentSetConfiguration::class.java)
+            ctx.refresh()
+
+            val props = ctx.getBean(EquipmentSetDefinitionProperties::class.java)
+            val lookup = EquipmentSetLookupImpl(props)
+
+            val iron = assertNotNull(lookup.byId(EquipmentSetId("IRON")))
+            assertEquals(5, iron.pieces.size)
+            assertTrue(ItemId("IRON_CHESTPLATE") in iron.pieces)
+            // Threshold tiers 2, 3, 5 are defined; below-2 yields nothing.
+            assertTrue(iron.activeBonuses(1).isEmpty())
+            assertTrue(iron.activeBonuses(2).isNotEmpty())
+            assertTrue(iron.activeBonuses(5).size >= 4, "5-piece tier stacks 2/3/5 bonuses additively")
+        }
+    }
+
+    @Test
+    fun `shipped IRON set passes the referential validator against the live items catalog`() {
+        AnnotationConfigApplicationContext().use { ctx ->
+            ConfigurationPropertiesBindingPostProcessor.register(ctx)
+            ctx.register(
+                EquipmentSetConfiguration::class.java,
+                ItemBalanceConfiguration::class.java,
+            )
+            ctx.refresh()
+
+            val sets = EquipmentSetLookupImpl(ctx.getBean(EquipmentSetDefinitionProperties::class.java))
+            val items = ItemLookupImpl(ctx.getBean(ItemDefinitionProperties::class.java))
+
+            EquipmentSetReferentialValidator(sets, items).validate()
+        }
+    }
+
+    @Test
+    fun `shipped equipment items bind their bonuses lists`() {
+        AnnotationConfigApplicationContext().use { ctx ->
+            ConfigurationPropertiesBindingPostProcessor.register(ctx)
+            ctx.register(ItemBalanceConfiguration::class.java)
+            ctx.refresh()
+
+            val items = ItemLookupImpl(ctx.getBean(ItemDefinitionProperties::class.java))
+
+            val ironChest = assertNotNull(items.byId(ItemId("IRON_CHESTPLATE")))
+            assertTrue(ironChest.bonuses.isNotEmpty(), "IRON_CHESTPLATE must carry bonuses")
+            assertTrue(
+                ironChest.bonuses.any { it is dev.gvart.genesara.world.EquippedBonus.ArmorDef &&
+                    it.damageType == dev.gvart.genesara.world.DamageType.SLASH },
+                "IRON_CHESTPLATE must carry an ArmorDef(SLASH, _) entry",
+            )
+
+            val gemRing = assertNotNull(items.byId(ItemId("GEM_RING")))
+            assertTrue(
+                gemRing.bonuses.any { it is dev.gvart.genesara.world.EquippedBonus.PassiveBuff &&
+                    it.effect == dev.gvart.genesara.player.ScalingEffect.CRIT_CHANCE },
+                "GEM_RING must carry a PassiveBuff(CRIT_CHANCE, _) entry",
+            )
+        }
+    }
+
+    @Test
+    fun `setsContaining reverse index resolves IRON_CHESTPLATE to the IRON set`() {
+        AnnotationConfigApplicationContext().use { ctx ->
+            ConfigurationPropertiesBindingPostProcessor.register(ctx)
+            ctx.register(EquipmentSetConfiguration::class.java)
+            ctx.refresh()
+
+            val lookup = EquipmentSetLookupImpl(ctx.getBean(EquipmentSetDefinitionProperties::class.java))
+            val sets = lookup.setsContaining(ItemId("IRON_CHESTPLATE")).map { it.id.value }
+            assertEquals(listOf("IRON"), sets)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Third slice of three implementing #147 — catalog migration. **Depends on #151 (Slice 2)** so this PR is targeted at \`feat/equipment-sets\`. Re-target to \`main\` after the prior slices merge.

- \`equipment-armor.yaml\` — populated \`bonuses:\` on all 12 armor pieces:
  - Leather (T1): single-digit ArmorDef per piece.
  - Iron (T2): ArmorDef + CONSTITUTION bonuses. Magnitudes tuned so iron-vs-iron exchanges don't trivialize to immunity under the lore §9 \`mitigation = CON × armorDef\` formula.
  - Cloth (T2 magic): ENERGY/MAGICAL defense + INTELLIGENCE.
- \`equipment-jewelry.yaml\` — 5 items populated:
  - GEM_AMULET: +2 CON
  - IRON_RING: +1 STR
  - GEM_RING: +1 LUCK, +2 CRIT_CHANCE
  - LEATHER_BRACELET: +1 DEX
  - IRON_BRACELET: +1 SLASH, +1 PIERCE defense
- \`equipment-sets.yaml\` — first IRON set (5 pieces, tiers 2/4/5):
  - 2-piece: +1 SLASH defense
  - 4-piece: +1 PIERCE defense
  - 5-piece (full set): +2 CON, +1 BLUNT defense
- \`AttackReducer\` now reads \`equipmentBonuses.passiveBuff(agent, CRIT_CHANCE)\` and \`DODGE_CHANCE\` so the new GEM_RING entries don't ship inert.

## What's not in this slice

- **STAMINA_REGEN wiring** — would require extending the per-tick \`Passives\` sweep with an equipment lookup per agent. Read-path perf concern; deferred. GEM_AMULET's STAMINA_REGEN was dropped from this slice rather than ship as inert data.
- **Derived-pool wiring (max HP from effective CON, etc.)** — attribute bonuses on items aggregate correctly but no derived-pool reader consumes them yet. Slice 4 / follow-up.
- **Set bonus triggered-passive dispatch** — ADR-0002 mentions it; deferred to a follow-up. The Lookup API is additive-compatible.

## Balance math (for the curious)

Iron full-set, base CON 12, vs a basic iron sword (raw = 10 × 8 = 80):
- SLASH armorDef = 1+2+1 (helm/chest/greaves) + 1 (set 2pc) = 5 → mitigation 60 → 20 damage.
- PIERCE armorDef = 1+1 + 1 (set 4pc) = 3 → mitigation 36 → 44 damage.
- BLUNT armorDef = 1+1+1+1 + 1 (set 5pc) = 5 → mitigation 60 → 20 damage.

Meaningful but non-immune; multi-turn combat. Compare with leather full-set (CON 1): mitigation 5 → 75 damage per hit (T1 is fragile, by design).

## Test plan

- [x] \`EquipmentSetsYamlLoadingTest\` — 4 cases: set binds, referential validator passes, reverse index works, items carry their declared bonuses.
- [x] \`AttackReducerTest\` new case: \`attacker's CRIT_CHANCE passive buff stacks on top of LUCK-derived crit chance\`.
- [x] \`./gradlew :world:test :api:test\` — all green.

## Review feedback addressed

- Bonuses **iron magnitudes rebalanced** down ~75% — full-set SLASH mitigation drops from immunity (228 vs 80) to a healthy 60 vs 80.
- **CRIT_CHANCE and DODGE_CHANCE wired** into AttackReducer (no longer inert).
- **STAMINA_REGEN dropped** from GEM_AMULET to avoid shipping inert data — wiring deferred to a follow-up.
- **Thresholds changed 2/3/5 → 2/4/5** so the 4-piece player gets a payoff.
- **Items-have-bonuses smoke test** added.
- **Header comment on equipment-armor.yaml** explaining the DamageType-target-as-defense convention.