### PR TITLE
feat(api): derived-pool refresh from effective attributes on equip/unequip (Slice 4 of #147)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsTool.kt
@@ -3,13 +3,12 @@ package dev.gvart.genesara.api.internal.mcp.tools.attributes
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.api.internal.mcp.tools.equipment.DerivedPoolsRefresher
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AllocateAttributesOutcome
 import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.events.AgentEvent
-import dev.gvart.genesara.world.WorldCommandGateway
-import dev.gvart.genesara.world.commands.WorldCommand
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.annotation.Tool
 import org.springframework.ai.tool.annotation.ToolParam
@@ -22,7 +21,7 @@ internal class AllocatePointsTool(
     private val activity: AgentActivityTracker,
     private val publisher: ApplicationEventPublisher,
     private val tickClock: TickClock,
-    private val world: WorldCommandGateway,
+    private val derivedPools: DerivedPoolsRefresher,
 ) {
 
     @Tool(
@@ -69,18 +68,11 @@ internal class AllocatePointsTool(
                         ),
                     )
                 }
-                // Profile pools just changed in player-side storage; queue a body-cache refresh
-                // so the next get_status reflects the new maxHp/Stamina/Mana instead of the
-                // stale values copied from the profile at spawn time.
-                world.submit(
-                    WorldCommand.RefreshDerivedPools(
-                        agent = agent,
-                        maxHp = outcome.pools.maxHp,
-                        maxStamina = outcome.pools.maxStamina,
-                        maxMana = outcome.pools.maxMana,
-                    ),
-                    appliesAtTick = tick + 1,
-                )
+                // Recompute pools through the shared refresher so the equipment-derived
+                // component (Slice 4) isn't wiped by a stale base-only computation. The
+                // registry has already been updated with the new base attributes; the
+                // refresher reads them and layers attribute bonuses on top.
+                derivedPools.refresh(agent)
                 AllocatePointsResponse.ok(
                     attrs = outcome.attributes,
                     remainingUnspent = outcome.remainingUnspent,

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/DerivedPoolsRefresher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/DerivedPoolsRefresher.kt
@@ -1,0 +1,63 @@
+package dev.gvart.genesara.api.internal.mcp.tools.equipment
+
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AttributeDerivation
+import dev.gvart.genesara.world.EffectiveAttributes
+import dev.gvart.genesara.world.EquipmentBonusAggregator
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.springframework.stereotype.Component
+
+/**
+ * Single entry point for "recompute max pools after something that changes
+ * the inputs". Both equip/unequip AND allocate_points must go through here
+ * — otherwise an `allocate_points` call would wipe the equipment-derived
+ * component of maxHp/Stamina/Mana until the next equip refresh.
+ *
+ * Computes effective attributes (base + equipped attribute bonuses) and
+ * queues a [WorldCommand.RefreshDerivedPools] at tick+1 so the body
+ * record's max cache reflects the new state next tick.
+ *
+ * **Current value semantics.** When the new max is **higher** (equipped
+ * +CON gear, spent attribute points), current HP/Stamina/Mana are
+ * preserved — a player at 50/100 stays at 50/120. When the new max is
+ * **lower** (unequipped +CON gear, de-leveled), the
+ * [dev.gvart.genesara.world.internal.body.reduceRefreshDerivedPools]
+ * reducer clamps current values down to the new max via `coerceAtMost`.
+ * D2 cap semantics, not WoW proportional rescaling.
+ */
+internal fun interface DerivedPoolsRefresher {
+    fun refresh(agent: AgentId)
+
+    companion object {
+        /** No-op refresher for tests that don't exercise pool recompute. */
+        val NoOp: DerivedPoolsRefresher = DerivedPoolsRefresher { /* nothing */ }
+    }
+}
+
+@Component
+internal class DerivedPoolsRefresherImpl(
+    private val agents: AgentRegistry,
+    private val bonuses: EquipmentBonusAggregator,
+    private val world: WorldCommandGateway,
+    private val tickClock: TickClock,
+) : DerivedPoolsRefresher {
+
+    override fun refresh(agent: AgentId) {
+        val record = agents.find(agent)
+            ?: error("derived-pool refresh: agent $agent missing from registry — upstream invariant broken")
+        val effective = EffectiveAttributes.compute(record.attributes, agent, bonuses)
+        val pools = AttributeDerivation.deriveMaxPools(effective)
+        world.submit(
+            WorldCommand.RefreshDerivedPools(
+                agent = agent,
+                maxHp = pools.maxHp,
+                maxStamina = pools.maxStamina,
+                maxMana = pools.maxMana,
+            ),
+            appliesAtTick = tickClock.currentTick() + 1,
+        )
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemTool.kt
@@ -17,6 +17,7 @@ import java.util.UUID
 internal class EquipItemTool(
     private val equipment: EquipmentService,
     private val activity: AgentActivityTracker,
+    private val derivedPools: DerivedPoolsRefresher,
 ) {
 
     @Tool(
@@ -46,10 +47,13 @@ internal class EquipItemTool(
         val agent = AgentContextHolder.current()
 
         return when (val result = equipment.equip(agent, instanceUuid, slot)) {
-            is EquipResult.Equipped -> EquipItemResponse.equipped(
-                instanceId = result.instance.instanceId,
-                slot = slot,
-            )
+            is EquipResult.Equipped -> {
+                derivedPools.refresh(agent)
+                EquipItemResponse.equipped(
+                    instanceId = result.instance.instanceId,
+                    slot = slot,
+                )
+            }
             is EquipResult.Rejected -> EquipItemResponse.rejected(
                 instanceId = instanceUuid.toString(),
                 slot = slot,

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotTool.kt
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component
 internal class UnequipSlotTool(
     private val equipment: EquipmentService,
     private val activity: AgentActivityTracker,
+    private val derivedPools: DerivedPoolsRefresher,
 ) {
 
     @Tool(
@@ -31,11 +32,14 @@ internal class UnequipSlotTool(
         val agent = AgentContextHolder.current()
 
         return when (val result = equipment.unequip(agent, slot)) {
-            is UnequipResult.Unequipped -> UnequipSlotResponse(
-                kind = "unequipped",
-                slot = slot,
-                instanceId = result.instance.instanceId,
-            )
+            is UnequipResult.Unequipped -> {
+                derivedPools.refresh(agent)
+                UnequipSlotResponse(
+                    kind = "unequipped",
+                    slot = slot,
+                    instanceId = result.instance.instanceId,
+                )
+            }
             is UnequipResult.SlotEmpty -> UnequipSlotResponse(
                 kind = "empty",
                 slot = slot,

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolTest.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.attributes
 import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.tools.equipment.DerivedPoolsRefresher
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentAttributes
@@ -13,8 +14,6 @@ import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.AttributeMilestoneCrossing
 import dev.gvart.genesara.player.MaxPools
 import dev.gvart.genesara.player.events.AgentEvent
-import dev.gvart.genesara.world.WorldCommandGateway
-import dev.gvart.genesara.world.commands.WorldCommand
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -61,8 +60,8 @@ class AllocatePointsToolTest {
         val newAttrs = AgentAttributes(intelligence = 100)
         val registry = RecordingRegistry(returns = allocated(newAttrs, crossings = crossings))
         val publisher = RecordingPublisher()
-        val gateway = RecordingGateway()
-        val tool = AllocatePointsTool(registry, activity, publisher, tickClock, gateway)
+        val refresher = RecordingRefresher()
+        val tool = AllocatePointsTool(registry, activity, publisher, tickClock, refresher)
 
         val response = tool.invoke(mapOf(Attribute.INTELLIGENCE to 99), toolContext)
 
@@ -78,26 +77,19 @@ class AllocatePointsToolTest {
     }
 
     @Test
-    fun `successful allocation queues a RefreshDerivedPools world command with the new pool maxima`() {
+    fun `successful allocation routes pool recompute through DerivedPoolsRefresher`() {
         val registry = RecordingRegistry(
             returns = allocated(
                 attrs = AgentAttributes(constitution = 5, intelligence = 3),
                 remainingUnspent = 0,
-                pools = MaxPools(maxHp = 100, maxStamina = 55, maxMana = 15),
             ),
         )
-        val gateway = RecordingGateway()
-        val tool = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, gateway)
+        val refresher = RecordingRefresher()
+        val tool = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, refresher)
 
         tool.invoke(mapOf(Attribute.CONSTITUTION to 4, Attribute.INTELLIGENCE to 2), toolContext)
 
-        val (cmd, appliesAt) = gateway.submissions.single()
-        val refresh = assertNotNull(cmd as? WorldCommand.RefreshDerivedPools)
-        assertEquals(agent, refresh.agent)
-        assertEquals(100, refresh.maxHp)
-        assertEquals(55, refresh.maxStamina)
-        assertEquals(15, refresh.maxMana)
-        assertEquals(43L, appliesAt)
+        assertEquals(listOf(agent), refresher.refreshed)
     }
 
     @Test
@@ -105,7 +97,7 @@ class AllocatePointsToolTest {
         val registry = RecordingRegistry(returns = allocated(AgentAttributes(strength = 4), remainingUnspent = 2))
         val publisher = RecordingPublisher()
 
-        AllocatePointsTool(registry, activity, publisher, tickClock, RecordingGateway())
+        AllocatePointsTool(registry, activity, publisher, tickClock, RecordingRefresher())
             .invoke(mapOf(Attribute.STRENGTH to 3), toolContext)
 
         assertTrue(publisher.events.isEmpty())
@@ -114,21 +106,21 @@ class AllocatePointsToolTest {
     @Test
     fun `negative delta from registry maps to NEGATIVE_DELTA reason and skips the gateway`() {
         val registry = RecordingRegistry(returns = AllocateAttributesOutcome.NegativeDelta)
-        val gateway = RecordingGateway()
+        val refresher = RecordingRefresher()
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, gateway)
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, refresher)
             .invoke(mapOf(Attribute.STRENGTH to 1), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
         assertEquals(AllocatePointsRejectionReason.NEGATIVE_DELTA, response.reason)
-        assertTrue(gateway.submissions.isEmpty())
+        assertTrue(refresher.refreshed.isEmpty())
     }
 
     @Test
     fun `insufficient points reports unspent and requested in detail`() {
         val registry = RecordingRegistry(returns = AllocateAttributesOutcome.InsufficientPoints(unspent = 2, requested = 5L))
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingGateway())
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingRefresher())
             .invoke(mapOf(Attribute.STRENGTH to 5), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
@@ -141,36 +133,36 @@ class AllocatePointsToolTest {
     @Test
     fun `empty deltas short-circuits to NO_OP without touching the registry`() {
         val registry = RecordingRegistry(returns = AllocateAttributesOutcome.NegativeDelta)
-        val gateway = RecordingGateway()
+        val refresher = RecordingRefresher()
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, gateway)
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, refresher)
             .invoke(emptyMap(), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
         assertEquals(AllocatePointsRejectionReason.NO_OP, response.reason)
         assertTrue(registry.calls.isEmpty())
-        assertTrue(gateway.submissions.isEmpty())
+        assertTrue(refresher.refreshed.isEmpty())
     }
 
     @Test
     fun `all-zero deltas short-circuits to NO_OP without touching the registry`() {
         val registry = RecordingRegistry(returns = AllocateAttributesOutcome.NegativeDelta)
-        val gateway = RecordingGateway()
+        val refresher = RecordingRefresher()
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, gateway)
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, refresher)
             .invoke(mapOf(Attribute.STRENGTH to 0, Attribute.DEXTERITY to 0), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
         assertEquals(AllocatePointsRejectionReason.NO_OP, response.reason)
         assertTrue(registry.calls.isEmpty())
-        assertTrue(gateway.submissions.isEmpty())
+        assertTrue(refresher.refreshed.isEmpty())
     }
 
     @Test
     fun `null registry result becomes AGENT_MISSING`() {
         val registry = RecordingRegistry(returns = null)
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingGateway())
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingRefresher())
             .invoke(mapOf(Attribute.STRENGTH to 1), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
@@ -181,7 +173,7 @@ class AllocatePointsToolTest {
     fun `touchActivity records the agent on every entry`() {
         val registry = RecordingRegistry(returns = allocated(AgentAttributes(), remainingUnspent = 4))
 
-        AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingGateway())
+        AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingRefresher())
             .invoke(mapOf(Attribute.STRENGTH to 1), toolContext)
 
         assertEquals(clock.instant(), activity.lastActiveAt(agent))
@@ -207,12 +199,9 @@ class AllocatePointsToolTest {
         }
     }
 
-    private class RecordingGateway : WorldCommandGateway {
-        val submissions = mutableListOf<Pair<WorldCommand, Long>>()
-        override fun submit(command: WorldCommand, appliesAtTick: Long): Long {
-            submissions += command to appliesAtTick
-            return appliesAtTick
-        }
+    private class RecordingRefresher : DerivedPoolsRefresher {
+        val refreshed = mutableListOf<AgentId>()
+        override fun refresh(agent: AgentId) { refreshed += agent }
     }
 
     private class StubTickClock(private val currentTick: Long) : TickClock {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/DerivedPoolsRefresherImplTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/DerivedPoolsRefresherImplTest.kt
@@ -1,0 +1,94 @@
+package dev.gvart.genesara.api.internal.mcp.tools.equipment
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.Attribute
+import dev.gvart.genesara.player.AttributeDerivation
+import dev.gvart.genesara.player.ScalingEffect
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.EquipmentBonusAggregator
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class DerivedPoolsRefresherImplTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+
+    @Test
+    fun `refresh queues RefreshDerivedPools at the next tick with effective-attribute pools`() {
+        val base = AgentAttributes(constitution = 4, intelligence = 2)
+        val agents = StubAgentRegistry(base)
+        val bonuses = ConCharmingBonuses(plusCon = 3, plusInt = 1)
+        val gateway = RecordingGateway()
+        val tickClock = StubTickClock(currentTick = 11)
+        val refresher = DerivedPoolsRefresherImpl(agents, bonuses, gateway, tickClock)
+
+        refresher.refresh(agent)
+
+        val expected = AttributeDerivation.deriveMaxPools(
+            AgentAttributes(constitution = 7, intelligence = 3),
+        )
+        val submitted = assertIs<WorldCommand.RefreshDerivedPools>(gateway.lastCommand)
+        assertEquals(agent, submitted.agent)
+        assertEquals(expected.maxHp, submitted.maxHp)
+        assertEquals(expected.maxStamina, submitted.maxStamina)
+        assertEquals(expected.maxMana, submitted.maxMana)
+        assertEquals(12L, gateway.lastAppliesAtTick)
+    }
+
+    @Test
+    fun `refresh throws when the agent is missing from the registry — surfaces upstream invariant break`() {
+        val agents = StubAgentRegistry(null)
+        val refresher = DerivedPoolsRefresherImpl(
+            agents,
+            EquipmentBonusAggregator.NoBonuses,
+            RecordingGateway(),
+            StubTickClock(currentTick = 0),
+        )
+
+        kotlin.test.assertFailsWith<IllegalStateException> { refresher.refresh(agent) }
+    }
+
+    private class StubAgentRegistry(private val attrs: AgentAttributes?) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = if (attrs == null) null else Agent(
+            id = id, owner = PlayerId(UUID.randomUUID()), name = "test", attributes = attrs,
+        )
+
+        override fun listForOwner(owner: PlayerId): List<Agent> = error("not used")
+    }
+
+    private class ConCharmingBonuses(
+        private val plusCon: Int,
+        private val plusInt: Int,
+    ) : EquipmentBonusAggregator {
+        override fun armorDef(agent: AgentId, damageType: DamageType): Int = 0
+        override fun attributeBonus(agent: AgentId, attribute: Attribute): Int = when (attribute) {
+            Attribute.CONSTITUTION -> plusCon
+            Attribute.INTELLIGENCE -> plusInt
+            else -> 0
+        }
+        override fun passiveBuff(agent: AgentId, effect: ScalingEffect): Int = 0
+    }
+
+    private class RecordingGateway : WorldCommandGateway {
+        var lastCommand: WorldCommand? = null
+        var lastAppliesAtTick: Long = -1
+        override fun submit(command: WorldCommand, appliesAtTick: Long): Long {
+            lastCommand = command
+            lastAppliesAtTick = appliesAtTick
+            return appliesAtTick
+        }
+    }
+
+    private class StubTickClock(private val currentTick: Long) : TickClock {
+        override fun currentTick(): Long = currentTick
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemToolTest.kt
@@ -39,7 +39,7 @@ class EquipItemToolTest {
         val service = StubEquipmentService(
             equipResult = EquipResult.Equipped(sampleInstance(instanceId, EquipSlot.MAIN_HAND)),
         )
-        val tool = EquipItemTool(service, activity)
+        val tool = EquipItemTool(service, activity, DerivedPoolsRefresher.NoOp)
 
         val res = tool.invoke(instanceId.toString(), EquipSlot.MAIN_HAND, toolContext)
 
@@ -50,11 +50,43 @@ class EquipItemToolTest {
     }
 
     @Test
+    fun `successful equip triggers derived-pool refresh for the calling agent`() {
+        val instanceId = UUID.randomUUID()
+        val service = StubEquipmentService(
+            equipResult = EquipResult.Equipped(sampleInstance(instanceId, EquipSlot.HELMET)),
+        )
+        val refresher = RecordingPoolsRefresher()
+        val tool = EquipItemTool(service, activity, refresher)
+
+        tool.invoke(instanceId.toString(), EquipSlot.HELMET, toolContext)
+
+        assertEquals(listOf(agent), refresher.refreshed)
+    }
+
+    @Test
+    fun `rejected equip does NOT trigger derived-pool refresh`() {
+        val service = StubEquipmentService(
+            equipResult = EquipResult.Rejected(EquipRejection.INSUFFICIENT_ATTRIBUTES),
+        )
+        val refresher = RecordingPoolsRefresher()
+        val tool = EquipItemTool(service, activity, refresher)
+
+        tool.invoke(UUID.randomUUID().toString(), EquipSlot.HELMET, toolContext)
+
+        assertTrue(refresher.refreshed.isEmpty())
+    }
+
+    private class RecordingPoolsRefresher : DerivedPoolsRefresher {
+        val refreshed = mutableListOf<AgentId>()
+        override fun refresh(agent: AgentId) { refreshed += agent }
+    }
+
+    @Test
     fun `rejection result returns kind=rejected with snake_case reason and detail`() {
         val service = StubEquipmentService(
             equipResult = EquipResult.Rejected(EquipRejection.OFF_HAND_BLOCKED_BY_TWO_HANDED),
         )
-        val tool = EquipItemTool(service, activity)
+        val tool = EquipItemTool(service, activity, DerivedPoolsRefresher.NoOp)
 
         val res = tool.invoke(UUID.randomUUID().toString(), EquipSlot.OFF_HAND, toolContext)
 
@@ -72,7 +104,7 @@ class EquipItemToolTest {
                 detail = customDetail,
             ),
         )
-        val tool = EquipItemTool(service, activity)
+        val tool = EquipItemTool(service, activity, DerivedPoolsRefresher.NoOp)
 
         val res = tool.invoke(UUID.randomUUID().toString(), EquipSlot.MAIN_HAND, toolContext)
 
@@ -84,7 +116,7 @@ class EquipItemToolTest {
     @Test
     fun `malformed instanceId is rejected at the tool boundary without hitting the service`() {
         val service = StubEquipmentService()
-        val tool = EquipItemTool(service, activity)
+        val tool = EquipItemTool(service, activity, DerivedPoolsRefresher.NoOp)
 
         val res = tool.invoke("not-a-uuid", EquipSlot.MAIN_HAND, toolContext)
 

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotToolTest.kt
@@ -39,6 +39,7 @@ class UnequipSlotToolTest {
                 unequipResult = UnequipResult.Unequipped(sampleInstance(instanceId, slot = null)),
             ),
             activity,
+            DerivedPoolsRefresher.NoOp,
         )
 
         val res = tool.invoke(EquipSlot.MAIN_HAND, toolContext)
@@ -50,13 +51,49 @@ class UnequipSlotToolTest {
 
     @Test
     fun `empty slot returns kind=empty`() {
-        val tool = UnequipSlotTool(StubEquipmentService(unequipResult = UnequipResult.SlotEmpty), activity)
+        val tool = UnequipSlotTool(StubEquipmentService(unequipResult = UnequipResult.SlotEmpty), activity, DerivedPoolsRefresher.NoOp)
 
         val res = tool.invoke(EquipSlot.HELMET, toolContext)
 
         assertEquals("empty", res.kind)
         assertEquals(EquipSlot.HELMET, res.slot)
         assertEquals(null, res.instanceId)
+    }
+
+    @Test
+    fun `successful unequip triggers derived-pool refresh for the calling agent`() {
+        val instanceId = UUID.randomUUID()
+        val refresher = RecordingPoolsRefresher()
+        val tool = UnequipSlotTool(
+            StubEquipmentService(
+                unequipResult = UnequipResult.Unequipped(sampleInstance(instanceId, slot = null)),
+            ),
+            activity,
+            refresher,
+        )
+
+        tool.invoke(EquipSlot.HELMET, toolContext)
+
+        assertEquals(listOf(agent), refresher.refreshed)
+    }
+
+    @Test
+    fun `empty-slot unequip does NOT trigger derived-pool refresh`() {
+        val refresher = RecordingPoolsRefresher()
+        val tool = UnequipSlotTool(
+            StubEquipmentService(unequipResult = UnequipResult.SlotEmpty),
+            activity,
+            refresher,
+        )
+
+        tool.invoke(EquipSlot.HELMET, toolContext)
+
+        kotlin.test.assertTrue(refresher.refreshed.isEmpty())
+    }
+
+    private class RecordingPoolsRefresher : DerivedPoolsRefresher {
+        val refreshed = mutableListOf<AgentId>()
+        override fun refresh(agent: AgentId) { refreshed += agent }
     }
 
     private fun sampleInstance(id: UUID, slot: EquipSlot?) = EquipmentInstance(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EffectiveAttributes.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EffectiveAttributes.kt
@@ -1,0 +1,31 @@
+package dev.gvart.genesara.world
+
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.Attribute
+
+/**
+ * Composes an agent's [AgentAttributes] from base + equipped attribute bonuses.
+ *
+ * Used by derived-pool calculations (max HP from CON, etc.) so equipped gear
+ * with `AttributeBonus` entries actually affects body maxes. Never used by
+ * `required-attributes` equip checks — those always read base (per ADR-0001,
+ * to prevent recursive bootstrap where +CON gear qualifies the agent for
+ * higher-CON gear).
+ *
+ * TODO(equipment-effective): extend usage to carry capacity (STR), sight range
+ *   (PER), and any future attribute-driven derived stat. Slice 4 only wires
+ *   max pools; the rest still read base attributes.
+ */
+object EffectiveAttributes {
+
+    fun compute(base: AgentAttributes, agent: AgentId, bonuses: EquipmentBonusAggregator): AgentAttributes =
+        AgentAttributes(
+            strength = base.strength + bonuses.attributeBonus(agent, Attribute.STRENGTH),
+            dexterity = base.dexterity + bonuses.attributeBonus(agent, Attribute.DEXTERITY),
+            constitution = base.constitution + bonuses.attributeBonus(agent, Attribute.CONSTITUTION),
+            perception = base.perception + bonuses.attributeBonus(agent, Attribute.PERCEPTION),
+            intelligence = base.intelligence + bonuses.attributeBonus(agent, Attribute.INTELLIGENCE),
+            luck = base.luck + bonuses.attributeBonus(agent, Attribute.LUCK),
+        )
+}


### PR DESCRIPTION
## Summary

Fourth slice of the #147 chain — wires the so-far-inert attribute bonuses into derived pools. **Depends on #152** so this PR is targeted at \`feat/equipment-catalog-migration\`. Re-target to \`main\` after the prior slices merge.

- New \`EffectiveAttributes.compute(base, agent, bonuses)\` — base + equipped \`AttributeBonus\` entries. Used by derived-pool calculations only; never by equip-time \`required-attributes\` checks (per ADR-0001, base-only to prevent recursive bootstrap).
- New \`DerivedPoolsRefresher\` (\`fun interface\` + \`NoOp\` companion + \`@Component\` impl) — single entry point that recomputes max HP / Stamina / Mana from effective attributes and queues \`WorldCommand.RefreshDerivedPools\` at tick+1.
- Wired into \`EquipItemTool\`, \`UnequipSlotTool\`, AND **\`AllocatePointsTool\`** (was computing pools from base attributes only — would have wiped the equipment-derived component on every point spend).

## Current HP/Stamina/Mana semantics

- **Max grew (equipped +CON gear or spent points)**: current values preserved. A player at 50/100 HP becomes 50/120 after equipping a +2 CON ring.
- **Max shrunk (unequipped +CON gear or de-leveled)**: current values clamped to new max via the existing \`reduceRefreshDerivedPools\` reducer's \`coerceAtMost\`.

D2 cap semantics, not WoW proportional rescaling. Documented in the refresher's KDoc.

## Test plan

- [x] \`DerivedPoolsRefresherImplTest\` — happy path computes correct pools from effective attrs; missing-agent throws (upstream invariant break).
- [x] \`EquipItemToolTest\` — new cases: successful equip triggers refresh, rejected equip does not.
- [x] \`UnequipSlotToolTest\` — new cases: successful unequip triggers refresh, empty-slot does not.
- [x] \`AllocatePointsToolTest\` — converted \`queues RefreshDerivedPools\` assertion to \`routes pool recompute through DerivedPoolsRefresher\`.
- [x] \`./gradlew :world:test :api:test\` — all green.

## Review feedback addressed (from inline reviewer on Slice 4)

- **Critical: AllocatePointsTool race fixed.** Was bypassing the equipment path entirely — pool computation now goes through the refresher.
- **KDoc clarification.** "Current values are NOT rescaled" was true for upward changes only; now documented that downward changes get clamped by the reducer.
- **Missing-agent: error() instead of silent no-op.** The path is only reachable on an upstream invariant break (equip succeeded against a registry-less agent).
- **Unequip refresh test added.**
- **TODO marker on \`EffectiveAttributes\`** for migrating carry cap / sight range / crit / dodge in a follow-up.
- **\`inner\` modifier dropped** on \`StubAgentRegistry\` in the refresher test.

## What's still deferred

- **STAMINA_REGEN PassiveBuff wiring** in the per-tick Passives sweep (needs batched-equipment query).
- **Set-bonus triggered passives** at thresholds.
- **Effective-attribute migration** for carry cap, sight, crit, dodge (currently base; tracked via \`TODO(equipment-effective)\`).