### PR TITLE
feat(world,api): include staminaSpent in agent.moved event payload

### DIFF
--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
@@ -30,7 +30,7 @@ class AgentEventDispatcherTest {
     @Test
     fun `AgentMoved appends an envelope and pings the per-agent resource URI`() {
         val cmdId = UUID.randomUUID()
-        val event = WorldEvent.AgentMoved(agent, NodeId(1L), NodeId(2L), tick = 5, causedBy = cmdId)
+        val event = WorldEvent.AgentMoved(agent, NodeId(1L), NodeId(2L), staminaSpent = 1, tick = 5, causedBy = cmdId)
 
         dispatcher.on(event)
 
@@ -43,6 +43,15 @@ class AgentEventDispatcherTest {
         assertEquals(cmdId.toString(), envelope.payload.get("causedBy").asString())
 
         verify(bus).publish(InvalidationMessage.AgentNotify(agent))
+    }
+
+    @Test
+    fun `AgentMoved payload carries the staminaSpent value on the stream`() {
+        val cmdId = UUID.randomUUID()
+        dispatcher.on(WorldEvent.AgentMoved(agent, NodeId(1L), NodeId(2L), staminaSpent = 7, tick = 5, causedBy = cmdId))
+
+        val envelope = log.since(agent, 0).single()
+        assertEquals(7, envelope.payload.get("staminaSpent").asInt())
     }
 
     @Test
@@ -67,7 +76,7 @@ class AgentEventDispatcherTest {
     @Test
     fun `monotonic seq across appends`() {
         repeat(3) { i ->
-            dispatcher.on(WorldEvent.AgentMoved(agent, NodeId(1L), NodeId(2L), tick = i.toLong(), causedBy = UUID.randomUUID()))
+            dispatcher.on(WorldEvent.AgentMoved(agent, NodeId(1L), NodeId(2L), staminaSpent = 1, tick = i.toLong(), causedBy = UUID.randomUUID()))
         }
         val seqs = log.since(agent, 0).map { it.seq }
         assertEquals(listOf(1L, 2L, 3L), seqs)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
@@ -33,6 +33,8 @@ sealed interface WorldEvent {
         val agent: AgentId,
         val from: NodeId,
         val to: NodeId,
+        /** Stamina actually charged for this step after terrain, road, and speed-scaling adjustments. */
+        val staminaSpent: Int,
         override val tick: Long,
         val causedBy: UUID,
     ) : WorldEvent

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
@@ -57,7 +57,14 @@ internal fun reduceMove(
         .moveAgent(command.agent, command.to)
         .updateBody(command.agent, body.spendStamina(cost))
     behaviorTracker.record(command.agent, ActionCategory.EXPLORE, tick)
-    val event = WorldEvent.AgentMoved(command.agent, from, command.to, tick, causedBy = command.commandId)
+    val event = WorldEvent.AgentMoved(
+        agent = command.agent,
+        from = from,
+        to = command.to,
+        staminaSpent = cost,
+        tick = tick,
+        causedBy = command.commandId,
+    )
 
     next to listOf(event)
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
@@ -73,7 +73,7 @@ class MovementReducerTest {
                 assertEquals(b, next.positions[agent])
                 assertEquals(9, next.bodyOf(agent)!!.stamina)
                 assertEquals(
-                    WorldEvent.AgentMoved(agent, a, b, tick = 1, causedBy = command.commandId),
+                    WorldEvent.AgentMoved(agent, a, b, staminaSpent = 1, tick = 1, causedBy = command.commandId),
                     events.single(),
                 )
                 assertEquals(mapOf(ActionCategory.EXPLORE to 1), tracker.snapshotFor(agent))
@@ -142,6 +142,44 @@ class MovementReducerTest {
             WorldRejection.TerrainNotTraversable(agent, b, Terrain.OCEAN),
             result.leftOrNull(),
         )
+    }
+
+    @Test
+    fun `emitted AgentMoved staminaSpent equals the per-terrain balance cost`() {
+        val perTerrain = perTerrainBalance(
+            mapOf(Terrain.PLAINS to 1, Terrain.MOUNTAIN to 6),
+        )
+        val plainsResult = reduceMove(world, WorldCommand.MoveAgent(agent, b), perTerrain, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val plainsMoved = plainsResult.getOrNull()!!.second.filterIsInstance<WorldEvent.AgentMoved>().single()
+        assertEquals(1, plainsMoved.staminaSpent)
+        assertEquals(9, plainsResult.getOrNull()!!.first.bodyOf(agent)!!.stamina)
+
+        val mountainous = world.copy(
+            nodes = world.nodes.mapValues { (id, n) ->
+                if (id == b) n.copy(terrain = Terrain.MOUNTAIN) else n
+            },
+        )
+        val mountainResult = reduceMove(mountainous, WorldCommand.MoveAgent(agent, b), perTerrain, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 2)
+        val mountainMoved = mountainResult.getOrNull()!!.second.filterIsInstance<WorldEvent.AgentMoved>().single()
+        assertEquals(6, mountainMoved.staminaSpent)
+        assertEquals(4, mountainResult.getOrNull()!!.first.bodyOf(agent)!!.stamina)
+    }
+
+    @Test
+    fun `emitted AgentMoved staminaSpent matches the road-discounted cost`() {
+        val cost10 = balanceLookup(cost = 10)
+        val road = activeBuilding(node = a, hint = BuildingCategoryHint.INFRASTRUCTURE_ROAD)
+        val buildings = StubBuildingsLookup(byNode = mapOf(a to listOf(road)))
+
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost10, buildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val moved = result.getOrNull()!!.second.filterIsInstance<WorldEvent.AgentMoved>().single()
+
+        assertEquals(5, moved.staminaSpent)
+    }
+
+    private fun perTerrainBalance(costs: Map<Terrain, Int>) = object : BalanceLookup by flatCost {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain): Int =
+            costs[terrain] ?: error("no cost configured for $terrain")
     }
 
     private fun balanceLookup(cost: Int) = object : BalanceLookup {


### PR DESCRIPTION
## Summary

Fixes the **[P3] agent.moved payload has no stamina-spent field** finding from `docs/playtest/findings.md`.

- Adds `staminaSpent: Int` to `WorldEvent.AgentMoved` and populates it from the cost the move reducer already charges (terrain + biome + climate, road-discounted, speed-scaling-adjusted, floored at 1).
- Agents previously had to infer the cost from the next `agent.passives` delta (`expected_regen − observed_delta`). Now it lands explicitly on the event, mirroring the existing `refilled` field on `agent.drank`.
- No balance change: only the existing local `cost` value is surfaced.

## Test plan

- [x] `:world:test` green — adds unit assertions in `MovementReducerTest` covering:
  - PLAINS (cost=1) vs MOUNTAIN (cost=6) via per-terrain balance lookup
  - Road-discounted cost (cost=10, road halves to 5)
- [x] `:api:test` green — new `AgentEventDispatcherTest` case asserts the serialized payload exposes `staminaSpent` on the agent's event stream.