### PR TITLE
feat(world,api): emit building.progressed and building.constructed events

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -106,13 +106,10 @@ internal class AgentEventDispatcher(
     fun on(event: WorldEvent.SafeNodeSet) = publish(event.agent, "agent.safe_node_set", event)
 
     @EventListener
-    fun on(event: WorldEvent.BuildingPlaced) = publish(event.building.builtByAgentId, "building.placed", event)
+    fun on(event: WorldEvent.BuildingProgressed) = publish(event.agent, "building.progressed", event)
 
     @EventListener
-    fun on(event: WorldEvent.BuildingProgressed) = publish(event.building.builtByAgentId, "building.progressed", event)
-
-    @EventListener
-    fun on(event: WorldEvent.BuildingCompleted) = publish(event.building.builtByAgentId, "building.completed", event)
+    fun on(event: WorldEvent.BuildingConstructed) = publish(event.agent, "building.constructed", event)
 
     @EventListener
     fun on(event: WorldEvent.ItemDeposited) = publish(event.agent, "item.deposited", event)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildTool.kt
@@ -23,8 +23,9 @@ internal class BuildTool(
         name = "build",
         description = "Spend one work step on a building type at the agent's current node. " +
             "First call lays the foundation; subsequent calls advance the same in-progress build until it completes. " +
-            "Queues a BuildStructure command; the resulting BuildingPlaced/Progressed/Completed event " +
-            "arrives on the agent's event stream once the tick lands. Costs per-step stamina + materials.",
+            "Queues a BuildStructure command; the resulting building.progressed event (or building.constructed " +
+            "on the terminal step) arrives on the agent's event stream once the tick lands. Costs per-step " +
+            "stamina + materials.",
     )
     fun invoke(
         @ToolParam(required = true, description = "Building type to advance one work step at the agent's current node (e.g. CAMPFIRE, WORKBENCH, STORAGE_CHEST).")

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.api.internal.mcp.events
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.DamageType
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.ItemId
@@ -256,6 +257,107 @@ class AgentEventDispatcherTest {
 
         val types = log.since(agent, 0).map { it.type }
         assertEquals(listOf("item.deposited", "item.withdrawn"), types)
+    }
+
+    @Test
+    fun `building progressed and constructed events reach the builder's stream with causedBy intact`() {
+        val instanceId = UUID.randomUUID()
+        val nodeId = NodeId(42L)
+        val progressedCmd = UUID.randomUUID()
+        val constructedCmd = UUID.randomUUID()
+
+        dispatcher.on(
+            WorldEvent.BuildingProgressed(
+                agent = agent,
+                instanceId = instanceId,
+                type = BuildingType.STORAGE_CHEST,
+                at = nodeId,
+                step = 3,
+                totalSteps = 8,
+                tick = 4L,
+                causedBy = progressedCmd,
+            ),
+        )
+        dispatcher.on(
+            WorldEvent.BuildingConstructed(
+                agent = agent,
+                instanceId = instanceId,
+                type = BuildingType.STORAGE_CHEST,
+                at = nodeId,
+                totalSteps = 8,
+                tick = 11L,
+                causedBy = constructedCmd,
+            ),
+        )
+
+        val all = log.since(agent, 0)
+        assertEquals(listOf("building.progressed", "building.constructed"), all.map { it.type })
+
+        val progressed = all[0]
+        assertEquals(4L, progressed.tick)
+        assertEquals(progressedCmd.toString(), progressed.payload.get("causedBy").asString())
+        assertEquals(instanceId.toString(), progressed.payload.get("instanceId").asString())
+        assertEquals(3, progressed.payload.get("step").asInt())
+        assertEquals(8, progressed.payload.get("totalSteps").asInt())
+        assertEquals("STORAGE_CHEST", progressed.payload.get("type").asString())
+
+        val constructed = all[1]
+        assertEquals(11L, constructed.tick)
+        assertEquals(constructedCmd.toString(), constructed.payload.get("causedBy").asString())
+        assertEquals(instanceId.toString(), constructed.payload.get("instanceId").asString())
+        assertEquals(8, constructed.payload.get("totalSteps").asInt())
+    }
+
+    @Test
+    fun `eight queued build calls land as 7 progressed + 1 constructed each with its own causedBy`() {
+        val instanceId = UUID.randomUUID()
+        val nodeId = NodeId(42L)
+        val totalSteps = 8
+        val commandIds = List(totalSteps) { UUID.randomUUID() }
+
+        commandIds.forEachIndexed { i, cmd ->
+            val step = i + 1
+            if (step < totalSteps) {
+                dispatcher.on(
+                    WorldEvent.BuildingProgressed(
+                        agent = agent,
+                        instanceId = instanceId,
+                        type = BuildingType.STORAGE_CHEST,
+                        at = nodeId,
+                        step = step,
+                        totalSteps = totalSteps,
+                        tick = (10 + i).toLong(),
+                        causedBy = cmd,
+                    ),
+                )
+            } else {
+                dispatcher.on(
+                    WorldEvent.BuildingConstructed(
+                        agent = agent,
+                        instanceId = instanceId,
+                        type = BuildingType.STORAGE_CHEST,
+                        at = nodeId,
+                        totalSteps = totalSteps,
+                        tick = (10 + i).toLong(),
+                        causedBy = cmd,
+                    ),
+                )
+            }
+        }
+
+        val all = log.since(agent, 0)
+        assertEquals(totalSteps, all.size)
+        assertEquals(
+            List(7) { "building.progressed" } + "building.constructed",
+            all.map { it.type },
+        )
+        all.forEachIndexed { i, envelope ->
+            assertEquals(
+                commandIds[i].toString(),
+                envelope.payload.get("causedBy").asString(),
+                "envelope $i must carry its own commandId",
+            )
+        }
     }
 
     @Test

--- a/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
@@ -8,7 +8,7 @@ import dev.gvart.genesara.player.PerkId
 import dev.gvart.genesara.player.TriggeredPassiveEffectKind
 import dev.gvart.genesara.player.TriggeredPassiveTrigger
 import dev.gvart.genesara.world.BodyDelta
-import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.DamageType
 import dev.gvart.genesara.world.DroppedItemView
 import dev.gvart.genesara.world.Gauge
@@ -146,23 +146,25 @@ sealed interface WorldEvent {
         val causedBy: UUID,
     ) : WorldEvent
 
-    /** First step of a new building — the row was just inserted at progress 1, UNDER_CONSTRUCTION. */
-    data class BuildingPlaced(
-        val building: Building,
-        override val tick: Long,
-        val causedBy: UUID,
-    ) : WorldEvent
-
-    /** A non-final build step landed — the building's progress advanced but it is still UNDER_CONSTRUCTION. */
+    /** A non-final build step landed — the building advanced to [step] but is still UNDER_CONSTRUCTION. */
     data class BuildingProgressed(
-        val building: Building,
+        val agent: AgentId,
+        val instanceId: UUID,
+        val type: BuildingType,
+        val at: NodeId,
+        val step: Int,
+        val totalSteps: Int,
         override val tick: Long,
         val causedBy: UUID,
     ) : WorldEvent
 
     /** The terminal step landed — the building flipped to ACTIVE on this tick. */
-    data class BuildingCompleted(
-        val building: Building,
+    data class BuildingConstructed(
+        val agent: AgentId,
+        val instanceId: UUID,
+        val type: BuildingType,
+        val at: NodeId,
+        val totalSteps: Int,
         override val tick: Long,
         val causedBy: UUID,
     ) : WorldEvent

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
@@ -90,18 +90,26 @@ internal fun reduceBuild(
             hpMax = def.hp,
         )
         buildings.insert(placed)
-        placed to WorldEvent.BuildingPlaced(placed, tick, command.commandId)
+        placed to progressedEvent(placed, command, tick)
     } else if (isFinalStep) {
         val completed = buildings.complete(existing.instanceId, tick)
             ?: error("Building ${existing.instanceId} vanished between findInProgress and complete")
-        completed to WorldEvent.BuildingCompleted(completed, tick, command.commandId)
+        completed to WorldEvent.BuildingConstructed(
+            agent = command.agent,
+            instanceId = completed.instanceId,
+            type = completed.type,
+            at = completed.nodeId,
+            totalSteps = completed.totalSteps,
+            tick = tick,
+            causedBy = command.commandId,
+        )
     } else {
         val advanced = buildings.advanceProgress(existing.instanceId, nextProgress, tick)
             ?: error("Building ${existing.instanceId} vanished between findInProgress and advanceProgress")
-        advanced to WorldEvent.BuildingProgressed(advanced, tick, command.commandId)
+        advanced to progressedEvent(advanced, command, tick)
     }
 
-    if (event is WorldEvent.BuildingCompleted) applyCompletionSideEffects(resultBuilding, safeNodes, tick)
+    if (event is WorldEvent.BuildingConstructed) applyCompletionSideEffects(resultBuilding, safeNodes, tick)
 
     progression.accrueXp(command.agent, def.requiredSkill, delta = 1, tick, command.commandId)
     behaviorTracker.record(command.agent, ActionCategory.BUILD, tick)
@@ -109,7 +117,7 @@ internal fun reduceBuild(
     val next = state
         .updateBody(command.agent, body.spendStamina(def.staminaPerStep))
         .updateInventory(command.agent, nextInventory)
-    val triggered = if (event is WorldEvent.BuildingCompleted) {
+    val triggered = if (event is WorldEvent.BuildingConstructed) {
         triggeredPassives.dispatch(
             firer = command.agent,
             trigger = TriggeredPassiveTrigger.ON_BUILD_COMPLETE,
@@ -122,6 +130,21 @@ internal fun reduceBuild(
     }
     next to (listOf(event) + triggered)
 }
+
+private fun progressedEvent(
+    building: Building,
+    command: WorldCommand.BuildStructure,
+    tick: Long,
+): WorldEvent.BuildingProgressed = WorldEvent.BuildingProgressed(
+    agent = command.agent,
+    instanceId = building.instanceId,
+    type = building.type,
+    at = building.nodeId,
+    step = building.progressSteps,
+    totalSteps = building.totalSteps,
+    tick = tick,
+    causedBy = command.commandId,
+)
 
 private fun Raise<WorldRejection>.requireMaterials(
     agent: AgentId,

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
@@ -101,28 +101,32 @@ class BuildReducerTest {
     }
 
     @Test
-    fun `first call inserts the building UNDER_CONSTRUCTION at progress 1 and emits BuildingPlaced`() {
+    fun `first call inserts the building UNDER_CONSTRUCTION at progress 1 and emits BuildingProgressed step 1`() {
         val state = stateWith()
         val store = StubBuildingsStore()
         val safeNodes = StubSafeNodes()
         val skills = StubSkillsRegistry()
         val publisher = RecordingPublisher()
+        val command = WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE)
 
         val (next, events) = assertNotNull(
             reduceBuild(
-                state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+                state, command,
                 catalog, skills, store, safeNodes, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
             ).getOrNull(),
         )
 
-        val placed = assertIs<WorldEvent.BuildingPlaced>(events.single())
-        assertEquals(BuildingStatus.UNDER_CONSTRUCTION, placed.building.status)
-        assertEquals(1, placed.building.progressSteps)
-        assertEquals(5, placed.building.totalSteps)
-        assertEquals(7L, placed.building.builtAtTick)
-        assertEquals(7L, placed.building.lastProgressTick)
-        assertEquals(30, placed.building.hpCurrent)
+        val progressed = assertIs<WorldEvent.BuildingProgressed>(events.single())
+        assertEquals(1, progressed.step)
+        assertEquals(5, progressed.totalSteps)
+        assertEquals(BuildingType.CAMPFIRE, progressed.type)
+        assertEquals(nodeId, progressed.at)
+        assertEquals(agent, progressed.agent)
+        assertEquals(7L, progressed.tick)
+        assertEquals(command.commandId, progressed.causedBy)
         assertEquals(1, store.inserted.size)
+        assertEquals(BuildingStatus.UNDER_CONSTRUCTION, store.rows.single().status)
+        assertEquals(progressed.instanceId, store.rows.single().instanceId)
         // step 1 of CAMPFIRE: floor(10/5)=2 wood, floor(5/5)=1 stone
         assertEquals(98, next.inventoryOf(agent).quantityOf(wood))
         assertEquals(99, next.inventoryOf(agent).quantityOf(stone))
@@ -137,18 +141,21 @@ class BuildReducerTest {
         val safeNodes = StubSafeNodes()
         val skills = StubSkillsRegistry()
         val publisher = RecordingPublisher()
+        val command = WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE)
 
         val (next, events) = assertNotNull(
             reduceBuild(
-                state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+                state, command,
                 catalog, skills, store, safeNodes, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 9,
             ).getOrNull(),
         )
 
         val progressed = assertIs<WorldEvent.BuildingProgressed>(events.single())
-        assertEquals(3, progressed.building.progressSteps)
-        assertEquals(BuildingStatus.UNDER_CONSTRUCTION, progressed.building.status)
-        assertEquals(9L, progressed.building.lastProgressTick)
+        assertEquals(3, progressed.step)
+        assertEquals(5, progressed.totalSteps)
+        assertEquals(existing.instanceId, progressed.instanceId)
+        assertEquals(9L, progressed.tick)
+        assertEquals(command.commandId, progressed.causedBy)
         assertEquals(1, store.advanced.size)
         assertEquals(0, store.completed.size)
         assertEquals(98, next.inventoryOf(agent).quantityOf(wood))
@@ -156,23 +163,29 @@ class BuildReducerTest {
     }
 
     @Test
-    fun `terminal step flips status to ACTIVE and emits BuildingCompleted`() {
+    fun `terminal step flips status to ACTIVE and emits BuildingConstructed`() {
         val state = stateWith()
         val nearlyDone = sampleBuilding(progress = 4)
         val store = StubBuildingsStore(rows = mutableListOf(nearlyDone))
         val skills = StubSkillsRegistry()
         val publisher = RecordingPublisher()
+        val command = WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE)
 
         val (_, events) = assertNotNull(
             reduceBuild(
-                state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+                state, command,
                 catalog, skills, store, StubSafeNodes(), SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 11,
             ).getOrNull(),
         )
 
-        val completed = assertIs<WorldEvent.BuildingCompleted>(events.single())
-        assertEquals(BuildingStatus.ACTIVE, completed.building.status)
-        assertEquals(5, completed.building.progressSteps)
+        val completed = assertIs<WorldEvent.BuildingConstructed>(events.single())
+        assertEquals(nearlyDone.instanceId, completed.instanceId)
+        assertEquals(BuildingType.CAMPFIRE, completed.type)
+        assertEquals(nodeId, completed.at)
+        assertEquals(5, completed.totalSteps)
+        assertEquals(11L, completed.tick)
+        assertEquals(command.commandId, completed.causedBy)
+        assertEquals(BuildingStatus.ACTIVE, store.rows.single().status)
         assertEquals(0, store.advanced.size)
         assertEquals(1, store.completed.size)
     }
@@ -304,7 +317,8 @@ class BuildReducerTest {
             ).getOrNull(),
         )
 
-        assertIs<WorldEvent.BuildingPlaced>(events.single())
+        val firstStep = assertIs<WorldEvent.BuildingProgressed>(events.single())
+        assertEquals(1, firstStep.step)
         assertEquals(2, store.rows.size)
         assertEquals(2, store.rows.first { it.builtByAgentId == agent }.progressSteps)
     }
@@ -323,7 +337,8 @@ class BuildReducerTest {
             ).getOrNull(),
         )
 
-        assertIs<WorldEvent.BuildingPlaced>(events.single())
+        val firstStep = assertIs<WorldEvent.BuildingProgressed>(events.single())
+        assertEquals(1, firstStep.step)
         assertEquals(2, store.rows.size)
         assertEquals(0, store.completed.size)
     }
@@ -375,6 +390,69 @@ class BuildReducerTest {
     }
 
     @Test
+    fun `eight calls through reduceBuild produce 7 BuildingProgressed plus 1 BuildingConstructed each tagged with its own commandId`() {
+        val chestType = BuildingType.STORAGE_CHEST
+        val totalSteps = 8
+        val customCatalog = BuildingsCatalog(
+            BuildingDefinitionProperties(
+                catalog = mapOf(
+                    chestType.name to BuildingProperties(
+                        requiredSkill = "CARPENTRY",
+                        totalSteps = totalSteps,
+                        staminaPerStep = 1,
+                        hp = 40,
+                        categoryHint = BuildingCategoryHint.STORAGE,
+                        totalMaterials = mapOf("WOOD" to 16),
+                        chestCapacityGrams = 50_000,
+                    ),
+                ),
+            ),
+        )
+        var state = stateWith(inventory = mapOf(wood to 100))
+        val store = StubBuildingsStore()
+        val skills = StubSkillsRegistry()
+
+        val emitted = mutableListOf<Pair<WorldEvent, UUID>>()
+        repeat(totalSteps) { i ->
+            val command = WorldCommand.BuildStructure(agent, chestType)
+            val (next, events) = assertNotNull(
+                reduceBuild(
+                    state, command, customCatalog, skills, store, StubSafeNodes(),
+                    SkillProgression(skills, RecordingPublisher()),
+                    triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker,
+                    tick = (100 + i).toLong(),
+                ).getOrNull(),
+            )
+            state = next
+            emitted += events.single() to command.commandId
+        }
+
+        val progressedEvents = emitted.dropLast(1)
+        val terminal = emitted.last()
+
+        assertEquals(totalSteps - 1, progressedEvents.size)
+        progressedEvents.forEachIndexed { i, (event, cmdId) ->
+            val progressed = assertIs<WorldEvent.BuildingProgressed>(event)
+            assertEquals(i + 1, progressed.step, "step index for emission $i")
+            assertEquals(totalSteps, progressed.totalSteps)
+            assertEquals(chestType, progressed.type)
+            assertEquals(nodeId, progressed.at)
+            assertEquals(agent, progressed.agent)
+            assertEquals(cmdId, progressed.causedBy, "causedBy must match per-call commandId")
+        }
+        val constructed = assertIs<WorldEvent.BuildingConstructed>(terminal.first)
+        assertEquals(totalSteps, constructed.totalSteps)
+        assertEquals(chestType, constructed.type)
+        assertEquals(nodeId, constructed.at)
+        assertEquals(agent, constructed.agent)
+        assertEquals(terminal.second, constructed.causedBy)
+
+        assertEquals(1, store.rows.size)
+        assertEquals(BuildingStatus.ACTIVE, store.rows.single().status)
+        assertEquals(totalSteps, store.rows.single().progressSteps)
+    }
+
+    @Test
     fun `walking the full step ladder accumulates per-step stamina cost and ends ACTIVE`() {
         var state = stateWith(inventory = mapOf(wood to 100, stone to 100))
         val store = StubBuildingsStore()
@@ -393,7 +471,7 @@ class BuildReducerTest {
             lastEvent = events.single()
         }
 
-        assertIs<WorldEvent.BuildingCompleted>(lastEvent)
+        assertIs<WorldEvent.BuildingConstructed>(lastEvent)
         assertEquals(initialStamina - 5 * 8, state.bodyOf(agent)!!.stamina)
         assertEquals(1, store.rows.size)
         assertEquals(BuildingStatus.ACTIVE, store.rows.single().status)


### PR DESCRIPTION
## Summary

- Closes the P2 finding in `docs/playtest/findings.md` where subsequent `build` calls produced no `causedBy` event on the success path (only the first call surfaced anything, via `skill.recommended`). This breaks the queue-and-ack contract documented in `docs/mcp-api.md`.
- Replaces the `BuildingPlaced / BuildingProgressed / BuildingCompleted` trio with a flat-shape pair: every successful `BuildStructure` step now emits either `building.progressed { agent, instanceId, type, at, step, totalSteps, tick, causedBy }` (steps 1..N-1) or `building.constructed { agent, instanceId, type, at, totalSteps, tick, causedBy }` (the terminal step that flips status to `ACTIVE`).
- Drops the legacy `building.placed` / `building.completed` event-type names from the dispatcher. No docs referenced them; only the dispatcher itself wired them, so no external consumers break.

## Test plan

- [x] `BuildReducerTest` — updated existing cases (`first call`, `subsequent call`, `terminal step`, full ladder, agent-B coexistence, post-completion follow-up) to assert the new flat fields + `causedBy`. Added `eight calls through reduceBuild produce 7 BuildingProgressed plus 1 BuildingConstructed each tagged with its own commandId` driving the STORAGE_CHEST 8-step ladder end-to-end through the reducer.
- [x] `AgentEventDispatcherTest` — added `building progressed and constructed events reach the builder's stream with causedBy intact` and `eight queued build calls land as 7 progressed + 1 constructed each with its own causedBy` to lock the dispatcher payload shape (`step`, `totalSteps`, `instanceId`, `type`, `causedBy` projected on the per-agent log).
- [x] `./gradlew :world:test :api:test` green.
- [x] Whole-project `./gradlew compileKotlin compileTestKotlin` green.