### PR TITLE
feat(world,api): rarity scales weapon damage and durability (closes #157)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/views/EquipmentStatsView.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/equipment/views/EquipmentStatsView.kt
@@ -3,6 +3,8 @@ package dev.gvart.genesara.api.internal.mcp.tools.equipment.views
 import dev.gvart.genesara.world.EquippedBonus
 import dev.gvart.genesara.world.Item
 import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.Rarity
+import kotlin.math.roundToInt
 
 data class EquipmentStatsView(
     val slots: List<String>,
@@ -15,6 +17,10 @@ data class EquipmentStatsView(
     val requiredAttributes: Map<String, Int>,
     val requiredSkills: Map<String, Int>,
     val bonuses: List<EquipmentBonusView>,
+    /** Rarity-scaled `weaponPower` per tier (COMMON..LEGENDARY). Null when [weaponPower] is null. */
+    val weaponPowerByRarity: Map<String, Int>? = null,
+    /** Rarity-scaled `maxDurability` per tier (COMMON..LEGENDARY). Null when [maxDurability] is null. */
+    val maxDurabilityByRarity: Map<String, Int>? = null,
 )
 
 data class EquipmentBonusView(
@@ -35,6 +41,8 @@ fun equipmentStatsViewOf(item: Item): EquipmentStatsView? {
         requiredAttributes = item.requiredAttributes.mapKeys { it.key.name },
         requiredSkills = item.requiredSkills.mapKeys { it.key.value },
         bonuses = item.bonuses.map(::bonusView),
+        weaponPowerByRarity = item.weaponPower?.let(::scaleByRarity),
+        maxDurabilityByRarity = item.maxDurability?.let(::scaleByRarity),
     )
 }
 
@@ -42,4 +50,18 @@ private fun bonusView(bonus: EquippedBonus): EquipmentBonusView = when (bonus) {
     is EquippedBonus.ArmorDef -> EquipmentBonusView(bonus.damageType.name, bonus.magnitude)
     is EquippedBonus.AttributeBonus -> EquipmentBonusView(bonus.attribute.name, bonus.magnitude)
     is EquippedBonus.PassiveBuff -> EquipmentBonusView(bonus.effect.name, bonus.magnitude)
+}
+
+private fun scaleByRarity(base: Int): Map<String, Int> =
+    Rarity.entries.associate { it.name to (base * rarityMultiplier(it)).roundToInt().coerceAtLeast(0) }
+
+// WHY: mirrors the curve in `BalanceLookup.rarityMultiplier` (ADR-0002). The world module
+// keeps that lookup `internal`, so the api side inlines the same constants for the preview.
+// Keep both sites in sync if the curve is retuned.
+private fun rarityMultiplier(rarity: Rarity): Double = when (rarity) {
+    Rarity.COMMON -> 1.0
+    Rarity.UNCOMMON -> 1.25
+    Rarity.RARE -> 1.5
+    Rarity.EPIC -> 1.75
+    Rarity.LEGENDARY -> 2.0
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getrecipes/GetRecipesToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getrecipes/GetRecipesToolIo.kt
@@ -43,4 +43,3 @@ data class RecipeInputView(
     val name: String,
     val quantity: Int,
 )
-

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getrecipes/GetRecipesToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getrecipes/GetRecipesToolTest.kt
@@ -238,6 +238,65 @@ class GetRecipesToolTest {
     }
 
     @Test
+    fun `equipmentStats projects rarity-scaled previews for weaponPower and maxDurability`() {
+        val swordId = ItemId("IRON_SWORD")
+        val sword = Item(
+            id = swordId,
+            displayName = "Iron Sword",
+            description = "",
+            category = ItemCategory.EQUIPMENT,
+            weightPerUnit = 0,
+            maxStack = 1,
+            validSlots = setOf(dev.gvart.genesara.world.EquipSlot.MAIN_HAND),
+            twoHanded = false,
+            maxDurability = 100,
+            damageType = dev.gvart.genesara.world.DamageType.SLASH,
+            weaponPower = 8,
+            combatSkill = SkillId("SWORD"),
+            range = 1,
+        )
+        val swordRecipe = recipe("IRON_SWORD_BASIC", output = swordId, skill = carpentry, requiredLevel = 0, unlock = RecipeUnlockMode.Open)
+        val items = StubItems(mapOf(swordId to sword))
+        val recipes = StubRecipes(listOf(swordRecipe))
+        val tool = GetRecipesTool(recipes, items, skillsAt(carpentry, level = 0), StubLedger(emptySet()), activity)
+
+        val stats = assertNotNull(tool.invoke(toolContext).recipes.single().output.equipmentStats)
+        assertEquals(
+            mapOf("COMMON" to 8, "UNCOMMON" to 10, "RARE" to 12, "EPIC" to 14, "LEGENDARY" to 16),
+            stats.weaponPowerByRarity,
+        )
+        assertEquals(
+            mapOf("COMMON" to 100, "UNCOMMON" to 125, "RARE" to 150, "EPIC" to 175, "LEGENDARY" to 200),
+            stats.maxDurabilityByRarity,
+        )
+    }
+
+    @Test
+    fun `equipmentStats omits rarity preview maps when template fields are null`() {
+        val tunicId = ItemId("LINEN_TUNIC")
+        val tunic = Item(
+            id = tunicId,
+            displayName = "Linen Tunic",
+            description = "",
+            category = ItemCategory.EQUIPMENT,
+            weightPerUnit = 0,
+            maxStack = 1,
+            validSlots = setOf(dev.gvart.genesara.world.EquipSlot.CHEST),
+            twoHanded = false,
+        )
+        val tunicRecipe = recipe("LINEN_TUNIC_BASIC", output = tunicId, skill = carpentry, requiredLevel = 0, unlock = RecipeUnlockMode.Open)
+        val items = StubItems(mapOf(tunicId to tunic))
+        val recipes = StubRecipes(listOf(tunicRecipe))
+        val tool = GetRecipesTool(recipes, items, skillsAt(carpentry, level = 0), StubLedger(emptySet()), activity)
+
+        val stats = assertNotNull(tool.invoke(toolContext).recipes.single().output.equipmentStats)
+        assertNull(stats.weaponPower)
+        assertNull(stats.maxDurability)
+        assertNull(stats.weaponPowerByRarity)
+        assertNull(stats.maxDurabilityByRarity)
+    }
+
+    @Test
     fun `output and input views carry the displayName from the item catalog`() {
         val tool = GetRecipesTool(recipes, items, skillsAt(carpentry, level = 0), StubLedger(emptySet()), activity)
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducer.kt
@@ -15,6 +15,7 @@ import dev.gvart.genesara.player.TriggeredPassiveTrigger
 import dev.gvart.genesara.world.DamageType
 import dev.gvart.genesara.world.EquipSlot
 import dev.gvart.genesara.world.EquipmentBonusAggregator
+import dev.gvart.genesara.world.EquipmentInstance
 import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.Item
 import dev.gvart.genesara.world.ItemLookup
@@ -31,6 +32,7 @@ import dev.gvart.genesara.world.internal.death.DeathProcessor
 import dev.gvart.genesara.world.internal.perks.TriggerContext
 import dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcher
 import dev.gvart.genesara.world.internal.worldstate.WorldState
+import kotlin.math.roundToInt
 import kotlin.random.Random
 
 /**
@@ -78,9 +80,9 @@ internal fun reduceAttack(
         WorldRejection.TargetNotInWorld(command.agent, command.target)
     }
 
-    val weaponDef = equipment.equippedFor(command.agent)[EquipSlot.MAIN_HAND]
-        ?.let { items.byId(it.itemId) }
-    val weaponProfile = weaponProfileFor(weaponDef, balance)
+    val weaponInstance = equipment.equippedFor(command.agent)[EquipSlot.MAIN_HAND]
+    val weaponDef = weaponInstance?.let { items.byId(it.itemId) }
+    val weaponProfile = weaponProfileFor(weaponDef, weaponInstance, balance)
 
     ensure(isWithinRange(state, attackerNode, targetNode, weaponProfile.range)) {
         WorldRejection.TargetOutOfRange(
@@ -276,9 +278,18 @@ private fun scalingEffectFor(type: DamageType): ScalingEffect? = when (type) {
     DamageType.MAGICAL -> null
 }
 
-private fun weaponProfileFor(weapon: Item?, balance: BalanceLookup): WeaponProfile {
+private fun weaponProfileFor(
+    weapon: Item?,
+    instance: EquipmentInstance?,
+    balance: BalanceLookup,
+): WeaponProfile {
     val damageType = weapon?.damageType ?: balance.unarmedDamageType()
-    val weaponPower = weapon?.weaponPower ?: balance.unarmedWeaponPower()
+    val basePower = weapon?.weaponPower ?: balance.unarmedWeaponPower()
+    val weaponPower = if (weapon != null && instance != null) {
+        (basePower * balance.rarityMultiplier(instance.rarity)).roundToInt().coerceAtLeast(0)
+    } else {
+        basePower
+    }
     val combatSkill = weapon?.combatSkill ?: balance.unarmedCombatSkill()
     val range = weapon?.range ?: balance.unarmedRange()
     return WeaponProfile(damageType, weaponPower, combatSkill, range)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
@@ -37,6 +37,7 @@ import dev.gvart.genesara.world.internal.perks.TriggerContext
 import dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcher
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import java.util.UUID
+import kotlin.math.roundToInt
 
 /**
  * Single-step reducer for [WorldCommand.CraftItem]. Mutates [EquipmentInstanceStore]
@@ -222,17 +223,20 @@ private fun Raise<WorldRejection>.equipmentMutation(
     val additionalGrams = outputItem.weightPerUnit * recipe.output.quantity
     enforceCarryCap(command.agent, agentRecord.attributes.strength, currentGrams, additionalGrams, balance)
 
-    val maxDurability = outputItem.maxDurability
+    val templateDurability = outputItem.maxDurability
         ?: error("Equipment item ${outputItem.id.value} has no max-durability — recipe ${recipe.id} mis-pointed")
     val rolled = rarityRoller.roll(skillLevel = skillLevel, luck = agentRecord.attributes.luck)
+    val scaledDurability = (templateDurability * balance.rarityMultiplier(rolled))
+        .roundToInt()
+        .coerceAtLeast(1)
 
     val instance = EquipmentInstance(
         instanceId = UUID.randomUUID(),
         agentId = command.agent,
         itemId = outputItem.id,
         rarity = rolled,
-        durabilityCurrent = maxDurability,
-        durabilityMax = maxDurability,
+        durabilityCurrent = scaledDurability,
+        durabilityMax = scaledDurability,
         creatorAgentId = command.agent,
         createdAtTick = tick,
         equippedInSlot = null,

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/combat/AttackReducerTest.kt
@@ -828,6 +828,62 @@ class AttackReducerTest {
     }
 
     @Test
+    fun `weapon rarity scales raw damage by the BalanceLookup multiplier across all five tiers`() {
+        // Baseline at COMMON: STR 10 × weaponPower 8 × 1.0 = 80. Scaling: {1.0, 1.25, 1.5, 1.75, 2.0}.
+        val expected = mapOf(
+            Rarity.COMMON to 80,
+            Rarity.UNCOMMON to 100,
+            Rarity.RARE to 120,
+            Rarity.EPIC to 140,
+            Rarity.LEGENDARY to 160,
+        )
+        for ((rarity, expectedDamage) in expected) {
+            val skills = StubSkillsRegistry()
+            val publisher = RecordingPublisher()
+            val (_, events) = assertNotNull(
+                reduceAttack(
+                    battleState(targetHp = 999),
+                    WorldCommand.AttackTarget(attacker, target),
+                    balance(), itemsWithSword(),
+                    agents(strength = 10, luck = 0, dex = 0),
+                    swordEquipped(rarity),
+                    SkillProgression(skills, publisher),
+                    equipmentBonuses = dev.gvart.genesara.world.EquipmentBonusAggregator.NoBonuses,
+                    deathProcessor = stubDeathProcessor(skills, publisher),
+                    rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura,
+                    triggeredPassives = NoOpTriggeredPassiveDispatcher,
+                    pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
+                ).getOrNull(),
+            )
+            val attacked = assertIs<WorldEvent.AgentAttacked>(events.single())
+            assertEquals(expectedDamage, attacked.baseDamage, "rarity $rarity should scale to $expectedDamage")
+        }
+    }
+
+    @Test
+    fun `unarmed attack ignores rarity scaling — no equipped instance, balance fallback only`() {
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val (_, events) = assertNotNull(
+            reduceAttack(
+                battleState(targetHp = 100),
+                WorldCommand.AttackTarget(attacker, target),
+                balance(), itemsWithSword(),
+                agents(strength = 5, luck = 0, dex = 0),
+                StubEquipmentStore(),
+                SkillProgression(skills, publisher),
+                equipmentBonuses = dev.gvart.genesara.world.EquipmentBonusAggregator.NoBonuses,
+                deathProcessor = stubDeathProcessor(skills, publisher),
+                rng = Random(seed = 1L), scaling = NoScaling, passiveAura = NoAura,
+                triggeredPassives = NoOpTriggeredPassiveDispatcher,
+                pendingScales = InMemoryPendingAttackScaleStore(), behaviorTracker = tracker, tick = 1,
+            ).getOrNull(),
+        )
+        val attacked = assertIs<WorldEvent.AgentAttacked>(events.single())
+        assertEquals(10, attacked.baseDamage, "STR 5 × unarmed power 2 = 10, no rarity multiplier")
+    }
+
+    @Test
     fun `armor-def cannot reduce raw damage below zero`() {
         val state = battleState(targetHp = 100)
         val skills = StubSkillsRegistry()
@@ -989,14 +1045,14 @@ class AttackReducerTest {
         ),
     )
 
-    private fun swordEquipped(): EquipmentInstanceStore = StubEquipmentStore(
+    private fun swordEquipped(rarity: Rarity = Rarity.COMMON): EquipmentInstanceStore = StubEquipmentStore(
         equippedByAgent = mapOf(
             attacker to mapOf(
                 EquipSlot.MAIN_HAND to EquipmentInstance(
                     instanceId = UUID.randomUUID(),
                     agentId = attacker,
                     itemId = rustySword,
-                    rarity = Rarity.COMMON,
+                    rarity = rarity,
                     durabilityCurrent = 50,
                     durabilityMax = 50,
                     creatorAgentId = null,

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
@@ -180,8 +180,8 @@ class CraftReducerTest {
         assertEquals(agent, instance.agentId)
         assertEquals(ironSword, instance.itemId)
         assertEquals(Rarity.UNCOMMON, instance.rarity)
-        assertEquals(100, instance.durabilityCurrent)
-        assertEquals(100, instance.durabilityMax)
+        assertEquals(125, instance.durabilityCurrent, "100 template * UNCOMMON 1.25 multiplier")
+        assertEquals(125, instance.durabilityMax)
         assertNull(instance.equippedInSlot)
 
         assertEquals(8, next.inventoryOf(agent).quantityOf(ironIngot))
@@ -429,6 +429,41 @@ class CraftReducerTest {
         val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()
         assertEquals(alchemy, rec.skill)
         assertEquals(1, rec.recommendCount)
+    }
+
+    @Test
+    fun `rolled rarity scales durabilityMax against the catalog template across all five tiers`() {
+        val expected = mapOf(
+            Rarity.COMMON to 100,
+            Rarity.UNCOMMON to 125,
+            Rarity.RARE to 150,
+            Rarity.EPIC to 175,
+            Rarity.LEGENDARY to 200,
+        )
+        for ((rarity, expectedDurability) in expected) {
+            val skills = StubSkillsRegistry().apply { slot(smithing, level = 12) }
+            val store = StubEquipmentStore()
+            assertNotNull(
+                reduceCraft(
+                    stateWith(),
+                    WorldCommand.CraftItem(agent, ironSwordRecipe.id),
+                    stubBalance(),
+                    items,
+                    recipes,
+                    AgentKnownRecipesGateway.Empty,
+                    store,
+                    StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_METAL))),
+                    skills,
+                    StubAgents(luckyAgent()),
+                    fixedRoller(rarity),
+                    SkillProgression(skills, RecordingPublisher()),
+                    scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+                ).getOrNull(),
+            )
+            val instance = store.inserted.single()
+            assertEquals(expectedDurability, instance.durabilityMax, "rarity $rarity should scale durabilityMax")
+            assertEquals(instance.durabilityMax, instance.durabilityCurrent, "fresh craft starts at full durability")
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `AttackReducer.weaponProfileFor` now reads the wielded `EquipmentInstance` and scales `weaponPower` by `BalanceLookup.rarityMultiplier(rarity)` per swing
- `CraftReducer` scales `maxDurability` (and the initial `durabilityCurrent`) by the rolled rarity, `roundToInt()`, `coerceAtLeast(1)` to keep `EquipmentInstance.init` happy
- `EquipmentStatsView` gains optional `weaponPowerByRarity` and `maxDurabilityByRarity` preview maps in `get_recipes`

## Decisions (per issue's open questions)
- Reused the existing `BalanceLookup.rarityMultiplier` curve (Q1) — `{COMMON: 1.0, UNCOMMON: 1.25, RARE: 1.5, EPIC: 1.75, LEGENDARY: 2.0}`
- Deterministic scaling, no per-instance variance band (Q2) — matches ADR-0002 set-bonus tone
- Computed inline at attack/craft time (Q3 option b) — no `EquipmentInstance` schema change
- Same scaling applied to `maxDurability` (Q4 yes)
- Catalog field rename deferred (Q5 — premature)
- `roundToInt()` for fairness across tiers, `coerceAtLeast(1)` defends against pathological multipliers and the `durabilityMax > 0` invariant

## Known duplication
`GetRecipesTool` carries a private `rarityMultiplier(Rarity)` helper mirroring `BalanceLookup.rarityMultiplier` because the world `BalanceLookup` is `internal` and unreachable from `:api`. Flagged inline; future curve retunings need both sites updated. Promoting `rarityMultiplier` to a public lookup would resolve this — out of scope here.

## Coordination with #158
PR #158 (issue #156) moves `EquipmentStatsView` into a shared package (`api/.../tools/equipment/views/`). Once #158 lands, this PR will need a small rebase: move the two new fields into the shared file and fold the rarity preview into the shared `equipmentStatsViewOf(item)` helper. As a bonus, `inspect`'s projection then inherits rarity previews automatically.

## Test plan
- [x] `./gradlew :world:test :api:test` BUILD SUCCESSFUL
- [x] AttackReducerTest: 5-tier table-driven assertion `{COMMON: 80, UNCOMMON: 100, RARE: 120, EPIC: 140, LEGENDARY: 160}` for the same baseline weapon; unarmed path still ignores rarity
- [x] CraftReducerTest: 5-tier table-driven assertion `{100, 125, 150, 175, 200}` for `durabilityMax`, plus `durabilityCurrent == durabilityMax` per tier
- [x] GetRecipesToolTest: preview maps populated for `IRON_SWORD`, omitted for items without `weaponPower` / `maxDurability`

Closes #157