### PR TITLE
fix(player): dedup skill.recommended within cooldown window per skill

### DIFF
--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentSkillsRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentSkillsRegistry.kt
@@ -277,7 +277,16 @@ internal class JooqAgentSkillsRegistry(
         const val SLOTS_PER_LEVEL_GROUP = 10
         const val XP_PER_LEVEL = 10
         const val RECOMMEND_CAP = 3
-        const val RECOMMEND_COOLDOWN_TICKS = 30L
+
+        /**
+         * Per-skill suppression window after a `SkillRecommended` event fires for
+         * (agent, skill). Dedupes near-adjacent actions that target the same skill
+         * (e.g. `harvest(FISH)` immediately followed by `consume(FISH)`) — the
+         * recommendation is the *discovery* surface, not a per-action telemetry
+         * ping. At 1s/tick the 60-tick window covers a typical action chain while
+         * still allowing all 3 recommendations to fire over a multi-minute session.
+         */
+        const val RECOMMEND_COOLDOWN_TICKS = 60L
         val MILESTONE_THRESHOLDS = listOf(50, 100, 150)
     }
 }

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentSkillsRegistryIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentSkillsRegistryIntegrationTest.kt
@@ -7,7 +7,9 @@ import dev.gvart.genesara.player.Skill
 import dev.gvart.genesara.player.SkillCategory
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillLookup
+import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.player.events.AgentEvent
 import dev.gvart.genesara.player.internal.jooq.tables.references.AGENTS
 import dev.gvart.genesara.player.internal.jooq.tables.references.AGENT_SKILLS
 import dev.gvart.genesara.player.internal.jooq.tables.references.AGENT_SKILL_RECOMMENDATIONS
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 import org.testcontainers.containers.PostgreSQLContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
@@ -151,20 +154,56 @@ class JooqAgentSkillsRegistryIntegrationTest {
         val first = registry.maybeRecommend(agent, foraging, tick = 100)
         assertEquals(1, first)
 
-        // Cooldown gate (~30 ticks) blocks tick 110.
         val cooledDown = registry.maybeRecommend(agent, foraging, tick = 110)
         assertNull(cooledDown)
 
-        // After cooldown, fires again.
         val second = registry.maybeRecommend(agent, foraging, tick = 200)
         assertEquals(2, second)
 
         val third = registry.maybeRecommend(agent, foraging, tick = 300)
         assertEquals(3, third)
 
-        // Capped at 3 — no further recommendations.
         val capped = registry.maybeRecommend(agent, foraging, tick = 400)
         assertNull(capped)
+    }
+
+    @Test
+    fun `maybeRecommend suppresses a same-skill call inside the cooldown window`() {
+        val first = registry.maybeRecommend(agent, foraging, tick = 0)
+        assertEquals(1, first)
+
+        val withinWindow = registry.maybeRecommend(agent, foraging, tick = 59)
+        assertNull(withinWindow, "second call within the 60-tick window must dedupe")
+    }
+
+    @Test
+    fun `maybeRecommend fires again once the cooldown window elapses`() {
+        registry.maybeRecommend(agent, foraging, tick = 0)
+
+        val afterWindow = registry.maybeRecommend(agent, foraging, tick = 60)
+        assertEquals(2, afterWindow, "call at tick equal to cooldown boundary must fire")
+    }
+
+    @Test
+    fun `maybeRecommend cooldown buckets are per-skill`() {
+        assertEquals(1, registry.maybeRecommend(agent, foraging, tick = 0))
+
+        val miningWithinForagingWindow = registry.maybeRecommend(agent, mining, tick = 5)
+        assertEquals(1, miningWithinForagingWindow, "mining cooldown must not inherit foraging's last-recommended tick")
+    }
+
+    @Test
+    fun `harvest then consume in the same tick emits exactly one SkillRecommended for the shared skill`() {
+        val publisher = RecordingPublisher()
+        val progression = SkillProgression(registry, publisher)
+        val commandId = UUID.randomUUID()
+
+        progression.accrueXp(agent, foraging, delta = 1, tick = 5, commandId = commandId)
+        progression.accrueXp(agent, foraging, delta = 1, tick = 5, commandId = UUID.randomUUID())
+
+        val emitted = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>()
+        assertEquals(1, emitted.size, "harvest+consume on the same skill must dedupe to one recommendation")
+        assertEquals(1, emitted.single().recommendCount)
     }
 
     @Test
@@ -337,5 +376,10 @@ class JooqAgentSkillsRegistryIntegrationTest {
         }
         override fun byId(id: SkillId): Skill? = byId[id]
         override fun all(): List<Skill> = byId.values.toList()
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) { events += event }
     }
 }


### PR DESCRIPTION
## Summary

Closes the [P3] finding in [`docs/playtest/findings.md`](../blob/main/docs/playtest/findings.md): `harvest(FISH)` immediately followed by `consume(FISH)` fired two `skill.recommended` events with `recommendCount:1` then `recommendCount:2`. Per project memory and `docs/lore/mechanics-reference.md` §3 (Skills), the recommendation is the *discovery* surface, not a per-action telemetry stream.

Root cause: the cooldown in `JooqAgentSkillsRegistry.maybeRecommend` already dedup'd by `skill` (not by `(skill, action-source)`), but `RECOMMEND_COOLDOWN_TICKS = 30L` was shorter than a typical chained-verb interval. Bumped to `60L` (1s/tick → 60s window), keeping a single source-of-truth constant and the cap of 3 unchanged. The window still permits all 3 recommendations to fire over a multi-minute session.

Files touched:
- `player/.../internal/store/JooqAgentSkillsRegistry.kt` — constant bump + KDoc on the why.
- `player/.../internal/store/JooqAgentSkillsRegistryIntegrationTest.kt` — focused tests + harvest→consume integration test through the `SkillProgression` seam.

## Test plan

- [x] `./gradlew :player:test :world:test :api:test` — green.
- [x] Unit: same-skill call inside window suppressed (`tick = 0`, `tick = 59`).
- [x] Unit: same-skill call at window boundary fires (`tick = 0`, `tick = 60`).
- [x] Unit: cooldown buckets are per-skill (foraging at `tick = 0` doesn't gate mining at `tick = 5`).
- [x] Integration: two `SkillProgression.accrueXp` calls (simulating harvest then consume) on the same skill at the same tick emit exactly one `SkillRecommended`.