### PR TITLE
feat(api): inspect tool projects equipment block (closes #156)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/views/EquipmentStatsView.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/views/EquipmentStatsView.kt
@@ -1,0 +1,45 @@
+package dev.gvart.genesara.api.internal.mcp.tools.equipment.views
+
+import dev.gvart.genesara.world.EquippedBonus
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+
+data class EquipmentStatsView(
+    val slots: List<String>,
+    val twoHanded: Boolean,
+    val maxDurability: Int?,
+    val damageType: String?,
+    val weaponPower: Int?,
+    val range: Int?,
+    val combatSkill: String?,
+    val requiredAttributes: Map<String, Int>,
+    val requiredSkills: Map<String, Int>,
+    val bonuses: List<EquipmentBonusView>,
+)
+
+data class EquipmentBonusView(
+    val target: String,
+    val magnitude: Int,
+)
+
+fun equipmentStatsViewOf(item: Item): EquipmentStatsView? {
+    if (item.category != ItemCategory.EQUIPMENT) return null
+    return EquipmentStatsView(
+        slots = item.validSlots.map { it.name }.sorted(),
+        twoHanded = item.twoHanded,
+        maxDurability = item.maxDurability,
+        damageType = item.damageType?.name,
+        weaponPower = item.weaponPower,
+        range = item.range,
+        combatSkill = item.combatSkill?.value,
+        requiredAttributes = item.requiredAttributes.mapKeys { it.key.name },
+        requiredSkills = item.requiredSkills.mapKeys { it.key.value },
+        bonuses = item.bonuses.map(::bonusView),
+    )
+}
+
+private fun bonusView(bonus: EquippedBonus): EquipmentBonusView = when (bonus) {
+    is EquippedBonus.ArmorDef -> EquipmentBonusView(bonus.damageType.name, bonus.magnitude)
+    is EquippedBonus.AttributeBonus -> EquipmentBonusView(bonus.attribute.name, bonus.magnitude)
+    is EquippedBonus.PassiveBuff -> EquipmentBonusView(bonus.effect.name, bonus.magnitude)
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getrecipes/GetRecipesTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getrecipes/GetRecipesTool.kt
@@ -3,10 +3,9 @@ package dev.gvart.genesara.api.internal.mcp.tools.getrecipes
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.api.internal.mcp.tools.equipment.views.equipmentStatsViewOf
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.world.AgentKnownRecipesGateway
-import dev.gvart.genesara.world.EquippedBonus
-import dev.gvart.genesara.world.Item
 import dev.gvart.genesara.world.ItemCategory
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.Recipe
@@ -71,7 +70,7 @@ internal class GetRecipesTool(
                     ConsumableEffectView(gauge = it.gauge.name, amount = it.amount)
                 },
                 harvestSkill = outputItem?.harvestSkill?.value,
-                equipmentStats = outputItem?.let(::equipmentStatsView),
+                equipmentStats = outputItem?.let(::equipmentStatsViewOf),
             ),
             inputs = recipe.inputs.entries
                 .sortedBy { it.key.value }
@@ -85,27 +84,5 @@ internal class GetRecipesTool(
             requiredStation = recipe.requiredStation.name,
             staminaCost = recipe.staminaCost,
         )
-    }
-
-    private fun equipmentStatsView(item: Item): EquipmentStatsView? {
-        if (item.category != ItemCategory.EQUIPMENT) return null
-        return EquipmentStatsView(
-            slots = item.validSlots.map { it.name }.sorted(),
-            twoHanded = item.twoHanded,
-            maxDurability = item.maxDurability,
-            damageType = item.damageType?.name,
-            weaponPower = item.weaponPower,
-            range = item.range,
-            combatSkill = item.combatSkill?.value,
-            requiredAttributes = item.requiredAttributes.mapKeys { it.key.name },
-            requiredSkills = item.requiredSkills.mapKeys { it.key.value },
-            bonuses = item.bonuses.map(::bonusView),
-        )
-    }
-
-    private fun bonusView(bonus: EquippedBonus): EquipmentBonusView = when (bonus) {
-        is EquippedBonus.ArmorDef -> EquipmentBonusView(bonus.damageType.name, bonus.magnitude)
-        is EquippedBonus.AttributeBonus -> EquipmentBonusView(bonus.attribute.name, bonus.magnitude)
-        is EquippedBonus.PassiveBuff -> EquipmentBonusView(bonus.effect.name, bonus.magnitude)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getrecipes/GetRecipesToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getrecipes/GetRecipesToolIo.kt
@@ -1,5 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.getrecipes
 
+import dev.gvart.genesara.api.internal.mcp.tools.equipment.views.EquipmentStatsView
+
 data class GetRecipesResponse(
     val recipes: List<RecipeView>,
 )
@@ -42,20 +44,3 @@ data class RecipeInputView(
     val quantity: Int,
 )
 
-data class EquipmentStatsView(
-    val slots: List<String>,
-    val twoHanded: Boolean,
-    val maxDurability: Int?,
-    val damageType: String?,
-    val weaponPower: Int?,
-    val range: Int?,
-    val combatSkill: String?,
-    val requiredAttributes: Map<String, Int>,
-    val requiredSkills: Map<String, Int>,
-    val bonuses: List<EquipmentBonusView>,
-)
-
-data class EquipmentBonusView(
-    val target: String,
-    val magnitude: Int,
-)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
@@ -4,6 +4,7 @@ import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.api.internal.mcp.projection.vitalBand
+import dev.gvart.genesara.api.internal.mcp.tools.equipment.views.equipmentStatsViewOf
 import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentId
@@ -14,6 +15,11 @@ import dev.gvart.genesara.world.BuildingDefLookup
 import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.ChestContentsStore
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.EquipmentSetLookup
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.NodeId
@@ -36,6 +42,8 @@ internal class InspectTool(
     private val buildings: BuildingsLookup,
     private val buildingDefs: BuildingDefLookup,
     private val chestContents: ChestContentsStore,
+    private val equipmentInstances: EquipmentInstanceStore,
+    private val equipmentSets: EquipmentSetLookup,
 ) {
 
     @Tool(
@@ -49,7 +57,8 @@ internal class InspectTool(
         targetType: InspectTargetType,
         @ToolParam(
             required = true,
-            description = "Target id. For NODE this is the numeric BIGINT id; for AGENT and BUILDING this is the UUID; for ITEM this is the ItemId string.",
+            description = "Target id. For NODE this is the numeric BIGINT id; for AGENT and BUILDING this is the UUID; " +
+                "for ITEM this is either the ItemId string (stackable resources) or the equipment instance UUID.",
         )
         targetId: String,
         toolContext: ToolContext,
@@ -166,13 +175,16 @@ internal class InspectTool(
     }
 
     private fun inspectItem(agentId: AgentId, targetId: String, depth: InspectDepth): InspectResponse {
-        val itemId = ItemId(targetId)
+        val instanceUuid = runCatching { UUID.fromString(targetId) }.getOrNull()
+        if (instanceUuid != null) {
+            return inspectEquipmentInstance(agentId, instanceUuid, depth)
+        }
+        return inspectStackableItem(agentId, ItemId(targetId), depth)
+    }
+
+    private fun inspectStackableItem(agentId: AgentId, itemId: ItemId, depth: InspectDepth): InspectResponse {
         val item = items.byId(itemId)
             ?: return errorResponse(depth, InspectError.NOT_FOUND, "item not found in catalog")
-        // TODO(equipment-slot): also resolve a per-instance lookup against
-        //   EquipmentInstanceStore so an agent can inspect a specific equipment
-        //   instance (with its rolled rarity + live current durability). For now
-        //   only the stackable inventory is checked.
         val inventory = world.inventoryOf(agentId)
         val held = inventory.entries.firstOrNull { it.itemId == itemId }
             ?: return errorResponse(depth, InspectError.NOT_IN_INVENTORY, "item is not in your inventory")
@@ -180,21 +192,62 @@ internal class InspectTool(
         return InspectResponse(
             kind = "item",
             depth = depth.name.lowercase(),
-            item = ItemInspectView(
-                itemId = item.id.value,
-                displayName = item.displayName,
-                description = item.description,
-                category = item.category.name,
-                quantity = held.quantity,
-                weightPerUnit = if (depth != InspectDepth.SHALLOW) item.weightPerUnit else null,
-                maxStack = if (depth != InspectDepth.SHALLOW) item.maxStack else null,
-                regenerating = if (depth != InspectDepth.SHALLOW) item.regenerating else null,
-                rarity = if (depth != InspectDepth.SHALLOW) item.rarity.name else null,
-                maxDurability = if (depth != InspectDepth.SHALLOW) item.maxDurability else null,
-                harvestSkill = if (depth == InspectDepth.EXPERT) item.harvestSkill?.value else null,
-            ),
+            item = projectCatalogItem(item, quantity = held.quantity, depth = depth, instanceState = null),
         )
     }
+
+    private fun inspectEquipmentInstance(agentId: AgentId, instanceId: UUID, depth: InspectDepth): InspectResponse {
+        val instance = equipmentInstances.findById(instanceId)
+            ?: return errorResponse(depth, InspectError.NOT_FOUND, "equipment instance not found")
+        if (instance.agentId != agentId) {
+            return errorResponse(depth, InspectError.NOT_IN_INVENTORY, "equipment instance is not in your inventory")
+        }
+        val item = items.byId(instance.itemId)
+            ?: return errorResponse(depth, InspectError.NOT_FOUND, "item not found in catalog")
+        val instanceState = if (depth != InspectDepth.SHALLOW) instance.toInstanceStateView() else null
+        return InspectResponse(
+            kind = "item",
+            depth = depth.name.lowercase(),
+            item = projectCatalogItem(item, quantity = 1, depth = depth, instanceState = instanceState),
+        )
+    }
+
+    private fun projectCatalogItem(
+        item: Item,
+        quantity: Int,
+        depth: InspectDepth,
+        instanceState: InstanceStateView?,
+    ): ItemInspectView {
+        val isDetailedPlus = depth != InspectDepth.SHALLOW
+        return ItemInspectView(
+            itemId = item.id.value,
+            displayName = item.displayName,
+            description = item.description,
+            category = item.category.name,
+            quantity = quantity,
+            weightPerUnit = if (isDetailedPlus) item.weightPerUnit else null,
+            maxStack = if (isDetailedPlus) item.maxStack else null,
+            regenerating = if (isDetailedPlus) item.regenerating else null,
+            rarity = if (isDetailedPlus) item.rarity.name else null,
+            maxDurability = if (isDetailedPlus) item.maxDurability else null,
+            harvestSkill = if (depth == InspectDepth.EXPERT) item.harvestSkill?.value else null,
+            equipmentStats = if (isDetailedPlus) equipmentStatsViewOf(item) else null,
+            instanceState = instanceState,
+            equipmentSets = if (isDetailedPlus) equipmentSetIdsFor(item) else null,
+        )
+    }
+
+    private fun equipmentSetIdsFor(item: Item): List<String>? {
+        if (item.category != ItemCategory.EQUIPMENT) return null
+        return equipmentSets.setsContaining(item.id).map { it.id.value }.sorted()
+    }
+
+    private fun EquipmentInstance.toInstanceStateView(): InstanceStateView = InstanceStateView(
+        rarity = rarity.name,
+        durabilityCurrent = durabilityCurrent,
+        durabilityMax = durabilityMax,
+        creator = creatorAgentId?.id?.toString(),
+    )
 
     private fun projectAgent(target: Agent, body: BodyView, depth: InspectDepth): AgentInspectView {
         val classId = if (depth != InspectDepth.SHALLOW) target.classId?.name else null

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
@@ -1,5 +1,7 @@
 package dev.gvart.genesara.api.internal.mcp.tools.inspect
 
+import dev.gvart.genesara.api.internal.mcp.tools.equipment.views.EquipmentStatsView
+
 /**
  * Kind of target the `inspect` tool resolves against. Explicit discriminator so a
  * numeric node id and a UUID agent id can never collide on the wire.
@@ -128,6 +130,27 @@ data class ItemInspectView(
      * deciding whether picking up an item also helps progression.
      */
     val harvestSkill: String? = null,
+    /** DETAILED+: catalog projection for `EQUIPMENT` items. Null for stackable resources. */
+    val equipmentStats: EquipmentStatsView? = null,
+    /**
+     * DETAILED+: per-instance state when the target id was an equipment instance UUID
+     * (rolled rarity, live durability, creator signature). Null for stackable resources
+     * AND when the agent inspected an equipment item by item id (catalog-only view).
+     */
+    val instanceState: InstanceStateView? = null,
+    /**
+     * DETAILED+: equipment-set membership ids. Empty list when the item is `EQUIPMENT`
+     * but belongs to no set (positive "no set membership" signal). Null for stackable
+     * resources where set membership is N/A.
+     */
+    val equipmentSets: List<String>? = null,
+)
+
+data class InstanceStateView(
+    val rarity: String,
+    val durabilityCurrent: Int,
+    val durabilityMax: Int,
+    val creator: String? = null,
 )
 
 /**

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
@@ -20,6 +20,12 @@ import dev.gvart.genesara.world.BuildingStatus
 import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.ChestContentsStore
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.EquipmentSet
+import dev.gvart.genesara.world.EquipmentSetId
+import dev.gvart.genesara.world.EquipmentSetLookup
 import dev.gvart.genesara.world.Item
 import dev.gvart.genesara.world.ItemCategory
 import dev.gvart.genesara.world.ItemId
@@ -241,6 +247,8 @@ class InspectBuildingTest {
             buildings = StubBuildings(buildings),
             buildingDefs = StubBuildingDefs(defs),
             chestContents = chestContents,
+            equipmentInstances = NoEquipmentInstances,
+            equipmentSets = NoEquipmentSets,
         )
     }
 
@@ -328,5 +336,22 @@ class InspectBuildingTest {
 
     private class FixedTickClock(private val current: Long) : TickClock {
         override fun currentTick(): Long = current
+    }
+
+    private object NoEquipmentInstances : EquipmentInstanceStore {
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = null
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = emptyList()
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> = emptyMap()
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? = null
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = null
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = null
+        override fun delete(instanceId: UUID): Boolean = false
+    }
+
+    private object NoEquipmentSets : EquipmentSetLookup {
+        override fun byId(id: EquipmentSetId): EquipmentSet? = null
+        override fun all(): List<EquipmentSet> = emptyList()
+        override fun setsContaining(itemId: ItemId): List<EquipmentSet> = emptyList()
     }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
@@ -11,9 +11,19 @@ import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.player.Attribute
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.BodyView
 import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.EquipmentSet
+import dev.gvart.genesara.world.EquipmentSetId
+import dev.gvart.genesara.world.EquipmentSetLookup
+import dev.gvart.genesara.world.EquipmentSetThreshold
+import dev.gvart.genesara.world.EquippedBonus
 import dev.gvart.genesara.world.InventoryEntry
 import dev.gvart.genesara.world.InventoryView
 import dev.gvart.genesara.world.Item
@@ -23,6 +33,7 @@ import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.Node
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.NodeResources
+import dev.gvart.genesara.world.Rarity
 import dev.gvart.genesara.world.Region
 import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.Terrain
@@ -258,6 +269,8 @@ class InspectToolTest {
             buildings = NoBuildings,
             buildingDefs = NoBuildingDefs,
             chestContents = NoChestContents,
+            equipmentInstances = StubEquipmentInstanceStore(),
+            equipmentSets = StubEquipmentSetLookup(),
         )
 
         val resp = selfTool.dispatch("agent", agentId.id.toString(), toolContext)
@@ -352,6 +365,162 @@ class InspectToolTest {
         assertEquals(InspectError.NOT_FOUND, resp.error?.code)
     }
 
+    @Test
+    fun `inspect stackable resource returns no equipmentStats, instanceState, or equipmentSets`() {
+        val tool = tool(perception = 10, inventory = listOf(InventoryEntry(ItemId("WOOD"), 5)))
+        val resp = tool.dispatch("item", "WOOD", toolContext)
+
+        val view = assertNotNull(resp.item)
+        assertNull(view.equipmentStats)
+        assertNull(view.instanceState)
+        assertNull(view.equipmentSets, "stackable resources have no set membership concept")
+    }
+
+    @Test
+    fun `inspect equipment instance projects catalog stats, per-instance state, and set ids`() {
+        val instanceId = UUID.randomUUID()
+        val creator = AgentId(UUID.randomUUID())
+        val instance = EquipmentInstance(
+            instanceId = instanceId,
+            agentId = agentId,
+            itemId = ItemId("IRON_CHESTPLATE"),
+            rarity = Rarity.RARE,
+            durabilityCurrent = 73,
+            durabilityMax = 100,
+            creatorAgentId = creator,
+            createdAtTick = 1L,
+        )
+        val ironSet = EquipmentSet(
+            id = EquipmentSetId("IRON"),
+            pieces = setOf(ItemId("IRON_CHESTPLATE")),
+            thresholds = mapOf(
+                1 to EquipmentSetThreshold(
+                    bonuses = listOf(EquippedBonus.AttributeBonus(Attribute.STRENGTH, 1)),
+                ),
+            ),
+        )
+        val tool = tool(
+            perception = 10,
+            equipmentInstances = StubEquipmentInstanceStore(listOf(instance)),
+            equipmentSets = StubEquipmentSetLookup(listOf(ironSet)),
+        )
+
+        val resp = tool.dispatch("item", instanceId.toString(), toolContext)
+
+        val view = assertNotNull(resp.item)
+        assertEquals("IRON_CHESTPLATE", view.itemId)
+        assertEquals(1, view.quantity, "an instance is one physical item")
+
+        val stats = assertNotNull(view.equipmentStats)
+        assertEquals(listOf("CHEST"), stats.slots)
+        assertEquals(false, stats.twoHanded)
+        assertEquals(100, stats.maxDurability)
+        assertEquals(2, stats.bonuses.size)
+
+        val state = assertNotNull(view.instanceState)
+        assertEquals("RARE", state.rarity)
+        assertEquals(73, state.durabilityCurrent)
+        assertEquals(100, state.durabilityMax)
+        assertEquals(creator.id.toString(), state.creator)
+
+        assertEquals(listOf("IRON"), view.equipmentSets)
+    }
+
+    @Test
+    fun `inspect equipment instance not in any set returns empty equipmentSets`() {
+        val instanceId = UUID.randomUUID()
+        val instance = EquipmentInstance(
+            instanceId = instanceId,
+            agentId = agentId,
+            itemId = ItemId("PLAIN_RING"),
+            rarity = Rarity.COMMON,
+            durabilityCurrent = 50,
+            durabilityMax = 50,
+            creatorAgentId = null,
+            createdAtTick = 1L,
+        )
+        val tool = tool(
+            perception = 10,
+            equipmentInstances = StubEquipmentInstanceStore(listOf(instance)),
+        )
+
+        val resp = tool.dispatch("item", instanceId.toString(), toolContext)
+
+        val view = assertNotNull(resp.item)
+        assertEquals(emptyList(), view.equipmentSets, "EQUIPMENT with no set membership returns an empty list, not null")
+        assertNull(view.instanceState?.creator, "loot drops carry no creator signature")
+    }
+
+    @Test
+    fun `inspect equipment instance at SHALLOW Perception hides instanceState and equipmentStats`() {
+        val instanceId = UUID.randomUUID()
+        val instance = EquipmentInstance(
+            instanceId = instanceId,
+            agentId = agentId,
+            itemId = ItemId("IRON_CHESTPLATE"),
+            rarity = Rarity.UNCOMMON,
+            durabilityCurrent = 100,
+            durabilityMax = 100,
+            creatorAgentId = null,
+            createdAtTick = 1L,
+        )
+        val tool = tool(
+            perception = 1,
+            equipmentInstances = StubEquipmentInstanceStore(listOf(instance)),
+        )
+
+        val resp = tool.dispatch("item", instanceId.toString(), toolContext)
+
+        val view = assertNotNull(resp.item)
+        assertNull(view.equipmentStats)
+        assertNull(view.instanceState)
+        assertNull(view.equipmentSets)
+    }
+
+    @Test
+    fun `inspect unknown equipment instance UUID returns NOT_FOUND`() {
+        val tool = tool(perception = 10)
+        val resp = tool.dispatch("item", UUID.randomUUID().toString(), toolContext)
+        assertEquals(InspectError.NOT_FOUND, resp.error?.code)
+    }
+
+    @Test
+    fun `inspect another agent's equipment instance returns NOT_IN_INVENTORY`() {
+        val instanceId = UUID.randomUUID()
+        val instance = EquipmentInstance(
+            instanceId = instanceId,
+            agentId = otherAgentId,
+            itemId = ItemId("IRON_CHESTPLATE"),
+            rarity = Rarity.COMMON,
+            durabilityCurrent = 100,
+            durabilityMax = 100,
+            creatorAgentId = null,
+            createdAtTick = 1L,
+        )
+        val tool = tool(
+            perception = 10,
+            equipmentInstances = StubEquipmentInstanceStore(listOf(instance)),
+        )
+
+        val resp = tool.dispatch("item", instanceId.toString(), toolContext)
+
+        assertEquals(InspectError.NOT_IN_INVENTORY, resp.error?.code)
+    }
+
+    @Test
+    fun `inspect equipment via item id returns catalog stats but no instanceState`() {
+        val tool = tool(
+            perception = 10,
+            inventory = listOf(InventoryEntry(ItemId("IRON_CHESTPLATE"), 1)),
+        )
+
+        val resp = tool.dispatch("item", "IRON_CHESTPLATE", toolContext)
+
+        val view = assertNotNull(resp.item)
+        assertNotNull(view.equipmentStats, "item-id path should still surface catalog equipment stats")
+        assertNull(view.instanceState, "instance state requires the UUID lookup path")
+    }
+
     // --- presence ---
 
     @Test
@@ -368,6 +537,8 @@ class InspectToolTest {
         otherAgentNode: NodeId? = null,
         body: BodyView? = null,
         inventory: List<InventoryEntry> = emptyList(),
+        equipmentInstances: EquipmentInstanceStore = StubEquipmentInstanceStore(),
+        equipmentSets: EquipmentSetLookup = StubEquipmentSetLookup(),
     ): InspectTool {
         val world = StubQuery(
             location = currentNodeId,
@@ -389,6 +560,8 @@ class InspectToolTest {
             buildings = NoBuildings,
             buildingDefs = NoBuildingDefs,
             chestContents = NoChestContents,
+            equipmentInstances = equipmentInstances,
+            equipmentSets = equipmentSets,
         )
     }
 
@@ -413,9 +586,62 @@ class InspectToolTest {
                 maxStack = 99,
                 harvestSkill = SkillId("FORESTRY"),
             ),
+            "IRON_CHESTPLATE" to Item(
+                id = ItemId("IRON_CHESTPLATE"),
+                displayName = "Iron Chestplate",
+                description = "Forged iron breastplate.",
+                category = ItemCategory.EQUIPMENT,
+                weightPerUnit = 8000,
+                maxStack = 1,
+                rarity = Rarity.COMMON,
+                maxDurability = 100,
+                validSlots = setOf(EquipSlot.CHEST),
+                requiredAttributes = mapOf(Attribute.STRENGTH to 6),
+                bonuses = listOf(
+                    EquippedBonus.ArmorDef(DamageType.SLASH, 12),
+                    EquippedBonus.AttributeBonus(Attribute.CONSTITUTION, 2),
+                ),
+            ),
+            "PLAIN_RING" to Item(
+                id = ItemId("PLAIN_RING"),
+                displayName = "Plain Ring",
+                description = "Unaffiliated trinket.",
+                category = ItemCategory.EQUIPMENT,
+                weightPerUnit = 50,
+                maxStack = 1,
+                rarity = Rarity.COMMON,
+                maxDurability = 50,
+                validSlots = setOf(EquipSlot.RING_LEFT, EquipSlot.RING_RIGHT),
+            ),
         )
         override fun byId(id: ItemId): Item? = catalog[id.value]
         override fun all(): List<Item> = catalog.values.toList()
+    }
+
+    private class StubEquipmentInstanceStore(
+        private val instances: List<EquipmentInstance> = emptyList(),
+    ) : EquipmentInstanceStore {
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? =
+            instances.firstOrNull { it.instanceId == instanceId }
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> =
+            instances.filter { it.agentId == agentId }
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> =
+            instances.filter { it.agentId == agentId && it.equippedInSlot != null }
+                .associateBy { it.equippedInSlot!! }
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? = null
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = null
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = null
+        override fun delete(instanceId: UUID): Boolean = false
+    }
+
+    private class StubEquipmentSetLookup(
+        private val sets: List<EquipmentSet> = emptyList(),
+    ) : EquipmentSetLookup {
+        override fun byId(id: EquipmentSetId): EquipmentSet? = sets.firstOrNull { it.id == id }
+        override fun all(): List<EquipmentSet> = sets
+        override fun setsContaining(itemId: ItemId): List<EquipmentSet> =
+            sets.filter { itemId in it.pieces }
     }
 
     private fun InspectTool.dispatch(targetType: String, targetId: String, ctx: org.springframework.ai.chat.model.ToolContext) =


### PR DESCRIPTION
## Summary
- Move `EquipmentStatsView` + `EquipmentBonusView` to a shared package (`api/.../tools/equipment/views/`); both `get_recipes` and `inspect` project the same wire shape via `equipmentStatsViewOf(item)`
- `inspect` resolves equipment by UUID → `EquipmentInstanceStore` lookup; falls back to item id → catalog + stackable inventory
- `ItemInspectView` gains `equipmentStats`, `instanceState` (sibling, not merged: `rarity`, `durabilityCurrent`, `durabilityMax`, optional `creator`), and `equipmentSets`

## Decisions
- **`targetId` parsing**: UUID first → instance lookup; otherwise item id → catalog. Stackable item ids are never UUIDs, so the branching is unambiguous.
- **`equipmentSets` semantics**: `null` for stackable resources (set membership N/A as a category), **empty list** for `EQUIPMENT` items with no set affiliation — positive "checked, none" signal.
- **Per-instance state shape**: sibling `instanceState` field rather than merged into `equipmentStats` (matches issue recommendation A — keeps catalog stable across loot/craft sources, lets agents compare two instances of the same item directly).
- **`equipmentStats` via item-id path**: still populated (catalog projection); `instanceState` is null since no specific instance was resolved.

## Out of scope
- Reusing `EquipmentStatsView` for `get_loadout` (separate followup per the issue).
- Per-instance bonus modifiers (Slice 4 of #147 keeps base+catalog-bonus only).
- Rarity-effective values for `weaponPower` / `maxDurability` — handled in #157, which adds preview maps to the shared `EquipmentStatsView`. Once #157 lands, `inspect`'s projection inherits those previews automatically since both tools share the same helper.

## Test plan
- [x] `./gradlew test` BUILD SUCCESSFUL (whole repo)
- [x] InspectToolTest: 32 / 0 failures (inc. 7 new cases covering equipment via UUID, equipment via item id, set-membership empty vs null, instance state population)
- [x] InspectBuildingTest: 8 / 0 failures (constructor wiring)
- [x] GetRecipesToolTest: 9 / 0 failures (shared `equipmentStatsViewOf` regression coverage)

Closes #156