### PR TITLE
feat(world): set-bonus triggered passives + STAMINA_REGEN via batched query (Slices 5+6 of #147)

### DIFF
--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/PerksValidator.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/PerksValidator.kt
@@ -59,6 +59,12 @@ internal object PerksValidator {
 
     private fun validatePerk(perk: PerkProperties, location: String, problems: MutableList<String>) {
         if (perk.id.isBlank()) problems += "$location: perk id is blank"
+        // The equipment-set dispatcher synthesizes PerkIds prefixed `"set:"` for cooldown
+        // keying (world/internal/perks/TriggeredPassiveDispatcher). A real catalog perk
+        // sharing that prefix would collide in PerkCooldownStore.
+        if (perk.id.startsWith("set:")) {
+            problems += "$location: perk id '${perk.id}' must not start with 'set:' (reserved prefix for equipment-set triggers)"
+        }
         if (perk.displayName.isBlank()) problems += "$location: missing display-name"
         if (perk.description.isBlank()) problems += "$location: missing description"
         validateEffect(perk.effect, location, problems)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentBonusAggregator.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentBonusAggregator.kt
@@ -25,6 +25,21 @@ interface EquipmentBonusAggregator {
 
     fun passiveBuff(agent: AgentId, effect: ScalingEffect): Int
 
+    /**
+     * Batched form of [passiveBuff] — one query for [agents], one [effect].
+     * Used by per-tick consumers (passive sweep) where issuing N
+     * single-agent queries would cost N DB round-trips. Agents with no
+     * matching bonus are absent from the map.
+     *
+     * Default impl falls back to N single-agent calls for stub
+     * implementations; production
+     * [dev.gvart.genesara.world.internal.equipment.EquipmentBonusAggregatorImpl]
+     * overrides with a single batched [EquipmentInstanceStore.equippedForAll]
+     * call.
+     */
+    fun passiveBuffBatch(agents: Set<AgentId>, effect: ScalingEffect): Map<AgentId, Int> =
+        agents.associateWith { passiveBuff(it, effect) }.filterValues { it != 0 }
+
     companion object {
         /** Empty-result aggregator for tests that don't exercise equipment bonuses. */
         val NoBonuses: EquipmentBonusAggregator = object : EquipmentBonusAggregator {

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentInstanceStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentInstanceStore.kt
@@ -45,6 +45,19 @@ interface EquipmentInstanceStore {
     fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance>
 
     /**
+     * Batched form of [equippedFor] for per-tick consumers (passive sweep,
+     * combat broadcast). Issues one query for all [agents] rather than N
+     * single-agent calls. Agents with no equipped gear are absent from the
+     * returned map.
+     *
+     * Default impl falls back to N single-agent calls for stub
+     * implementations; production [dev.gvart.genesara.world.internal.equipment.JooqEquipmentInstanceStore]
+     * overrides with a single SQL query.
+     */
+    fun equippedForAll(agents: Set<AgentId>): Map<AgentId, Map<EquipSlot, EquipmentInstance>> =
+        agents.associateWith { equippedFor(it) }.filterValues { it.isNotEmpty() }
+
+    /**
      * Move the instance into [slot]. Atomic: returns the updated row, or null
      * when no row matches `(instance_id, agent_id)` — the [agentId] predicate
      * is part of the WHERE clause so this also rejects an attempt to move

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSet.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSet.kt
@@ -1,9 +1,16 @@
 package dev.gvart.genesara.world
 
+import dev.gvart.genesara.player.PerkEffect
+
 @JvmInline
 value class EquipmentSetId(val value: String) {
     init {
         require(value.isNotBlank()) { "EquipmentSetId must not be blank" }
+        // The dispatcher synthesizes "set:<id>@<tier>:<index>" PerkIds for cooldown keying;
+        // a set id containing ':' or '@' would deform the key and collide ambiguously.
+        require(':' !in value && '@' !in value) {
+            "EquipmentSetId '$value' must not contain ':' or '@' (reserved for synthetic perk-id keying)"
+        }
     }
 
     override fun toString(): String = value
@@ -40,12 +47,36 @@ data class EquipmentSet(
         thresholds.entries
             .filter { (tier, _) -> tier <= equippedCount }
             .flatMap { it.value.bonuses }
+
+    /**
+     * Triggered passives armed by every threshold whose tier ≤ [equippedCount].
+     * Returned as `(tier, indexInTier, effect)` triples so the dispatcher can
+     * synthesize a stable cooldown id per active set-bonus trigger.
+     */
+    fun activeTriggeredPassives(equippedCount: Int): List<ActiveTriggeredPassive> =
+        thresholds.entries
+            .filter { (tier, _) -> tier <= equippedCount }
+            .sortedBy { it.key }
+            .flatMap { (tier, threshold) ->
+                threshold.triggeredPassives.mapIndexed { idx, effect ->
+                    ActiveTriggeredPassive(tier = tier, indexInTier = idx, effect = effect)
+                }
+            }
+
+    data class ActiveTriggeredPassive(
+        val tier: Int,
+        val indexInTier: Int,
+        val effect: PerkEffect.TriggeredPassive,
+    )
 }
 
 data class EquipmentSetThreshold(
     val bonuses: List<EquippedBonus>,
+    val triggeredPassives: List<PerkEffect.TriggeredPassive> = emptyList(),
 ) {
     init {
-        require(bonuses.isNotEmpty()) { "EquipmentSetThreshold.bonuses must not be empty" }
+        require(bonuses.isNotEmpty() || triggeredPassives.isNotEmpty()) {
+            "EquipmentSetThreshold must declare at least one bonus or triggered passive"
+        }
     }
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSetTriggerLookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSetTriggerLookup.kt
@@ -1,0 +1,38 @@
+package dev.gvart.genesara.world
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+
+/**
+ * Per-agent lookup for set-bonus triggered passives — the sister surface to
+ * [dev.gvart.genesara.player.TriggeredPassiveLookup] but sourced from
+ * equipped set pieces instead of chosen perks.
+ *
+ * The dispatcher combines both lookups when firing
+ * [WorldEvent.PerkTriggered][dev.gvart.genesara.world.events.WorldEvent.PerkTriggered]
+ * events; set bonuses get a synthetic perk id `"set:<setId>@<tier>:<index>"`
+ * so the existing [dev.gvart.genesara.player.PerkCooldownStore] keys them
+ * without a parallel store.
+ */
+interface EquipmentSetTriggerLookup {
+
+    fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<ActiveSetTrigger>
+
+    companion object {
+        /** Empty-result lookup for tests that don't exercise set-bonus triggers. */
+        val NoSetTriggers: EquipmentSetTriggerLookup = object : EquipmentSetTriggerLookup {
+            override fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<ActiveSetTrigger> = emptyList()
+        }
+    }
+}
+
+data class ActiveSetTrigger(
+    val setId: EquipmentSetId,
+    val tier: Int,
+    val indexInTier: Int,
+    val effect: PerkEffect.TriggeredPassive,
+) {
+    /** Synthetic perk id used by the dispatcher for cooldown keying and event emission. */
+    val syntheticPerkId: String = "set:${setId.value}@$tier:$indexInTier"
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImpl.kt
@@ -34,6 +34,19 @@ internal class EquipmentBonusAggregatorImpl(
     override fun passiveBuff(agent: AgentId, effect: ScalingEffect): Int =
         total(agent) { it is EquippedBonus.PassiveBuff && it.effect == effect }
 
+    override fun passiveBuffBatch(agents: Set<AgentId>, effect: ScalingEffect): Map<AgentId, Int> {
+        if (agents.isEmpty()) return emptyMap()
+        val equippedByAgent = equipment.equippedForAll(agents)
+        if (equippedByAgent.isEmpty()) return emptyMap()
+        val match: (EquippedBonus) -> Boolean = { it is EquippedBonus.PassiveBuff && it.effect == effect }
+        val result = mutableMapOf<AgentId, Int>()
+        for ((agent, equipped) in equippedByAgent) {
+            val value = perPieceSum(equipped, match) + setBonusSum(equipped, match)
+            if (value != 0) result[agent] = value
+        }
+        return result
+    }
+
     private inline fun total(agent: AgentId, match: (EquippedBonus) -> Boolean): Int {
         val equipped = equipment.equippedFor(agent)
         if (equipped.isEmpty()) return 0

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetLookupImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetLookupImpl.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.equipment
 
+import dev.gvart.genesara.player.PerkEffect
 import dev.gvart.genesara.world.EquipmentSet
 import dev.gvart.genesara.world.EquipmentSetId
 import dev.gvart.genesara.world.EquipmentSetLookup
@@ -34,6 +35,14 @@ internal class EquipmentSetLookupImpl(
         thresholds = thresholds.mapValues { (tier, threshold) ->
             EquipmentSetThreshold(
                 bonuses = threshold.bonuses.map { it.bindToDomain("${id.value}@$tier") },
+                triggeredPassives = threshold.triggeredPassives.map { p ->
+                    PerkEffect.TriggeredPassive(
+                        trigger = p.trigger,
+                        effectKind = p.effectKind,
+                        params = p.params,
+                        internalCooldownTicks = p.internalCooldownTicks,
+                    )
+                },
             )
         },
     )

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetProperties.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetProperties.kt
@@ -1,5 +1,8 @@
 package dev.gvart.genesara.world.internal.equipment
 
+import dev.gvart.genesara.player.TriggeredPassiveEffectKind
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+
 internal data class EquipmentSetProperties(
     val pieces: List<String>,
     /** Map<tierCount, threshold> — tier 2/4/6/etc → bonuses added at that tier. */
@@ -8,4 +11,18 @@ internal data class EquipmentSetProperties(
 
 internal data class EquipmentSetThresholdProperties(
     val bonuses: List<dev.gvart.genesara.world.internal.balance.EquippedBonusProperties> = emptyList(),
+    /**
+     * Optional triggered passives that arm when this threshold is active. Re-uses
+     * the [TriggeredPassiveTrigger] / [TriggeredPassiveEffectKind] enums from the
+     * perk system; the dispatcher composes set-bonus triggers alongside chosen
+     * perks via a synthetic perk id keyed `"set:<setId>@<tier>:<index>"`.
+     */
+    val triggeredPassives: List<EquipmentSetTriggeredPassiveProperties> = emptyList(),
+)
+
+internal data class EquipmentSetTriggeredPassiveProperties(
+    val trigger: TriggeredPassiveTrigger,
+    val effectKind: TriggeredPassiveEffectKind,
+    val params: Map<String, String> = emptyMap(),
+    val internalCooldownTicks: Int = 0,
 )

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetTriggerLookupImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetTriggerLookupImpl.kt
@@ -1,0 +1,44 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import dev.gvart.genesara.world.ActiveSetTrigger
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.EquipmentSet
+import dev.gvart.genesara.world.EquipmentSetLookup
+import dev.gvart.genesara.world.EquipmentSetTriggerLookup
+import org.springframework.stereotype.Component
+
+@Component
+internal class EquipmentSetTriggerLookupImpl(
+    private val equipment: EquipmentInstanceStore,
+    private val sets: EquipmentSetLookup,
+) : EquipmentSetTriggerLookup {
+
+    override fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<ActiveSetTrigger> {
+        val equipped = equipment.equippedFor(agent)
+        if (equipped.isEmpty()) return emptyList()
+
+        val countsPerSet = mutableMapOf<EquipmentSet, Int>()
+        for ((_, instance) in equipped) {
+            for (set in sets.setsContaining(instance.itemId)) {
+                countsPerSet[set] = (countsPerSet[set] ?: 0) + 1
+            }
+        }
+        if (countsPerSet.isEmpty()) return emptyList()
+
+        val matches = mutableListOf<ActiveSetTrigger>()
+        for ((set, count) in countsPerSet) {
+            for (active in set.activeTriggeredPassives(count)) {
+                if (active.effect.trigger != trigger) continue
+                matches += ActiveSetTrigger(
+                    setId = set.id,
+                    tier = active.tier,
+                    indexInTier = active.indexInTier,
+                    effect = active.effect,
+                )
+            }
+        }
+        return matches
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/JooqEquipmentInstanceStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/JooqEquipmentInstanceStore.kt
@@ -53,6 +53,17 @@ internal class JooqEquipmentInstanceStore(
             .fetch(::toDomain)
             .associateBy { it.equippedInSlot!! }
 
+    @Transactional(readOnly = true)
+    override fun equippedForAll(agents: Set<AgentId>): Map<AgentId, Map<EquipSlot, EquipmentInstance>> {
+        if (agents.isEmpty()) return emptyMap()
+        return dsl.selectFrom(AGENT_EQUIPMENT_INSTANCES)
+            .where(AGENT_EQUIPMENT_INSTANCES.AGENT_ID.`in`(agents.map { it.id }))
+            .and(AGENT_EQUIPMENT_INSTANCES.EQUIPPED_IN_SLOT.isNotNull)
+            .fetch(::toDomain)
+            .groupBy({ it.agentId }, { it })
+            .mapValues { (_, instances) -> instances.associateBy { it.equippedInSlot!! } }
+    }
+
     @Transactional
     override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? =
         dsl.update(AGENT_EQUIPMENT_INSTANCES)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/passive/Passives.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/passive/Passives.kt
@@ -1,15 +1,30 @@
 package dev.gvart.genesara.world.internal.passive
 
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.world.BodyDelta
+import dev.gvart.genesara.world.EquipmentBonusAggregator
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import kotlin.math.roundToInt
 
+/**
+ * Per-tick equipment-bonus snapshot for the bodies in `state.bodies`. Built once
+ * via [EquipmentBonusAggregator.passiveBuffBatch] at the [applyPassives] boundary
+ * so passives don't issue N single-agent queries.
+ */
+internal data class EquipmentBonusSnapshot(
+    val staminaRegen: Map<AgentId, Int>,
+) {
+    companion object {
+        val Empty: EquipmentBonusSnapshot = EquipmentBonusSnapshot(emptyMap())
+    }
+}
+
 internal fun interface Passive {
-    fun deltasFor(state: WorldState, balance: BalanceLookup): Map<AgentId, BodyDelta>
+    fun deltasFor(state: WorldState, balance: BalanceLookup, bonuses: EquipmentBonusSnapshot): Map<AgentId, BodyDelta>
 }
 
 /**
@@ -18,7 +33,7 @@ internal fun interface Passive {
  * multiply it. The low-gate runs first so halt and buff stay mutually exclusive. HP /
  * Mana regen will read the same gates when those passives ship.
  */
-internal val staminaRegenPassive = Passive { state, balance ->
+internal val staminaRegenPassive = Passive { state, balance, bonuses ->
     state.bodies.mapNotNull { (id, body) ->
         if (body.isVitalsLow(balance::gaugeLowThreshold)) return@mapNotNull null
         val nodeId = state.positions[id] ?: return@mapNotNull null
@@ -31,7 +46,11 @@ internal val staminaRegenPassive = Passive { state, balance ->
         } else {
             baseRegen
         }
-        if (regen == 0) null else id to BodyDelta(stamina = regen)
+        // Equipment STAMINA_REGEN bonuses add on top of the base/buff-multiplied
+        // value — flat additive, same shape as PassiveAura aggregator entries.
+        val equipBonus = bonuses.staminaRegen[id] ?: 0
+        val total = regen + equipBonus
+        if (total == 0) null else id to BodyDelta(stamina = total)
     }.toMap()
 }
 
@@ -43,7 +62,7 @@ internal val staminaRegenPassive = Passive { state, balance ->
  * Fast-path returns an empty map when both drains are zero — saves one allocation per
  * body per tick in tests and any future "rested" world configuration.
  */
-internal val gaugeDrainPassive = Passive { state, balance ->
+internal val gaugeDrainPassive = Passive { state, balance, _ ->
     val hungerDrain = -balance.gaugeDrainPerTick(Gauge.HUNGER)
     val thirstDrain = -balance.gaugeDrainPerTick(Gauge.THIRST)
     if (hungerDrain == 0 && thirstDrain == 0) {
@@ -71,7 +90,7 @@ internal val gaugeDrainPassive = Passive { state, balance ->
  * Fast-path returns an empty map when both drain and regen are zero (e.g. in tests that
  * disable survival entirely).
  */
-internal val sleepPassive = Passive { state, balance ->
+internal val sleepPassive = Passive { state, balance, _ ->
     val drain = balance.gaugeDrainPerTick(Gauge.SLEEP)
     val regen = balance.sleepRegenPerOfflineTick()
     if (drain == 0 && regen == 0) {
@@ -89,7 +108,7 @@ internal val sleepPassive = Passive { state, balance ->
  * A single tick of damage covers all zero-gauges combined — agents die from prolonged
  * neglect, not from triple-overlap punishment.
  */
-internal val starvationDamagePassive = Passive { state, balance ->
+internal val starvationDamagePassive = Passive { state, balance, _ ->
     val damage = balance.starvationDamagePerTick()
     state.bodies.mapNotNull { (id, body) ->
         if (!body.isStarving()) null else id to BodyDelta(hp = -damage)
@@ -110,10 +129,23 @@ internal fun applyPassives(
     state: WorldState,
     balance: BalanceLookup,
     tick: Long,
+    equipmentBonuses: EquipmentBonusAggregator = EquipmentBonusAggregator.NoBonuses,
     passives: List<Passive> = defaultPassives(tick, balance),
 ): Pair<WorldState, WorldEvent.PassivesApplied?> {
+    // Build the per-tick equipment-bonus snapshot via a single batched query
+    // before the passives loop. The passive sweep itself stays cache-only.
+    // `state.bodies.keys` is naturally bounded to online + pending-spawn agents
+    // by WorldTickHandler.tickOne's `repository.load(worldId, loadSet)` filter —
+    // not the full agent population — so the batch is small per tick.
+    val snapshot = if (state.bodies.isEmpty()) {
+        EquipmentBonusSnapshot.Empty
+    } else {
+        EquipmentBonusSnapshot(
+            staminaRegen = equipmentBonuses.passiveBuffBatch(state.bodies.keys, ScalingEffect.STAMINA_REGEN),
+        )
+    }
     val desired: Map<AgentId, BodyDelta> = passives
-        .flatMap { it.deltasFor(state, balance).entries }
+        .flatMap { it.deltasFor(state, balance, snapshot).entries }
         .groupBy({ it.key }, { it.value })
         .mapValues { (_, deltas) -> deltas.fold(BodyDelta()) { acc, d -> acc + d } }
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/perks/TriggeredPassiveDispatcher.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/perks/TriggeredPassiveDispatcher.kt
@@ -2,9 +2,11 @@ package dev.gvart.genesara.world.internal.perks
 
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.PerkCooldownStore
+import dev.gvart.genesara.player.PerkId
 import dev.gvart.genesara.player.TriggeredPassiveLookup
 import dev.gvart.genesara.player.TriggeredPassiveTrigger
 import dev.gvart.genesara.player.TriggeredPerk
+import dev.gvart.genesara.world.EquipmentSetTriggerLookup
 import dev.gvart.genesara.world.events.WorldEvent
 import org.springframework.stereotype.Component
 import java.util.UUID
@@ -33,6 +35,7 @@ interface TriggeredPassiveDispatcher {
 @Component
 internal class TriggeredPassiveDispatcherImpl(
     private val lookup: TriggeredPassiveLookup,
+    private val setTriggers: EquipmentSetTriggerLookup,
     private val cooldowns: PerkCooldownStore,
 ) : TriggeredPassiveDispatcher {
 
@@ -43,12 +46,13 @@ internal class TriggeredPassiveDispatcherImpl(
         tick: Long,
         causedBy: UUID?,
     ): List<WorldEvent> {
-        val candidates = lookup.matching(firer, trigger)
-        if (candidates.isEmpty()) return emptyList()
+        val perkCandidates = lookup.matching(firer, trigger)
+        val setCandidates = setTriggers.matching(firer, trigger)
+        if (perkCandidates.isEmpty() && setCandidates.isEmpty()) return emptyList()
 
         val emitted = mutableListOf<WorldEvent>()
-        for (candidate in candidates) {
-            if (!shouldFire(candidate, ctx)) continue
+        for (candidate in perkCandidates) {
+            if (!shouldFirePerk(candidate, ctx)) continue
             if (!cooldowns.isReady(firer, candidate.perk.id, tick)) continue
 
             cooldowns.arm(firer, candidate.perk.id, tick + candidate.effect.internalCooldownTicks, tick)
@@ -63,19 +67,47 @@ internal class TriggeredPassiveDispatcherImpl(
                 causedBy = causedBy,
             )
         }
+        // Set-bonus triggers share the dispatcher loop but use synthetic perk ids
+        // for cooldown keying + event emission (ADR-0002). Same PerkTriggered event
+        // surface, so subscribers don't need a new variant — the `perkId` field's
+        // `set:` prefix is the discriminator.
+        for (candidate in setCandidates) {
+            if (!shouldFireSet(candidate.effect, ctx)) continue
+            val syntheticId = PerkId(candidate.syntheticPerkId)
+            if (!cooldowns.isReady(firer, syntheticId, tick)) continue
+
+            cooldowns.arm(firer, syntheticId, tick + candidate.effect.internalCooldownTicks, tick)
+            emitted += WorldEvent.PerkTriggered(
+                agent = firer,
+                perkId = syntheticId,
+                trigger = trigger,
+                effectKind = candidate.effect.effectKind,
+                params = candidate.effect.params,
+                target = (ctx as? TriggerContext.Combat)?.target,
+                tick = tick,
+                causedBy = causedBy,
+            )
+        }
         return emitted
     }
 
-    private fun shouldFire(perk: TriggeredPerk, ctx: TriggerContext): Boolean = when (perk.effect.trigger) {
-        TriggeredPassiveTrigger.ON_LOW_HP -> evaluateHpBandCross(perk, ctx)
-        else -> true
-    }
+    private fun shouldFirePerk(perk: TriggeredPerk, ctx: TriggerContext): Boolean =
+        shouldFireSet(perk.effect, ctx)
+
+    private fun shouldFireSet(effect: dev.gvart.genesara.player.PerkEffect.TriggeredPassive, ctx: TriggerContext): Boolean =
+        when (effect.trigger) {
+            TriggeredPassiveTrigger.ON_LOW_HP -> evaluateHpBandCross(effect, ctx)
+            else -> true
+        }
 
     // Descending-edge only: `prev > limit && new <= limit` is naturally idempotent —
     // successive damage while already below the band cannot re-satisfy `prev > limit`.
-    private fun evaluateHpBandCross(perk: TriggeredPerk, ctx: TriggerContext): Boolean {
+    private fun evaluateHpBandCross(
+        effect: dev.gvart.genesara.player.PerkEffect.TriggeredPassive,
+        ctx: TriggerContext,
+    ): Boolean {
         if (ctx !is TriggerContext.HpChange) return false
-        val thresholdPct = perk.effect.params["thresholdPct"]?.toIntOrNull() ?: return false
+        val thresholdPct = effect.params["thresholdPct"]?.toIntOrNull() ?: return false
         val limit = ctx.maxHp * thresholdPct / 100
         return ctx.prevHp > limit && ctx.newHp <= limit
     }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -134,7 +134,7 @@ internal class WorldTickHandler(
         // is resumed by the reducer instead of overwritten with a fresh one.
         val loadSet = if (commands.isEmpty()) online else online + commands.map { it.agent }
         val initial = repository.load(worldId, loadSet)
-        val (afterPassives, passivesEvent) = applyPassives(initial, balance, number)
+        val (afterPassives, passivesEvent) = applyPassives(initial, balance, number, equipmentBonuses)
         val (afterDeaths, deathEvents) = processDeaths(afterPassives, deathProcessor, number)
 
         val (next, commandEvents) = commands.fold(afterDeaths to emptyList<WorldEvent>()) { (state, acc), command ->

--- a/world/src/main/resources/world-definition/equipment-jewelry.yaml
+++ b/world/src/main/resources/world-definition/equipment-jewelry.yaml
@@ -7,7 +7,7 @@ items:
       display-name: Gem Amulet
       description: >-
         Polished gemstone set in an iron mounting. Boosts the wearer's
-        constitution.
+        constitution and grants a touch of stamina regeneration.
       category: EQUIPMENT
       weight-per-unit: 200
       max-stack: 1
@@ -17,6 +17,7 @@ items:
       two-handed: false
       bonuses:
         - { target: CONSTITUTION, magnitude: 2 }
+        - { target: STAMINA_REGEN, magnitude: 1 }
 
     # ──────────────────────── Rings ────────────────────────
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/BleederCanaryIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/BleederCanaryIntegrationTest.kt
@@ -126,7 +126,7 @@ class BleederCanaryIntegrationTest {
         val progression = SkillProgression(skills, publisher)
 
         val cd = InMemoryPerkCooldownStore()
-        val dispatcher = TriggeredPassiveDispatcherImpl(BleederLookup(attacker), cd)
+        val dispatcher = TriggeredPassiveDispatcherImpl(BleederLookup(attacker), dev.gvart.genesara.world.EquipmentSetTriggerLookup.NoSetTriggers, cd)
 
         val initial = WorldState(
             regions = mapOf(regionId to region),
@@ -206,7 +206,7 @@ class BleederCanaryIntegrationTest {
         val publisher = RecordingPublisher()
         val progression = SkillProgression(skills, publisher)
         val cd = InMemoryPerkCooldownStore()
-        val dispatcher = TriggeredPassiveDispatcherImpl(BothTriggersLookup(target), cd)
+        val dispatcher = TriggeredPassiveDispatcherImpl(BothTriggersLookup(target), dev.gvart.genesara.world.EquipmentSetTriggerLookup.NoSetTriggers, cd)
 
         val initial = WorldState(
             regions = mapOf(regionId to region),

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImplTest.kt
@@ -308,6 +308,9 @@ class EquipmentBonusAggregatorImplTest {
         override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> =
             perAgent[agentId].orEmpty()
 
+        override fun equippedForAll(agents: Set<AgentId>): Map<AgentId, Map<EquipSlot, EquipmentInstance>> =
+            perAgent.filterKeys { it in agents }
+
         override fun insert(instance: EquipmentInstance) = error("not used")
         override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
         override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = error("not used")

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetTriggerLookupImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetTriggerLookupImplTest.kt
@@ -1,0 +1,156 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.TriggeredPassiveEffectKind
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquippedBonus
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.EquipmentSet
+import dev.gvart.genesara.world.EquipmentSetId
+import dev.gvart.genesara.world.EquipmentSetLookup
+import dev.gvart.genesara.world.EquipmentSetThreshold
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.Rarity
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EquipmentSetTriggerLookupImplTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val ironHelm = ItemId("IRON_HELM")
+    private val ironChest = ItemId("IRON_CHEST")
+    private val ironBoots = ItemId("IRON_BOOTS")
+
+    private val reflect = PerkEffect.TriggeredPassive(
+        trigger = TriggeredPassiveTrigger.ON_HIT_TAKEN,
+        effectKind = TriggeredPassiveEffectKind.HEAL_SELF,
+        params = mapOf("multiplierPct" to "10"),
+        internalCooldownTicks = 5,
+    )
+    private val onHitDealt = PerkEffect.TriggeredPassive(
+        trigger = TriggeredPassiveTrigger.ON_HIT_DEALT,
+        effectKind = TriggeredPassiveEffectKind.GRANT_SELF_BUFF,
+        params = emptyMap(),
+        internalCooldownTicks = 3,
+    )
+    private val ironSet = EquipmentSet(
+        id = EquipmentSetId("IRON"),
+        pieces = setOf(ironHelm, ironChest, ironBoots),
+        thresholds = mapOf(
+            2 to EquipmentSetThreshold(
+                bonuses = listOf(EquippedBonus.ArmorDef(DamageType.SLASH, 1)),
+                triggeredPassives = listOf(reflect),
+            ),
+            3 to EquipmentSetThreshold(
+                bonuses = listOf(EquippedBonus.ArmorDef(DamageType.SLASH, 1)),
+                triggeredPassives = listOf(onHitDealt),
+            ),
+        ),
+    )
+
+    @Test
+    fun `no equipped pieces yields no triggers`() {
+        val lookup = EquipmentSetTriggerLookupImpl(EmptyStore, SetLookupOf(ironSet))
+        assertTrue(lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_TAKEN).isEmpty())
+    }
+
+    @Test
+    fun `equipping below the smallest threshold yields no triggers`() {
+        val store = SingleAgentStore(agent, mapOf(EquipSlot.HELMET to instance(ironHelm)))
+        val lookup = EquipmentSetTriggerLookupImpl(store, SetLookupOf(ironSet))
+
+        assertTrue(lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_TAKEN).isEmpty())
+    }
+
+    @Test
+    fun `2-piece equipped fires the 2-piece trigger only`() {
+        val store = SingleAgentStore(agent, mapOf(
+            EquipSlot.HELMET to instance(ironHelm),
+            EquipSlot.CHEST to instance(ironChest),
+        ))
+        val lookup = EquipmentSetTriggerLookupImpl(store, SetLookupOf(ironSet))
+
+        val active = lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_TAKEN)
+        assertEquals(1, active.size)
+        assertEquals(2, active.single().tier)
+        assertEquals("set:IRON@2:0", active.single().syntheticPerkId)
+    }
+
+    @Test
+    fun `3-piece equipped exposes both tier triggers, each on its own trigger key`() {
+        val store = SingleAgentStore(agent, mapOf(
+            EquipSlot.HELMET to instance(ironHelm),
+            EquipSlot.CHEST to instance(ironChest),
+            EquipSlot.BOOTS to instance(ironBoots),
+        ))
+        val lookup = EquipmentSetTriggerLookupImpl(store, SetLookupOf(ironSet))
+
+        val onHit = lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_TAKEN)
+        val onDealt = lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_DEALT)
+        assertEquals(listOf(2), onHit.map { it.tier })
+        assertEquals(listOf(3), onDealt.map { it.tier })
+    }
+
+    @Test
+    fun `mismatched trigger returns no entries`() {
+        val store = SingleAgentStore(agent, mapOf(
+            EquipSlot.HELMET to instance(ironHelm),
+            EquipSlot.CHEST to instance(ironChest),
+        ))
+        val lookup = EquipmentSetTriggerLookupImpl(store, SetLookupOf(ironSet))
+
+        assertTrue(lookup.matching(agent, TriggeredPassiveTrigger.ON_CRIT).isEmpty())
+    }
+
+    private fun instance(itemId: ItemId, rarity: Rarity = Rarity.COMMON): EquipmentInstance = EquipmentInstance(
+        instanceId = UUID.randomUUID(),
+        agentId = agent,
+        itemId = itemId,
+        rarity = rarity,
+        durabilityCurrent = 100,
+        durabilityMax = 100,
+        creatorAgentId = agent,
+        createdAtTick = 0L,
+        equippedInSlot = EquipSlot.HELMET,
+    )
+
+    private object EmptyStore : EquipmentInstanceStore {
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = emptyList()
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> = emptyMap()
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = error("not used")
+        override fun delete(instanceId: UUID): Boolean = error("not used")
+    }
+
+    private class SingleAgentStore(
+        private val target: AgentId,
+        private val equipped: Map<EquipSlot, EquipmentInstance>,
+    ) : EquipmentInstanceStore {
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = emptyList()
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> =
+            if (agentId == target) equipped else emptyMap()
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = error("not used")
+        override fun delete(instanceId: UUID): Boolean = error("not used")
+    }
+
+    private class SetLookupOf(vararg sets: EquipmentSet) : EquipmentSetLookup {
+        private val all = sets.toList()
+        override fun byId(id: EquipmentSetId): EquipmentSet? = all.firstOrNull { it.id == id }
+        override fun all(): List<EquipmentSet> = all
+        override fun setsContaining(itemId: ItemId): List<EquipmentSet> =
+            all.filter { itemId in it.pieces }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/passive/PassivesTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/passive/PassivesTest.kt
@@ -102,6 +102,42 @@ class PassivesTest {
         assertNull(event)
     }
 
+    @Test
+    fun `equipment STAMINA_REGEN bonus adds on top of the balance-driven regen`() {
+        val plusOneBonus = object : dev.gvart.genesara.world.EquipmentBonusAggregator {
+            override fun armorDef(agent: AgentId, damageType: dev.gvart.genesara.world.DamageType): Int = 0
+            override fun attributeBonus(agent: AgentId, attribute: dev.gvart.genesara.player.Attribute): Int = 0
+            override fun passiveBuff(agent: AgentId, effect: dev.gvart.genesara.player.ScalingEffect): Int =
+                if (effect == dev.gvart.genesara.player.ScalingEffect.STAMINA_REGEN) 2 else 0
+        }
+        // body at 5/10, base regen 1 + equipment +2 → +3 total → 8/10.
+        val (next, event) = applyPassives(world(stamina = 5), regenOne, tick = 1, equipmentBonuses = plusOneBonus)
+
+        assertEquals(8, next.bodyOf(agent)!!.stamina)
+        assertEquals(
+            WorldEvent.PassivesApplied(mapOf(agent to BodyDelta(stamina = 3)), tick = 1),
+            event,
+        )
+    }
+
+    @Test
+    fun `equipment STAMINA_REGEN does not bypass the low-vitals halt`() {
+        val plusBonus = object : dev.gvart.genesara.world.EquipmentBonusAggregator {
+            override fun armorDef(agent: AgentId, damageType: dev.gvart.genesara.world.DamageType): Int = 0
+            override fun attributeBonus(agent: AgentId, attribute: dev.gvart.genesara.player.Attribute): Int = 0
+            override fun passiveBuff(agent: AgentId, effect: dev.gvart.genesara.player.ScalingEffect): Int = 999
+        }
+        // Hunger=0 zeros isVitalsLow → no regen even with massive equipment bonus.
+        val starvedState = world(stamina = 5).let { state ->
+            state.copy(bodies = state.bodies.mapValues { (_, body) -> body.copy(hunger = 0, thirst = 0) })
+        }
+        val (next, event) = applyPassives(starvedState, regenOne, tick = 1, equipmentBonuses = plusBonus)
+
+        assertEquals(5, next.bodyOf(agent)!!.stamina)
+        // Other passives may still fire (starvation damage etc.) — assert specifically about stamina.
+        assertEquals(0, event?.deltas?.get(agent)?.stamina ?: 0)
+    }
+
     private fun balanceLookup(regen: Int) = object : BalanceLookup {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
         override fun staminaRegenPerTick(climate: Climate) = regen

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/perks/TriggeredPassiveDispatcherImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/perks/TriggeredPassiveDispatcherImplTest.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.world.internal.perks
 
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.EquipmentSetTriggerLookup
 import dev.gvart.genesara.player.Perk
 import dev.gvart.genesara.player.PerkCooldownStore
 import dev.gvart.genesara.player.PerkEffect
@@ -34,7 +35,7 @@ class TriggeredPassiveDispatcherImplTest {
     @Test
     fun `emits PerkTriggered when perk matches and cooldown ready`() {
         val cd = StubCooldownStore(initialReady = true)
-        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(bleeder)), cd)
+        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(bleeder)), EquipmentSetTriggerLookup.NoSetTriggers, cd)
 
         val events = dispatcher.dispatch(
             firer = agent,
@@ -59,7 +60,7 @@ class TriggeredPassiveDispatcherImplTest {
     @Test
     fun `skips perk when cooldown is not ready`() {
         val cd = StubCooldownStore(initialReady = false)
-        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(bleeder)), cd)
+        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(bleeder)), EquipmentSetTriggerLookup.NoSetTriggers, cd)
 
         val events = dispatcher.dispatch(
             firer = agent,
@@ -84,6 +85,7 @@ class TriggeredPassiveDispatcherImplTest {
         )
         val dispatcher = TriggeredPassiveDispatcherImpl(
             StubLookup(listOf(bleeder, rage)),
+            EquipmentSetTriggerLookup.NoSetTriggers,
             StubCooldownStore(initialReady = true),
         )
 
@@ -110,6 +112,7 @@ class TriggeredPassiveDispatcherImplTest {
         )
         val dispatcher = TriggeredPassiveDispatcherImpl(
             StubLookup(listOf(onHarvest)),
+            EquipmentSetTriggerLookup.NoSetTriggers,
             StubCooldownStore(initialReady = true),
         )
 
@@ -134,6 +137,7 @@ class TriggeredPassiveDispatcherImplTest {
         )
         val dispatcher = TriggeredPassiveDispatcherImpl(
             StubLookup(listOf(perk)),
+            EquipmentSetTriggerLookup.NoSetTriggers,
             StubCooldownStore(initialReady = true),
         )
 
@@ -175,7 +179,7 @@ class TriggeredPassiveDispatcherImplTest {
             params = mapOf("thresholdPct" to "25"),
         )
         val cd = StubCooldownStore(initialReady = false)
-        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(perk)), cd)
+        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(perk)), EquipmentSetTriggerLookup.NoSetTriggers, cd)
 
         val events = dispatcher.dispatch(
             firer = agent,
@@ -198,6 +202,7 @@ class TriggeredPassiveDispatcherImplTest {
         )
         val dispatcher = TriggeredPassiveDispatcherImpl(
             StubLookup(listOf(malformed)),
+            EquipmentSetTriggerLookup.NoSetTriggers,
             StubCooldownStore(initialReady = true),
         )
 
@@ -209,6 +214,73 @@ class TriggeredPassiveDispatcherImplTest {
             causedBy = cause,
         )
         assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `set-bonus triggered passive fires alongside perks with synthetic perk id`() {
+        val setTrigger = dev.gvart.genesara.world.ActiveSetTrigger(
+            setId = dev.gvart.genesara.world.EquipmentSetId("IRON"),
+            tier = 4,
+            indexInTier = 0,
+            effect = PerkEffect.TriggeredPassive(
+                trigger = TriggeredPassiveTrigger.ON_HIT_TAKEN,
+                effectKind = TriggeredPassiveEffectKind.HEAL_SELF,
+                params = mapOf("multiplierPct" to "10"),
+                internalCooldownTicks = 5,
+            ),
+        )
+        val setLookup = SingleSetTriggerLookup(setTrigger)
+        val cd = StubCooldownStore(initialReady = true)
+        val dispatcher = TriggeredPassiveDispatcherImpl(
+            StubLookup(emptyList()), setLookup, cd,
+        )
+
+        val events = dispatcher.dispatch(
+            firer = agent,
+            trigger = TriggeredPassiveTrigger.ON_HIT_TAKEN,
+            ctx = TriggerContext.Combat(target),
+            tick = 0L,
+            causedBy = cause,
+        )
+
+        val ev = events.single() as WorldEvent.PerkTriggered
+        assertEquals(PerkId("set:IRON@4:0"), ev.perkId)
+        assertEquals(TriggeredPassiveEffectKind.HEAL_SELF, ev.effectKind)
+        assertEquals(5L, cd.armedUntil[agent to PerkId("set:IRON@4:0")])
+    }
+
+    @Test
+    fun `set-bonus trigger respects cooldown like perks`() {
+        val setTrigger = dev.gvart.genesara.world.ActiveSetTrigger(
+            setId = dev.gvart.genesara.world.EquipmentSetId("IRON"),
+            tier = 4,
+            indexInTier = 0,
+            effect = PerkEffect.TriggeredPassive(
+                trigger = TriggeredPassiveTrigger.ON_HIT_TAKEN,
+                effectKind = TriggeredPassiveEffectKind.HEAL_SELF,
+                params = emptyMap(),
+                internalCooldownTicks = 5,
+            ),
+        )
+        val dispatcher = TriggeredPassiveDispatcherImpl(
+            StubLookup(emptyList()),
+            SingleSetTriggerLookup(setTrigger),
+            StubCooldownStore(initialReady = false),
+        )
+
+        val events = dispatcher.dispatch(
+            firer = agent,
+            trigger = TriggeredPassiveTrigger.ON_HIT_TAKEN,
+            ctx = TriggerContext.None,
+            tick = 0L,
+            causedBy = cause,
+        )
+        assertTrue(events.isEmpty())
+    }
+
+    private class SingleSetTriggerLookup(private val trigger: dev.gvart.genesara.world.ActiveSetTrigger) : EquipmentSetTriggerLookup {
+        override fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<dev.gvart.genesara.world.ActiveSetTrigger> =
+            if (this.trigger.effect.trigger == trigger) listOf(this.trigger) else emptyList()
     }
 
     private fun triggeredPerk(


### PR DESCRIPTION
## Summary

Final follow-ups for the #147 chain — both deferred items shipped in one PR. **Depends on #153** so this PR is targeted at \`feat/equipment-derived-pools\`. Re-target to \`main\` once the prior slices merge.

### Slice 5 — set-bonus triggered passives at thresholds

- \`EquipmentSetThreshold.triggeredPassives: List<PerkEffect.TriggeredPassive>\` — set thresholds can now declare ON_HIT_TAKEN reflects, ON_CRIT bleeds, etc. alongside stat bonuses.
- New \`EquipmentSetTriggerLookup\` (interface + \`NoSetTriggers\` companion + \`@Component\` impl).
- \`TriggeredPassiveDispatcher\` now composes \`TriggeredPassiveLookup\` (perks) + \`EquipmentSetTriggerLookup\` (sets). Set-bonus triggers use synthetic \`PerkId(\"set:<setId>@<tier>:<index>\")\` for cooldown keying via the existing \`PerkCooldownStore\`; same \`WorldEvent.PerkTriggered\` event surface.
- **Collision-prevention validators**: \`PerksValidator\` rejects real perks starting with \`\"set:\"\`; \`EquipmentSetId.init\` rejects \`':'\` / \`'@'\` in values.

### Slice 6 — STAMINA_REGEN wired via batched equipment query

- \`EquipmentInstanceStore.equippedForAll(agents: Set<AgentId>)\` — single batched WHERE-IN query (default impl falls back to N single calls for test stubs).
- \`EquipmentBonusAggregator.passiveBuffBatch(agents, effect): Map<AgentId, Int>\` — consumes the batched store call.
- \`applyPassives\` builds one \`EquipmentBonusSnapshot\` before the passive loop; the passive sweep is cache-only.
- \`staminaRegenPassive\` adds equipment STAMINA_REGEN on top of the climate-driven base; respects the low-vitals halt.
- **\`GEM_AMULET\` gets its \`STAMINA_REGEN +1\` bonus back** (dropped in Slice 3 to avoid shipping inert data).

## Test plan

- [x] \`EquipmentSetTriggerLookupImplTest\` — 5 cases (no equipped pieces, below-threshold, 2pc/3pc tiers, mismatched trigger).
- [x] \`TriggeredPassiveDispatcherImplTest\` — 2 new cases: set trigger fires alongside perks with synthetic id; set trigger respects cooldown.
- [x] \`PassivesTest\` — 2 new cases: equipment STAMINA_REGEN stacks on base regen; does NOT bypass low-vitals halt.
- [x] \`./gradlew :world:test :api:test :player:test\` — all green.

## Review feedback addressed

- **High**: synthetic-perk-id collision risk → validators added on both \`PerksValidator\` (reject \`\"set:\"\` perk-id prefix) and \`EquipmentSetId.init\` (reject \`':'\` / \`'@'\` chars).
- **Medium**: WHY comment on the \`passiveBuffBatch(state.bodies.keys, …)\` call site noting the load-set is naturally bounded to online + pending-spawn agents.
- Multi-effect snapshot batching (one query per effect → one query per snapshot) tracked under the existing \`TODO(equipment-effective)\` from Slice 4.

## #147 status after this PR

All four originally-planned slices + both deferred follow-ups are shipped. The remaining open trackers are:

- \`TODO(equipment-effective)\`: migrate carry cap / sight / crit / dodge to effective attributes (from Slice 4).
- \`TODO(perk-effects)\`: per-effect-kind resolvers (HEAL_SELF, APPLY_STATUS_TO_TARGET, …) attach to TriggeredPassive events.
- \`TODO(magic-class)\`: \`ScalingEffect.MAGICAL_DAMAGE_BONUS\` asymmetry with \`DamageType.MAGICAL\`.

None of these are blockers for closing #147.