### PR TITLE
feat(world,api): equipment definition — Slices 2–6 of #147

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsTool.kt
@@ -3,13 +3,12 @@ package dev.gvart.genesara.api.internal.mcp.tools.attributes
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.api.internal.mcp.tools.equipment.DerivedPoolsRefresher
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AllocateAttributesOutcome
 import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.events.AgentEvent
-import dev.gvart.genesara.world.WorldCommandGateway
-import dev.gvart.genesara.world.commands.WorldCommand
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.annotation.Tool
 import org.springframework.ai.tool.annotation.ToolParam
@@ -22,7 +21,7 @@ internal class AllocatePointsTool(
     private val activity: AgentActivityTracker,
     private val publisher: ApplicationEventPublisher,
     private val tickClock: TickClock,
-    private val world: WorldCommandGateway,
+    private val derivedPools: DerivedPoolsRefresher,
 ) {
 
     @Tool(
@@ -69,18 +68,11 @@ internal class AllocatePointsTool(
                         ),
                     )
                 }
-                // Profile pools just changed in player-side storage; queue a body-cache refresh
-                // so the next get_status reflects the new maxHp/Stamina/Mana instead of the
-                // stale values copied from the profile at spawn time.
-                world.submit(
-                    WorldCommand.RefreshDerivedPools(
-                        agent = agent,
-                        maxHp = outcome.pools.maxHp,
-                        maxStamina = outcome.pools.maxStamina,
-                        maxMana = outcome.pools.maxMana,
-                    ),
-                    appliesAtTick = tick + 1,
-                )
+                // Recompute pools through the shared refresher so the equipment-derived
+                // component (Slice 4) isn't wiped by a stale base-only computation. The
+                // registry has already been updated with the new base attributes; the
+                // refresher reads them and layers attribute bonuses on top.
+                derivedPools.refresh(agent)
                 AllocatePointsResponse.ok(
                     attrs = outcome.attributes,
                     remainingUnspent = outcome.remainingUnspent,

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/DerivedPoolsRefresher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/DerivedPoolsRefresher.kt
@@ -1,0 +1,63 @@
+package dev.gvart.genesara.api.internal.mcp.tools.equipment
+
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AttributeDerivation
+import dev.gvart.genesara.world.EffectiveAttributes
+import dev.gvart.genesara.world.EquipmentBonusAggregator
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.springframework.stereotype.Component
+
+/**
+ * Single entry point for "recompute max pools after something that changes
+ * the inputs". Both equip/unequip AND allocate_points must go through here
+ * — otherwise an `allocate_points` call would wipe the equipment-derived
+ * component of maxHp/Stamina/Mana until the next equip refresh.
+ *
+ * Computes effective attributes (base + equipped attribute bonuses) and
+ * queues a [WorldCommand.RefreshDerivedPools] at tick+1 so the body
+ * record's max cache reflects the new state next tick.
+ *
+ * **Current value semantics.** When the new max is **higher** (equipped
+ * +CON gear, spent attribute points), current HP/Stamina/Mana are
+ * preserved — a player at 50/100 stays at 50/120. When the new max is
+ * **lower** (unequipped +CON gear, de-leveled), the
+ * [dev.gvart.genesara.world.internal.body.reduceRefreshDerivedPools]
+ * reducer clamps current values down to the new max via `coerceAtMost`.
+ * D2 cap semantics, not WoW proportional rescaling.
+ */
+internal fun interface DerivedPoolsRefresher {
+    fun refresh(agent: AgentId)
+
+    companion object {
+        /** No-op refresher for tests that don't exercise pool recompute. */
+        val NoOp: DerivedPoolsRefresher = DerivedPoolsRefresher { /* nothing */ }
+    }
+}
+
+@Component
+internal class DerivedPoolsRefresherImpl(
+    private val agents: AgentRegistry,
+    private val bonuses: EquipmentBonusAggregator,
+    private val world: WorldCommandGateway,
+    private val tickClock: TickClock,
+) : DerivedPoolsRefresher {
+
+    override fun refresh(agent: AgentId) {
+        val record = agents.find(agent)
+            ?: error("derived-pool refresh: agent $agent missing from registry — upstream invariant broken")
+        val effective = EffectiveAttributes.compute(record.attributes, agent, bonuses)
+        val pools = AttributeDerivation.deriveMaxPools(effective)
+        world.submit(
+            WorldCommand.RefreshDerivedPools(
+                agent = agent,
+                maxHp = pools.maxHp,
+                maxStamina = pools.maxStamina,
+                maxMana = pools.maxMana,
+            ),
+            appliesAtTick = tickClock.currentTick() + 1,
+        )
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemTool.kt
@@ -17,6 +17,7 @@ import java.util.UUID
 internal class EquipItemTool(
     private val equipment: EquipmentService,
     private val activity: AgentActivityTracker,
+    private val derivedPools: DerivedPoolsRefresher,
 ) {
 
     @Tool(
@@ -46,10 +47,13 @@ internal class EquipItemTool(
         val agent = AgentContextHolder.current()
 
         return when (val result = equipment.equip(agent, instanceUuid, slot)) {
-            is EquipResult.Equipped -> EquipItemResponse.equipped(
-                instanceId = result.instance.instanceId,
-                slot = slot,
-            )
+            is EquipResult.Equipped -> {
+                derivedPools.refresh(agent)
+                EquipItemResponse.equipped(
+                    instanceId = result.instance.instanceId,
+                    slot = slot,
+                )
+            }
             is EquipResult.Rejected -> EquipItemResponse.rejected(
                 instanceId = instanceUuid.toString(),
                 slot = slot,

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotTool.kt
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component
 internal class UnequipSlotTool(
     private val equipment: EquipmentService,
     private val activity: AgentActivityTracker,
+    private val derivedPools: DerivedPoolsRefresher,
 ) {
 
     @Tool(
@@ -31,11 +32,14 @@ internal class UnequipSlotTool(
         val agent = AgentContextHolder.current()
 
         return when (val result = equipment.unequip(agent, slot)) {
-            is UnequipResult.Unequipped -> UnequipSlotResponse(
-                kind = "unequipped",
-                slot = slot,
-                instanceId = result.instance.instanceId,
-            )
+            is UnequipResult.Unequipped -> {
+                derivedPools.refresh(agent)
+                UnequipSlotResponse(
+                    kind = "unequipped",
+                    slot = slot,
+                    instanceId = result.instance.instanceId,
+                )
+            }
             is UnequipResult.SlotEmpty -> UnequipSlotResponse(
                 kind = "empty",
                 slot = slot,

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/attributes/AllocatePointsToolTest.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.attributes
 import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.tools.equipment.DerivedPoolsRefresher
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentAttributes
@@ -13,8 +14,6 @@ import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.AttributeMilestoneCrossing
 import dev.gvart.genesara.player.MaxPools
 import dev.gvart.genesara.player.events.AgentEvent
-import dev.gvart.genesara.world.WorldCommandGateway
-import dev.gvart.genesara.world.commands.WorldCommand
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -61,8 +60,8 @@ class AllocatePointsToolTest {
         val newAttrs = AgentAttributes(intelligence = 100)
         val registry = RecordingRegistry(returns = allocated(newAttrs, crossings = crossings))
         val publisher = RecordingPublisher()
-        val gateway = RecordingGateway()
-        val tool = AllocatePointsTool(registry, activity, publisher, tickClock, gateway)
+        val refresher = RecordingRefresher()
+        val tool = AllocatePointsTool(registry, activity, publisher, tickClock, refresher)
 
         val response = tool.invoke(mapOf(Attribute.INTELLIGENCE to 99), toolContext)
 
@@ -78,26 +77,19 @@ class AllocatePointsToolTest {
     }
 
     @Test
-    fun `successful allocation queues a RefreshDerivedPools world command with the new pool maxima`() {
+    fun `successful allocation routes pool recompute through DerivedPoolsRefresher`() {
         val registry = RecordingRegistry(
             returns = allocated(
                 attrs = AgentAttributes(constitution = 5, intelligence = 3),
                 remainingUnspent = 0,
-                pools = MaxPools(maxHp = 100, maxStamina = 55, maxMana = 15),
             ),
         )
-        val gateway = RecordingGateway()
-        val tool = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, gateway)
+        val refresher = RecordingRefresher()
+        val tool = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, refresher)
 
         tool.invoke(mapOf(Attribute.CONSTITUTION to 4, Attribute.INTELLIGENCE to 2), toolContext)
 
-        val (cmd, appliesAt) = gateway.submissions.single()
-        val refresh = assertNotNull(cmd as? WorldCommand.RefreshDerivedPools)
-        assertEquals(agent, refresh.agent)
-        assertEquals(100, refresh.maxHp)
-        assertEquals(55, refresh.maxStamina)
-        assertEquals(15, refresh.maxMana)
-        assertEquals(43L, appliesAt)
+        assertEquals(listOf(agent), refresher.refreshed)
     }
 
     @Test
@@ -105,7 +97,7 @@ class AllocatePointsToolTest {
         val registry = RecordingRegistry(returns = allocated(AgentAttributes(strength = 4), remainingUnspent = 2))
         val publisher = RecordingPublisher()
 
-        AllocatePointsTool(registry, activity, publisher, tickClock, RecordingGateway())
+        AllocatePointsTool(registry, activity, publisher, tickClock, RecordingRefresher())
             .invoke(mapOf(Attribute.STRENGTH to 3), toolContext)
 
         assertTrue(publisher.events.isEmpty())
@@ -114,21 +106,21 @@ class AllocatePointsToolTest {
     @Test
     fun `negative delta from registry maps to NEGATIVE_DELTA reason and skips the gateway`() {
         val registry = RecordingRegistry(returns = AllocateAttributesOutcome.NegativeDelta)
-        val gateway = RecordingGateway()
+        val refresher = RecordingRefresher()
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, gateway)
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, refresher)
             .invoke(mapOf(Attribute.STRENGTH to 1), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
         assertEquals(AllocatePointsRejectionReason.NEGATIVE_DELTA, response.reason)
-        assertTrue(gateway.submissions.isEmpty())
+        assertTrue(refresher.refreshed.isEmpty())
     }
 
     @Test
     fun `insufficient points reports unspent and requested in detail`() {
         val registry = RecordingRegistry(returns = AllocateAttributesOutcome.InsufficientPoints(unspent = 2, requested = 5L))
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingGateway())
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingRefresher())
             .invoke(mapOf(Attribute.STRENGTH to 5), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
@@ -141,36 +133,36 @@ class AllocatePointsToolTest {
     @Test
     fun `empty deltas short-circuits to NO_OP without touching the registry`() {
         val registry = RecordingRegistry(returns = AllocateAttributesOutcome.NegativeDelta)
-        val gateway = RecordingGateway()
+        val refresher = RecordingRefresher()
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, gateway)
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, refresher)
             .invoke(emptyMap(), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
         assertEquals(AllocatePointsRejectionReason.NO_OP, response.reason)
         assertTrue(registry.calls.isEmpty())
-        assertTrue(gateway.submissions.isEmpty())
+        assertTrue(refresher.refreshed.isEmpty())
     }
 
     @Test
     fun `all-zero deltas short-circuits to NO_OP without touching the registry`() {
         val registry = RecordingRegistry(returns = AllocateAttributesOutcome.NegativeDelta)
-        val gateway = RecordingGateway()
+        val refresher = RecordingRefresher()
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, gateway)
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, refresher)
             .invoke(mapOf(Attribute.STRENGTH to 0, Attribute.DEXTERITY to 0), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
         assertEquals(AllocatePointsRejectionReason.NO_OP, response.reason)
         assertTrue(registry.calls.isEmpty())
-        assertTrue(gateway.submissions.isEmpty())
+        assertTrue(refresher.refreshed.isEmpty())
     }
 
     @Test
     fun `null registry result becomes AGENT_MISSING`() {
         val registry = RecordingRegistry(returns = null)
 
-        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingGateway())
+        val response = AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingRefresher())
             .invoke(mapOf(Attribute.STRENGTH to 1), toolContext)
 
         assertEquals(AllocatePointsKind.REJECTED, response.kind)
@@ -181,7 +173,7 @@ class AllocatePointsToolTest {
     fun `touchActivity records the agent on every entry`() {
         val registry = RecordingRegistry(returns = allocated(AgentAttributes(), remainingUnspent = 4))
 
-        AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingGateway())
+        AllocatePointsTool(registry, activity, RecordingPublisher(), tickClock, RecordingRefresher())
             .invoke(mapOf(Attribute.STRENGTH to 1), toolContext)
 
         assertEquals(clock.instant(), activity.lastActiveAt(agent))
@@ -207,12 +199,9 @@ class AllocatePointsToolTest {
         }
     }
 
-    private class RecordingGateway : WorldCommandGateway {
-        val submissions = mutableListOf<Pair<WorldCommand, Long>>()
-        override fun submit(command: WorldCommand, appliesAtTick: Long): Long {
-            submissions += command to appliesAtTick
-            return appliesAtTick
-        }
+    private class RecordingRefresher : DerivedPoolsRefresher {
+        val refreshed = mutableListOf<AgentId>()
+        override fun refresh(agent: AgentId) { refreshed += agent }
     }
 
     private class StubTickClock(private val currentTick: Long) : TickClock {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/DerivedPoolsRefresherImplTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/DerivedPoolsRefresherImplTest.kt
@@ -1,0 +1,94 @@
+package dev.gvart.genesara.api.internal.mcp.tools.equipment
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.Attribute
+import dev.gvart.genesara.player.AttributeDerivation
+import dev.gvart.genesara.player.ScalingEffect
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.EquipmentBonusAggregator
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class DerivedPoolsRefresherImplTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+
+    @Test
+    fun `refresh queues RefreshDerivedPools at the next tick with effective-attribute pools`() {
+        val base = AgentAttributes(constitution = 4, intelligence = 2)
+        val agents = StubAgentRegistry(base)
+        val bonuses = ConCharmingBonuses(plusCon = 3, plusInt = 1)
+        val gateway = RecordingGateway()
+        val tickClock = StubTickClock(currentTick = 11)
+        val refresher = DerivedPoolsRefresherImpl(agents, bonuses, gateway, tickClock)
+
+        refresher.refresh(agent)
+
+        val expected = AttributeDerivation.deriveMaxPools(
+            AgentAttributes(constitution = 7, intelligence = 3),
+        )
+        val submitted = assertIs<WorldCommand.RefreshDerivedPools>(gateway.lastCommand)
+        assertEquals(agent, submitted.agent)
+        assertEquals(expected.maxHp, submitted.maxHp)
+        assertEquals(expected.maxStamina, submitted.maxStamina)
+        assertEquals(expected.maxMana, submitted.maxMana)
+        assertEquals(12L, gateway.lastAppliesAtTick)
+    }
+
+    @Test
+    fun `refresh throws when the agent is missing from the registry — surfaces upstream invariant break`() {
+        val agents = StubAgentRegistry(null)
+        val refresher = DerivedPoolsRefresherImpl(
+            agents,
+            EquipmentBonusAggregator.NoBonuses,
+            RecordingGateway(),
+            StubTickClock(currentTick = 0),
+        )
+
+        kotlin.test.assertFailsWith<IllegalStateException> { refresher.refresh(agent) }
+    }
+
+    private class StubAgentRegistry(private val attrs: AgentAttributes?) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = if (attrs == null) null else Agent(
+            id = id, owner = PlayerId(UUID.randomUUID()), name = "test", attributes = attrs,
+        )
+
+        override fun listForOwner(owner: PlayerId): List<Agent> = error("not used")
+    }
+
+    private class ConCharmingBonuses(
+        private val plusCon: Int,
+        private val plusInt: Int,
+    ) : EquipmentBonusAggregator {
+        override fun armorDef(agent: AgentId, damageType: DamageType): Int = 0
+        override fun attributeBonus(agent: AgentId, attribute: Attribute): Int = when (attribute) {
+            Attribute.CONSTITUTION -> plusCon
+            Attribute.INTELLIGENCE -> plusInt
+            else -> 0
+        }
+        override fun passiveBuff(agent: AgentId, effect: ScalingEffect): Int = 0
+    }
+
+    private class RecordingGateway : WorldCommandGateway {
+        var lastCommand: WorldCommand? = null
+        var lastAppliesAtTick: Long = -1
+        override fun submit(command: WorldCommand, appliesAtTick: Long): Long {
+            lastCommand = command
+            lastAppliesAtTick = appliesAtTick
+            return appliesAtTick
+        }
+    }
+
+    private class StubTickClock(private val currentTick: Long) : TickClock {
+        override fun currentTick(): Long = currentTick
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/EquipItemToolTest.kt
@@ -39,7 +39,7 @@ class EquipItemToolTest {
         val service = StubEquipmentService(
             equipResult = EquipResult.Equipped(sampleInstance(instanceId, EquipSlot.MAIN_HAND)),
         )
-        val tool = EquipItemTool(service, activity)
+        val tool = EquipItemTool(service, activity, DerivedPoolsRefresher.NoOp)
 
         val res = tool.invoke(instanceId.toString(), EquipSlot.MAIN_HAND, toolContext)
 
@@ -50,11 +50,43 @@ class EquipItemToolTest {
     }
 
     @Test
+    fun `successful equip triggers derived-pool refresh for the calling agent`() {
+        val instanceId = UUID.randomUUID()
+        val service = StubEquipmentService(
+            equipResult = EquipResult.Equipped(sampleInstance(instanceId, EquipSlot.HELMET)),
+        )
+        val refresher = RecordingPoolsRefresher()
+        val tool = EquipItemTool(service, activity, refresher)
+
+        tool.invoke(instanceId.toString(), EquipSlot.HELMET, toolContext)
+
+        assertEquals(listOf(agent), refresher.refreshed)
+    }
+
+    @Test
+    fun `rejected equip does NOT trigger derived-pool refresh`() {
+        val service = StubEquipmentService(
+            equipResult = EquipResult.Rejected(EquipRejection.INSUFFICIENT_ATTRIBUTES),
+        )
+        val refresher = RecordingPoolsRefresher()
+        val tool = EquipItemTool(service, activity, refresher)
+
+        tool.invoke(UUID.randomUUID().toString(), EquipSlot.HELMET, toolContext)
+
+        assertTrue(refresher.refreshed.isEmpty())
+    }
+
+    private class RecordingPoolsRefresher : DerivedPoolsRefresher {
+        val refreshed = mutableListOf<AgentId>()
+        override fun refresh(agent: AgentId) { refreshed += agent }
+    }
+
+    @Test
     fun `rejection result returns kind=rejected with snake_case reason and detail`() {
         val service = StubEquipmentService(
             equipResult = EquipResult.Rejected(EquipRejection.OFF_HAND_BLOCKED_BY_TWO_HANDED),
         )
-        val tool = EquipItemTool(service, activity)
+        val tool = EquipItemTool(service, activity, DerivedPoolsRefresher.NoOp)
 
         val res = tool.invoke(UUID.randomUUID().toString(), EquipSlot.OFF_HAND, toolContext)
 
@@ -72,7 +104,7 @@ class EquipItemToolTest {
                 detail = customDetail,
             ),
         )
-        val tool = EquipItemTool(service, activity)
+        val tool = EquipItemTool(service, activity, DerivedPoolsRefresher.NoOp)
 
         val res = tool.invoke(UUID.randomUUID().toString(), EquipSlot.MAIN_HAND, toolContext)
 
@@ -84,7 +116,7 @@ class EquipItemToolTest {
     @Test
     fun `malformed instanceId is rejected at the tool boundary without hitting the service`() {
         val service = StubEquipmentService()
-        val tool = EquipItemTool(service, activity)
+        val tool = EquipItemTool(service, activity, DerivedPoolsRefresher.NoOp)
 
         val res = tool.invoke("not-a-uuid", EquipSlot.MAIN_HAND, toolContext)
 

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/UnequipSlotToolTest.kt
@@ -39,6 +39,7 @@ class UnequipSlotToolTest {
                 unequipResult = UnequipResult.Unequipped(sampleInstance(instanceId, slot = null)),
             ),
             activity,
+            DerivedPoolsRefresher.NoOp,
         )
 
         val res = tool.invoke(EquipSlot.MAIN_HAND, toolContext)
@@ -50,13 +51,49 @@ class UnequipSlotToolTest {
 
     @Test
     fun `empty slot returns kind=empty`() {
-        val tool = UnequipSlotTool(StubEquipmentService(unequipResult = UnequipResult.SlotEmpty), activity)
+        val tool = UnequipSlotTool(StubEquipmentService(unequipResult = UnequipResult.SlotEmpty), activity, DerivedPoolsRefresher.NoOp)
 
         val res = tool.invoke(EquipSlot.HELMET, toolContext)
 
         assertEquals("empty", res.kind)
         assertEquals(EquipSlot.HELMET, res.slot)
         assertEquals(null, res.instanceId)
+    }
+
+    @Test
+    fun `successful unequip triggers derived-pool refresh for the calling agent`() {
+        val instanceId = UUID.randomUUID()
+        val refresher = RecordingPoolsRefresher()
+        val tool = UnequipSlotTool(
+            StubEquipmentService(
+                unequipResult = UnequipResult.Unequipped(sampleInstance(instanceId, slot = null)),
+            ),
+            activity,
+            refresher,
+        )
+
+        tool.invoke(EquipSlot.HELMET, toolContext)
+
+        assertEquals(listOf(agent), refresher.refreshed)
+    }
+
+    @Test
+    fun `empty-slot unequip does NOT trigger derived-pool refresh`() {
+        val refresher = RecordingPoolsRefresher()
+        val tool = UnequipSlotTool(
+            StubEquipmentService(unequipResult = UnequipResult.SlotEmpty),
+            activity,
+            refresher,
+        )
+
+        tool.invoke(EquipSlot.HELMET, toolContext)
+
+        kotlin.test.assertTrue(refresher.refreshed.isEmpty())
+    }
+
+    private class RecordingPoolsRefresher : DerivedPoolsRefresher {
+        val refreshed = mutableListOf<AgentId>()
+        override fun refresh(agent: AgentId) { refreshed += agent }
     }
 
     private fun sampleInstance(id: UUID, slot: EquipSlot?) = EquipmentInstance(

--- a/docs/adr/0002-equipment-set-bonuses.md
+++ b/docs/adr/0002-equipment-set-bonuses.md
@@ -31,6 +31,8 @@ sets:
 
 A startup `EquipmentSetReferentialValidator` enforces: every id in `pieces` resolves in `ItemLookup` AND has `category: EQUIPMENT`. An item can appear in multiple sets.
 
+**Threshold stacking.** Tiers stack additively — wearing 4 IRON pieces grants the 2-piece bonus AND the 4-piece bonus (Diablo / WoW convention). Each threshold defines the bonuses *added at that tier*, not the total for that tier.
+
 ### Rarity scaling
 
 Item rarity is per-instance (`EquipmentInstance.rarity`, rolled at craft). With mismatched-rarity loadouts (3 Legendary IRON + 1 Common IRON), the set magnitude scales by the **average rarity** of the equipped pieces from that set:

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/PerksValidator.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/balance/PerksValidator.kt
@@ -59,6 +59,12 @@ internal object PerksValidator {
 
     private fun validatePerk(perk: PerkProperties, location: String, problems: MutableList<String>) {
         if (perk.id.isBlank()) problems += "$location: perk id is blank"
+        // The equipment-set dispatcher synthesizes PerkIds prefixed `"set:"` for cooldown
+        // keying (world/internal/perks/TriggeredPassiveDispatcher). A real catalog perk
+        // sharing that prefix would collide in PerkCooldownStore.
+        if (perk.id.startsWith("set:")) {
+            problems += "$location: perk id '${perk.id}' must not start with 'set:' (reserved prefix for equipment-set triggers)"
+        }
         if (perk.displayName.isBlank()) problems += "$location: missing display-name"
         if (perk.description.isBlank()) problems += "$location: missing description"
         validateEffect(perk.effect, location, problems)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EffectiveAttributes.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EffectiveAttributes.kt
@@ -1,0 +1,31 @@
+package dev.gvart.genesara.world
+
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.Attribute
+
+/**
+ * Composes an agent's [AgentAttributes] from base + equipped attribute bonuses.
+ *
+ * Used by derived-pool calculations (max HP from CON, etc.) so equipped gear
+ * with `AttributeBonus` entries actually affects body maxes. Never used by
+ * `required-attributes` equip checks — those always read base (per ADR-0001,
+ * to prevent recursive bootstrap where +CON gear qualifies the agent for
+ * higher-CON gear).
+ *
+ * TODO(equipment-effective): extend usage to carry capacity (STR), sight range
+ *   (PER), and any future attribute-driven derived stat. Slice 4 only wires
+ *   max pools; the rest still read base attributes.
+ */
+object EffectiveAttributes {
+
+    fun compute(base: AgentAttributes, agent: AgentId, bonuses: EquipmentBonusAggregator): AgentAttributes =
+        AgentAttributes(
+            strength = base.strength + bonuses.attributeBonus(agent, Attribute.STRENGTH),
+            dexterity = base.dexterity + bonuses.attributeBonus(agent, Attribute.DEXTERITY),
+            constitution = base.constitution + bonuses.attributeBonus(agent, Attribute.CONSTITUTION),
+            perception = base.perception + bonuses.attributeBonus(agent, Attribute.PERCEPTION),
+            intelligence = base.intelligence + bonuses.attributeBonus(agent, Attribute.INTELLIGENCE),
+            luck = base.luck + bonuses.attributeBonus(agent, Attribute.LUCK),
+        )
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentBonusAggregator.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentBonusAggregator.kt
@@ -25,6 +25,21 @@ interface EquipmentBonusAggregator {
 
     fun passiveBuff(agent: AgentId, effect: ScalingEffect): Int
 
+    /**
+     * Batched form of [passiveBuff] — one query for [agents], one [effect].
+     * Used by per-tick consumers (passive sweep) where issuing N
+     * single-agent queries would cost N DB round-trips. Agents with no
+     * matching bonus are absent from the map.
+     *
+     * Default impl falls back to N single-agent calls for stub
+     * implementations; production
+     * [dev.gvart.genesara.world.internal.equipment.EquipmentBonusAggregatorImpl]
+     * overrides with a single batched [EquipmentInstanceStore.equippedForAll]
+     * call.
+     */
+    fun passiveBuffBatch(agents: Set<AgentId>, effect: ScalingEffect): Map<AgentId, Int> =
+        agents.associateWith { passiveBuff(it, effect) }.filterValues { it != 0 }
+
     companion object {
         /** Empty-result aggregator for tests that don't exercise equipment bonuses. */
         val NoBonuses: EquipmentBonusAggregator = object : EquipmentBonusAggregator {

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentInstanceStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentInstanceStore.kt
@@ -45,6 +45,19 @@ interface EquipmentInstanceStore {
     fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance>
 
     /**
+     * Batched form of [equippedFor] for per-tick consumers (passive sweep,
+     * combat broadcast). Issues one query for all [agents] rather than N
+     * single-agent calls. Agents with no equipped gear are absent from the
+     * returned map.
+     *
+     * Default impl falls back to N single-agent calls for stub
+     * implementations; production [dev.gvart.genesara.world.internal.equipment.JooqEquipmentInstanceStore]
+     * overrides with a single SQL query.
+     */
+    fun equippedForAll(agents: Set<AgentId>): Map<AgentId, Map<EquipSlot, EquipmentInstance>> =
+        agents.associateWith { equippedFor(it) }.filterValues { it.isNotEmpty() }
+
+    /**
      * Move the instance into [slot]. Atomic: returns the updated row, or null
      * when no row matches `(instance_id, agent_id)` — the [agentId] predicate
      * is part of the WHERE clause so this also rejects an attempt to move

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSet.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSet.kt
@@ -1,0 +1,51 @@
+package dev.gvart.genesara.world
+
+@JvmInline
+value class EquipmentSetId(val value: String) {
+    init {
+        require(value.isNotBlank()) { "EquipmentSetId must not be blank" }
+    }
+
+    override fun toString(): String = value
+}
+
+/**
+ * A named group of equipment items granting threshold bonuses when an agent
+ * has N pieces equipped. Pieces are declared in [pieces]; items stay
+ * agnostic of which sets they belong to (an item can appear in multiple
+ * sets). See ADR-0002.
+ */
+data class EquipmentSet(
+    val id: EquipmentSetId,
+    val pieces: Set<ItemId>,
+    /** Tier count (must be ≥1) → bonuses granted while the agent has that many pieces equipped. */
+    val thresholds: Map<Int, EquipmentSetThreshold>,
+) {
+    init {
+        require(pieces.isNotEmpty()) { "$id: pieces must not be empty" }
+        require(thresholds.isNotEmpty()) { "$id: thresholds must not be empty" }
+        thresholds.keys.forEach { tier ->
+            require(tier in 1..pieces.size) {
+                "$id: threshold tier $tier must be in 1..${pieces.size} (pieces in set)"
+            }
+        }
+    }
+
+    /**
+     * Bonuses granted by every threshold whose tier ≤ [equippedCount]. Tiers
+     * stack additively — wearing 4 IRON pieces grants the 2-piece bonus AND
+     * the 4-piece bonus (matches the WoW/Diablo convention).
+     */
+    fun activeBonuses(equippedCount: Int): List<EquippedBonus> =
+        thresholds.entries
+            .filter { (tier, _) -> tier <= equippedCount }
+            .flatMap { it.value.bonuses }
+}
+
+data class EquipmentSetThreshold(
+    val bonuses: List<EquippedBonus>,
+) {
+    init {
+        require(bonuses.isNotEmpty()) { "EquipmentSetThreshold.bonuses must not be empty" }
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSet.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSet.kt
@@ -1,9 +1,16 @@
 package dev.gvart.genesara.world
 
+import dev.gvart.genesara.player.PerkEffect
+
 @JvmInline
 value class EquipmentSetId(val value: String) {
     init {
         require(value.isNotBlank()) { "EquipmentSetId must not be blank" }
+        // The dispatcher synthesizes "set:<id>@<tier>:<index>" PerkIds for cooldown keying;
+        // a set id containing ':' or '@' would deform the key and collide ambiguously.
+        require(':' !in value && '@' !in value) {
+            "EquipmentSetId '$value' must not contain ':' or '@' (reserved for synthetic perk-id keying)"
+        }
     }
 
     override fun toString(): String = value
@@ -40,12 +47,36 @@ data class EquipmentSet(
         thresholds.entries
             .filter { (tier, _) -> tier <= equippedCount }
             .flatMap { it.value.bonuses }
+
+    /**
+     * Triggered passives armed by every threshold whose tier ≤ [equippedCount].
+     * Returned as `(tier, indexInTier, effect)` triples so the dispatcher can
+     * synthesize a stable cooldown id per active set-bonus trigger.
+     */
+    fun activeTriggeredPassives(equippedCount: Int): List<ActiveTriggeredPassive> =
+        thresholds.entries
+            .filter { (tier, _) -> tier <= equippedCount }
+            .sortedBy { it.key }
+            .flatMap { (tier, threshold) ->
+                threshold.triggeredPassives.mapIndexed { idx, effect ->
+                    ActiveTriggeredPassive(tier = tier, indexInTier = idx, effect = effect)
+                }
+            }
+
+    data class ActiveTriggeredPassive(
+        val tier: Int,
+        val indexInTier: Int,
+        val effect: PerkEffect.TriggeredPassive,
+    )
 }
 
 data class EquipmentSetThreshold(
     val bonuses: List<EquippedBonus>,
+    val triggeredPassives: List<PerkEffect.TriggeredPassive> = emptyList(),
 ) {
     init {
-        require(bonuses.isNotEmpty()) { "EquipmentSetThreshold.bonuses must not be empty" }
+        require(bonuses.isNotEmpty() || triggeredPassives.isNotEmpty()) {
+            "EquipmentSetThreshold must declare at least one bonus or triggered passive"
+        }
     }
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSetLookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSetLookup.kt
@@ -1,0 +1,16 @@
+package dev.gvart.genesara.world
+
+/** Catalog-level read surface for the [EquipmentSet] registry (ADR-0002). */
+interface EquipmentSetLookup {
+
+    fun byId(id: EquipmentSetId): EquipmentSet?
+
+    fun all(): List<EquipmentSet>
+
+    /**
+     * Sets that contain [itemId] in their `pieces` list. Used by the bonus
+     * aggregator to discover which sets an agent's equipped item contributes
+     * to without walking every catalog entry per call.
+     */
+    fun setsContaining(itemId: ItemId): List<EquipmentSet>
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSetTriggerLookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/EquipmentSetTriggerLookup.kt
@@ -1,0 +1,38 @@
+package dev.gvart.genesara.world
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+
+/**
+ * Per-agent lookup for set-bonus triggered passives — the sister surface to
+ * [dev.gvart.genesara.player.TriggeredPassiveLookup] but sourced from
+ * equipped set pieces instead of chosen perks.
+ *
+ * The dispatcher combines both lookups when firing
+ * [WorldEvent.PerkTriggered][dev.gvart.genesara.world.events.WorldEvent.PerkTriggered]
+ * events; set bonuses get a synthetic perk id `"set:<setId>@<tier>:<index>"`
+ * so the existing [dev.gvart.genesara.player.PerkCooldownStore] keys them
+ * without a parallel store.
+ */
+interface EquipmentSetTriggerLookup {
+
+    fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<ActiveSetTrigger>
+
+    companion object {
+        /** Empty-result lookup for tests that don't exercise set-bonus triggers. */
+        val NoSetTriggers: EquipmentSetTriggerLookup = object : EquipmentSetTriggerLookup {
+            override fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<ActiveSetTrigger> = emptyList()
+        }
+    }
+}
+
+data class ActiveSetTrigger(
+    val setId: EquipmentSetId,
+    val tier: Int,
+    val indexInTier: Int,
+    val effect: PerkEffect.TriggeredPassive,
+) {
+    /** Synthetic perk id used by the dispatcher for cooldown keying and event emission. */
+    val syntheticPerkId: String = "set:${setId.value}@$tier:$indexInTier"
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/EquippedBonusBinder.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/EquippedBonusBinder.kt
@@ -1,0 +1,20 @@
+package dev.gvart.genesara.world.internal.balance
+
+import dev.gvart.genesara.player.Attribute
+import dev.gvart.genesara.player.ScalingEffect
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.EquippedBonus
+
+/**
+ * Dispatches a YAML `{ target, magnitude }` bonus entry into the typed
+ * [EquippedBonus] variant by checking [target] against three enum lists.
+ * Throws on unknown targets — the calling context names the source
+ * ([sourceId]: item id, set id, etc.) for the error message.
+ */
+internal fun EquippedBonusProperties.bindToDomain(sourceId: String): EquippedBonus {
+    val raw = target
+    DamageType.entries.firstOrNull { it.name == raw }?.let { return EquippedBonus.ArmorDef(it, magnitude) }
+    Attribute.entries.firstOrNull { it.name == raw }?.let { return EquippedBonus.AttributeBonus(it, magnitude) }
+    ScalingEffect.entries.firstOrNull { it.name == raw }?.let { return EquippedBonus.PassiveBuff(it, magnitude) }
+    error("$sourceId: unknown bonus target '$raw' (expected one of DamageType, Attribute, or ScalingEffect)")
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemLookupImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemLookupImpl.kt
@@ -1,11 +1,7 @@
 package dev.gvart.genesara.world.internal.balance
 
-import dev.gvart.genesara.player.Attribute
-import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.world.ConsumableEffect
-import dev.gvart.genesara.world.DamageType
-import dev.gvart.genesara.world.EquippedBonus
 import dev.gvart.genesara.world.Item
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.ItemLookup
@@ -50,14 +46,6 @@ internal class ItemLookupImpl(
         weaponPower = weaponPower,
         combatSkill = combatSkill?.let(::SkillId),
         range = range,
-        bonuses = bonuses.map { it.toDomain(id) },
+        bonuses = bonuses.map { it.bindToDomain(id.value) },
     )
-
-    private fun EquippedBonusProperties.toDomain(itemId: ItemId): EquippedBonus {
-        val raw = target
-        DamageType.entries.firstOrNull { it.name == raw }?.let { return EquippedBonus.ArmorDef(it, magnitude) }
-        Attribute.entries.firstOrNull { it.name == raw }?.let { return EquippedBonus.AttributeBonus(it, magnitude) }
-        ScalingEffect.entries.firstOrNull { it.name == raw }?.let { return EquippedBonus.PassiveBuff(it, magnitude) }
-        error("${itemId.value}: unknown bonus target '$raw' (expected one of DamageType, Attribute, or ScalingEffect)")
-    }
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -7,6 +7,7 @@ import dev.gvart.genesara.world.Climate
 import dev.gvart.genesara.world.DamageType
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.Rarity
 import dev.gvart.genesara.world.ResourceSpawnRule
 import dev.gvart.genesara.world.Terrain
 import org.springframework.stereotype.Component
@@ -188,6 +189,20 @@ internal interface BalanceLookup {
     fun combatStatFor(skill: SkillId): Attribute = when (skill.value) {
         "BOW" -> Attribute.DEXTERITY
         else -> Attribute.STRENGTH
+    }
+
+    /**
+     * Magnitude scaler for equipment-set bonuses, keyed by the average rarity
+     * ordinal of the equipped set pieces (rounded to the nearest tier). Curve
+     * is `{COMMON: 1.0, UNCOMMON: 1.25, RARE: 1.5, EPIC: 1.75, LEGENDARY: 2.0}`
+     * per ADR-0002. Tunable from one place.
+     */
+    fun rarityMultiplier(avgRarity: Rarity): Double = when (avgRarity) {
+        Rarity.COMMON -> 1.0
+        Rarity.UNCOMMON -> 1.25
+        Rarity.RARE -> 1.5
+        Rarity.EPIC -> 1.75
+        Rarity.LEGENDARY -> 2.0
     }
 
     /** XP delta granted to the weapon's combat-skill per successful attack. Mirrors craft/build at 1. */

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
@@ -143,12 +143,16 @@ internal fun reduceAttack(
     // Dodge rolls FIRST so a successful dodge short-circuits the crit roll. Otherwise a crit
     // followed by a dodge would burn the RNG cursor on a discarded crit and shift downstream
     // rolls — keeping order matters for reproducible seeds.
-    val dodgeChance = balance.dodgeChancePercent(defender.attributes.dexterity)
+    val dodgeChance = balance.dodgeChancePercent(defender.attributes.dexterity) +
+        equipmentBonuses.passiveBuff(command.target, ScalingEffect.DODGE_CHANCE)
     val isDodged = rng.nextInt(100) < dodgeChance
     val (hpLost, isCrit) = if (isDodged) {
         0 to false
     } else {
-        val critChance = balance.critChancePercent(attacker.attributes.luck)
+        // Equipped CRIT_CHANCE bonuses (e.g. GEM_RING) add percentage points on top
+        // of the LUCK-derived base. Same shape as DODGE_CHANCE on the defender side.
+        val critChance = balance.critChancePercent(attacker.attributes.luck) +
+            equipmentBonuses.passiveBuff(command.agent, ScalingEffect.CRIT_CHANCE)
         val crit = rng.nextInt(100) < critChance
         val landed = if (crit) scaledDamage * balance.critMultiplier() else scaledDamage
         landed to crit

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImpl.kt
@@ -34,6 +34,19 @@ internal class EquipmentBonusAggregatorImpl(
     override fun passiveBuff(agent: AgentId, effect: ScalingEffect): Int =
         total(agent) { it is EquippedBonus.PassiveBuff && it.effect == effect }
 
+    override fun passiveBuffBatch(agents: Set<AgentId>, effect: ScalingEffect): Map<AgentId, Int> {
+        if (agents.isEmpty()) return emptyMap()
+        val equippedByAgent = equipment.equippedForAll(agents)
+        if (equippedByAgent.isEmpty()) return emptyMap()
+        val match: (EquippedBonus) -> Boolean = { it is EquippedBonus.PassiveBuff && it.effect == effect }
+        val result = mutableMapOf<AgentId, Int>()
+        for ((agent, equipped) in equippedByAgent) {
+            val value = perPieceSum(equipped, match) + setBonusSum(equipped, match)
+            if (value != 0) result[agent] = value
+        }
+        return result
+    }
+
     private inline fun total(agent: AgentId, match: (EquippedBonus) -> Boolean): Int {
         val equipped = equipment.equippedFor(agent)
         if (equipped.isEmpty()) return 0

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImpl.kt
@@ -5,36 +5,92 @@ import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.world.DamageType
 import dev.gvart.genesara.world.EquipmentBonusAggregator
+import dev.gvart.genesara.world.EquipmentInstance
 import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.EquipmentSet
+import dev.gvart.genesara.world.EquipmentSetLookup
 import dev.gvart.genesara.world.EquippedBonus
+import dev.gvart.genesara.world.EquipSlot
 import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.Rarity
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import org.springframework.stereotype.Component
+import kotlin.math.roundToInt
 
 @Component
 internal class EquipmentBonusAggregatorImpl(
     private val equipment: EquipmentInstanceStore,
     private val items: ItemLookup,
+    private val sets: EquipmentSetLookup,
+    private val balance: BalanceLookup,
 ) : EquipmentBonusAggregator {
 
     override fun armorDef(agent: AgentId, damageType: DamageType): Int =
-        sum(agent) { it is EquippedBonus.ArmorDef && it.damageType == damageType }
+        total(agent) { it is EquippedBonus.ArmorDef && it.damageType == damageType }
 
     override fun attributeBonus(agent: AgentId, attribute: Attribute): Int =
-        sum(agent) { it is EquippedBonus.AttributeBonus && it.attribute == attribute }
+        total(agent) { it is EquippedBonus.AttributeBonus && it.attribute == attribute }
 
     override fun passiveBuff(agent: AgentId, effect: ScalingEffect): Int =
-        sum(agent) { it is EquippedBonus.PassiveBuff && it.effect == effect }
+        total(agent) { it is EquippedBonus.PassiveBuff && it.effect == effect }
 
-    private inline fun sum(agent: AgentId, match: (EquippedBonus) -> Boolean): Int {
+    private inline fun total(agent: AgentId, match: (EquippedBonus) -> Boolean): Int {
         val equipped = equipment.equippedFor(agent)
         if (equipped.isEmpty()) return 0
+        return perPieceSum(equipped, match) + setBonusSum(equipped, match)
+    }
+
+    private inline fun perPieceSum(
+        equipped: Map<EquipSlot, EquipmentInstance>,
+        match: (EquippedBonus) -> Boolean,
+    ): Int {
         var acc = 0
         for ((_, instance) in equipped) {
             val item = items.byId(instance.itemId) ?: continue
-            for (bonus in item.bonuses) {
-                if (match(bonus)) acc += bonus.magnitude
+            for (bonus in item.bonuses) if (match(bonus)) acc += bonus.magnitude
+        }
+        return acc
+    }
+
+    private inline fun setBonusSum(
+        equipped: Map<EquipSlot, EquipmentInstance>,
+        match: (EquippedBonus) -> Boolean,
+    ): Int {
+        // Walk instances once, grouping by set membership. An item can belong
+        // to multiple sets (ADR-0002), so a single instance may push multiple
+        // counts and rarity contributions.
+        val contributions = mutableMapOf<EquipmentSet, MutableList<Rarity>>()
+        for ((_, instance) in equipped) {
+            for (set in sets.setsContaining(instance.itemId)) {
+                contributions.getOrPut(set) { mutableListOf() }.add(instance.rarity)
+            }
+        }
+        if (contributions.isEmpty()) return 0
+        var acc = 0
+        for ((set, rarities) in contributions) {
+            val activeBonuses = set.activeBonuses(rarities.size)
+            if (activeBonuses.isEmpty()) continue
+            val avgRarity = averageRarity(rarities)
+            val multiplier = balance.rarityMultiplier(avgRarity)
+            for (bonus in activeBonuses) {
+                if (match(bonus)) {
+                    acc += (bonus.magnitude * multiplier).roundToInt()
+                }
             }
         }
         return acc
+    }
+
+    /**
+     * Average ordinal across [rarities], rounded **half-up** (Kotlin
+     * `Double.roundToInt` is half-away-from-zero; all ordinals are
+     * non-negative so it collapses to half-up here). Mean 2.5 rounds to
+     * 3 (EPIC), not 2 (RARE). Mixed loadouts smooth through the rarity
+     * multiplier curve in [BalanceLookup] — see ADR-0002.
+     */
+    private fun averageRarity(rarities: List<Rarity>): Rarity {
+        val mean = rarities.sumOf { it.ordinal }.toDouble() / rarities.size
+        val rounded = mean.roundToInt().coerceIn(0, Rarity.entries.lastIndex)
+        return Rarity.entries[rounded]
     }
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetConfiguration.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetConfiguration.kt
@@ -1,0 +1,14 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.world.internal.balance.YamlPropertySourceFactory
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.PropertySource
+
+@Configuration
+@PropertySource(
+    value = ["classpath:world-definition/equipment-sets.yaml"],
+    factory = YamlPropertySourceFactory::class,
+)
+@EnableConfigurationProperties(EquipmentSetDefinitionProperties::class)
+internal class EquipmentSetConfiguration

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetDefinitionProperties.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetDefinitionProperties.kt
@@ -1,0 +1,8 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "sets")
+internal data class EquipmentSetDefinitionProperties(
+    val catalog: Map<String, EquipmentSetProperties> = emptyMap(),
+)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetLookupImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetLookupImpl.kt
@@ -1,0 +1,40 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.world.EquipmentSet
+import dev.gvart.genesara.world.EquipmentSetId
+import dev.gvart.genesara.world.EquipmentSetLookup
+import dev.gvart.genesara.world.EquipmentSetThreshold
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.internal.balance.bindToDomain
+import org.springframework.stereotype.Component
+
+@Component
+internal class EquipmentSetLookupImpl(
+    props: EquipmentSetDefinitionProperties,
+) : EquipmentSetLookup {
+
+    private val byId: Map<EquipmentSetId, EquipmentSet> = props.catalog.entries.associate { (key, properties) ->
+        val id = EquipmentSetId(key)
+        id to properties.toDomain(id)
+    }
+
+    private val byItem: Map<ItemId, List<EquipmentSet>> = byId.values
+        .flatMap { set -> set.pieces.map { it to set } }
+        .groupBy({ it.first }, { it.second })
+
+    override fun byId(id: EquipmentSetId): EquipmentSet? = byId[id]
+
+    override fun all(): List<EquipmentSet> = byId.values.toList()
+
+    override fun setsContaining(itemId: ItemId): List<EquipmentSet> = byItem[itemId].orEmpty()
+
+    private fun EquipmentSetProperties.toDomain(id: EquipmentSetId): EquipmentSet = EquipmentSet(
+        id = id,
+        pieces = pieces.map(::ItemId).toSet(),
+        thresholds = thresholds.mapValues { (tier, threshold) ->
+            EquipmentSetThreshold(
+                bonuses = threshold.bonuses.map { it.bindToDomain("${id.value}@$tier") },
+            )
+        },
+    )
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetLookupImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetLookupImpl.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.world.internal.equipment
 
+import dev.gvart.genesara.player.PerkEffect
 import dev.gvart.genesara.world.EquipmentSet
 import dev.gvart.genesara.world.EquipmentSetId
 import dev.gvart.genesara.world.EquipmentSetLookup
@@ -34,6 +35,14 @@ internal class EquipmentSetLookupImpl(
         thresholds = thresholds.mapValues { (tier, threshold) ->
             EquipmentSetThreshold(
                 bonuses = threshold.bonuses.map { it.bindToDomain("${id.value}@$tier") },
+                triggeredPassives = threshold.triggeredPassives.map { p ->
+                    PerkEffect.TriggeredPassive(
+                        trigger = p.trigger,
+                        effectKind = p.effectKind,
+                        params = p.params,
+                        internalCooldownTicks = p.internalCooldownTicks,
+                    )
+                },
             )
         },
     )

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetProperties.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetProperties.kt
@@ -1,5 +1,8 @@
 package dev.gvart.genesara.world.internal.equipment
 
+import dev.gvart.genesara.player.TriggeredPassiveEffectKind
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+
 internal data class EquipmentSetProperties(
     val pieces: List<String>,
     /** Map<tierCount, threshold> — tier 2/4/6/etc → bonuses added at that tier. */
@@ -8,4 +11,18 @@ internal data class EquipmentSetProperties(
 
 internal data class EquipmentSetThresholdProperties(
     val bonuses: List<dev.gvart.genesara.world.internal.balance.EquippedBonusProperties> = emptyList(),
+    /**
+     * Optional triggered passives that arm when this threshold is active. Re-uses
+     * the [TriggeredPassiveTrigger] / [TriggeredPassiveEffectKind] enums from the
+     * perk system; the dispatcher composes set-bonus triggers alongside chosen
+     * perks via a synthetic perk id keyed `"set:<setId>@<tier>:<index>"`.
+     */
+    val triggeredPassives: List<EquipmentSetTriggeredPassiveProperties> = emptyList(),
+)
+
+internal data class EquipmentSetTriggeredPassiveProperties(
+    val trigger: TriggeredPassiveTrigger,
+    val effectKind: TriggeredPassiveEffectKind,
+    val params: Map<String, String> = emptyMap(),
+    val internalCooldownTicks: Int = 0,
 )

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetProperties.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetProperties.kt
@@ -1,0 +1,11 @@
+package dev.gvart.genesara.world.internal.equipment
+
+internal data class EquipmentSetProperties(
+    val pieces: List<String>,
+    /** Map<tierCount, threshold> — tier 2/4/6/etc → bonuses added at that tier. */
+    val thresholds: Map<Int, EquipmentSetThresholdProperties>,
+)
+
+internal data class EquipmentSetThresholdProperties(
+    val bonuses: List<dev.gvart.genesara.world.internal.balance.EquippedBonusProperties> = emptyList(),
+)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetReferentialValidator.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetReferentialValidator.kt
@@ -1,0 +1,40 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.world.EquipmentSetLookup
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemLookup
+import jakarta.annotation.PostConstruct
+import org.springframework.stereotype.Component
+
+/**
+ * Boot-time check that every set piece resolves in [ItemLookup] AND has
+ * `category: EQUIPMENT`. Set bonuses only make sense on items that can be
+ * equipped — a typo or accidental RESOURCE inclusion silently dies otherwise.
+ */
+@Component
+internal class EquipmentSetReferentialValidator(
+    private val sets: EquipmentSetLookup,
+    private val items: ItemLookup,
+) {
+
+    @PostConstruct
+    fun validate() {
+        val problems = mutableListOf<String>()
+        for (set in sets.all()) {
+            for (piece in set.pieces) {
+                val item = items.byId(piece)
+                if (item == null) {
+                    problems += "${set.id}: piece '${piece.value}' is not in the items catalog"
+                } else if (item.category != ItemCategory.EQUIPMENT) {
+                    problems += "${set.id}: piece '${piece.value}' is ${item.category} — must be EQUIPMENT"
+                }
+            }
+        }
+        require(problems.isEmpty()) {
+            buildString {
+                append("Equipment-set referential validation failed:\n")
+                problems.forEach { append("  - $it\n") }
+            }
+        }
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetTriggerLookupImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetTriggerLookupImpl.kt
@@ -1,0 +1,44 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import dev.gvart.genesara.world.ActiveSetTrigger
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.EquipmentSet
+import dev.gvart.genesara.world.EquipmentSetLookup
+import dev.gvart.genesara.world.EquipmentSetTriggerLookup
+import org.springframework.stereotype.Component
+
+@Component
+internal class EquipmentSetTriggerLookupImpl(
+    private val equipment: EquipmentInstanceStore,
+    private val sets: EquipmentSetLookup,
+) : EquipmentSetTriggerLookup {
+
+    override fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<ActiveSetTrigger> {
+        val equipped = equipment.equippedFor(agent)
+        if (equipped.isEmpty()) return emptyList()
+
+        val countsPerSet = mutableMapOf<EquipmentSet, Int>()
+        for ((_, instance) in equipped) {
+            for (set in sets.setsContaining(instance.itemId)) {
+                countsPerSet[set] = (countsPerSet[set] ?: 0) + 1
+            }
+        }
+        if (countsPerSet.isEmpty()) return emptyList()
+
+        val matches = mutableListOf<ActiveSetTrigger>()
+        for ((set, count) in countsPerSet) {
+            for (active in set.activeTriggeredPassives(count)) {
+                if (active.effect.trigger != trigger) continue
+                matches += ActiveSetTrigger(
+                    setId = set.id,
+                    tier = active.tier,
+                    indexInTier = active.indexInTier,
+                    effect = active.effect,
+                )
+            }
+        }
+        return matches
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/JooqEquipmentInstanceStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/equipment/JooqEquipmentInstanceStore.kt
@@ -53,6 +53,17 @@ internal class JooqEquipmentInstanceStore(
             .fetch(::toDomain)
             .associateBy { it.equippedInSlot!! }
 
+    @Transactional(readOnly = true)
+    override fun equippedForAll(agents: Set<AgentId>): Map<AgentId, Map<EquipSlot, EquipmentInstance>> {
+        if (agents.isEmpty()) return emptyMap()
+        return dsl.selectFrom(AGENT_EQUIPMENT_INSTANCES)
+            .where(AGENT_EQUIPMENT_INSTANCES.AGENT_ID.`in`(agents.map { it.id }))
+            .and(AGENT_EQUIPMENT_INSTANCES.EQUIPPED_IN_SLOT.isNotNull)
+            .fetch(::toDomain)
+            .groupBy({ it.agentId }, { it })
+            .mapValues { (_, instances) -> instances.associateBy { it.equippedInSlot!! } }
+    }
+
     @Transactional
     override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? =
         dsl.update(AGENT_EQUIPMENT_INSTANCES)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/passive/Passives.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/passive/Passives.kt
@@ -1,15 +1,30 @@
 package dev.gvart.genesara.world.internal.passive
 
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.world.BodyDelta
+import dev.gvart.genesara.world.EquipmentBonusAggregator
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import kotlin.math.roundToInt
 
+/**
+ * Per-tick equipment-bonus snapshot for the bodies in `state.bodies`. Built once
+ * via [EquipmentBonusAggregator.passiveBuffBatch] at the [applyPassives] boundary
+ * so passives don't issue N single-agent queries.
+ */
+internal data class EquipmentBonusSnapshot(
+    val staminaRegen: Map<AgentId, Int>,
+) {
+    companion object {
+        val Empty: EquipmentBonusSnapshot = EquipmentBonusSnapshot(emptyMap())
+    }
+}
+
 internal fun interface Passive {
-    fun deltasFor(state: WorldState, balance: BalanceLookup): Map<AgentId, BodyDelta>
+    fun deltasFor(state: WorldState, balance: BalanceLookup, bonuses: EquipmentBonusSnapshot): Map<AgentId, BodyDelta>
 }
 
 /**
@@ -18,7 +33,7 @@ internal fun interface Passive {
  * multiply it. The low-gate runs first so halt and buff stay mutually exclusive. HP /
  * Mana regen will read the same gates when those passives ship.
  */
-internal val staminaRegenPassive = Passive { state, balance ->
+internal val staminaRegenPassive = Passive { state, balance, bonuses ->
     state.bodies.mapNotNull { (id, body) ->
         if (body.isVitalsLow(balance::gaugeLowThreshold)) return@mapNotNull null
         val nodeId = state.positions[id] ?: return@mapNotNull null
@@ -31,7 +46,11 @@ internal val staminaRegenPassive = Passive { state, balance ->
         } else {
             baseRegen
         }
-        if (regen == 0) null else id to BodyDelta(stamina = regen)
+        // Equipment STAMINA_REGEN bonuses add on top of the base/buff-multiplied
+        // value — flat additive, same shape as PassiveAura aggregator entries.
+        val equipBonus = bonuses.staminaRegen[id] ?: 0
+        val total = regen + equipBonus
+        if (total == 0) null else id to BodyDelta(stamina = total)
     }.toMap()
 }
 
@@ -43,7 +62,7 @@ internal val staminaRegenPassive = Passive { state, balance ->
  * Fast-path returns an empty map when both drains are zero — saves one allocation per
  * body per tick in tests and any future "rested" world configuration.
  */
-internal val gaugeDrainPassive = Passive { state, balance ->
+internal val gaugeDrainPassive = Passive { state, balance, _ ->
     val hungerDrain = -balance.gaugeDrainPerTick(Gauge.HUNGER)
     val thirstDrain = -balance.gaugeDrainPerTick(Gauge.THIRST)
     if (hungerDrain == 0 && thirstDrain == 0) {
@@ -71,7 +90,7 @@ internal val gaugeDrainPassive = Passive { state, balance ->
  * Fast-path returns an empty map when both drain and regen are zero (e.g. in tests that
  * disable survival entirely).
  */
-internal val sleepPassive = Passive { state, balance ->
+internal val sleepPassive = Passive { state, balance, _ ->
     val drain = balance.gaugeDrainPerTick(Gauge.SLEEP)
     val regen = balance.sleepRegenPerOfflineTick()
     if (drain == 0 && regen == 0) {
@@ -89,7 +108,7 @@ internal val sleepPassive = Passive { state, balance ->
  * A single tick of damage covers all zero-gauges combined — agents die from prolonged
  * neglect, not from triple-overlap punishment.
  */
-internal val starvationDamagePassive = Passive { state, balance ->
+internal val starvationDamagePassive = Passive { state, balance, _ ->
     val damage = balance.starvationDamagePerTick()
     state.bodies.mapNotNull { (id, body) ->
         if (!body.isStarving()) null else id to BodyDelta(hp = -damage)
@@ -110,10 +129,23 @@ internal fun applyPassives(
     state: WorldState,
     balance: BalanceLookup,
     tick: Long,
+    equipmentBonuses: EquipmentBonusAggregator = EquipmentBonusAggregator.NoBonuses,
     passives: List<Passive> = defaultPassives(tick, balance),
 ): Pair<WorldState, WorldEvent.PassivesApplied?> {
+    // Build the per-tick equipment-bonus snapshot via a single batched query
+    // before the passives loop. The passive sweep itself stays cache-only.
+    // `state.bodies.keys` is naturally bounded to online + pending-spawn agents
+    // by WorldTickHandler.tickOne's `repository.load(worldId, loadSet)` filter —
+    // not the full agent population — so the batch is small per tick.
+    val snapshot = if (state.bodies.isEmpty()) {
+        EquipmentBonusSnapshot.Empty
+    } else {
+        EquipmentBonusSnapshot(
+            staminaRegen = equipmentBonuses.passiveBuffBatch(state.bodies.keys, ScalingEffect.STAMINA_REGEN),
+        )
+    }
     val desired: Map<AgentId, BodyDelta> = passives
-        .flatMap { it.deltasFor(state, balance).entries }
+        .flatMap { it.deltasFor(state, balance, snapshot).entries }
         .groupBy({ it.key }, { it.value })
         .mapValues { (_, deltas) -> deltas.fold(BodyDelta()) { acc, d -> acc + d } }
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/perks/TriggeredPassiveDispatcher.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/perks/TriggeredPassiveDispatcher.kt
@@ -2,9 +2,11 @@ package dev.gvart.genesara.world.internal.perks
 
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.PerkCooldownStore
+import dev.gvart.genesara.player.PerkId
 import dev.gvart.genesara.player.TriggeredPassiveLookup
 import dev.gvart.genesara.player.TriggeredPassiveTrigger
 import dev.gvart.genesara.player.TriggeredPerk
+import dev.gvart.genesara.world.EquipmentSetTriggerLookup
 import dev.gvart.genesara.world.events.WorldEvent
 import org.springframework.stereotype.Component
 import java.util.UUID
@@ -33,6 +35,7 @@ interface TriggeredPassiveDispatcher {
 @Component
 internal class TriggeredPassiveDispatcherImpl(
     private val lookup: TriggeredPassiveLookup,
+    private val setTriggers: EquipmentSetTriggerLookup,
     private val cooldowns: PerkCooldownStore,
 ) : TriggeredPassiveDispatcher {
 
@@ -43,12 +46,13 @@ internal class TriggeredPassiveDispatcherImpl(
         tick: Long,
         causedBy: UUID?,
     ): List<WorldEvent> {
-        val candidates = lookup.matching(firer, trigger)
-        if (candidates.isEmpty()) return emptyList()
+        val perkCandidates = lookup.matching(firer, trigger)
+        val setCandidates = setTriggers.matching(firer, trigger)
+        if (perkCandidates.isEmpty() && setCandidates.isEmpty()) return emptyList()
 
         val emitted = mutableListOf<WorldEvent>()
-        for (candidate in candidates) {
-            if (!shouldFire(candidate, ctx)) continue
+        for (candidate in perkCandidates) {
+            if (!shouldFirePerk(candidate, ctx)) continue
             if (!cooldowns.isReady(firer, candidate.perk.id, tick)) continue
 
             cooldowns.arm(firer, candidate.perk.id, tick + candidate.effect.internalCooldownTicks, tick)
@@ -63,19 +67,47 @@ internal class TriggeredPassiveDispatcherImpl(
                 causedBy = causedBy,
             )
         }
+        // Set-bonus triggers share the dispatcher loop but use synthetic perk ids
+        // for cooldown keying + event emission (ADR-0002). Same PerkTriggered event
+        // surface, so subscribers don't need a new variant — the `perkId` field's
+        // `set:` prefix is the discriminator.
+        for (candidate in setCandidates) {
+            if (!shouldFireSet(candidate.effect, ctx)) continue
+            val syntheticId = PerkId(candidate.syntheticPerkId)
+            if (!cooldowns.isReady(firer, syntheticId, tick)) continue
+
+            cooldowns.arm(firer, syntheticId, tick + candidate.effect.internalCooldownTicks, tick)
+            emitted += WorldEvent.PerkTriggered(
+                agent = firer,
+                perkId = syntheticId,
+                trigger = trigger,
+                effectKind = candidate.effect.effectKind,
+                params = candidate.effect.params,
+                target = (ctx as? TriggerContext.Combat)?.target,
+                tick = tick,
+                causedBy = causedBy,
+            )
+        }
         return emitted
     }
 
-    private fun shouldFire(perk: TriggeredPerk, ctx: TriggerContext): Boolean = when (perk.effect.trigger) {
-        TriggeredPassiveTrigger.ON_LOW_HP -> evaluateHpBandCross(perk, ctx)
-        else -> true
-    }
+    private fun shouldFirePerk(perk: TriggeredPerk, ctx: TriggerContext): Boolean =
+        shouldFireSet(perk.effect, ctx)
+
+    private fun shouldFireSet(effect: dev.gvart.genesara.player.PerkEffect.TriggeredPassive, ctx: TriggerContext): Boolean =
+        when (effect.trigger) {
+            TriggeredPassiveTrigger.ON_LOW_HP -> evaluateHpBandCross(effect, ctx)
+            else -> true
+        }
 
     // Descending-edge only: `prev > limit && new <= limit` is naturally idempotent —
     // successive damage while already below the band cannot re-satisfy `prev > limit`.
-    private fun evaluateHpBandCross(perk: TriggeredPerk, ctx: TriggerContext): Boolean {
+    private fun evaluateHpBandCross(
+        effect: dev.gvart.genesara.player.PerkEffect.TriggeredPassive,
+        ctx: TriggerContext,
+    ): Boolean {
         if (ctx !is TriggerContext.HpChange) return false
-        val thresholdPct = perk.effect.params["thresholdPct"]?.toIntOrNull() ?: return false
+        val thresholdPct = effect.params["thresholdPct"]?.toIntOrNull() ?: return false
         val limit = ctx.maxHp * thresholdPct / 100
         return ctx.prevHp > limit && ctx.newHp <= limit
     }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -134,7 +134,7 @@ internal class WorldTickHandler(
         // is resumed by the reducer instead of overwritten with a fresh one.
         val loadSet = if (commands.isEmpty()) online else online + commands.map { it.agent }
         val initial = repository.load(worldId, loadSet)
-        val (afterPassives, passivesEvent) = applyPassives(initial, balance, number)
+        val (afterPassives, passivesEvent) = applyPassives(initial, balance, number, equipmentBonuses)
         val (afterDeaths, deathEvents) = processDeaths(afterPassives, deathProcessor, number)
 
         val (next, commandEvents) = commands.fold(afterDeaths to emptyList<WorldEvent>()) { (state, acc), command ->

--- a/world/src/main/resources/world-definition/equipment-armor.yaml
+++ b/world/src/main/resources/world-definition/equipment-armor.yaml
@@ -1,3 +1,13 @@
+# Armor catalog. The `bonuses:` list under each item carries wearer-bonuses while
+# the item is equipped. On armor pieces, bonus `target` values that name a damage
+# type (SLASH/PIERCE/BLUNT/ENERGY/MAGICAL) are interpreted as defensive bonuses
+# against that type — the binder dispatches to EquippedBonus.ArmorDef and the
+# combat reducer multiplies armor-def by defender CON to get mitigation per lore §9.
+#
+# Magnitudes are tuned small (single digits per piece) because the combat formula
+# already amplifies them by defender CON. A full iron set + CON 12 should yield
+# meaningful but non-immune mitigation against an iron-tier weapon swing.
+
 items:
   catalog:
 
@@ -14,6 +24,8 @@ items:
       max-durability: 60
       valid-slots: [HELMET]
       two-handed: false
+      bonuses:
+        - { target: SLASH, magnitude: 1 }
 
     LEATHER_TUNIC:
       display-name: Leather Tunic
@@ -27,6 +39,9 @@ items:
       max-durability: 80
       valid-slots: [CHEST]
       two-handed: false
+      bonuses:
+        - { target: SLASH, magnitude: 2 }
+        - { target: PIERCE, magnitude: 1 }
 
     LEATHER_PANTS:
       display-name: Leather Pants
@@ -40,6 +55,9 @@ items:
       max-durability: 70
       valid-slots: [PANTS]
       two-handed: false
+      bonuses:
+        - { target: SLASH, magnitude: 1 }
+        - { target: PIERCE, magnitude: 1 }
 
     LEATHER_BOOTS:
       display-name: Leather Boots
@@ -53,6 +71,8 @@ items:
       max-durability: 60
       valid-slots: [BOOTS]
       two-handed: false
+      bonuses:
+        - { target: BLUNT, magnitude: 1 }
 
     LEATHER_GLOVES:
       display-name: Leather Gloves
@@ -65,6 +85,8 @@ items:
       max-durability: 50
       valid-slots: [GLOVES]
       two-handed: false
+      bonuses:
+        - { target: SLASH, magnitude: 1 }
 
     # ───────────────────── T2 armor: iron (forge) ─────────────────────
 
@@ -82,6 +104,10 @@ items:
       two-handed: false
       required-attributes:
         STRENGTH: 8
+      bonuses:
+        - { target: SLASH, magnitude: 1 }
+        - { target: BLUNT, magnitude: 1 }
+        - { target: CONSTITUTION, magnitude: 1 }
 
     IRON_CHESTPLATE:
       display-name: Iron Chestplate
@@ -97,6 +123,11 @@ items:
       two-handed: false
       required-attributes:
         STRENGTH: 12
+      bonuses:
+        - { target: SLASH, magnitude: 2 }
+        - { target: PIERCE, magnitude: 1 }
+        - { target: BLUNT, magnitude: 1 }
+        - { target: CONSTITUTION, magnitude: 1 }
 
     IRON_GREAVES:
       display-name: Iron Greaves
@@ -112,6 +143,9 @@ items:
       two-handed: false
       required-attributes:
         STRENGTH: 10
+      bonuses:
+        - { target: SLASH, magnitude: 1 }
+        - { target: PIERCE, magnitude: 1 }
 
     IRON_BOOTS:
       display-name: Iron Boots
@@ -127,6 +161,8 @@ items:
       two-handed: false
       required-attributes:
         STRENGTH: 8
+      bonuses:
+        - { target: BLUNT, magnitude: 1 }
 
     IRON_GAUNTLETS:
       display-name: Iron Gauntlets
@@ -142,6 +178,8 @@ items:
       two-handed: false
       required-attributes:
         STRENGTH: 8
+      bonuses:
+        - { target: BLUNT, magnitude: 1 }
 
     # ───────────────────── T2 armor: cloth (workbench, magic-flavored) ─────────────────────
 
@@ -157,6 +195,10 @@ items:
       max-durability: 40
       valid-slots: [HELMET]
       two-handed: false
+      bonuses:
+        - { target: ENERGY, magnitude: 2 }
+        - { target: MAGICAL, magnitude: 2 }
+        - { target: INTELLIGENCE, magnitude: 1 }
 
     CLOTH_ROBE:
       display-name: Cloth Robe
@@ -170,3 +212,7 @@ items:
       max-durability: 60
       valid-slots: [CHEST]
       two-handed: false
+      bonuses:
+        - { target: ENERGY, magnitude: 3 }
+        - { target: MAGICAL, magnitude: 3 }
+        - { target: INTELLIGENCE, magnitude: 2 }

--- a/world/src/main/resources/world-definition/equipment-jewelry.yaml
+++ b/world/src/main/resources/world-definition/equipment-jewelry.yaml
@@ -7,7 +7,7 @@ items:
       display-name: Gem Amulet
       description: >-
         Polished gemstone set in an iron mounting. Boosts the wearer's
-        constitution.
+        constitution and grants a touch of stamina regeneration.
       category: EQUIPMENT
       weight-per-unit: 200
       max-stack: 1
@@ -17,6 +17,7 @@ items:
       two-handed: false
       bonuses:
         - { target: CONSTITUTION, magnitude: 2 }
+        - { target: STAMINA_REGEN, magnitude: 1 }
 
     # ──────────────────────── Rings ────────────────────────
 

--- a/world/src/main/resources/world-definition/equipment-jewelry.yaml
+++ b/world/src/main/resources/world-definition/equipment-jewelry.yaml
@@ -6,8 +6,8 @@ items:
     GEM_AMULET:
       display-name: Gem Amulet
       description: >-
-        Polished gemstone set in an iron mounting. The forge-tier amulet —
-        future perks will hang attribute bonuses off this slot.
+        Polished gemstone set in an iron mounting. Boosts the wearer's
+        constitution.
       category: EQUIPMENT
       weight-per-unit: 200
       max-stack: 1
@@ -15,6 +15,8 @@ items:
       max-durability: 80
       valid-slots: [AMULET]
       two-handed: false
+      bonuses:
+        - { target: CONSTITUTION, magnitude: 2 }
 
     # ──────────────────────── Rings ────────────────────────
 
@@ -30,12 +32,14 @@ items:
       max-durability: 100
       valid-slots: [RING_LEFT, RING_RIGHT]
       two-handed: false
+      bonuses:
+        - { target: STRENGTH, magnitude: 1 }
 
     GEM_RING:
       display-name: Gem Ring
       description: >-
-        Gemstone-set ring on an iron band. T2 equivalent of the iron ring;
-        future perk surface for crit / Luck bonuses.
+        Gemstone-set ring on an iron band. Sharpens the wearer's edge in
+        combat — a small but reliable luck and crit nudge.
       category: EQUIPMENT
       weight-per-unit: 120
       max-stack: 1
@@ -43,6 +47,9 @@ items:
       max-durability: 90
       valid-slots: [RING_LEFT, RING_RIGHT]
       two-handed: false
+      bonuses:
+        - { target: LUCK, magnitude: 1 }
+        - { target: CRIT_CHANCE, magnitude: 2 }
 
     # ──────────────────────── Bracelets ────────────────────────
 
@@ -57,6 +64,8 @@ items:
       max-durability: 60
       valid-slots: [BRACELET_LEFT, BRACELET_RIGHT]
       two-handed: false
+      bonuses:
+        - { target: DEXTERITY, magnitude: 1 }
 
     IRON_BRACELET:
       display-name: Iron Bracelet
@@ -69,3 +78,6 @@ items:
       max-durability: 100
       valid-slots: [BRACELET_LEFT, BRACELET_RIGHT]
       two-handed: false
+      bonuses:
+        - { target: SLASH, magnitude: 1 }
+        - { target: PIERCE, magnitude: 1 }

--- a/world/src/main/resources/world-definition/equipment-sets.yaml
+++ b/world/src/main/resources/world-definition/equipment-sets.yaml
@@ -5,8 +5,29 @@
 # Magnitudes scale by average rarity of equipped set pieces via the rarityMultiplier
 # curve in BalanceLookup. See ADR-0002.
 #
-# Slice 2 ships the infrastructure with an empty catalog; Slice 3 populates the
-# first IRON set after equipment items grow their `bonuses:` blocks.
+# Bonus `target` values that name a DamageType (SLASH/PIERCE/BLUNT/ENERGY/MAGICAL)
+# are interpreted as defensive bonuses against that type — the binder dispatches to
+# EquippedBonus.ArmorDef. The combat reducer multiplies armor-def by defender CON
+# per lore §9; keep magnitudes single-digit accordingly.
 
 sets:
-  catalog: {}
+  catalog:
+
+    IRON:
+      pieces:
+        - IRON_HELM
+        - IRON_CHESTPLATE
+        - IRON_GREAVES
+        - IRON_BOOTS
+        - IRON_GAUNTLETS
+      thresholds:
+        2:
+          bonuses:
+            - { target: SLASH, magnitude: 1 }
+        4:
+          bonuses:
+            - { target: PIERCE, magnitude: 1 }
+        5:
+          bonuses:
+            - { target: CONSTITUTION, magnitude: 2 }
+            - { target: BLUNT, magnitude: 1 }

--- a/world/src/main/resources/world-definition/equipment-sets.yaml
+++ b/world/src/main/resources/world-definition/equipment-sets.yaml
@@ -1,0 +1,12 @@
+# Equipment set bonuses. Pieces declared per-set; items themselves stay agnostic
+# of which sets they belong to (an item can appear in multiple sets). Threshold
+# tiers stack additively — wearing 4 IRON pieces grants 2-piece AND 4-piece bonuses.
+#
+# Magnitudes scale by average rarity of equipped set pieces via the rarityMultiplier
+# curve in BalanceLookup. See ADR-0002.
+#
+# Slice 2 ships the infrastructure with an empty catalog; Slice 3 populates the
+# first IRON set after equipment items grow their `bonuses:` blocks.
+
+sets:
+  catalog: {}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
@@ -737,6 +737,36 @@ class AttackReducerTest {
     }
 
     @Test
+    fun `attacker's CRIT_CHANCE passive buff stacks on top of LUCK-derived crit chance`() {
+        // Without the buff (LUCK=0), crit chance is 0% and the crit roll cannot succeed.
+        // With +90 CRIT_CHANCE from equipment, the same RNG sequence lifts into crit territory.
+        val state = battleState(targetHp = 999)
+        val skills = StubSkillsRegistry()
+        val critBoost = object : dev.gvart.genesara.world.EquipmentBonusAggregator {
+            override fun armorDef(agent: AgentId, damageType: dev.gvart.genesara.world.DamageType): Int = 0
+            override fun attributeBonus(agent: AgentId, attribute: dev.gvart.genesara.player.Attribute): Int = 0
+            override fun passiveBuff(agent: AgentId, effect: dev.gvart.genesara.player.ScalingEffect): Int =
+                if (effect == dev.gvart.genesara.player.ScalingEffect.CRIT_CHANCE) 90 else 0
+        }
+
+        val (_, events) = assertNotNull(
+            reduceAttack(
+                state, WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithSword(), agents(strength = 10, luck = 0, dex = 0), swordEquipped(),
+                SkillProgression(skills, RecordingPublisher()),
+                equipmentBonuses = critBoost,
+                deathProcessor = stubDeathProcessor(skills, RecordingPublisher()),
+                rng = Random(seed = 1L),
+                scaling = NoScaling, passiveAura = NoAura, triggeredPassives = NoOpTriggeredPassiveDispatcher,
+                pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
+            ).getOrNull(),
+        )
+
+        val attacked = events.filterIsInstance<WorldEvent.AgentAttacked>().single()
+        assertEquals(true, attacked.isCrit, "equipment CRIT_CHANCE buff must lift the roll into crit territory")
+    }
+
+    @Test
     fun `armor-def sums across multiple equipped pieces matching the damage type`() {
         // End-to-end: chest + helmet both grant SLASH armor — total armorDef enters the
         // formula once after the aggregator sums them.

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/BleederCanaryIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/BleederCanaryIntegrationTest.kt
@@ -126,7 +126,7 @@ class BleederCanaryIntegrationTest {
         val progression = SkillProgression(skills, publisher)
 
         val cd = InMemoryPerkCooldownStore()
-        val dispatcher = TriggeredPassiveDispatcherImpl(BleederLookup(attacker), cd)
+        val dispatcher = TriggeredPassiveDispatcherImpl(BleederLookup(attacker), dev.gvart.genesara.world.EquipmentSetTriggerLookup.NoSetTriggers, cd)
 
         val initial = WorldState(
             regions = mapOf(regionId to region),
@@ -206,7 +206,7 @@ class BleederCanaryIntegrationTest {
         val publisher = RecordingPublisher()
         val progression = SkillProgression(skills, publisher)
         val cd = InMemoryPerkCooldownStore()
-        val dispatcher = TriggeredPassiveDispatcherImpl(BothTriggersLookup(target), cd)
+        val dispatcher = TriggeredPassiveDispatcherImpl(BothTriggersLookup(target), dev.gvart.genesara.world.EquipmentSetTriggerLookup.NoSetTriggers, cd)
 
         val initial = WorldState(
             regions = mapOf(regionId to region),

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImplTest.kt
@@ -86,13 +86,121 @@ class EquipmentBonusAggregatorImplTest {
     }
 
     @Test
+    fun `set bonus stacks on top of per-piece bonus when threshold is met`() {
+        val helmet = itemWithBonuses("IRON_HELMET", EquipSlot.HELMET, listOf(
+            EquippedBonus.ArmorDef(DamageType.SLASH, 2),
+        ))
+        val chest = itemWithBonuses("IRON_CHEST", EquipSlot.CHEST, listOf(
+            EquippedBonus.ArmorDef(DamageType.SLASH, 3),
+        ))
+        val ironSet = dev.gvart.genesara.world.EquipmentSet(
+            id = dev.gvart.genesara.world.EquipmentSetId("IRON"),
+            pieces = setOf(helmet.id, chest.id),
+            thresholds = mapOf(
+                2 to dev.gvart.genesara.world.EquipmentSetThreshold(
+                    bonuses = listOf(EquippedBonus.ArmorDef(DamageType.SLASH, 4)),
+                ),
+            ),
+        )
+        val store = InMemoryStore(mapOf(agent to mapOf(
+            EquipSlot.HELMET to instanceOf(helmet),
+            EquipSlot.CHEST to instanceOf(chest),
+        )))
+        val items = StubItems(listOf(helmet, chest))
+        val sets = SingleSetLookup(ironSet)
+        val aggregator = EquipmentBonusAggregatorImpl(store, items, sets, NoOpBalance)
+
+        // per-piece SLASH = 2 + 3 = 5; set 2-piece SLASH = 4 × 1.0 (COMMON avg) = 4; total = 9.
+        assertEquals(9, aggregator.armorDef(agent, DamageType.SLASH))
+    }
+
+    @Test
+    fun `set bonus tiers stack additively when count crosses multiple thresholds`() {
+        val pieceIds = (1..4).map { ItemId("IRON_$it") }
+        val pieces = pieceIds.map { id ->
+            Item(
+                id = id, displayName = id.value, description = "",
+                category = ItemCategory.EQUIPMENT, weightPerUnit = 0, maxStack = 1,
+                validSlots = setOf(EquipSlot.CHEST), maxDurability = 100,
+            )
+        }
+        val ironSet = dev.gvart.genesara.world.EquipmentSet(
+            id = dev.gvart.genesara.world.EquipmentSetId("IRON"),
+            pieces = pieceIds.toSet(),
+            thresholds = mapOf(
+                2 to dev.gvart.genesara.world.EquipmentSetThreshold(
+                    bonuses = listOf(EquippedBonus.AttributeBonus(Attribute.CONSTITUTION, 1)),
+                ),
+                4 to dev.gvart.genesara.world.EquipmentSetThreshold(
+                    bonuses = listOf(EquippedBonus.AttributeBonus(Attribute.CONSTITUTION, 3)),
+                ),
+            ),
+        )
+        // Equipping all 4 pieces — but only one slot can hold each; for the aggregator test
+        // we just need any 4 instances in any slots since the aggregator counts membership, not slot.
+        val instances = listOf(EquipSlot.HELMET, EquipSlot.CHEST, EquipSlot.PANTS, EquipSlot.BOOTS)
+            .zip(pieces).associate { (slot, item) -> slot to instanceOf(item) }
+        val store = InMemoryStore(mapOf(agent to instances))
+        val items = StubItems(pieces)
+        val aggregator = EquipmentBonusAggregatorImpl(store, items, SingleSetLookup(ironSet), NoOpBalance)
+
+        // 4 pieces equipped → 2-piece tier (+1) + 4-piece tier (+3) = +4 CON.
+        assertEquals(4, aggregator.attributeBonus(agent, Attribute.CONSTITUTION))
+    }
+
+    @Test
+    fun `set bonus uses average-rarity multiplier from BalanceLookup`() {
+        val helmet = itemWithBonuses("IRON_HELMET", EquipSlot.HELMET, emptyList())
+        val chest = itemWithBonuses("IRON_CHEST", EquipSlot.CHEST, emptyList())
+        val ironSet = dev.gvart.genesara.world.EquipmentSet(
+            id = dev.gvart.genesara.world.EquipmentSetId("IRON"),
+            pieces = setOf(helmet.id, chest.id),
+            thresholds = mapOf(
+                2 to dev.gvart.genesara.world.EquipmentSetThreshold(
+                    bonuses = listOf(EquippedBonus.ArmorDef(DamageType.SLASH, 10)),
+                ),
+            ),
+        )
+        // Two pieces with rarities RARE (ordinal 2) and EPIC (ordinal 3) — mean 2.5 → rounds
+        // to 3 (EPIC). Multiplier per default curve: 1.75. Expected armorDef = 10 × 1.75 = 17.5 → 18.
+        val rareHelmet = instanceOf(helmet).copy(rarity = Rarity.RARE)
+        val epicChest = instanceOf(chest).copy(rarity = Rarity.EPIC)
+        val store = InMemoryStore(mapOf(agent to mapOf(
+            EquipSlot.HELMET to rareHelmet,
+            EquipSlot.CHEST to epicChest,
+        )))
+        val items = StubItems(listOf(helmet, chest))
+        val aggregator = EquipmentBonusAggregatorImpl(store, items, SingleSetLookup(ironSet), NoOpBalance)
+
+        assertEquals(18, aggregator.armorDef(agent, DamageType.SLASH))
+    }
+
+    @Test
+    fun `equipping only one piece below the lowest threshold yields no set bonus`() {
+        val helmet = itemWithBonuses("IRON_HELMET", EquipSlot.HELMET, emptyList())
+        val chest = itemWithBonuses("IRON_CHEST", EquipSlot.CHEST, emptyList())
+        val ironSet = dev.gvart.genesara.world.EquipmentSet(
+            id = dev.gvart.genesara.world.EquipmentSetId("IRON"),
+            pieces = setOf(helmet.id, chest.id),
+            thresholds = mapOf(2 to dev.gvart.genesara.world.EquipmentSetThreshold(
+                bonuses = listOf(EquippedBonus.ArmorDef(DamageType.SLASH, 5)),
+            )),
+        )
+        val store = InMemoryStore(mapOf(agent to mapOf(EquipSlot.HELMET to instanceOf(helmet))))
+        val items = StubItems(listOf(helmet, chest))
+        val aggregator = EquipmentBonusAggregatorImpl(store, items, SingleSetLookup(ironSet), NoOpBalance)
+
+        assertEquals(0, aggregator.armorDef(agent, DamageType.SLASH))
+    }
+
+    @Test
     fun `bonuses scoped to the queried agent — other agents' gear is invisible`() {
         val chest = itemWithBonuses("CHEST", EquipSlot.CHEST, listOf(
             EquippedBonus.ArmorDef(DamageType.SLASH, 8),
         ))
         val store = InMemoryStore(mapOf(agent to mapOf(EquipSlot.CHEST to instanceOf(chest))))
         val items = StubItems(listOf(chest))
-        val aggregator = EquipmentBonusAggregatorImpl(store, items)
+        val aggregator = EquipmentBonusAggregatorImpl(store, items, EmptySetLookup, NoOpBalance)
 
         assertEquals(8, aggregator.armorDef(agent, DamageType.SLASH))
         assertEquals(0, aggregator.armorDef(other, DamageType.SLASH))
@@ -120,7 +228,7 @@ class EquipmentBonusAggregatorImplTest {
         val store = InMemoryStore(mapOf(agent to instances))
         // Mystery item NOT in items catalog → aggregator skips its bonuses.
         val items = StubItems(listOf(chest))
-        val aggregator = EquipmentBonusAggregatorImpl(store, items)
+        val aggregator = EquipmentBonusAggregatorImpl(store, items, EmptySetLookup, NoOpBalance)
 
         assertEquals(5, aggregator.armorDef(agent, DamageType.SLASH))
     }
@@ -141,7 +249,7 @@ class EquipmentBonusAggregatorImplTest {
         val instances = equipped.mapValues { (_, item) -> instanceOf(item) }
         val store = InMemoryStore(mapOf(agent to instances))
         val items = StubItems(equipped.values.toList())
-        return EquipmentBonusAggregatorImpl(store, items)
+        return EquipmentBonusAggregatorImpl(store, items, EmptySetLookup, NoOpBalance)
     }
 
     private fun instanceOf(item: Item): EquipmentInstance = EquipmentInstance(
@@ -160,6 +268,38 @@ class EquipmentBonusAggregatorImplTest {
         private val byId = items.associateBy { it.id }
         override fun byId(id: ItemId): Item? = byId[id]
         override fun all(): List<Item> = byId.values.toList()
+    }
+
+    private object EmptySetLookup : dev.gvart.genesara.world.EquipmentSetLookup {
+        override fun byId(id: dev.gvart.genesara.world.EquipmentSetId): dev.gvart.genesara.world.EquipmentSet? = null
+        override fun all(): List<dev.gvart.genesara.world.EquipmentSet> = emptyList()
+        override fun setsContaining(itemId: ItemId): List<dev.gvart.genesara.world.EquipmentSet> = emptyList()
+    }
+
+    private class SingleSetLookup(private val set: dev.gvart.genesara.world.EquipmentSet) : dev.gvart.genesara.world.EquipmentSetLookup {
+        override fun byId(id: dev.gvart.genesara.world.EquipmentSetId): dev.gvart.genesara.world.EquipmentSet? =
+            set.takeIf { it.id == id }
+
+        override fun all(): List<dev.gvart.genesara.world.EquipmentSet> = listOf(set)
+
+        override fun setsContaining(itemId: ItemId): List<dev.gvart.genesara.world.EquipmentSet> =
+            if (itemId in set.pieces) listOf(set) else emptyList()
+    }
+
+    private object NoOpBalance : dev.gvart.genesara.world.internal.balance.BalanceLookup {
+        override fun moveStaminaCost(biome: dev.gvart.genesara.world.Biome, climate: dev.gvart.genesara.world.Climate, terrain: dev.gvart.genesara.world.Terrain): Int = 1
+        override fun staminaRegenPerTick(climate: dev.gvart.genesara.world.Climate): Int = 0
+        override fun resourceSpawnsFor(terrain: dev.gvart.genesara.world.Terrain): List<dev.gvart.genesara.world.ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = 1
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: dev.gvart.genesara.world.Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: dev.gvart.genesara.world.Terrain): Boolean = true
     }
 
     private class InMemoryStore(

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentBonusAggregatorImplTest.kt
@@ -308,6 +308,9 @@ class EquipmentBonusAggregatorImplTest {
         override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> =
             perAgent[agentId].orEmpty()
 
+        override fun equippedForAll(agents: Set<AgentId>): Map<AgentId, Map<EquipSlot, EquipmentInstance>> =
+            perAgent.filterKeys { it in agents }
+
         override fun insert(instance: EquipmentInstance) = error("not used")
         override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
         override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = error("not used")

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetLookupImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetLookupImplTest.kt
@@ -1,0 +1,78 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.world.EquipmentSetId
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.internal.balance.EquippedBonusProperties
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class EquipmentSetLookupImplTest {
+
+    @Test
+    fun `byId returns the bound set or null`() {
+        val lookup = lookupOf(
+            "IRON" to setProps(
+                pieces = listOf("IRON_HELMET", "IRON_CHEST"),
+                thresholds = mapOf(2 to listOf(EquippedBonusProperties("SLASH", 3))),
+            ),
+        )
+        assertNotNull(lookup.byId(EquipmentSetId("IRON")))
+        assertNull(lookup.byId(EquipmentSetId("PHANTOM")))
+    }
+
+    @Test
+    fun `setsContaining reverse-indexes items to their containing sets`() {
+        val lookup = lookupOf(
+            "IRON" to setProps(
+                pieces = listOf("IRON_HELMET", "IRON_CHEST"),
+                thresholds = mapOf(2 to listOf(EquippedBonusProperties("SLASH", 3))),
+            ),
+            "STEEL" to setProps(
+                pieces = listOf("STEEL_HELMET", "IRON_CHEST"),
+                thresholds = mapOf(2 to listOf(EquippedBonusProperties("PIERCE", 2))),
+            ),
+        )
+        val sharedItem = ItemId("IRON_CHEST")
+        val sets = lookup.setsContaining(sharedItem).map { it.id.value }.toSet()
+        assertEquals(setOf("IRON", "STEEL"), sets)
+    }
+
+    @Test
+    fun `unknown bonus target in a threshold fails at construction time`() {
+        val ex = assertFailsWith<IllegalStateException> {
+            lookupOf(
+                "IRON" to setProps(
+                    pieces = listOf("IRON_HELMET"),
+                    thresholds = mapOf(1 to listOf(EquippedBonusProperties("PHANTOM_TARGET", 1))),
+                ),
+            )
+        }
+        kotlin.test.assertTrue("PHANTOM_TARGET" in ex.message!!)
+    }
+
+    @Test
+    fun `threshold tier above piece count fails the EquipmentSet require`() {
+        // tier 3 on a 2-piece set is invalid per EquipmentSet.init
+        val ex = assertFailsWith<IllegalArgumentException> {
+            lookupOf(
+                "IRON" to setProps(
+                    pieces = listOf("A", "B"),
+                    thresholds = mapOf(3 to listOf(EquippedBonusProperties("SLASH", 1))),
+                ),
+            )
+        }
+        kotlin.test.assertTrue("threshold tier 3" in ex.message!!)
+    }
+
+    private fun setProps(pieces: List<String>, thresholds: Map<Int, List<EquippedBonusProperties>>): EquipmentSetProperties =
+        EquipmentSetProperties(
+            pieces = pieces,
+            thresholds = thresholds.mapValues { (_, bonuses) -> EquipmentSetThresholdProperties(bonuses) },
+        )
+
+    private fun lookupOf(vararg sets: Pair<String, EquipmentSetProperties>): EquipmentSetLookupImpl =
+        EquipmentSetLookupImpl(EquipmentSetDefinitionProperties(catalog = sets.toMap()))
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetReferentialValidatorTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetReferentialValidatorTest.kt
@@ -1,0 +1,90 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentSet
+import dev.gvart.genesara.world.EquipmentSetId
+import dev.gvart.genesara.world.EquipmentSetLookup
+import dev.gvart.genesara.world.EquipmentSetThreshold
+import dev.gvart.genesara.world.EquippedBonus
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class EquipmentSetReferentialValidatorTest {
+
+    @Test
+    fun `passes when every piece is an EQUIPMENT-category item in the catalog`() {
+        val helmet = equipmentItem("IRON_HELMET")
+        val chest = equipmentItem("IRON_CHEST")
+        val validator = EquipmentSetReferentialValidator(
+            sets = StubSets(setOf(setOf(helmet.id, chest.id))),
+            items = StubItems(listOf(helmet, chest)),
+        )
+        validator.validate()
+    }
+
+    @Test
+    fun `fails when a piece is missing from the items catalog`() {
+        val helmet = equipmentItem("IRON_HELMET")
+        val validator = EquipmentSetReferentialValidator(
+            sets = StubSets(setOf(setOf(helmet.id, ItemId("PHANTOM_PIECE")))),
+            items = StubItems(listOf(helmet)),
+        )
+        val ex = assertFailsWith<IllegalArgumentException> { validator.validate() }
+        assertTrue("PHANTOM_PIECE" in ex.message!!)
+    }
+
+    @Test
+    fun `fails when a piece is RESOURCE category instead of EQUIPMENT`() {
+        val helmet = equipmentItem("IRON_HELMET")
+        val woodId = ItemId("WOOD")
+        val wood = Item(
+            id = woodId, displayName = "Wood", description = "",
+            category = ItemCategory.RESOURCE, weightPerUnit = 100, maxStack = 99,
+        )
+        val validator = EquipmentSetReferentialValidator(
+            sets = StubSets(setOf(setOf(helmet.id, woodId))),
+            items = StubItems(listOf(helmet, wood)),
+        )
+        val ex = assertFailsWith<IllegalArgumentException> { validator.validate() }
+        assertTrue("WOOD" in ex.message!! && "RESOURCE" in ex.message!!)
+    }
+
+    private fun equipmentItem(id: String) = Item(
+        id = ItemId(id),
+        displayName = id,
+        description = "",
+        category = ItemCategory.EQUIPMENT,
+        weightPerUnit = 0,
+        maxStack = 1,
+        validSlots = setOf(EquipSlot.HELMET),
+        maxDurability = 100,
+    )
+
+    private class StubItems(items: List<Item>) : ItemLookup {
+        private val byId = items.associateBy { it.id }
+        override fun byId(id: ItemId): Item? = byId[id]
+        override fun all(): List<Item> = byId.values.toList()
+    }
+
+    private class StubSets(private val setsAsPieces: Set<Set<ItemId>>) : EquipmentSetLookup {
+        private val builtSets: List<EquipmentSet> = setsAsPieces.mapIndexed { idx, pieces ->
+            EquipmentSet(
+                id = EquipmentSetId("SET_$idx"),
+                pieces = pieces,
+                thresholds = mapOf(1 to EquipmentSetThreshold(
+                    bonuses = listOf(EquippedBonus.ArmorDef(DamageType.SLASH, 1)),
+                )),
+            )
+        }
+        override fun byId(id: EquipmentSetId): EquipmentSet? = builtSets.firstOrNull { it.id == id }
+        override fun all(): List<EquipmentSet> = builtSets
+        override fun setsContaining(itemId: ItemId): List<EquipmentSet> =
+            builtSets.filter { itemId in it.pieces }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetTriggerLookupImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetTriggerLookupImplTest.kt
@@ -1,0 +1,156 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.TriggeredPassiveEffectKind
+import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquippedBonus
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.EquipmentSet
+import dev.gvart.genesara.world.EquipmentSetId
+import dev.gvart.genesara.world.EquipmentSetLookup
+import dev.gvart.genesara.world.EquipmentSetThreshold
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.Rarity
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EquipmentSetTriggerLookupImplTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val ironHelm = ItemId("IRON_HELM")
+    private val ironChest = ItemId("IRON_CHEST")
+    private val ironBoots = ItemId("IRON_BOOTS")
+
+    private val reflect = PerkEffect.TriggeredPassive(
+        trigger = TriggeredPassiveTrigger.ON_HIT_TAKEN,
+        effectKind = TriggeredPassiveEffectKind.HEAL_SELF,
+        params = mapOf("multiplierPct" to "10"),
+        internalCooldownTicks = 5,
+    )
+    private val onHitDealt = PerkEffect.TriggeredPassive(
+        trigger = TriggeredPassiveTrigger.ON_HIT_DEALT,
+        effectKind = TriggeredPassiveEffectKind.GRANT_SELF_BUFF,
+        params = emptyMap(),
+        internalCooldownTicks = 3,
+    )
+    private val ironSet = EquipmentSet(
+        id = EquipmentSetId("IRON"),
+        pieces = setOf(ironHelm, ironChest, ironBoots),
+        thresholds = mapOf(
+            2 to EquipmentSetThreshold(
+                bonuses = listOf(EquippedBonus.ArmorDef(DamageType.SLASH, 1)),
+                triggeredPassives = listOf(reflect),
+            ),
+            3 to EquipmentSetThreshold(
+                bonuses = listOf(EquippedBonus.ArmorDef(DamageType.SLASH, 1)),
+                triggeredPassives = listOf(onHitDealt),
+            ),
+        ),
+    )
+
+    @Test
+    fun `no equipped pieces yields no triggers`() {
+        val lookup = EquipmentSetTriggerLookupImpl(EmptyStore, SetLookupOf(ironSet))
+        assertTrue(lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_TAKEN).isEmpty())
+    }
+
+    @Test
+    fun `equipping below the smallest threshold yields no triggers`() {
+        val store = SingleAgentStore(agent, mapOf(EquipSlot.HELMET to instance(ironHelm)))
+        val lookup = EquipmentSetTriggerLookupImpl(store, SetLookupOf(ironSet))
+
+        assertTrue(lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_TAKEN).isEmpty())
+    }
+
+    @Test
+    fun `2-piece equipped fires the 2-piece trigger only`() {
+        val store = SingleAgentStore(agent, mapOf(
+            EquipSlot.HELMET to instance(ironHelm),
+            EquipSlot.CHEST to instance(ironChest),
+        ))
+        val lookup = EquipmentSetTriggerLookupImpl(store, SetLookupOf(ironSet))
+
+        val active = lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_TAKEN)
+        assertEquals(1, active.size)
+        assertEquals(2, active.single().tier)
+        assertEquals("set:IRON@2:0", active.single().syntheticPerkId)
+    }
+
+    @Test
+    fun `3-piece equipped exposes both tier triggers, each on its own trigger key`() {
+        val store = SingleAgentStore(agent, mapOf(
+            EquipSlot.HELMET to instance(ironHelm),
+            EquipSlot.CHEST to instance(ironChest),
+            EquipSlot.BOOTS to instance(ironBoots),
+        ))
+        val lookup = EquipmentSetTriggerLookupImpl(store, SetLookupOf(ironSet))
+
+        val onHit = lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_TAKEN)
+        val onDealt = lookup.matching(agent, TriggeredPassiveTrigger.ON_HIT_DEALT)
+        assertEquals(listOf(2), onHit.map { it.tier })
+        assertEquals(listOf(3), onDealt.map { it.tier })
+    }
+
+    @Test
+    fun `mismatched trigger returns no entries`() {
+        val store = SingleAgentStore(agent, mapOf(
+            EquipSlot.HELMET to instance(ironHelm),
+            EquipSlot.CHEST to instance(ironChest),
+        ))
+        val lookup = EquipmentSetTriggerLookupImpl(store, SetLookupOf(ironSet))
+
+        assertTrue(lookup.matching(agent, TriggeredPassiveTrigger.ON_CRIT).isEmpty())
+    }
+
+    private fun instance(itemId: ItemId, rarity: Rarity = Rarity.COMMON): EquipmentInstance = EquipmentInstance(
+        instanceId = UUID.randomUUID(),
+        agentId = agent,
+        itemId = itemId,
+        rarity = rarity,
+        durabilityCurrent = 100,
+        durabilityMax = 100,
+        creatorAgentId = agent,
+        createdAtTick = 0L,
+        equippedInSlot = EquipSlot.HELMET,
+    )
+
+    private object EmptyStore : EquipmentInstanceStore {
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = emptyList()
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> = emptyMap()
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = error("not used")
+        override fun delete(instanceId: UUID): Boolean = error("not used")
+    }
+
+    private class SingleAgentStore(
+        private val target: AgentId,
+        private val equipped: Map<EquipSlot, EquipmentInstance>,
+    ) : EquipmentInstanceStore {
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = emptyList()
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> =
+            if (agentId == target) equipped else emptyMap()
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = error("not used")
+        override fun delete(instanceId: UUID): Boolean = error("not used")
+    }
+
+    private class SetLookupOf(vararg sets: EquipmentSet) : EquipmentSetLookup {
+        private val all = sets.toList()
+        override fun byId(id: EquipmentSetId): EquipmentSet? = all.firstOrNull { it.id == id }
+        override fun all(): List<EquipmentSet> = all
+        override fun setsContaining(itemId: ItemId): List<EquipmentSet> =
+            all.filter { itemId in it.pieces }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetsYamlLoadingTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/equipment/EquipmentSetsYamlLoadingTest.kt
@@ -1,0 +1,92 @@
+package dev.gvart.genesara.world.internal.equipment
+
+import dev.gvart.genesara.world.EquipmentSetId
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.internal.balance.ItemBalanceConfiguration
+import dev.gvart.genesara.world.internal.balance.ItemDefinitionProperties
+import dev.gvart.genesara.world.internal.balance.ItemLookupImpl
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class EquipmentSetsYamlLoadingTest {
+
+    @Test
+    fun `shipped equipment-sets_yaml binds into the catalog`() {
+        AnnotationConfigApplicationContext().use { ctx ->
+            ConfigurationPropertiesBindingPostProcessor.register(ctx)
+            ctx.register(EquipmentSetConfiguration::class.java)
+            ctx.refresh()
+
+            val props = ctx.getBean(EquipmentSetDefinitionProperties::class.java)
+            val lookup = EquipmentSetLookupImpl(props)
+
+            val iron = assertNotNull(lookup.byId(EquipmentSetId("IRON")))
+            assertEquals(5, iron.pieces.size)
+            assertTrue(ItemId("IRON_CHESTPLATE") in iron.pieces)
+            // Threshold tiers 2, 3, 5 are defined; below-2 yields nothing.
+            assertTrue(iron.activeBonuses(1).isEmpty())
+            assertTrue(iron.activeBonuses(2).isNotEmpty())
+            assertTrue(iron.activeBonuses(5).size >= 4, "5-piece tier stacks 2/3/5 bonuses additively")
+        }
+    }
+
+    @Test
+    fun `shipped IRON set passes the referential validator against the live items catalog`() {
+        AnnotationConfigApplicationContext().use { ctx ->
+            ConfigurationPropertiesBindingPostProcessor.register(ctx)
+            ctx.register(
+                EquipmentSetConfiguration::class.java,
+                ItemBalanceConfiguration::class.java,
+            )
+            ctx.refresh()
+
+            val sets = EquipmentSetLookupImpl(ctx.getBean(EquipmentSetDefinitionProperties::class.java))
+            val items = ItemLookupImpl(ctx.getBean(ItemDefinitionProperties::class.java))
+
+            EquipmentSetReferentialValidator(sets, items).validate()
+        }
+    }
+
+    @Test
+    fun `shipped equipment items bind their bonuses lists`() {
+        AnnotationConfigApplicationContext().use { ctx ->
+            ConfigurationPropertiesBindingPostProcessor.register(ctx)
+            ctx.register(ItemBalanceConfiguration::class.java)
+            ctx.refresh()
+
+            val items = ItemLookupImpl(ctx.getBean(ItemDefinitionProperties::class.java))
+
+            val ironChest = assertNotNull(items.byId(ItemId("IRON_CHESTPLATE")))
+            assertTrue(ironChest.bonuses.isNotEmpty(), "IRON_CHESTPLATE must carry bonuses")
+            assertTrue(
+                ironChest.bonuses.any { it is dev.gvart.genesara.world.EquippedBonus.ArmorDef &&
+                    it.damageType == dev.gvart.genesara.world.DamageType.SLASH },
+                "IRON_CHESTPLATE must carry an ArmorDef(SLASH, _) entry",
+            )
+
+            val gemRing = assertNotNull(items.byId(ItemId("GEM_RING")))
+            assertTrue(
+                gemRing.bonuses.any { it is dev.gvart.genesara.world.EquippedBonus.PassiveBuff &&
+                    it.effect == dev.gvart.genesara.player.ScalingEffect.CRIT_CHANCE },
+                "GEM_RING must carry a PassiveBuff(CRIT_CHANCE, _) entry",
+            )
+        }
+    }
+
+    @Test
+    fun `setsContaining reverse index resolves IRON_CHESTPLATE to the IRON set`() {
+        AnnotationConfigApplicationContext().use { ctx ->
+            ConfigurationPropertiesBindingPostProcessor.register(ctx)
+            ctx.register(EquipmentSetConfiguration::class.java)
+            ctx.refresh()
+
+            val lookup = EquipmentSetLookupImpl(ctx.getBean(EquipmentSetDefinitionProperties::class.java))
+            val sets = lookup.setsContaining(ItemId("IRON_CHESTPLATE")).map { it.id.value }
+            assertEquals(listOf("IRON"), sets)
+        }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/passive/PassivesTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/passive/PassivesTest.kt
@@ -102,6 +102,42 @@ class PassivesTest {
         assertNull(event)
     }
 
+    @Test
+    fun `equipment STAMINA_REGEN bonus adds on top of the balance-driven regen`() {
+        val plusOneBonus = object : dev.gvart.genesara.world.EquipmentBonusAggregator {
+            override fun armorDef(agent: AgentId, damageType: dev.gvart.genesara.world.DamageType): Int = 0
+            override fun attributeBonus(agent: AgentId, attribute: dev.gvart.genesara.player.Attribute): Int = 0
+            override fun passiveBuff(agent: AgentId, effect: dev.gvart.genesara.player.ScalingEffect): Int =
+                if (effect == dev.gvart.genesara.player.ScalingEffect.STAMINA_REGEN) 2 else 0
+        }
+        // body at 5/10, base regen 1 + equipment +2 → +3 total → 8/10.
+        val (next, event) = applyPassives(world(stamina = 5), regenOne, tick = 1, equipmentBonuses = plusOneBonus)
+
+        assertEquals(8, next.bodyOf(agent)!!.stamina)
+        assertEquals(
+            WorldEvent.PassivesApplied(mapOf(agent to BodyDelta(stamina = 3)), tick = 1),
+            event,
+        )
+    }
+
+    @Test
+    fun `equipment STAMINA_REGEN does not bypass the low-vitals halt`() {
+        val plusBonus = object : dev.gvart.genesara.world.EquipmentBonusAggregator {
+            override fun armorDef(agent: AgentId, damageType: dev.gvart.genesara.world.DamageType): Int = 0
+            override fun attributeBonus(agent: AgentId, attribute: dev.gvart.genesara.player.Attribute): Int = 0
+            override fun passiveBuff(agent: AgentId, effect: dev.gvart.genesara.player.ScalingEffect): Int = 999
+        }
+        // Hunger=0 zeros isVitalsLow → no regen even with massive equipment bonus.
+        val starvedState = world(stamina = 5).let { state ->
+            state.copy(bodies = state.bodies.mapValues { (_, body) -> body.copy(hunger = 0, thirst = 0) })
+        }
+        val (next, event) = applyPassives(starvedState, regenOne, tick = 1, equipmentBonuses = plusBonus)
+
+        assertEquals(5, next.bodyOf(agent)!!.stamina)
+        // Other passives may still fire (starvation damage etc.) — assert specifically about stamina.
+        assertEquals(0, event?.deltas?.get(agent)?.stamina ?: 0)
+    }
+
     private fun balanceLookup(regen: Int) = object : BalanceLookup {
         override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
         override fun staminaRegenPerTick(climate: Climate) = regen

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/perks/TriggeredPassiveDispatcherImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/perks/TriggeredPassiveDispatcherImplTest.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.world.internal.perks
 
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.EquipmentSetTriggerLookup
 import dev.gvart.genesara.player.Perk
 import dev.gvart.genesara.player.PerkCooldownStore
 import dev.gvart.genesara.player.PerkEffect
@@ -34,7 +35,7 @@ class TriggeredPassiveDispatcherImplTest {
     @Test
     fun `emits PerkTriggered when perk matches and cooldown ready`() {
         val cd = StubCooldownStore(initialReady = true)
-        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(bleeder)), cd)
+        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(bleeder)), EquipmentSetTriggerLookup.NoSetTriggers, cd)
 
         val events = dispatcher.dispatch(
             firer = agent,
@@ -59,7 +60,7 @@ class TriggeredPassiveDispatcherImplTest {
     @Test
     fun `skips perk when cooldown is not ready`() {
         val cd = StubCooldownStore(initialReady = false)
-        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(bleeder)), cd)
+        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(bleeder)), EquipmentSetTriggerLookup.NoSetTriggers, cd)
 
         val events = dispatcher.dispatch(
             firer = agent,
@@ -84,6 +85,7 @@ class TriggeredPassiveDispatcherImplTest {
         )
         val dispatcher = TriggeredPassiveDispatcherImpl(
             StubLookup(listOf(bleeder, rage)),
+            EquipmentSetTriggerLookup.NoSetTriggers,
             StubCooldownStore(initialReady = true),
         )
 
@@ -110,6 +112,7 @@ class TriggeredPassiveDispatcherImplTest {
         )
         val dispatcher = TriggeredPassiveDispatcherImpl(
             StubLookup(listOf(onHarvest)),
+            EquipmentSetTriggerLookup.NoSetTriggers,
             StubCooldownStore(initialReady = true),
         )
 
@@ -134,6 +137,7 @@ class TriggeredPassiveDispatcherImplTest {
         )
         val dispatcher = TriggeredPassiveDispatcherImpl(
             StubLookup(listOf(perk)),
+            EquipmentSetTriggerLookup.NoSetTriggers,
             StubCooldownStore(initialReady = true),
         )
 
@@ -175,7 +179,7 @@ class TriggeredPassiveDispatcherImplTest {
             params = mapOf("thresholdPct" to "25"),
         )
         val cd = StubCooldownStore(initialReady = false)
-        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(perk)), cd)
+        val dispatcher = TriggeredPassiveDispatcherImpl(StubLookup(listOf(perk)), EquipmentSetTriggerLookup.NoSetTriggers, cd)
 
         val events = dispatcher.dispatch(
             firer = agent,
@@ -198,6 +202,7 @@ class TriggeredPassiveDispatcherImplTest {
         )
         val dispatcher = TriggeredPassiveDispatcherImpl(
             StubLookup(listOf(malformed)),
+            EquipmentSetTriggerLookup.NoSetTriggers,
             StubCooldownStore(initialReady = true),
         )
 
@@ -209,6 +214,73 @@ class TriggeredPassiveDispatcherImplTest {
             causedBy = cause,
         )
         assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun `set-bonus triggered passive fires alongside perks with synthetic perk id`() {
+        val setTrigger = dev.gvart.genesara.world.ActiveSetTrigger(
+            setId = dev.gvart.genesara.world.EquipmentSetId("IRON"),
+            tier = 4,
+            indexInTier = 0,
+            effect = PerkEffect.TriggeredPassive(
+                trigger = TriggeredPassiveTrigger.ON_HIT_TAKEN,
+                effectKind = TriggeredPassiveEffectKind.HEAL_SELF,
+                params = mapOf("multiplierPct" to "10"),
+                internalCooldownTicks = 5,
+            ),
+        )
+        val setLookup = SingleSetTriggerLookup(setTrigger)
+        val cd = StubCooldownStore(initialReady = true)
+        val dispatcher = TriggeredPassiveDispatcherImpl(
+            StubLookup(emptyList()), setLookup, cd,
+        )
+
+        val events = dispatcher.dispatch(
+            firer = agent,
+            trigger = TriggeredPassiveTrigger.ON_HIT_TAKEN,
+            ctx = TriggerContext.Combat(target),
+            tick = 0L,
+            causedBy = cause,
+        )
+
+        val ev = events.single() as WorldEvent.PerkTriggered
+        assertEquals(PerkId("set:IRON@4:0"), ev.perkId)
+        assertEquals(TriggeredPassiveEffectKind.HEAL_SELF, ev.effectKind)
+        assertEquals(5L, cd.armedUntil[agent to PerkId("set:IRON@4:0")])
+    }
+
+    @Test
+    fun `set-bonus trigger respects cooldown like perks`() {
+        val setTrigger = dev.gvart.genesara.world.ActiveSetTrigger(
+            setId = dev.gvart.genesara.world.EquipmentSetId("IRON"),
+            tier = 4,
+            indexInTier = 0,
+            effect = PerkEffect.TriggeredPassive(
+                trigger = TriggeredPassiveTrigger.ON_HIT_TAKEN,
+                effectKind = TriggeredPassiveEffectKind.HEAL_SELF,
+                params = emptyMap(),
+                internalCooldownTicks = 5,
+            ),
+        )
+        val dispatcher = TriggeredPassiveDispatcherImpl(
+            StubLookup(emptyList()),
+            SingleSetTriggerLookup(setTrigger),
+            StubCooldownStore(initialReady = false),
+        )
+
+        val events = dispatcher.dispatch(
+            firer = agent,
+            trigger = TriggeredPassiveTrigger.ON_HIT_TAKEN,
+            ctx = TriggerContext.None,
+            tick = 0L,
+            causedBy = cause,
+        )
+        assertTrue(events.isEmpty())
+    }
+
+    private class SingleSetTriggerLookup(private val trigger: dev.gvart.genesara.world.ActiveSetTrigger) : EquipmentSetTriggerLookup {
+        override fun matching(agent: AgentId, trigger: TriggeredPassiveTrigger): List<dev.gvart.genesara.world.ActiveSetTrigger> =
+            if (this.trigger.effect.trigger == trigger) listOf(this.trigger) else emptyList()
     }
 
     private fun triggeredPerk(


### PR DESCRIPTION
## Summary

Consolidates the remaining four merged sub-PRs from the #147 stack onto \`main\`. Slice 1 (#150) is already on main; this PR lands the rest:

| Commit | What |
|---|---|
| \`ea0c4c5\` (#151) | Set bonuses with average-rarity scaling |
| \`f0cfe66\` (#152) | Catalog migration + first IRON set + CRIT/DODGE wiring |
| \`e2b6762\` (#153) | Derived-pool refresh from effective attributes on equip/unequip/allocate |
| \`7ad9f64\` (#154) | Set-bonus triggered passives + STAMINA_REGEN via batched query |

All four were merged into intermediate stacked branches but never reached main. Rebased onto \`origin/main\` so the duplicate Slice 1 commits auto-skipped. Each PR was reviewed by the code-quality-reviewer agent at merge time.

## Test plan

- [x] \`./gradlew :world:test :api:test :player:test\` — all green on rebased state.

## #147 status after this lands

Three original-acceptance items remain unchecked:

- [ ] \`inspect\` projects the equipment block (the new \`bonuses:\` / \`damageType\` / \`armorDef\` / etc.).
- [ ] Rarity roller / crafting quality wires against the template (catalog \`weaponPower\` still fixed; rarity tier doesn't scale damage/durability variance yet).

And three in-code TODOs that originated outside #147:

- \`TODO(equipment-effective)\` — migrate carry cap / sight / crit / dodge to effective attributes.
- \`TODO(perk-effects)\` — per-effect-kind resolvers (predates #147).
- \`TODO(magic-class)\` — \`ScalingEffect.MAGICAL_DAMAGE_BONUS\` symmetry with \`DamageType.MAGICAL\`.

Suggest opening follow-up issues for the two unchecked acceptance items rather than blocking this consolidation.