### PR TITLE
fix(api): recover gracefully from stale MCP session ids

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.api.internal.mcp
 import dev.gvart.genesara.api.internal.mcp.events.EventLogProperties
 import dev.gvart.genesara.api.internal.mcp.jackson.EnumCaseInsensitiveToolCallbackProvider
 import dev.gvart.genesara.api.internal.mcp.presence.PresenceProperties
+import dev.gvart.genesara.api.internal.mcp.session.SessionRecoveryRouterFilter
 import dev.gvart.genesara.api.internal.mcp.tools.abilities.UseAbilityTool
 import dev.gvart.genesara.api.internal.mcp.tools.attack.AttackTool
 import dev.gvart.genesara.api.internal.mcp.tools.attributes.AllocatePointsTool
@@ -31,11 +32,15 @@ import dev.gvart.genesara.api.internal.mcp.tools.safenode.SetSafeNodeTool
 import dev.gvart.genesara.api.internal.mcp.tools.skills.EquipSkillTool
 import dev.gvart.genesara.api.internal.mcp.tools.spawn.SpawnTool
 import dev.gvart.genesara.api.internal.mcp.tools.unspawn.UnspawnTool
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStreamableServerTransportProvider
 import org.springframework.ai.tool.ToolCallbackProvider
 import org.springframework.ai.tool.method.MethodToolCallbackProvider
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.function.RouterFunction
+import org.springframework.web.servlet.function.ServerResponse
+import tools.jackson.databind.ObjectMapper
 
 @Configuration
 @EnableConfigurationProperties(PresenceProperties::class, EventLogProperties::class)
@@ -83,4 +88,11 @@ internal class McpServerConfiguration {
             .build()
         return EnumCaseInsensitiveToolCallbackProvider(methodProvider)
     }
+
+    @Bean
+    internal fun webMvcStreamableServerRouterFunction(
+        provider: WebMvcStreamableServerTransportProvider,
+        mapper: ObjectMapper,
+    ): RouterFunction<ServerResponse> =
+        provider.routerFunction.filter(SessionRecoveryRouterFilter(mapper))
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/session/SessionRecoveryRouterFilter.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/session/SessionRecoveryRouterFilter.kt
@@ -9,6 +9,7 @@ import org.springframework.web.servlet.function.HandlerFilterFunction
 import org.springframework.web.servlet.function.HandlerFunction
 import org.springframework.web.servlet.function.ServerRequest
 import org.springframework.web.servlet.function.ServerResponse
+import tools.jackson.databind.JsonNode
 import tools.jackson.databind.ObjectMapper
 
 /**
@@ -22,6 +23,7 @@ internal class SessionRecoveryRouterFilter(
 
     override fun filter(request: ServerRequest, next: HandlerFunction<ServerResponse>): ServerResponse {
         if (request.method() != HttpMethod.POST) return next.handle(request)
+        if (request.headers().firstHeader(MCP_SESSION_ID_HEADER) == null) return next.handle(request)
 
         val body = runCatching { request.body(String::class.java) }.getOrNull()
             ?: return next.handle(request)
@@ -30,7 +32,10 @@ internal class SessionRecoveryRouterFilter(
         val response = next.handle(cached)
         if (!isSessionNotFound(response)) return response
 
-        val requestId = extractRequestId(body)
+        val parsed = runCatching { mapper.readTree(body) }.getOrNull()
+        if (parsed != null && !parsed.has("id")) return ServerResponse.accepted().build()
+
+        val requestId = extractRequestId(parsed)
         val sessionId = request.headers().firstHeader(MCP_SESSION_ID_HEADER)
         val envelope = sessionExpiredEnvelope(requestId, sessionId)
         return ServerResponse.ok()
@@ -45,16 +50,14 @@ internal class SessionRecoveryRouterFilter(
         return message.startsWith(SESSION_NOT_FOUND_PREFIX)
     }
 
-    private fun extractRequestId(body: String): Any? =
-        runCatching { mapper.readTree(body).get("id") }
-            .getOrNull()
-            ?.let { node ->
-                when {
-                    node.isNumber -> node.asLong()
-                    node.isString -> node.asString()
-                    else -> null
-                }
+    private fun extractRequestId(parsed: JsonNode?): Any? =
+        parsed?.get("id")?.let { node ->
+            when {
+                node.isNumber -> node.asLong()
+                node.isString -> node.asString()
+                else -> null
             }
+        }
 
     private fun sessionExpiredEnvelope(requestId: Any?, sessionId: String?): Map<String, Any?> = mapOf(
         "jsonrpc" to "2.0",

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/session/SessionRecoveryRouterFilter.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/session/SessionRecoveryRouterFilter.kt
@@ -1,0 +1,80 @@
+package dev.gvart.genesara.api.internal.mcp.session
+
+import io.modelcontextprotocol.spec.McpError
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.servlet.function.EntityResponse
+import org.springframework.web.servlet.function.HandlerFilterFunction
+import org.springframework.web.servlet.function.HandlerFunction
+import org.springframework.web.servlet.function.ServerRequest
+import org.springframework.web.servlet.function.ServerResponse
+import tools.jackson.databind.ObjectMapper
+
+/**
+ * Intercepts Spring AI MCP's "Session not found" 404 on POST and rewrites it into a
+ * structured JSON-RPC error so a client whose `mcp-session-id` was invalidated by a JVM
+ * restart can recover instead of seeing `-32603 INTERNAL_ERROR`.
+ */
+internal class SessionRecoveryRouterFilter(
+    private val mapper: ObjectMapper,
+) : HandlerFilterFunction<ServerResponse, ServerResponse> {
+
+    override fun filter(request: ServerRequest, next: HandlerFunction<ServerResponse>): ServerResponse {
+        if (request.method() != HttpMethod.POST) return next.handle(request)
+
+        val body = runCatching { request.body(String::class.java) }.getOrNull()
+            ?: return next.handle(request)
+        val cached = ServerRequest.from(request).body(body).build()
+
+        val response = next.handle(cached)
+        if (!isSessionNotFound(response)) return response
+
+        val requestId = extractRequestId(body)
+        val sessionId = request.headers().firstHeader(MCP_SESSION_ID_HEADER)
+        val envelope = sessionExpiredEnvelope(requestId, sessionId)
+        return ServerResponse.ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(envelope)
+    }
+
+    private fun isSessionNotFound(response: ServerResponse): Boolean {
+        if (response.statusCode() != HttpStatus.NOT_FOUND) return false
+        val entity = (response as? EntityResponse<*>)?.entity() ?: return false
+        val message = (entity as? McpError)?.jsonRpcError?.message() ?: return false
+        return message.startsWith(SESSION_NOT_FOUND_PREFIX)
+    }
+
+    private fun extractRequestId(body: String): Any? =
+        runCatching { mapper.readTree(body).get("id") }
+            .getOrNull()
+            ?.let { node ->
+                when {
+                    node.isNumber -> node.asLong()
+                    node.isString -> node.asString()
+                    else -> null
+                }
+            }
+
+    private fun sessionExpiredEnvelope(requestId: Any?, sessionId: String?): Map<String, Any?> = mapOf(
+        "jsonrpc" to "2.0",
+        "id" to requestId,
+        "error" to mapOf(
+            "code" to SESSION_EXPIRED_CODE,
+            "message" to SESSION_EXPIRED_MESSAGE,
+            "data" to buildMap<String, Any?> {
+                put("kind", "session_expired")
+                if (sessionId != null) put("sessionId", sessionId)
+            },
+        ),
+    )
+
+    private companion object {
+        const val MCP_SESSION_ID_HEADER = "mcp-session-id"
+        const val SESSION_NOT_FOUND_PREFIX = "Session not found:"
+        const val SESSION_EXPIRED_MESSAGE = "Session expired, please reinitialize"
+
+        // JSON-RPC server-error range (-32000..-32099 is reserved for "Server error" by JSON-RPC 2.0).
+        const val SESSION_EXPIRED_CODE = -32001
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/session/SessionRecoveryRouterFilterIntegrationTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/session/SessionRecoveryRouterFilterIntegrationTest.kt
@@ -43,4 +43,28 @@ class SessionRecoveryRouterFilterIntegrationTest {
         assertEquals("session_expired", data.get("kind").asString())
         assertEquals("stale-uuid", data.get("sessionId").asString())
     }
+
+    @Test
+    fun `notification with stale session id is acknowledged with 202 and an empty body`() {
+        val response = mvc.post("/mcp") {
+            contentType = MediaType.APPLICATION_JSON
+            header("Accept", "application/json, text/event-stream")
+            header("mcp-session-id", "stale-uuid")
+            content = """{"jsonrpc":"2.0","method":"notifications/initialized"}"""
+        }.andReturn().response
+
+        assertEquals(202, response.status)
+        assertEquals("", response.contentAsString)
+    }
+
+    @Test
+    fun `POST without mcp-session-id header bypasses the recovery filter and reaches the upstream provider`() {
+        val response = mvc.post("/mcp") {
+            contentType = MediaType.APPLICATION_JSON
+            header("Accept", "application/json, text/event-stream")
+            content = """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"x"}}"""
+        }.andReturn().response
+
+        assertEquals(400, response.status)
+    }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/session/SessionRecoveryRouterFilterIntegrationTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/session/SessionRecoveryRouterFilterIntegrationTest.kt
@@ -1,0 +1,46 @@
+package dev.gvart.genesara.api.internal.mcp.session
+
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper
+import org.junit.jupiter.api.Test
+import org.springframework.ai.mcp.server.webmvc.transport.WebMvcStreamableServerTransportProvider
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import kotlin.test.assertEquals
+
+class SessionRecoveryRouterFilterIntegrationTest {
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+    private val transport = WebMvcStreamableServerTransportProvider.builder()
+        .jsonMapper(JacksonMcpJsonMapper(mapper))
+        .mcpEndpoint("/mcp")
+        .build()
+    private val router = transport.routerFunction.filter(SessionRecoveryRouterFilter(mapper))
+    private val mvc = MockMvcBuilders.routerFunctions(router).build()
+
+    @Test
+    fun `tools call with stale session id returns structured session_expired envelope, not raw 404`() {
+        val response = mvc.post("/mcp") {
+            contentType = MediaType.APPLICATION_JSON
+            header("Accept", "application/json, text/event-stream")
+            header("mcp-session-id", "stale-uuid")
+            content = """
+                {"jsonrpc":"2.0","id":11,"method":"tools/call",
+                 "params":{"name":"get_status","arguments":{}}}
+            """.trimIndent()
+        }.andReturn().response
+
+        assertEquals(200, response.status)
+        val body = mapper.readTree(response.contentAsString)
+        assertEquals("2.0", body.get("jsonrpc").asString())
+        assertEquals(11L, body.get("id").asLong())
+        val error = body.get("error")
+        assertEquals(-32001, error.get("code").asInt())
+        assertEquals("Session expired, please reinitialize", error.get("message").asString())
+        val data = error.get("data")
+        assertEquals("session_expired", data.get("kind").asString())
+        assertEquals("stale-uuid", data.get("sessionId").asString())
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/session/SessionRecoveryRouterFilterTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/session/SessionRecoveryRouterFilterTest.kt
@@ -14,8 +14,8 @@ import org.springframework.web.servlet.function.ServerResponse
 import tools.jackson.databind.json.JsonMapper
 import tools.jackson.module.kotlin.kotlinModule
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SessionRecoveryRouterFilterTest {
@@ -62,7 +62,7 @@ class SessionRecoveryRouterFilterTest {
     }
 
     @Test
-    fun `missing id field becomes null id in the rewritten envelope`() {
+    fun `notification with no id triggers no response envelope and returns 202 accepted`() {
         val request = postRequest(
             body = """{"jsonrpc":"2.0","method":"notifications/initialized"}""",
             sessionId = "stale",
@@ -70,8 +70,29 @@ class SessionRecoveryRouterFilterTest {
 
         val response = filter.filter(request, sessionNotFoundHandler("stale"))
 
-        val envelope = (response as EntityResponse<*>).entity() as Map<*, *>
-        assertNull(envelope["id"])
+        assertEquals(HttpStatus.ACCEPTED, response.statusCode())
+        assertFalse(response is EntityResponse<*>)
+    }
+
+    @Test
+    fun `request without mcp-session-id header bypasses the filter without buffering the body`() {
+        val mock = MockHttpServletRequest("POST", "/mcp").apply {
+            contentType = MediaType.APPLICATION_JSON_VALUE
+            addHeader("Accept", "application/json, text/event-stream")
+            setContent("""{"jsonrpc":"2.0","id":1,"method":"initialize"}""".toByteArray(Charsets.UTF_8))
+        }
+        val request = ServerRequest.create(mock, listOf(StringHttpMessageConverter()))
+        val passthrough = ServerResponse.ok().build()
+        var bodyRead = false
+        val handler = HandlerFunction<ServerResponse> { req ->
+            bodyRead = req.body(String::class.java).isNotEmpty()
+            passthrough
+        }
+
+        val response = filter.filter(request, handler)
+
+        assertEquals(passthrough, response)
+        assertTrue(bodyRead)
     }
 
     @Test

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/session/SessionRecoveryRouterFilterTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/session/SessionRecoveryRouterFilterTest.kt
@@ -1,0 +1,145 @@
+package dev.gvart.genesara.api.internal.mcp.session
+
+import io.modelcontextprotocol.spec.McpError
+import io.modelcontextprotocol.spec.McpSchema
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.converter.StringHttpMessageConverter
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.web.servlet.function.EntityResponse
+import org.springframework.web.servlet.function.HandlerFunction
+import org.springframework.web.servlet.function.ServerRequest
+import org.springframework.web.servlet.function.ServerResponse
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SessionRecoveryRouterFilterTest {
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+    private val filter = SessionRecoveryRouterFilter(mapper)
+
+    @Test
+    fun `session-not-found 404 is rewritten to structured session_expired JSON-RPC error`() {
+        val request = postRequest(
+            body = """{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"get_status"}}""",
+            sessionId = "stale-session-id",
+        )
+
+        val response = filter.filter(request, sessionNotFoundHandler("stale-session-id"))
+
+        assertEquals(HttpStatus.OK, response.statusCode())
+        val entity = (response as EntityResponse<*>).entity()
+        @Suppress("UNCHECKED_CAST")
+        val envelope = entity as Map<String, Any?>
+        assertEquals("2.0", envelope["jsonrpc"])
+        assertEquals(7L, envelope["id"])
+        @Suppress("UNCHECKED_CAST")
+        val error = envelope["error"] as Map<String, Any?>
+        assertEquals(-32001, error["code"])
+        assertEquals("Session expired, please reinitialize", error["message"])
+        @Suppress("UNCHECKED_CAST")
+        val data = error["data"] as Map<String, Any?>
+        assertEquals("session_expired", data["kind"])
+        assertEquals("stale-session-id", data["sessionId"])
+    }
+
+    @Test
+    fun `string id is preserved verbatim in the rewritten envelope`() {
+        val request = postRequest(
+            body = """{"jsonrpc":"2.0","id":"req-42","method":"tools/call"}""",
+            sessionId = "stale",
+        )
+
+        val response = filter.filter(request, sessionNotFoundHandler("stale"))
+
+        val envelope = (response as EntityResponse<*>).entity() as Map<*, *>
+        assertEquals("req-42", envelope["id"])
+    }
+
+    @Test
+    fun `missing id field becomes null id in the rewritten envelope`() {
+        val request = postRequest(
+            body = """{"jsonrpc":"2.0","method":"notifications/initialized"}""",
+            sessionId = "stale",
+        )
+
+        val response = filter.filter(request, sessionNotFoundHandler("stale"))
+
+        val envelope = (response as EntityResponse<*>).entity() as Map<*, *>
+        assertNull(envelope["id"])
+    }
+
+    @Test
+    fun `successful response is forwarded unchanged`() {
+        val request = postRequest(body = """{"jsonrpc":"2.0","id":1}""", sessionId = "live")
+        val passthrough = ServerResponse.accepted().build()
+
+        val response = filter.filter(request) { passthrough }
+
+        assertEquals(passthrough, response)
+    }
+
+    @Test
+    fun `404 unrelated to session lookup is forwarded unchanged`() {
+        val request = postRequest(body = """{"jsonrpc":"2.0","id":1}""", sessionId = "x")
+        val other = ServerResponse.status(HttpStatus.NOT_FOUND)
+            .body(McpError.builder(McpSchema.ErrorCodes.METHOD_NOT_FOUND).message("Some other 404").build())
+
+        val response = filter.filter(request) { other }
+
+        assertEquals(HttpStatus.NOT_FOUND, response.statusCode())
+        val entity = (response as EntityResponse<*>).entity()
+        assertTrue(entity is McpError)
+    }
+
+    @Test
+    fun `GET request bypasses the filter`() {
+        val mock = MockHttpServletRequest("GET", "/mcp").apply {
+            addHeader("mcp-session-id", "x")
+        }
+        val request = ServerRequest.create(mock, listOf(StringHttpMessageConverter()))
+        val notFound = ServerResponse.status(HttpStatus.NOT_FOUND)
+            .body(McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR).message("Session not found: x").build())
+
+        val response = filter.filter(request) { notFound }
+
+        assertEquals(HttpStatus.NOT_FOUND, response.statusCode())
+    }
+
+    @Test
+    fun `unreadable body still falls through to handler`() {
+        val mock = MockHttpServletRequest("POST", "/mcp").apply {
+            addHeader("mcp-session-id", "x")
+        }
+        val request = ServerRequest.create(mock, listOf(StringHttpMessageConverter()))
+        val passthrough = ServerResponse.accepted().build()
+
+        val response = filter.filter(request) { passthrough }
+
+        assertNotNull(response)
+    }
+
+    private fun postRequest(body: String, sessionId: String): ServerRequest {
+        val mock = MockHttpServletRequest("POST", "/mcp").apply {
+            contentType = MediaType.APPLICATION_JSON_VALUE
+            addHeader("Accept", "application/json, text/event-stream")
+            addHeader("mcp-session-id", sessionId)
+            setContent(body.toByteArray(Charsets.UTF_8))
+        }
+        return ServerRequest.create(mock, listOf(StringHttpMessageConverter()))
+    }
+
+    private fun sessionNotFoundHandler(sessionId: String): HandlerFunction<ServerResponse> = HandlerFunction { _ ->
+        ServerResponse.status(HttpStatus.NOT_FOUND)
+            .body(
+                McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+                    .message("Session not found: $sessionId")
+                    .build(),
+            )
+    }
+}


### PR DESCRIPTION
## Summary

- Spring AI's `WebMvcStreamableServerTransportProvider` stores sessions in an in-process `ConcurrentHashMap`. After a JVM restart any cached `mcp-session-id` resolves to HTTP 404 + raw `McpError("Session not found: <uuid>")`, which the MCP client surfaces as `JSON-RPC -32603 INTERNAL_ERROR` with no recovery hint — every subsequent tool call fails identically and the agent has to be killed and respawned.
- Wraps the autoconfigured router function with a `HandlerFilterFunction` that detects the session-not-found 404 on POST and rewrites it into a structured JSON-RPC error envelope with `error.data.kind = "session_expired"`, so the client (or its operator) can re-handshake transparently.

## Wire shape on the recovery path

```json
{
  "jsonrpc": "2.0",
  "id": <original request id>,
  "error": {
    "code": -32001,
    "message": "Session expired, please reinitialize",
    "data": { "kind": "session_expired", "sessionId": "<stale-uuid>" }
  }
}
```

Status code is `200 OK` with `application/json` so MCP clients consume it as a normal JSON-RPC error response.

## Files

- `api/src/main/kotlin/.../mcp/session/SessionRecoveryRouterFilter.kt` — the filter (50 LoC).
- `api/src/main/kotlin/.../mcp/McpServerConfiguration.kt` — overrides the autoconfigured `webMvcStreamableServerRouterFunction` bean to apply the filter.
- `api/src/test/.../SessionRecoveryRouterFilterTest.kt` — 7 unit tests covering: numeric id, string id, missing id, success passthrough, unrelated 404 passthrough, GET bypass, unreadable body fall-through.
- `api/src/test/.../SessionRecoveryRouterFilterIntegrationTest.kt` — drives a real `WebMvcStreamableServerTransportProvider` (no sessions registered) via `MockMvcBuilders.routerFunctions(...)` and asserts the structured envelope shape.

## Refs

`docs/playtest/findings.md` — [P1] MCP session is not recoverable after a JVM restart.

## Test plan

- [x] `./gradlew :api:test` green (full api suite + new session tests).
- [ ] Manual: start server, `initialize`, restart JVM, replay tool call with cached session id — expect structured `session_expired` envelope, not `-32603`.