### PR TITLE
fix(api): structured rejections for enum + missing-param binder errors

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/McpToolInputValidationCallback.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/McpToolInputValidationCallback.kt
@@ -3,18 +3,21 @@ package dev.gvart.genesara.api.internal.mcp.jackson
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.ToolCallback
 import org.springframework.ai.tool.definition.ToolDefinition
+import org.springframework.ai.tool.execution.ToolExecutionException
 import org.springframework.ai.tool.metadata.ToolMetadata
 import org.springframework.ai.util.json.JsonParser
 import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.exc.InvalidFormatException
+import tools.jackson.databind.exc.MismatchedInputException
 import tools.jackson.databind.node.ObjectNode
 
-/** Catches Spring AI [org.springframework.ai.tool.method.MethodToolCallback] binder errors
- *  before they reach the reflective invocation — Kotlin NPE on a missing required param and
- *  `IllegalArgumentException` on an unknown enum constant both leak fully-qualified internal
- *  class names back to the agent. Pre-validates against the tool's own inputSchema and
- *  returns a structured `{"kind":"error", ...}` JSON shape instead. Runs *inside*
- *  [EnumCaseInsensitiveToolCallback], so any case-normalised enum value has already been
- *  rewritten to its canonical form by the time we validate. */
+/** Wraps Spring AI's [org.springframework.ai.tool.method.MethodToolCallback] argument binder so its
+ *  failures surface as a structured `{"kind":"rejected", "reason":..., "detail":..., "validValues":[...]}`
+ *  payload instead of a Kotlin / Jackson stack trace with fully-qualified internal class names. Two
+ *  layers: a schema-driven pre-check rejects obvious cases (missing top-level required, unknown
+ *  top-level enum) before the binder runs; a try/catch around the delegate translates anything the
+ *  pre-check can't see (Map-key enums, Kotlin non-null NPE) into the same shape. Runs *inside*
+ *  [EnumCaseInsensitiveToolCallback] so case-normalised enums reach this layer in canonical form. */
 internal class McpToolInputValidationCallback(
     private val delegate: ToolCallback,
 ) : ToolCallback {
@@ -35,76 +38,122 @@ internal class McpToolInputValidationCallback(
     override fun call(toolInput: String): String = call(toolInput, null)
 
     override fun call(toolInput: String, toolContext: ToolContext?): String {
-        if (required.isEmpty() && enumValues.isEmpty()) return delegate.call(toolInput, toolContext)
         val mapper = JsonParser.getJsonMapper()
+        val preCheck = preValidate(mapper, toolInput)
+        if (preCheck != null) return preCheck
+        return try {
+            delegate.call(toolInput, toolContext)
+        } catch (e: ToolExecutionException) {
+            translate(mapper, e.cause ?: e) ?: throw e
+        }
+    }
+
+    private fun preValidate(mapper: ObjectMapper, toolInput: String): String? {
+        if (required.isEmpty() && enumValues.isEmpty()) return null
         val node = runCatching { mapper.readTree(toolInput) }.getOrNull()
-        if (node !is ObjectNode) return delegate.call(toolInput, toolContext)
+        if (node !is ObjectNode) return null
 
         for (param in required) {
             val value = node.get(param)
-            if (value == null || value.isNull) {
-                return missingParamError(mapper, param)
-            }
-            if (value.isString && value.asString().isBlank()) {
-                return blankParamError(mapper, param)
-            }
+            if (value == null || value.isNull) return missingRequired(mapper, param)
+            if (value.isString && value.asString().isBlank()) return blankRequired(mapper, param)
         }
 
         for ((param, allowed) in enumValues) {
             val value = node.get(param) ?: continue
             if (!value.isString) continue
             val raw = value.asString()
-            if (raw !in allowed) {
-                return unknownEnumError(mapper, param, raw, allowed)
-            }
+            if (raw !in allowed) return unknownEnum(mapper, param, raw, allowed)
         }
-
-        return delegate.call(toolInput, toolContext)
+        return null
     }
 
-    private fun missingParamError(mapper: ObjectMapper, parameter: String): String {
-        val error = mapper.createObjectNode()
-        error.put("code", "MISSING_REQUIRED_PARAMETER")
-        error.put("parameter", parameter)
-        error.put("message", "Required parameter '$parameter' is missing")
-        return wrap(mapper, error)
+    private fun translate(mapper: ObjectMapper, cause: Throwable): String? {
+        cause.findKotlinNonNullParameter()?.let { return missingRequired(mapper, it) }
+        (cause as? MismatchedInputException)?.let { return fromJackson(mapper, it) }
+        cause.findEnumValueOf()?.let { (klass, value) ->
+            return unknownEnum(mapper, klass.simpleName, value, klass.enumConstantNames())
+        }
+        return null
     }
 
-    private fun blankParamError(mapper: ObjectMapper, parameter: String): String {
-        val error = mapper.createObjectNode()
-        error.put("code", "MISSING_REQUIRED_PARAMETER")
-        error.put("parameter", parameter)
-        error.put("message", "Required parameter '$parameter' must not be blank")
-        return wrap(mapper, error)
+    private fun fromJackson(mapper: ObjectMapper, exc: MismatchedInputException): String? {
+        val target = exc.targetType ?: return null
+        if (!target.isEnum) return null
+        val attemptedValue = (exc as? InvalidFormatException)?.value?.toString()
+            ?: extractJacksonAttemptedValue(exc.originalMessage)
+            ?: return null
+        val parameter = exc.path.firstOrNull()?.propertyName ?: target.simpleName
+        return unknownEnum(mapper, parameter, attemptedValue, target.enumConstantNames())
     }
 
-    private fun unknownEnumError(
+    private fun missingRequired(mapper: ObjectMapper, parameter: String): String =
+        rejection(mapper, "missing_required", "required parameter '$parameter' was not provided", parameter = parameter)
+
+    private fun blankRequired(mapper: ObjectMapper, parameter: String): String =
+        rejection(mapper, "missing_required", "required parameter '$parameter' must not be blank", parameter = parameter)
+
+    private fun unknownEnum(
         mapper: ObjectMapper,
         parameter: String,
         received: String,
         validValues: List<String>,
-    ): String {
-        val error = mapper.createObjectNode()
-        error.put("code", "INVALID_ENUM_VALUE")
-        error.put("parameter", parameter)
-        error.put("received", received)
-        error.put(
-            "message",
-            "Unknown value '$received' for parameter '$parameter'. Valid values: ${validValues.joinToString()}",
-        )
-        val arr = error.putArray("validValues")
-        validValues.forEach { arr.add(it) }
-        return wrap(mapper, error)
-    }
+    ): String = rejection(
+        mapper,
+        reason = "unknown_enum_value",
+        detail = "$parameter: '$received' is not one of [${validValues.joinToString()}]",
+        parameter = parameter,
+        received = received,
+        validValues = validValues,
+    )
 
-    private fun wrap(mapper: ObjectMapper, error: ObjectNode): String {
+    private fun rejection(
+        mapper: ObjectMapper,
+        reason: String,
+        detail: String,
+        parameter: String? = null,
+        received: String? = null,
+        validValues: List<String>? = null,
+    ): String {
         val root = mapper.createObjectNode()
-        root.put("kind", "error")
-        root.set("error", error)
+        root.put("kind", "rejected")
+        root.put("reason", reason)
+        root.put("detail", detail)
+        if (parameter != null) root.put("parameter", parameter)
+        if (received != null) root.put("received", received)
+        if (validValues != null) {
+            val arr = root.putArray("validValues")
+            validValues.forEach { arr.add(it) }
+        }
         return mapper.writeValueAsString(root)
     }
 
     private companion object {
+        private val NON_NULL_PARAM = Regex("""Parameter specified as non-null is null:.*parameter\s+(\w+)""")
+        private val NO_ENUM_CONSTANT = Regex("""No enum constant ([\w.$]+)\.(\w+)""")
+        private val JACKSON_FROM_STRING = Regex("""from String "([^"]*)"""")
+
+        fun Throwable.findKotlinNonNullParameter(): String? {
+            val msg = this.message ?: return null
+            return NON_NULL_PARAM.find(msg)?.groupValues?.get(1)
+        }
+
+        fun Throwable.findEnumValueOf(): Pair<Class<*>, String>? {
+            val msg = this.message ?: return null
+            val match = NO_ENUM_CONSTANT.find(msg) ?: return null
+            val klass = runCatching { Class.forName(match.groupValues[1]) }.getOrNull() ?: return null
+            if (!klass.isEnum) return null
+            return klass to match.groupValues[2]
+        }
+
+        fun extractJacksonAttemptedValue(message: String?): String? {
+            if (message == null) return null
+            return JACKSON_FROM_STRING.find(message)?.groupValues?.get(1)
+        }
+
+        fun Class<*>.enumConstantNames(): List<String> =
+            (enumConstants ?: emptyArray<Any>()).map { (it as Enum<*>).name }
+
         fun parseSchema(schema: String): Pair<List<String>, Map<String, List<String>>> {
             val tree = runCatching { JsonParser.getJsonMapper().readTree(schema) }.getOrNull()
                 ?: return emptyList<String>() to emptyMap()

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/McpToolBinderIntegrationTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/McpToolBinderIntegrationTest.kt
@@ -1,0 +1,93 @@
+package dev.gvart.genesara.api.internal.mcp.jackson
+
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.definition.ToolDefinition
+import org.springframework.ai.tool.method.MethodToolCallback
+import org.springframework.ai.util.json.JsonParser
+import org.springframework.ai.util.json.schema.JsonSchemaGenerator
+import java.lang.reflect.Method
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class McpToolBinderIntegrationTest {
+
+    enum class TestBuildingType { CAMPFIRE, WORKBENCH, STORAGE_CHEST }
+    enum class TestAttribute { STRENGTH, DEXTERITY, INTELLIGENCE }
+
+    @Suppress("unused")
+    internal class TestTool {
+        fun build(type: TestBuildingType, toolContext: ToolContext): String = "built ${type.name}"
+        fun allocate(deltas: Map<TestAttribute, Int>, toolContext: ToolContext): String = "allocated ${deltas.size}"
+        fun inspect(targetType: TestBuildingType, targetId: String, toolContext: ToolContext): String =
+            "inspected ${targetType.name} $targetId"
+        fun harvest(itemId: String, toolContext: ToolContext): String = "harvested $itemId"
+    }
+
+    private val ctx = ToolContext(mapOf("any" to "value"))
+
+    private fun wrap(methodName: String): EnumCaseInsensitiveToolCallback {
+        val method: Method = TestTool::class.java.declaredMethods.first { it.name == methodName }
+        val schema = JsonSchemaGenerator.generateForMethodInput(method)
+        val def = ToolDefinition.builder().name(methodName).description("test").inputSchema(schema).build()
+        val raw = MethodToolCallback(def, null, method, TestTool(), null)
+        return EnumCaseInsensitiveToolCallback(McpToolInputValidationCallback(raw))
+    }
+
+    @Test
+    fun `build with unknown BuildingType returns structured rejection without FQN`() {
+        val out = wrap("build").call("""{"type":"CASTLE"}""", ctx)
+        val tree = JsonParser.getJsonMapper().readTree(out)
+
+        assertEquals("rejected", tree.get("kind").asString())
+        assertEquals("unknown_enum_value", tree.get("reason").asString())
+        assertEquals("type", tree.get("parameter").asString())
+        assertEquals("CASTLE", tree.get("received").asString())
+        val valid = mutableListOf<String>()
+        tree.get("validValues").forEach { valid.add(it.asString()) }
+        assertEquals(listOf("CAMPFIRE", "WORKBENCH", "STORAGE_CHEST"), valid)
+        assertTrue(!out.contains("dev.gvart"), "must not leak FQN: $out")
+        assertTrue(!out.contains("TestBuildingType."), "no FQN-ish dotted enum names: $out")
+    }
+
+    @Test
+    fun `allocate with unknown Map-key enum returns structured rejection without FQN`() {
+        val out = wrap("allocate").call("""{"deltas":{"FOOBAR":1}}""", ctx)
+        val tree = JsonParser.getJsonMapper().readTree(out)
+
+        assertEquals("rejected", tree.get("kind").asString())
+        assertEquals("unknown_enum_value", tree.get("reason").asString())
+        assertEquals("FOOBAR", tree.get("received").asString())
+        val valid = mutableListOf<String>()
+        tree.get("validValues").forEach { valid.add(it.asString()) }
+        assertEquals(setOf("STRENGTH", "DEXTERITY", "INTELLIGENCE"), valid.toSet())
+        assertTrue(!out.contains("dev.gvart"), "must not leak FQN: $out")
+        assertTrue(!out.contains("McpToolBinderIntegrationTest"), "must not leak nested class FQN: $out")
+    }
+
+    @Test
+    fun `inspect with lowercase targetType is canonicalised and succeeds`() {
+        val out = wrap("inspect").call("""{"targetType":"campfire","targetId":"x"}""", ctx)
+        assertTrue(out.contains("CAMPFIRE"), "lowercase enum should be normalised: $out")
+    }
+
+    @Test
+    fun `inspect with missing required parameter returns structured rejection`() {
+        val out = wrap("inspect").call("""{}""", ctx)
+        val tree = JsonParser.getJsonMapper().readTree(out)
+
+        assertEquals("rejected", tree.get("kind").asString())
+        assertEquals("missing_required", tree.get("reason").asString())
+        assertEquals("targetType", tree.get("parameter").asString())
+    }
+
+    @Test
+    fun `harvest with missing required string parameter returns structured rejection`() {
+        val out = wrap("harvest").call("""{}""", ctx)
+        val tree = JsonParser.getJsonMapper().readTree(out)
+
+        assertEquals("rejected", tree.get("kind").asString())
+        assertEquals("missing_required", tree.get("reason").asString())
+        assertEquals("itemId", tree.get("parameter").asString())
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/McpToolInputValidationCallbackTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/jackson/McpToolInputValidationCallbackTest.kt
@@ -4,8 +4,10 @@ import org.junit.jupiter.api.Test
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.ToolCallback
 import org.springframework.ai.tool.definition.ToolDefinition
+import org.springframework.ai.tool.execution.ToolExecutionException
 import org.springframework.ai.tool.metadata.ToolMetadata
 import org.springframework.ai.util.json.JsonParser
+import tools.jackson.databind.exc.InvalidFormatException
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -32,8 +34,18 @@ class McpToolInputValidationCallbackTest {
         }
     """.trimIndent()
 
+    private val allocateSchema = """
+        {
+          "type": "object",
+          "properties": {
+            "deltas": {"type": "object"}
+          },
+          "required": ["deltas"]
+        }
+    """.trimIndent()
+
     @Test
-    fun `missing required param returns structured error and does not call delegate`() {
+    fun `missing required param returns structured rejection and does not call delegate`() {
         val recorder = RecordingToolCallback(harvestSchema)
         val wrapped = McpToolInputValidationCallback(recorder)
 
@@ -41,13 +53,14 @@ class McpToolInputValidationCallbackTest {
         val tree = JsonParser.getJsonMapper().readTree(result)
 
         assertNull(recorder.lastInput, "delegate must not be invoked for invalid input")
-        assertEquals("error", tree.get("kind").asString())
-        assertEquals("MISSING_REQUIRED_PARAMETER", tree.path("error").path("code").asString())
-        assertEquals("itemId", tree.path("error").path("parameter").asString())
+        assertEquals("rejected", tree.get("kind").asString())
+        assertEquals("missing_required", tree.get("reason").asString())
+        assertEquals("itemId", tree.get("parameter").asString())
+        assertTrue(tree.get("detail").asString().contains("'itemId'"))
     }
 
     @Test
-    fun `explicit null for required param returns structured error`() {
+    fun `explicit null for required param returns structured rejection`() {
         val recorder = RecordingToolCallback(harvestSchema)
         val wrapped = McpToolInputValidationCallback(recorder)
 
@@ -55,11 +68,11 @@ class McpToolInputValidationCallbackTest {
         val tree = JsonParser.getJsonMapper().readTree(result)
 
         assertNull(recorder.lastInput)
-        assertEquals("MISSING_REQUIRED_PARAMETER", tree.path("error").path("code").asString())
+        assertEquals("missing_required", tree.get("reason").asString())
     }
 
     @Test
-    fun `blank required string returns structured error`() {
+    fun `blank required string returns structured rejection`() {
         val recorder = RecordingToolCallback(harvestSchema)
         val wrapped = McpToolInputValidationCallback(recorder)
 
@@ -67,12 +80,12 @@ class McpToolInputValidationCallbackTest {
         val tree = JsonParser.getJsonMapper().readTree(result)
 
         assertNull(recorder.lastInput)
-        assertEquals("MISSING_REQUIRED_PARAMETER", tree.path("error").path("code").asString())
-        assertTrue(tree.path("error").path("message").asString().contains("must not be blank"))
+        assertEquals("missing_required", tree.get("reason").asString())
+        assertTrue(tree.get("detail").asString().contains("must not be blank"))
     }
 
     @Test
-    fun `unknown enum value returns structured error with validValues list`() {
+    fun `unknown enum value at top level returns structured rejection with validValues`() {
         val recorder = RecordingToolCallback(buildSchema)
         val wrapped = McpToolInputValidationCallback(recorder)
 
@@ -80,12 +93,14 @@ class McpToolInputValidationCallbackTest {
         val tree = JsonParser.getJsonMapper().readTree(result)
 
         assertNull(recorder.lastInput)
-        assertEquals("INVALID_ENUM_VALUE", tree.path("error").path("code").asString())
-        assertEquals("type", tree.path("error").path("parameter").asString())
-        assertEquals("CASTLE", tree.path("error").path("received").asString())
+        assertEquals("rejected", tree.get("kind").asString())
+        assertEquals("unknown_enum_value", tree.get("reason").asString())
+        assertEquals("type", tree.get("parameter").asString())
+        assertEquals("CASTLE", tree.get("received").asString())
         val valid = mutableListOf<String>()
-        tree.path("error").path("validValues").forEach { valid.add(it.asString()) }
+        tree.get("validValues").forEach { valid.add(it.asString()) }
         assertEquals(listOf("CAMPFIRE", "WORKBENCH", "STORAGE_CHEST"), valid)
+        assertTrue(tree.get("detail").asString().contains("'CASTLE' is not one of"))
     }
 
     @Test
@@ -109,7 +124,7 @@ class McpToolInputValidationCallbackTest {
     }
 
     @Test
-    fun `schema with no required and no enum fields skips validation entirely`() {
+    fun `schema with no required and no enum fields skips pre-validation entirely`() {
         val plainSchema = """{"type":"object","properties":{"nodeId":{"type":"integer"}}}"""
         val recorder = RecordingToolCallback(plainSchema)
         val wrapped = McpToolInputValidationCallback(recorder)
@@ -139,8 +154,100 @@ class McpToolInputValidationCallbackTest {
         val tree = JsonParser.getJsonMapper().readTree(result)
 
         assertNull(recorder.lastInput)
-        assertEquals("INVALID_ENUM_VALUE", tree.path("error").path("code").asString())
+        assertEquals("unknown_enum_value", tree.get("reason").asString())
     }
+
+    @Test
+    fun `kotlin non-null IllegalArgumentException from binder translates to missing_required`() {
+        val def = ToolDefinition.builder().name("test").description("t").inputSchema(harvestSchema).build()
+        val cause = IllegalArgumentException("Parameter specified as non-null is null: method foo.Bar.invoke, parameter itemId")
+        val throwing = ThrowingToolCallback(def, ToolExecutionException(def, cause))
+        val wrapped = McpToolInputValidationCallback(throwing)
+
+        val result = wrapped.call("""{"itemId":"WOOD"}""", ToolContext(emptyMap()))
+        val tree = JsonParser.getJsonMapper().readTree(result)
+
+        assertEquals("rejected", tree.get("kind").asString())
+        assertEquals("missing_required", tree.get("reason").asString())
+        assertEquals("itemId", tree.get("parameter").asString())
+        assertTrue(tree.get("detail").asString().contains("'itemId'"))
+    }
+
+    @Test
+    fun `kotlin non-null NullPointerException from binder translates to missing_required`() {
+        val def = ToolDefinition.builder().name("test").description("t").inputSchema(harvestSchema).build()
+        val cause = NullPointerException("Parameter specified as non-null is null: method foo.Bar.invoke, parameter itemId")
+        val throwing = ThrowingToolCallback(def, ToolExecutionException(def, cause))
+        val wrapped = McpToolInputValidationCallback(throwing)
+
+        val result = wrapped.call("""{"itemId":"WOOD"}""", ToolContext(emptyMap()))
+        val tree = JsonParser.getJsonMapper().readTree(result)
+
+        assertEquals("missing_required", tree.get("reason").asString())
+        assertEquals("itemId", tree.get("parameter").asString())
+    }
+
+    @Test
+    fun `IllegalArgumentException with No enum constant translates to unknown_enum_value`() {
+        val def = ToolDefinition.builder().name("test").description("t").inputSchema(allocateSchema).build()
+        val cause = IllegalArgumentException("No enum constant ${ProbeEnum::class.java.name}.FOOBAR")
+        val throwing = ThrowingToolCallback(def, ToolExecutionException(def, cause))
+        val wrapped = McpToolInputValidationCallback(throwing)
+
+        val result = wrapped.call("""{"deltas":{}}""", ToolContext(emptyMap()))
+        val tree = JsonParser.getJsonMapper().readTree(result)
+
+        assertEquals("rejected", tree.get("kind").asString())
+        assertEquals("unknown_enum_value", tree.get("reason").asString())
+        assertEquals("ProbeEnum", tree.get("parameter").asString())
+        assertEquals("FOOBAR", tree.get("received").asString())
+        val valid = mutableListOf<String>()
+        tree.get("validValues").forEach { valid.add(it.asString()) }
+        assertEquals(listOf("ALPHA", "BETA"), valid)
+        assertTrue(!tree.get("detail").asString().contains("dev.gvart"))
+    }
+
+    @Test
+    fun `Jackson Map key InvalidFormatException for enum translates to unknown_enum_value with simple name`() {
+        val def = ToolDefinition.builder().name("test").description("t").inputSchema(allocateSchema).build()
+        val cause = InvalidFormatException.from(
+            null,
+            "Cannot deserialize Map key of type `${ProbeEnum::class.java.name}` from String \"FOOBAR\"",
+            "FOOBAR",
+            ProbeEnum::class.java,
+        )
+        val throwing = ThrowingToolCallback(def, ToolExecutionException(def, cause))
+        val wrapped = McpToolInputValidationCallback(throwing)
+
+        val result = wrapped.call("""{"deltas":{"FOOBAR":1}}""", ToolContext(emptyMap()))
+        val tree = JsonParser.getJsonMapper().readTree(result)
+
+        assertEquals("rejected", tree.get("kind").asString())
+        assertEquals("unknown_enum_value", tree.get("reason").asString())
+        assertEquals("FOOBAR", tree.get("received").asString())
+        val valid = mutableListOf<String>()
+        tree.get("validValues").forEach { valid.add(it.asString()) }
+        assertEquals(listOf("ALPHA", "BETA"), valid)
+        assertTrue(!tree.get("detail").asString().contains("dev.gvart"), "detail must not leak FQN: ${tree.get("detail").asString()}")
+        assertTrue(!tree.get("detail").asString().contains("."), "detail uses simple name only: ${tree.get("detail").asString()}")
+    }
+
+    @Test
+    fun `unrecognized ToolExecutionException is rethrown so callers still observe the failure`() {
+        val def = ToolDefinition.builder().name("test").description("t").inputSchema(harvestSchema).build()
+        val cause = RuntimeException("something else")
+        val throwing = ThrowingToolCallback(def, ToolExecutionException(def, cause))
+        val wrapped = McpToolInputValidationCallback(throwing)
+
+        try {
+            wrapped.call("""{"itemId":"WOOD"}""", ToolContext(emptyMap()))
+            error("expected ToolExecutionException to bubble up")
+        } catch (e: ToolExecutionException) {
+            assertEquals(cause, e.cause)
+        }
+    }
+
+    enum class ProbeEnum { ALPHA, BETA }
 
     private class RecordingToolCallback(private val schema: String) : ToolCallback {
         var lastInput: String? = null
@@ -152,5 +259,15 @@ class McpToolInputValidationCallbackTest {
             lastInput = toolInput
             return "{}"
         }
+    }
+
+    private class ThrowingToolCallback(
+        private val def: ToolDefinition,
+        private val toThrow: RuntimeException,
+    ) : ToolCallback {
+        override fun getToolDefinition(): ToolDefinition = def
+        override fun getToolMetadata(): ToolMetadata = ToolMetadata.builder().build()
+        override fun call(toolInput: String): String = throw toThrow
+        override fun call(toolInput: String, toolContext: ToolContext?): String = throw toThrow
     }
 }


### PR DESCRIPTION
## Summary

Two related P2 findings from the 2026-05-12 playtest sweep
(`docs/playtest/findings.md`) — both rooted in Spring AI's
`MethodToolCallback` argument binder leaking raw Jackson / Kotlin
exception messages (with fully-qualified internal class names) back
to MCP clients:

- **enum-binder leaks raw exceptions with FQN class names**, e.g.
  `build(type=CASTLE)` →
  `No enum constant dev.gvart.genesara.world.BuildingType.CASTLE`
  and `allocate_points(deltas={"FOOBAR":1})` →
  `Cannot deserialize Map key of type 'dev.gvart.genesara.player.Attribute'`;
- **mutating tools (inspect, harvest, pickup) throw raw Kotlin NPE**
  when a required parameter is omitted.

PR #139 already pre-validated top-level enums + required fields, but
the Map-key enum case (`allocate_points.deltas`) fell through to the
raw exception, and the response shape (`{kind:"error", error:{...}}`)
diverged from the rest of the tool surface
(`{kind:"rejected", reason, detail, validValues}`).

This PR rewires `McpToolInputValidationCallback` so every binder
failure exits via the same `{kind:"rejected", reason, detail,
validValues}` envelope used elsewhere in the codebase:

- schema-driven pre-check rejects top-level missing required + top-level
  unknown enum before the binder runs (covers `build.type`,
  `inspect.targetType`, `harvest.itemId`, missing `inspect.targetType` /
  `harvest.itemId` / `pickup.dropId`);
- a `try/catch` around `delegate.call` translates the runtime cases the
  pre-check can't see — Jackson `MismatchedInputException` /
  `InvalidFormatException` (Map-key enums), `IllegalArgumentException`
  with `No enum constant ...`, Kotlin non-null
  `IllegalArgumentException` / `NullPointerException` — into the same
  shape;
- parameter and detail fields use the enum's `simpleName` only — no
  `dev.gvart.genesara.*` ever reaches the agent.

`EnumCaseInsensitiveToolCallback` continues to wrap on the outside, so
case-normalised enums are still canonicalised before validation runs.

Applies uniformly to the whole MCP tool surface via the existing
`EnumCaseInsensitiveToolCallbackProvider` wiring — not per-tool.

## Test plan

- [x] `:api:test` green (327 tests, 0 failures, 0 errors).
- [x] Unit tests in `McpToolInputValidationCallbackTest` cover every
  rejection shape: missing required (omitted / null / blank), unknown
  top-level enum, Kotlin non-null IAE, Kotlin non-null NPE, Jackson
  Map-key `InvalidFormatException`, raw `IllegalArgumentException("No
  enum constant ...")`, FQN-stripping, and unrecognised
  `ToolExecutionException` rethrow.
- [x] New `McpToolBinderIntegrationTest` exercises the real
  `MethodToolCallback` wiring end-to-end for the four playtest
  scenarios (`build(CASTLE)`, `allocate(FOOBAR)`,
  `inspect(targetType=lowercase)`, `inspect({})`,
  `harvest({})`) — every output asserts no `dev.gvart.*` leakage.