### PR TITLE
feat(world): wire LEATHERWORKING, TAILORING, JEWELRYCRAFTING into craft XP

### DIFF
--- a/world/src/main/resources/world-definition/equipment-weapons.yaml
+++ b/world/src/main/resources/world-definition/equipment-weapons.yaml
@@ -110,6 +110,10 @@ items:
       max-durability: 60
       valid-slots: [MAIN_HAND]
       two-handed: false
+      damage-type: PIERCE
+      weapon-power: 9
+      combat-skill: DAGGER
+      range: 1
 
     IRON_SWORD:
       display-name: Iron Sword
@@ -161,6 +165,10 @@ items:
       two-handed: true
       required-attributes:
         STRENGTH: 14
+      damage-type: BLUNT
+      weapon-power: 15
+      combat-skill: CLUB
+      range: 1
 
     COMPOSITE_BOW:
       display-name: Composite Bow

--- a/world/src/main/resources/world-definition/recipes-armor.yaml
+++ b/world/src/main/resources/world-definition/recipes-armor.yaml
@@ -1,22 +1,18 @@
 # Armor recipes — every clothing slot at T1 (LEATHER) and T2 (IRON or CLOTH).
-# Leather and cloth lines run at the workbench under CARPENTRY; iron line runs at
-# the forge under SMITHING.
-#
-# TODO(weaving): split CARPENTRY into CARPENTRY (frames / wood crafts), LEATHERWORKING
-#   (HIDE → LEATHER, leather armor), and WEAVING (FIBER → CLOTH, cloth armor) once
-#   those skills land. Recipe metadata is the only field that needs to change.
+# Leather line runs at the workbench under LEATHERWORKING; cloth line runs at
+# the workbench under TAILORING; iron line runs at the forge under SMITHING.
 
 recipes:
   catalog:
 
-    # ───────────────────────── T1 leather (workbench / CARPENTRY) ─────────────────────────
+    # ───────────────────────── T1 leather (workbench / LEATHERWORKING) ─────────────────────────
 
     LEATHER_HELMET_BASIC:
       output: { item: LEATHER_HELMET, quantity: 1 }
       inputs:
         LEATHER: 2
       required-station: CRAFTING_STATION_WOOD
-      required-skill: CARPENTRY
+      required-skill: LEATHERWORKING
       required-skill-level: 0
       stamina-cost: 10
 
@@ -25,7 +21,7 @@ recipes:
       inputs:
         LEATHER: 4
       required-station: CRAFTING_STATION_WOOD
-      required-skill: CARPENTRY
+      required-skill: LEATHERWORKING
       required-skill-level: 0
       stamina-cost: 14
 
@@ -34,7 +30,7 @@ recipes:
       inputs:
         LEATHER: 3
       required-station: CRAFTING_STATION_WOOD
-      required-skill: CARPENTRY
+      required-skill: LEATHERWORKING
       required-skill-level: 0
       stamina-cost: 12
 
@@ -43,7 +39,7 @@ recipes:
       inputs:
         LEATHER: 2
       required-station: CRAFTING_STATION_WOOD
-      required-skill: CARPENTRY
+      required-skill: LEATHERWORKING
       required-skill-level: 0
       stamina-cost: 10
 
@@ -52,7 +48,7 @@ recipes:
       inputs:
         LEATHER: 2
       required-station: CRAFTING_STATION_WOOD
-      required-skill: CARPENTRY
+      required-skill: LEATHERWORKING
       required-skill-level: 0
       stamina-cost: 10
 
@@ -103,15 +99,15 @@ recipes:
       required-skill-level: 5
       stamina-cost: 16
 
-    # ───────────────────────── T2 cloth (workbench / CARPENTRY) ─────────────────────────
+    # ───────────────────────── T2 cloth (workbench / TAILORING) ─────────────────────────
 
     CLOTH_HOOD_BASIC:
       output: { item: CLOTH_HOOD, quantity: 1 }
       inputs:
         CLOTH: 2
       required-station: CRAFTING_STATION_WOOD
-      required-skill: CARPENTRY
-      required-skill-level: 5
+      required-skill: TAILORING
+      required-skill-level: 0
       stamina-cost: 8
 
     CLOTH_ROBE_BASIC:
@@ -120,6 +116,6 @@ recipes:
         CLOTH: 4
         FIBER: 2
       required-station: CRAFTING_STATION_WOOD
-      required-skill: CARPENTRY
+      required-skill: TAILORING
       required-skill-level: 5
       stamina-cost: 12

--- a/world/src/main/resources/world-definition/recipes-jewelry.yaml
+++ b/world/src/main/resources/world-definition/recipes-jewelry.yaml
@@ -12,7 +12,7 @@ recipes:
         GEM: 1
         IRON_INGOT: 1
       required-station: CRAFTING_STATION_METAL
-      required-skill: SMITHING
+      required-skill: JEWELRYCRAFTING
       required-skill-level: 5
       stamina-cost: 18
 
@@ -21,7 +21,7 @@ recipes:
       inputs:
         IRON_INGOT: 1
       required-station: CRAFTING_STATION_METAL
-      required-skill: SMITHING
+      required-skill: JEWELRYCRAFTING
       required-skill-level: 3
       stamina-cost: 12
 
@@ -31,7 +31,7 @@ recipes:
         GEM: 1
         IRON_INGOT: 1
       required-station: CRAFTING_STATION_METAL
-      required-skill: SMITHING
+      required-skill: JEWELRYCRAFTING
       required-skill-level: 6
       stamina-cost: 16
 
@@ -41,7 +41,7 @@ recipes:
         LEATHER: 1
         FIBER: 1
       required-station: CRAFTING_STATION_WOOD
-      required-skill: CARPENTRY
+      required-skill: JEWELRYCRAFTING
       required-skill-level: 0
       stamina-cost: 8
 
@@ -51,6 +51,6 @@ recipes:
         IRON_INGOT: 1
         LEATHER: 1
       required-station: CRAFTING_STATION_METAL
-      required-skill: SMITHING
+      required-skill: JEWELRYCRAFTING
       required-skill-level: 4
       stamina-cost: 14

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/WeaponsCombatSkillTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/balance/WeaponsCombatSkillTest.kt
@@ -1,0 +1,36 @@
+package dev.gvart.genesara.world.internal.balance
+
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.world.ItemId
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class WeaponsCombatSkillTest {
+
+    @Test
+    fun `every weapon item in the catalog declares a combat-skill so attacks dont silently route to UNARMED`() {
+        AnnotationConfigApplicationContext().use { ctx ->
+            ConfigurationPropertiesBindingPostProcessor.register(ctx)
+            ctx.register(ItemBalanceConfiguration::class.java)
+            ctx.refresh()
+
+            val lookup = ItemLookupImpl(ctx.getBean(ItemDefinitionProperties::class.java))
+
+            fun combatSkillOf(id: String) =
+                assertNotNull(lookup.byId(ItemId(id)), "weapon $id missing from catalog").combatSkill
+
+            assertEquals(SkillId("SWORD"), combatSkillOf("RUSTY_SWORD"))
+            assertEquals(SkillId("SWORD"), combatSkillOf("IRON_SWORD"))
+            assertEquals(SkillId("SWORD"), combatSkillOf("IRON_GREATSWORD"))
+            assertEquals(SkillId("BOW"), combatSkillOf("WOODEN_BOW"))
+            assertEquals(SkillId("BOW"), combatSkillOf("COMPOSITE_BOW"))
+            assertEquals(SkillId("CLUB"), combatSkillOf("WOODEN_CLUB"))
+            assertEquals(SkillId("CLUB"), combatSkillOf("WAR_HAMMER"))
+            assertEquals(SkillId("SPEAR"), combatSkillOf("HUNTING_SPEAR"))
+            assertEquals(SkillId("DAGGER"), combatSkillOf("IRON_DAGGER"))
+        }
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/RecipesYamlLoadingTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/RecipesYamlLoadingTest.kt
@@ -13,6 +13,7 @@ import dev.gvart.genesara.world.internal.buildings.BuildingsConfiguration
 import org.junit.jupiter.api.Test
 import org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -68,6 +69,37 @@ class RecipesYamlLoadingTest {
             val skills = StubSkillLookup(referencedSkills)
 
             RecipeCatalogValidator(recipes, items, skills, buildings).validate()
+        }
+    }
+
+    @Test
+    fun `leather, cloth and jewelry recipes route to LEATHERWORKING, TAILORING and JEWELRYCRAFTING`() {
+        AnnotationConfigApplicationContext().use { ctx ->
+            ConfigurationPropertiesBindingPostProcessor.register(ctx)
+            ctx.register(RecipeBalanceConfiguration::class.java)
+            ctx.refresh()
+
+            val byId = RecipeLookupImpl(ctx.getBean(RecipeDefinitionProperties::class.java))
+                .all()
+                .associateBy { it.id.value }
+
+            fun requireSkillOf(id: String) =
+                assertNotNull(byId[id], "recipe $id missing from catalog").requiredSkill
+
+            assertEquals(SkillId("LEATHERWORKING"), requireSkillOf("LEATHER_HELMET_BASIC"))
+            assertEquals(SkillId("LEATHERWORKING"), requireSkillOf("LEATHER_TUNIC_BASIC"))
+            assertEquals(SkillId("LEATHERWORKING"), requireSkillOf("LEATHER_PANTS_BASIC"))
+            assertEquals(SkillId("LEATHERWORKING"), requireSkillOf("LEATHER_BOOTS_BASIC"))
+            assertEquals(SkillId("LEATHERWORKING"), requireSkillOf("LEATHER_GLOVES_BASIC"))
+
+            assertEquals(SkillId("TAILORING"), requireSkillOf("CLOTH_HOOD_BASIC"))
+            assertEquals(SkillId("TAILORING"), requireSkillOf("CLOTH_ROBE_BASIC"))
+
+            assertEquals(SkillId("JEWELRYCRAFTING"), requireSkillOf("GEM_AMULET_BASIC"))
+            assertEquals(SkillId("JEWELRYCRAFTING"), requireSkillOf("IRON_RING_BASIC"))
+            assertEquals(SkillId("JEWELRYCRAFTING"), requireSkillOf("GEM_RING_BASIC"))
+            assertEquals(SkillId("JEWELRYCRAFTING"), requireSkillOf("LEATHER_BRACELET_BASIC"))
+            assertEquals(SkillId("JEWELRYCRAFTING"), requireSkillOf("IRON_BRACELET_BASIC"))
         }
     }
 


### PR DESCRIPTION
## Summary

Unblocks **4 of the 16 skills** deferred by [#75](https://github.com/Genesara/genesara-engine/pull/75)'s carve-out on #68 by retagging existing recipes and completing two stub weapon profiles. The reducers (`HarvestReducer`, `CraftReducer`, `BuildReducer`, `AttackReducer`, `AbilityResolver`) are already fully generic — each reads the skill id from substrate YAML and passes it to `progression.accrueXp`, so wiring a new skill is data-only.

### Recipe retags (3 skills wired)

- **`recipes-armor.yaml`** — 5 LEATHER_* recipes CARPENTRY → LEATHERWORKING, 2 CLOTH_* recipes CARPENTRY → TAILORING. The pre-existing `TODO(weaving):` header comment anticipated this exact retag — removed.
- **`recipes-jewelry.yaml`** — all 5 recipes (GEM_AMULET / IRON_RING / GEM_RING / LEATHER_BRACELET / IRON_BRACELET) → JEWELRYCRAFTING. Output type wins over input material; IRON_BRACELET routes to jewelry skill despite iron input.
- **`CLOTH_HOOD_BASIC` gate L5 → L0** — fixes a soft-lock the TAILORING retag would otherwise introduce: both cloth recipes were gated at level 5 under CARPENTRY (fine when CARPENTRY had L0 wood recipes to ramp), but TAILORING in isolation had no L0 entry rung.

### Weapon profile completion (1 skill wired + 1 bug fix)

`IRON_DAGGER` and `WAR_HAMMER` were defined as stubs missing `damage-type`, `weapon-power`, `combat-skill`, and `range`. Attacks made with either silently fell through `AttackReducer`'s UNARMED defaults — both granted UNARMED XP regardless of weapon.

- **IRON_DAGGER** — `PIERCE / 9 / DAGGER / range 1`. **Unblocks DAGGER skill.**
- **WAR_HAMMER** — `BLUNT / 15 / CLUB / range 1`. Bug fix — routes to CLUB (already wired via WOODEN_CLUB).

Power values interpolated from the existing weapon ladder (T1 club 6 → T1 sword 8 → T1 spear 9 → T2 bow 11 → T2 sword 12 → T2 greatsword 14). IRON_DAGGER at 9 sits between T1/T2 sword; WAR_HAMMER at 15 sits one above greatsword (per "heavy, slow, ruinous on a clean hit"). **Flagged for balance review** — easy to adjust if the curve should look different.

### Level-0 entry-rung invariant

Audited every currently wired skill to confirm a level-0 entry path exists. All pass:

| Skill | L0 path |
|---|---|
| FORAGING / LUMBERJACKING / FISHING / MINING | harvest items, no level gate |
| ALCHEMY / CARPENTRY / SMITHING | multiple L0 recipes |
| LEATHERWORKING (new) | all 5 leather armor at L0 |
| JEWELRYCRAFTING (new) | LEATHER_BRACELET_BASIC at L0 |
| TAILORING (new) | CLOTH_HOOD_BASIC at L0 (fixed here) |
| SWORD / BOW / CLUB / SPEAR / DAGGER (new) | weapons exist, no equip floor |
| Build skills (SURVIVAL etc.) | no level gates on buildings |

### Test plan

- [x] `./gradlew :world:test :player:test :api:test` — green
- [x] New `RecipesYamlLoadingTest` canary: pins the 12 retagged recipes
- [x] New `WeaponsCombatSkillTest` canary: pins every weapon's combat-skill mapping (catches future stub weapons silently routing to UNARMED)

### Does this close #68?

**No.** This PR closes a real chunk of #75's deferred carve-out (4 of the 16 deferred skills), but substantial substrate-blocked work remains on #68:

| Category | Still deferred | Why |
|---|---|---|
| **Substrate-blocked craft skills** | COOKING, ENGINEERING, ELECTRONICS, BREWING | No food / machine / electronic / beverage recipes exist; need new substrate authoring |
| **Substrate-blocked harvest/build** | HUNTING, TRAPS | No huntable fauna items, no trap buildings |
| **Substrate-blocked combat** | AXE, CROSSBOW, FIREARMS, THROWN, POLEARM | No weapons declare these `combat-skill` ids; weapons need to be authored |
| **Verb-blocked** | TRACKING, FIRECRAFT, STEALTH, LOCKPICKING, PICKPOCKET, MEDICINE, HERBALISM, ANATOMY, PERSUASION, INTIMIDATION, LEADERSHIP, ANIMAL_HANDLING, BEAST_LORE, ACROBATICS, CLIMBING, SWIMMING, ATHLETICS, CARTOGRAPHY, SCANNING | No verb maps to these yet — most need Phase 2+ feature work |
| **Reducer-blocked** | SHIELD, DUAL_WIELD, UNARMED | SHIELD needs a defender-side block-XP hook; DUAL_WIELD needs AttackReducer to detect two-weapon attacks; UNARMED routes via fallback already |

Each is a follow-up substrate or feature slice in its own right. #68 stays open with the carve-out updated.

### Follow-ups after merge

- Tick LEATHERWORKING / TAILORING / JEWELRYCRAFTING / DAGGER rows on #5 (recommendation-hook coverage tracker).
- Update `docs/skill-feature-sequence.md` Step 4 carve-out: "4 of 16 deferred skills now wired."
- Add a comment on #68 with the updated deferred-skill table.