### PR TITLE
feat(player,world): emit agent.xp_gained on character XP grants

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -78,6 +78,12 @@ internal class AgentEventDispatcher(
     fun on(event: AgentEvent.RecipeLearned) = publish(event.agent, "recipe.learned", event)
 
     @EventListener
+    fun on(event: AgentEvent.CharacterXpGained) = publish(event.agent, "agent.xp_gained", event)
+
+    @EventListener
+    fun on(event: AgentEvent.AgentLeveled) = publish(event.agent, "agent.leveled", event)
+
+    @EventListener
     fun on(event: WorldEvent.ItemCrafted) = publish(event.agent, "item.crafted", event)
 
     @EventListener

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
@@ -135,6 +135,49 @@ class AgentEventDispatcherTest {
     }
 
     @Test
+    fun `CharacterXpGained and AgentLeveled reach the agent's stream with the right type strings`() {
+        val cmdId = UUID.randomUUID()
+        dispatcher.on(
+            AgentEvent.CharacterXpGained(
+                agent = agent,
+                source = dev.gvart.genesara.player.CharacterXpSource.HARVEST,
+                amount = 3,
+                total = 17,
+                toNext = 100,
+                level = 1,
+                unspentAttributePoints = 0,
+                tick = 11,
+                causedBy = cmdId,
+            ),
+        )
+        dispatcher.on(
+            AgentEvent.AgentLeveled(
+                agent = agent,
+                fromLevel = 1,
+                toLevel = 2,
+                unspentAttributePoints = 5,
+                tick = 12,
+                causedBy = cmdId,
+            ),
+        )
+
+        val all = log.since(agent, 0)
+        assertEquals(listOf("agent.xp_gained", "agent.leveled"), all.map { it.type })
+        assertEquals(11L, all[0].tick)
+        assertEquals(12L, all[1].tick)
+        assertEquals("HARVEST", all[0].payload.get("source").asString())
+        assertEquals(3, all[0].payload.get("amount").asInt())
+        assertEquals(17, all[0].payload.get("total").asInt())
+        assertEquals(100, all[0].payload.get("toNext").asInt())
+        assertEquals(1, all[0].payload.get("level").asInt())
+        assertEquals(cmdId.toString(), all[0].payload.get("causedBy").asString())
+        assertEquals(1, all[1].payload.get("fromLevel").asInt())
+        assertEquals(2, all[1].payload.get("toLevel").asInt())
+        assertEquals(5, all[1].payload.get("unspentAttributePoints").asInt())
+        assertEquals(cmdId.toString(), all[1].payload.get("causedBy").asString())
+    }
+
+    @Test
     fun `AttributeMilestoneReached reaches the agent's stream`() {
         dispatcher.on(
             AgentEvent.AttributeMilestoneReached(

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
@@ -195,6 +195,15 @@ sealed interface AddCharacterXpOutcome {
         val xpToNext: Int,
         val unspentAttributePoints: Int,
         /**
+         * Accrued XP actually absorbed by the bar — equals the requested delta
+         * in the uncapped path, and `requested - droppedSurplus` when a level
+         * cap (L10 unclassed / L50 base-class) halted the cascade with surplus
+         * to drop. Always in `[0, requested]`. This is what
+         * [dev.gvart.genesara.player.events.AgentEvent.CharacterXpGained.amount]
+         * reports so the event matches the bar movement.
+         */
+        val accruedDelta: Int,
+        /**
          * True when the agent reached level 10 with no class assigned and the
          * grant's surplus XP was dropped at the boundary. Mutually exclusive
          * with [cappedAtPendingEvolutionChoice]: at most one cap fires per

--- a/player/src/main/kotlin/dev/gvart/genesara/player/CharacterXpSource.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/CharacterXpSource.kt
@@ -1,0 +1,12 @@
+package dev.gvart.genesara.player
+
+/**
+ * Which agent action caused a [dev.gvart.genesara.player.events.AgentEvent.CharacterXpGained]
+ * event. Mirrors `docs/lore/mechanics-reference.md` §3 — a single action grants both
+ * character XP and skill XP, and the source disambiguates which verb fired the grant
+ * so an agent can correlate without parsing the paired `WorldEvent`.
+ */
+enum class CharacterXpSource {
+    HARVEST,
+    CONSUME,
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/events/AgentEvent.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/events/AgentEvent.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.player.events
 import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.Attribute
+import dev.gvart.genesara.player.CharacterXpSource
 import dev.gvart.genesara.player.PerkId
 import dev.gvart.genesara.player.SkillId
 import java.util.UUID
@@ -151,5 +152,41 @@ sealed interface AgentEvent {
         val source: String,
         val sourceRef: String,
         override val tick: Long,
+    ) : AgentEvent
+
+    /**
+     * Emitted once per character-XP grant that produced an
+     * [dev.gvart.genesara.player.AddCharacterXpOutcome.Granted] outcome, paired with the
+     * action that caused it ([source]). [total] / [toNext] are the post-grant XP bar;
+     * [unspentAttributePoints] reflects any points granted by level-ups inside the same
+     * cascade. When the cascade also crossed a level boundary the matching [AgentLeveled]
+     * event fires immediately after this one with the same [causedBy].
+     */
+    data class CharacterXpGained(
+        val agent: AgentId,
+        val source: CharacterXpSource,
+        val amount: Int,
+        val total: Int,
+        val toNext: Int,
+        val level: Int,
+        val unspentAttributePoints: Int,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : AgentEvent
+
+    /**
+     * Emitted alongside [CharacterXpGained] when a grant's XP cascade crossed one or more
+     * level boundaries. Fires once per grant regardless of how many levels the cascade
+     * absorbed; [fromLevel] / [toLevel] bracket the transition. [unspentAttributePoints]
+     * is the post-grant attribute pool — the agent uses it to size their next allocate
+     * call without polling.
+     */
+    data class AgentLeveled(
+        val agent: AgentId,
+        val fromLevel: Int,
+        val toLevel: Int,
+        val unspentAttributePoints: Int,
+        override val tick: Long,
+        val causedBy: UUID,
     ) : AgentEvent
 }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/events/AgentEvent.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/events/AgentEvent.kt
@@ -165,6 +165,9 @@ sealed interface AgentEvent {
     data class CharacterXpGained(
         val agent: AgentId,
         val source: CharacterXpSource,
+        /** Accrued XP absorbed by the bar — equals the requested grant in the uncapped
+         *  path, and is partially or fully clamped to 0 when the L10/L50 cap dropped
+         *  surplus XP. Always matches the bar movement implied by [total] / [toNext]. */
         val amount: Int,
         val total: Int,
         val toNext: Int,

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
@@ -237,6 +237,7 @@ internal class JooqAgentRegistry(
                 xpCurrent = previousXpCurrent,
                 xpToNext = previousXpToNext,
                 unspentAttributePoints = previousUnspent,
+                accruedDelta = 0,
                 cappedAtPendingClassChoice = false,
                 cappedAtPendingEvolutionChoice = false,
             )
@@ -249,9 +250,11 @@ internal class JooqAgentRegistry(
         var xpToNext = previousXpToNext
         var unspent = previousUnspent
         var capped = false
+        var droppedSurplus = 0
 
         while (xpCurrent >= xpToNext) {
             if (level >= capLevel) {
+                droppedSurplus = xpCurrent - xpToNext
                 xpCurrent = xpToNext
                 capped = true
                 break
@@ -276,6 +279,7 @@ internal class JooqAgentRegistry(
             xpCurrent = xpCurrent,
             xpToNext = xpToNext,
             unspentAttributePoints = unspent,
+            accruedDelta = delta - droppedSurplus,
             cappedAtPendingClassChoice = capped && capLevel == LEVEL_TEN_PENDING_CHOICE_CAP,
             cappedAtPendingEvolutionChoice = capped && capLevel == LEVEL_FIFTY_EVOLUTION_CAP,
         )

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryAddCharacterXpIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryAddCharacterXpIntegrationTest.kt
@@ -86,6 +86,7 @@ class JooqAgentRegistryAddCharacterXpIntegrationTest {
         assertEquals(50, granted.xpCurrent)
         assertEquals(100, granted.xpToNext)
         assertEquals(5, granted.unspentAttributePoints)
+        assertEquals(50, granted.accruedDelta, "uncapped grants accrue the full requested delta")
         assertEquals(false, granted.cappedAtPendingClassChoice)
         val row = readAgent(agent.id)
         assertEquals(50, row[AGENTS.XP_CURRENT])
@@ -140,9 +141,25 @@ class JooqAgentRegistryAddCharacterXpIntegrationTest {
         assertEquals(1000, granted.xpCurrent, "bar parks at xp_to_next")
         assertEquals(1000, granted.xpToNext)
         assertEquals(true, granted.cappedAtPendingClassChoice)
+        assertEquals(1900, granted.accruedDelta, "absorbed 900 (L9→L10) + 1000 (parked at cap); 5000 surplus dropped")
         val row = readAgent(agent.id)
         assertEquals(10, row[AGENTS.LEVEL])
         assertEquals(1000, row[AGENTS.XP_CURRENT])
+    }
+
+    @Test
+    fun `already-capped agent accrues zero from any further grant`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Stuck")
+        seed(agent.id, level = 10, xpCurrent = 1000, xpToNext = 1000)
+
+        val outcome = registry.addCharacterXp(agent.id, 5)
+
+        val granted = assertIs<AddCharacterXpOutcome.Granted>(outcome)
+        assertEquals(10, granted.currentLevel)
+        assertEquals(1000, granted.xpCurrent)
+        assertEquals(0, granted.accruedDelta, "no headroom at the cap; the requested 5 XP is fully dropped")
+        assertEquals(true, granted.cappedAtPendingClassChoice)
     }
 
     @Test

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgression.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgression.kt
@@ -4,20 +4,31 @@ import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AddCharacterXpOutcome
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.CharacterXpSource
+import dev.gvart.genesara.player.events.AgentEvent
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
+import java.util.UUID
 
 /**
  * Canonical character-XP grant entry point. Wraps the atomic [AgentRegistry.addCharacterXp]
- * mutation and routes level-milestone transitions through the matching emitter so future
- * XP-source slices (quest rewards, NPC kills) only need to call this method.
+ * mutation, publishes [AgentEvent.CharacterXpGained] (always) and [AgentEvent.AgentLeveled]
+ * (when the grant cascade crossed at least one level boundary), and routes level-milestone
+ * transitions through the matching emitter so future XP-source slices (quest rewards, NPC
+ * kills) only need to call this method.
  */
 internal interface CharacterXpProgression {
-    fun grant(agentId: AgentId, delta: Int): AddCharacterXpOutcome?
+    fun grant(agentId: AgentId, source: CharacterXpSource, delta: Int, commandId: UUID): AddCharacterXpOutcome?
 
     companion object {
         /** Drop-in no-op for tests that exercise reducers but don't care about XP propagation. */
         val NoOp: CharacterXpProgression = object : CharacterXpProgression {
-            override fun grant(agentId: AgentId, delta: Int): AddCharacterXpOutcome? = null
+            override fun grant(
+                agentId: AgentId,
+                source: CharacterXpSource,
+                delta: Int,
+                commandId: UUID,
+            ): AddCharacterXpOutcome? = null
         }
     }
 }
@@ -28,12 +39,43 @@ internal class DefaultCharacterXpProgression(
     private val level10: Level10ChoiceEmitter,
     private val level50: Level50EvolutionEmitter,
     private val tickClock: TickClock,
+    private val publisher: ApplicationEventPublisher,
 ) : CharacterXpProgression {
 
-    override fun grant(agentId: AgentId, delta: Int): AddCharacterXpOutcome? {
+    override fun grant(
+        agentId: AgentId,
+        source: CharacterXpSource,
+        delta: Int,
+        commandId: UUID,
+    ): AddCharacterXpOutcome? {
         val outcome = agents.addCharacterXp(agentId, delta) ?: return null
         if (outcome is AddCharacterXpOutcome.Granted) {
             val tick = tickClock.currentTick()
+            publisher.publishEvent(
+                AgentEvent.CharacterXpGained(
+                    agent = agentId,
+                    source = source,
+                    amount = delta,
+                    total = outcome.xpCurrent,
+                    toNext = outcome.xpToNext,
+                    level = outcome.currentLevel,
+                    unspentAttributePoints = outcome.unspentAttributePoints,
+                    tick = tick,
+                    causedBy = commandId,
+                ),
+            )
+            if (outcome.currentLevel > outcome.previousLevel) {
+                publisher.publishEvent(
+                    AgentEvent.AgentLeveled(
+                        agent = agentId,
+                        fromLevel = outcome.previousLevel,
+                        toLevel = outcome.currentLevel,
+                        unspentAttributePoints = outcome.unspentAttributePoints,
+                        tick = tick,
+                        causedBy = commandId,
+                    ),
+                )
+            }
             if (outcome.previousLevel < LEVEL_TEN_THRESHOLD && outcome.currentLevel >= LEVEL_TEN_THRESHOLD) {
                 level10.tryEmitFor(agentId, tick)
             }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgression.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgression.kt
@@ -55,7 +55,7 @@ internal class DefaultCharacterXpProgression(
                 AgentEvent.CharacterXpGained(
                     agent = agentId,
                     source = source,
-                    amount = delta,
+                    amount = outcome.accruedDelta,
                     total = outcome.xpCurrent,
                     toNext = outcome.xpToNext,
                     level = outcome.currentLevel,

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducer.kt
@@ -5,6 +5,7 @@ import arrow.core.raise.either
 import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.CharacterXpSource
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.RecipeLearning
@@ -64,7 +65,7 @@ internal fun reduceConsume(
             ?: error("Invariant violated: agent ${command.agent} has a position but no registry row")
         progression.accrueXp(command.agent, skill, delta = 1, tick, command.commandId, agentRecord.classId)
     }
-    characterXp.grant(command.agent, delta = 1)
+    characterXp.grant(command.agent, CharacterXpSource.CONSUME, delta = 1, commandId = command.commandId)
     recipeLearning.learnFromItem(command.agent, command.item, tick)
     val next = state
         .updateBody(command.agent, nextBody)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
@@ -7,6 +7,7 @@ import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.CharacterXpSource
 import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillProgression
@@ -86,7 +87,7 @@ internal fun reduceHarvest(
     itemDef.harvestSkill?.let { skill ->
         progression.accrueXp(command.agent, skill, delta = quantity, tick, command.commandId, agentRecord.classId)
     }
-    characterXp.grant(command.agent, quantity)
+    characterXp.grant(command.agent, CharacterXpSource.HARVEST, delta = quantity, commandId = command.commandId)
     behaviorTracker.record(command.agent, ActionCategory.GATHER, tick)
 
     // TODO(max-stack): reject (StackFull) when adding `quantity` would exceed maxStack.

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgressionTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgressionTest.kt
@@ -32,6 +32,7 @@ class CharacterXpProgressionTest {
                 xpCurrent = 0,
                 xpToNext = 1000,
                 unspentAttributePoints = 50,
+                accruedDelta = 100,
                 cappedAtPendingClassChoice = false,
             ),
             stateAfter = level10Unclassed(),
@@ -56,6 +57,7 @@ class CharacterXpProgressionTest {
                 xpCurrent = 0,
                 xpToNext = 600,
                 unspentAttributePoints = 30,
+                accruedDelta = 100,
                 cappedAtPendingClassChoice = false,
             ),
             stateAfter = level10Unclassed().copy(level = 6),
@@ -79,6 +81,7 @@ class CharacterXpProgressionTest {
                 xpCurrent = 0,
                 xpToNext = 1100,
                 unspentAttributePoints = 55,
+                accruedDelta = 1100,
                 cappedAtPendingClassChoice = false,
             ),
             stateAfter = level10Unclassed().copy(level = 11),
@@ -102,6 +105,7 @@ class CharacterXpProgressionTest {
                 xpCurrent = 0,
                 xpToNext = 5000,
                 unspentAttributePoints = 250,
+                accruedDelta = 100,
                 cappedAtPendingClassChoice = false,
                 cappedAtPendingEvolutionChoice = false,
             ),
@@ -159,6 +163,7 @@ class CharacterXpProgressionTest {
                 xpCurrent = 17,
                 xpToNext = 100,
                 unspentAttributePoints = 0,
+                accruedDelta = 1,
                 cappedAtPendingClassChoice = false,
             ),
             stateAfter = level10Unclassed().copy(level = 1),
@@ -195,6 +200,7 @@ class CharacterXpProgressionTest {
                 xpCurrent = 10,
                 xpToNext = 500,
                 unspentAttributePoints = 25,
+                accruedDelta = 600,
                 cappedAtPendingClassChoice = false,
             ),
             stateAfter = level10Unclassed().copy(level = 5),
@@ -232,6 +238,7 @@ class CharacterXpProgressionTest {
                 xpCurrent = 50,
                 xpToNext = 200,
                 unspentAttributePoints = 5,
+                accruedDelta = 5,
                 cappedAtPendingClassChoice = false,
             ),
             stateAfter = level10Unclassed().copy(level = 2),
@@ -252,7 +259,7 @@ class CharacterXpProgressionTest {
     }
 
     @Test
-    fun `publishes CharacterXpGained even when the cascade is capped at the level-10 boundary`() {
+    fun `CharacterXpGained amount reports partial accrual when the L10 cap drops surplus`() {
         val agents = SequencedRegistry(
             grant = AddCharacterXpOutcome.Granted(
                 previousLevel = 9,
@@ -260,6 +267,7 @@ class CharacterXpProgressionTest {
                 xpCurrent = 1000,
                 xpToNext = 1000,
                 unspentAttributePoints = 50,
+                accruedDelta = 1000,
                 cappedAtPendingClassChoice = true,
             ),
             stateAfter = level10Unclassed(),
@@ -273,10 +281,41 @@ class CharacterXpProgressionTest {
             publisher,
         )
 
-        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 200, commandId = commandId)
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 1100, commandId = commandId)
 
         val types = publisher.published.map { it::class.simpleName }
         assertEquals(listOf("CharacterXpGained", "AgentLeveled"), types)
+        val gained = publisher.published.first() as AgentEvent.CharacterXpGained
+        assertEquals(1000, gained.amount, "amount is the absorbed delta; the 100 XP surplus the cap dropped is excluded")
+    }
+
+    @Test
+    fun `CharacterXpGained amount is zero when the agent is already parked at the L10 cap`() {
+        val agents = SequencedRegistry(
+            grant = AddCharacterXpOutcome.Granted(
+                previousLevel = 10,
+                currentLevel = 10,
+                xpCurrent = 1000,
+                xpToNext = 1000,
+                unspentAttributePoints = 50,
+                accruedDelta = 0,
+                cappedAtPendingClassChoice = true,
+            ),
+            stateAfter = level10Unclassed(),
+        )
+        val publisher = RecordingPublisher()
+        val progression = DefaultCharacterXpProgression(
+            agents,
+            RecordingL10Emitter(agents),
+            RecordingL50Emitter(agents),
+            FixedTickClock(tick),
+            publisher,
+        )
+
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 5, commandId = commandId)
+
+        val gained = publisher.published.single() as AgentEvent.CharacterXpGained
+        assertEquals(0, gained.amount, "no headroom at the cap; the requested 5 XP is fully dropped")
     }
 
     private fun level10Unclassed() = Agent(

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgressionTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgressionTest.kt
@@ -6,7 +6,9 @@ import dev.gvart.genesara.player.AddCharacterXpOutcome
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.CharacterXpSource
 import dev.gvart.genesara.player.NoOpClassLookup
+import dev.gvart.genesara.player.events.AgentEvent
 import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
@@ -19,6 +21,7 @@ class CharacterXpProgressionTest {
 
     private val agentId = AgentId(UUID.randomUUID())
     private val tick = 7L
+    private val commandId = UUID.randomUUID()
 
     @Test
     fun `routes a 9-to-10 transition through the level-10 emitter`() {
@@ -31,18 +34,13 @@ class CharacterXpProgressionTest {
                 unspentAttributePoints = 50,
                 cappedAtPendingClassChoice = false,
             ),
-            // Agent is at level 10 with no class — emitter conditions met but the
-            // catalog is empty (NoOpClassLookup) so the emitter aborts internally.
-            // That's fine for this test: we only assert the orchestrator routed
-            // through to it (recordCalls == 0 means we never reached the registry path,
-            // which would happen on the no-op catalog's empty list).
             stateAfter = level10Unclassed(),
         )
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick), RecordingPublisher())
 
-        progression.grant(agentId, 100)
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 100, commandId = commandId)
 
         assertEquals(1, l10.invocations)
         assertEquals(tick, l10.lastTick)
@@ -64,9 +62,9 @@ class CharacterXpProgressionTest {
         )
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick), RecordingPublisher())
 
-        progression.grant(agentId, 100)
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 100, commandId = commandId)
 
         assertEquals(0, l10.invocations)
         assertEquals(0, l50.invocations)
@@ -87,9 +85,9 @@ class CharacterXpProgressionTest {
         )
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick), RecordingPublisher())
 
-        progression.grant(agentId, 1100)
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 1100, commandId = commandId)
 
         assertEquals(0, l10.invocations, "the offer fires only once, on the 9→10 boundary")
         assertEquals(0, l50.invocations)
@@ -111,9 +109,9 @@ class CharacterXpProgressionTest {
         )
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick), RecordingPublisher())
 
-        progression.grant(agentId, 100)
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 100, commandId = commandId)
 
         assertEquals(0, l10.invocations, "L10 emitter only fires on the 9→10 boundary")
         assertEquals(1, l50.invocations)
@@ -125,13 +123,15 @@ class CharacterXpProgressionTest {
         val agents = SequencedRegistry(grant = AddCharacterXpOutcome.NegativeDelta, stateAfter = level10Unclassed())
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
+        val publisher = RecordingPublisher()
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick), publisher)
 
-        val outcome = progression.grant(agentId, -5)
+        val outcome = progression.grant(agentId, CharacterXpSource.HARVEST, delta = -5, commandId = commandId)
 
         assertEquals(AddCharacterXpOutcome.NegativeDelta, outcome)
         assertEquals(0, l10.invocations)
         assertEquals(0, l50.invocations)
+        assertTrue(publisher.published.isEmpty(), "NegativeDelta must not publish CharacterXpGained")
     }
 
     @Test
@@ -139,13 +139,144 @@ class CharacterXpProgressionTest {
         val agents = SequencedRegistry(grant = null, stateAfter = level10Unclassed())
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick))
+        val publisher = RecordingPublisher()
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick), publisher)
 
-        val outcome = progression.grant(agentId, 100)
+        val outcome = progression.grant(agentId, CharacterXpSource.HARVEST, delta = 100, commandId = commandId)
 
         assertNull(outcome)
         assertEquals(0, l10.invocations)
         assertEquals(0, l50.invocations)
+        assertTrue(publisher.published.isEmpty())
+    }
+
+    @Test
+    fun `publishes CharacterXpGained with source, amount, total, toNext, level, causedBy on Granted`() {
+        val agents = SequencedRegistry(
+            grant = AddCharacterXpOutcome.Granted(
+                previousLevel = 1,
+                currentLevel = 1,
+                xpCurrent = 17,
+                xpToNext = 100,
+                unspentAttributePoints = 0,
+                cappedAtPendingClassChoice = false,
+            ),
+            stateAfter = level10Unclassed().copy(level = 1),
+        )
+        val publisher = RecordingPublisher()
+        val progression = DefaultCharacterXpProgression(
+            agents,
+            RecordingL10Emitter(agents),
+            RecordingL50Emitter(agents),
+            FixedTickClock(tick),
+            publisher,
+        )
+
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 1, commandId = commandId)
+
+        val gained = publisher.published.single() as AgentEvent.CharacterXpGained
+        assertEquals(agentId, gained.agent)
+        assertEquals(CharacterXpSource.HARVEST, gained.source)
+        assertEquals(1, gained.amount)
+        assertEquals(17, gained.total)
+        assertEquals(100, gained.toNext)
+        assertEquals(1, gained.level)
+        assertEquals(0, gained.unspentAttributePoints)
+        assertEquals(tick, gained.tick)
+        assertEquals(commandId, gained.causedBy)
+    }
+
+    @Test
+    fun `publishes AgentLeveled after CharacterXpGained when the cascade crossed a level boundary`() {
+        val agents = SequencedRegistry(
+            grant = AddCharacterXpOutcome.Granted(
+                previousLevel = 3,
+                currentLevel = 5,
+                xpCurrent = 10,
+                xpToNext = 500,
+                unspentAttributePoints = 25,
+                cappedAtPendingClassChoice = false,
+            ),
+            stateAfter = level10Unclassed().copy(level = 5),
+        )
+        val publisher = RecordingPublisher()
+        val progression = DefaultCharacterXpProgression(
+            agents,
+            RecordingL10Emitter(agents),
+            RecordingL50Emitter(agents),
+            FixedTickClock(tick),
+            publisher,
+        )
+
+        progression.grant(agentId, CharacterXpSource.CONSUME, delta = 600, commandId = commandId)
+
+        val (gained, leveled) = publisher.published.let { it[0] to it[1] }
+        gained as AgentEvent.CharacterXpGained
+        leveled as AgentEvent.AgentLeveled
+        assertEquals(CharacterXpSource.CONSUME, gained.source)
+        assertEquals(5, gained.level)
+        assertEquals(agentId, leveled.agent)
+        assertEquals(3, leveled.fromLevel)
+        assertEquals(5, leveled.toLevel)
+        assertEquals(25, leveled.unspentAttributePoints)
+        assertEquals(tick, leveled.tick)
+        assertEquals(commandId, leveled.causedBy)
+    }
+
+    @Test
+    fun `does not publish AgentLeveled when the grant did not cross a level boundary`() {
+        val agents = SequencedRegistry(
+            grant = AddCharacterXpOutcome.Granted(
+                previousLevel = 2,
+                currentLevel = 2,
+                xpCurrent = 50,
+                xpToNext = 200,
+                unspentAttributePoints = 5,
+                cappedAtPendingClassChoice = false,
+            ),
+            stateAfter = level10Unclassed().copy(level = 2),
+        )
+        val publisher = RecordingPublisher()
+        val progression = DefaultCharacterXpProgression(
+            agents,
+            RecordingL10Emitter(agents),
+            RecordingL50Emitter(agents),
+            FixedTickClock(tick),
+            publisher,
+        )
+
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 5, commandId = commandId)
+
+        assertEquals(1, publisher.published.size, "only CharacterXpGained fires; level did not change")
+        assertTrue(publisher.published.single() is AgentEvent.CharacterXpGained)
+    }
+
+    @Test
+    fun `publishes CharacterXpGained even when the cascade is capped at the level-10 boundary`() {
+        val agents = SequencedRegistry(
+            grant = AddCharacterXpOutcome.Granted(
+                previousLevel = 9,
+                currentLevel = 10,
+                xpCurrent = 1000,
+                xpToNext = 1000,
+                unspentAttributePoints = 50,
+                cappedAtPendingClassChoice = true,
+            ),
+            stateAfter = level10Unclassed(),
+        )
+        val publisher = RecordingPublisher()
+        val progression = DefaultCharacterXpProgression(
+            agents,
+            RecordingL10Emitter(agents),
+            RecordingL50Emitter(agents),
+            FixedTickClock(tick),
+            publisher,
+        )
+
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 200, commandId = commandId)
+
+        val types = publisher.published.map { it::class.simpleName }
+        assertEquals(listOf("CharacterXpGained", "AgentLeveled"), types)
     }
 
     private fun level10Unclassed() = Agent(
@@ -197,8 +328,14 @@ class CharacterXpProgressionTest {
 
     private object SilentPublisher : ApplicationEventPublisher {
         override fun publishEvent(event: Any) {
-            // Discard — the test only cares whether tryEmitFor was reached.
             assertTrue(true)
+        }
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val published = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            published += event
         }
     }
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducerTest.kt
@@ -5,8 +5,10 @@ import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AddCharacterXpOutcome
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillState
+import dev.gvart.genesara.player.CharacterXpSource
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.AgentSkillsSnapshot
 import dev.gvart.genesara.player.SkillId
@@ -112,6 +114,25 @@ class ConsumeReducerTest {
         assertEquals(10, consumed.refilled)
         assertEquals(7L, consumed.tick)
         assertEquals(command.commandId, consumed.causedBy)
+    }
+
+    @Test
+    fun `grants 1 character XP tagged CONSUME with the command id on every consume`() {
+        val state = stateWith(inventory = AgentInventory(mapOf(berry to 1)))
+        val command = WorldCommand.ConsumeItem(agent, berry)
+        val characterXp = RecordingCharacterXpProgression()
+
+        val result = reduceConsume(
+            state, command, items, agents, noOpProgression(),
+            characterXp, RecipeLearning.NoOp, tick = 7,
+        )
+
+        assertNotNull(result.getOrNull())
+        val call = characterXp.calls.single()
+        assertEquals(agent, call.agentId)
+        assertEquals(CharacterXpSource.CONSUME, call.source)
+        assertEquals(1, call.delta)
+        assertEquals(command.commandId, call.commandId)
     }
 
     @Test
@@ -303,6 +324,27 @@ class ConsumeReducerTest {
         val events = mutableListOf<Any>()
         override fun publishEvent(event: Any) {
             events += event
+        }
+    }
+
+    private class RecordingCharacterXpProgression : CharacterXpProgression {
+        data class Call(
+            val agentId: AgentId,
+            val source: CharacterXpSource,
+            val delta: Int,
+            val commandId: UUID,
+        )
+
+        val calls = mutableListOf<Call>()
+
+        override fun grant(
+            agentId: AgentId,
+            source: CharacterXpSource,
+            delta: Int,
+            commandId: UUID,
+        ): AddCharacterXpOutcome? {
+            calls += Call(agentId, source, delta, commandId)
+            return null
         }
     }
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.world.internal.harvest
 import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
 import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AddCharacterXpOutcome
 import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
 import dev.gvart.genesara.player.Agent
@@ -10,6 +11,7 @@ import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillState
+import dev.gvart.genesara.player.CharacterXpSource
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.AgentSkillsSnapshot
 import dev.gvart.genesara.player.SkillId
@@ -127,6 +129,28 @@ class HarvestReducerTest {
         assertEquals(7L, harvested.tick)
         assertEquals(command.commandId, harvested.causedBy)
         assertEquals(mapOf(ActionCategory.GATHER to 1), tracker.snapshotFor(agent))
+    }
+
+    @Test
+    fun `grants character XP tagged HARVEST with the harvested quantity and command id`() {
+        val state = stateWith()
+        val command = WorldCommand.Harvest(agent, wood)
+        val store = StubResourceStore(initial = mapOf(wood to 100))
+        val characterXp = RecordingCharacterXpProgression()
+
+        val result = reduceHarvest(
+            state, command, balance, items, store, agents, equipment,
+            SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            characterXp = characterXp, scaling = NoScaling,
+            triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
+        )
+
+        assertNotNull(result.getOrNull())
+        val call = characterXp.calls.single()
+        assertEquals(agent, call.agentId)
+        assertEquals(CharacterXpSource.HARVEST, call.source)
+        assertEquals(1, call.delta)
+        assertEquals(command.commandId, call.commandId)
     }
 
     @Test
@@ -608,6 +632,28 @@ class HarvestReducerTest {
         val events = mutableListOf<Any>()
         override fun publishEvent(event: Any) {
             events += event
+        }
+    }
+
+    private class RecordingCharacterXpProgression :
+        dev.gvart.genesara.world.internal.classes.CharacterXpProgression {
+        data class Call(
+            val agentId: AgentId,
+            val source: CharacterXpSource,
+            val delta: Int,
+            val commandId: UUID,
+        )
+
+        val calls = mutableListOf<Call>()
+
+        override fun grant(
+            agentId: AgentId,
+            source: CharacterXpSource,
+            delta: Int,
+            commandId: UUID,
+        ): AddCharacterXpOutcome? {
+            calls += Call(agentId, source, delta, commandId)
+            return null
         }
     }
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
@@ -390,9 +390,11 @@ class WorldTickHandlerHarvestXpEventIntegrationTest {
             if (delta < 0) return AddCharacterXpOutcome.NegativeDelta
             val previousLevel = level
             var capped = false
+            var droppedSurplus = 0
             xpCurrent += delta
             while (xpCurrent >= xpToNext) {
                 if (classId == null && level >= LEVEL_TEN_CAP) {
+                    droppedSurplus = xpCurrent - xpToNext
                     xpCurrent = xpToNext
                     capped = true
                     break
@@ -408,6 +410,7 @@ class WorldTickHandlerHarvestXpEventIntegrationTest {
                 xpCurrent = xpCurrent,
                 xpToNext = xpToNext,
                 unspentAttributePoints = unspent,
+                accruedDelta = delta - droppedSurplus,
                 cappedAtPendingClassChoice = capped,
             )
         }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
@@ -1,0 +1,471 @@
+package dev.gvart.genesara.world.internal.tick
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AddCharacterXpOutcome
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentProfile
+import dev.gvart.genesara.player.AgentProfileLookup
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.CharacterXpSource
+import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
+import dev.gvart.genesara.player.NoOpClassLookup
+import dev.gvart.genesara.player.PassiveAuraAggregator.Companion.NoAura
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.AgentKillStreak
+import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsLookup
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.ChestContentsStore
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DroppedItemView
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.Gauge
+import dev.gvart.genesara.world.GroundItemStore
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NodeResources
+import dev.gvart.genesara.world.NodeResourceView
+import dev.gvart.genesara.world.Recipe
+import dev.gvart.genesara.world.RecipeId
+import dev.gvart.genesara.world.RecipeLookup
+import dev.gvart.genesara.world.ResourceSpawnRule
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.buildings.BuildingDefinitionProperties
+import dev.gvart.genesara.world.internal.buildings.BuildingsCatalog
+import dev.gvart.genesara.world.internal.classes.DefaultCharacterXpProgression
+import dev.gvart.genesara.world.internal.classes.Level10ChoiceEmitter
+import dev.gvart.genesara.world.internal.classes.Level50EvolutionEmitter
+import dev.gvart.genesara.world.internal.crafting.RarityRoller
+import dev.gvart.genesara.world.internal.death.DeathProcessor
+import dev.gvart.genesara.world.internal.death.SafeNodeResolution
+import dev.gvart.genesara.world.internal.death.SafeNodeResolver
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_BODIES
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_INVENTORY
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_POSITIONS
+import dev.gvart.genesara.world.internal.jooq.tables.references.NODES
+import dev.gvart.genesara.world.internal.jooq.tables.references.REGIONS
+import dev.gvart.genesara.world.internal.jooq.tables.references.WORLDS
+import dev.gvart.genesara.world.internal.killstreaks.KillStreakStore
+import dev.gvart.genesara.world.internal.resources.InitialResourceRow
+import dev.gvart.genesara.world.internal.resources.NodeResourceCell
+import dev.gvart.genesara.world.internal.resources.NodeResourceStore
+import dev.gvart.genesara.world.internal.spawn.SpawnLocationResolver
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
+import dev.gvart.genesara.world.internal.testsupport.InMemoryPendingAttackScaleStore
+import dev.gvart.genesara.world.internal.testsupport.InMemoryPerkCooldownStore
+import dev.gvart.genesara.world.internal.testsupport.NoOpActivePerkLookup
+import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
+import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
+import dev.gvart.genesara.world.internal.tick.lease.WorldLeaseFence
+import dev.gvart.genesara.world.internal.worldstate.JooqWorldOnlinePresence
+import dev.gvart.genesara.world.internal.worldstate.JooqWorldStateRepository
+import dev.gvart.genesara.world.internal.worldstate.WorldStaticConfig
+import org.jooq.DSLContext
+import org.jooq.JSON
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import java.time.Duration
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@Testcontainers
+class WorldTickHandlerHarvestXpEventIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("xp_event_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = WorldFlyway.pooledDataSource(postgres)
+            WorldFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private lateinit var repository: JooqWorldStateRepository
+    private lateinit var staticConfig: WorldStaticConfig
+    private lateinit var presence: JooqWorldOnlinePresence
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+    private val wood = ItemId("WOOD")
+
+    @BeforeEach
+    fun resetState() {
+        dsl.truncate(AGENT_INVENTORY).cascade().execute()
+        dsl.truncate(AGENT_BODIES).cascade().execute()
+        dsl.truncate(AGENT_POSITIONS).cascade().execute()
+        dsl.truncate(NODES).cascade().execute()
+        dsl.truncate(REGIONS).cascade().execute()
+        dsl.truncate(WORLDS).cascade().execute()
+
+        staticConfig = WorldStaticConfig(dsl, mapper)
+        presence = JooqWorldOnlinePresence(dsl)
+        repository = JooqWorldStateRepository(dsl, staticConfig, NoopKillStreakStore)
+    }
+
+    @Test
+    fun `a successful harvest publishes AgentEvent CharacterXpGained tagged HARVEST on the agent stream`() {
+        val (worldId, nodeId) = seedSingleNodeWorld("world-harvest-xp")
+        staticConfig.reload()
+
+        val agent = AgentId(UUID.randomUUID())
+        seedPersistedBody(agent, hp = 50, stamina = 50)
+        seedPositionedAgent(agent, worldId, nodeId)
+
+        val command = WorldCommand.Harvest(agent, wood)
+        val queue = InMemoryCommandQueue()
+        queue.submitTo(worldId, command, appliesAtTick = 1)
+
+        val publisher = RecordingPublisher()
+        val agentRegistry = InMemoryAgentRegistry(agent)
+        val handler = newHandler(
+            queue = queue,
+            publisher = publisher,
+            agentRegistry = agentRegistry,
+            tick = 1,
+        )
+
+        handler.tickOne(worldId, 1)
+
+        val xpEvents = publisher.events.filterIsInstance<AgentEvent.CharacterXpGained>()
+        val xp = assertIs<AgentEvent.CharacterXpGained>(xpEvents.single())
+        assertEquals(agent, xp.agent)
+        assertEquals(CharacterXpSource.HARVEST, xp.source)
+        assertEquals(1, xp.amount)
+        assertEquals(1, xp.total)
+        assertEquals(100, xp.toNext)
+        assertEquals(1, xp.level)
+        assertEquals(1L, xp.tick)
+        assertEquals(command.commandId, xp.causedBy)
+        assertTrue(
+            publisher.events.none { it is AgentEvent.AgentLeveled },
+            "single-unit harvest must not cross a level boundary",
+        )
+    }
+
+    private fun seedPersistedBody(agent: AgentId, hp: Int, stamina: Int) {
+        dsl.insertInto(AGENT_BODIES)
+            .set(AGENT_BODIES.AGENT_ID, agent.id)
+            .set(AGENT_BODIES.HP, hp).set(AGENT_BODIES.MAX_HP, 100)
+            .set(AGENT_BODIES.STAMINA, stamina).set(AGENT_BODIES.MAX_STAMINA, 50)
+            .set(AGENT_BODIES.MANA, 0).set(AGENT_BODIES.MAX_MANA, 0)
+            .set(AGENT_BODIES.HUNGER, 100).set(AGENT_BODIES.MAX_HUNGER, 100)
+            .set(AGENT_BODIES.THIRST, 100).set(AGENT_BODIES.MAX_THIRST, 100)
+            .set(AGENT_BODIES.SLEEP, 100).set(AGENT_BODIES.MAX_SLEEP, 100)
+            .execute()
+    }
+
+    private fun seedPositionedAgent(agent: AgentId, worldId: WorldId, nodeId: NodeId) {
+        dsl.insertInto(AGENT_POSITIONS)
+            .set(AGENT_POSITIONS.AGENT_ID, agent.id)
+            .set(AGENT_POSITIONS.WORLD_ID, worldId.value)
+            .set(AGENT_POSITIONS.NODE_ID, nodeId.value)
+            .set(AGENT_POSITIONS.ACTIVE, true)
+            .execute()
+    }
+
+    private data class SeededWorld(val worldId: WorldId, val nodeId: NodeId)
+
+    private fun seedSingleNodeWorld(name: String): SeededWorld {
+        val worldIdValue = dsl.insertInto(WORLDS)
+            .set(WORLDS.NAME, name)
+            .set(WORLDS.NODE_COUNT, 1)
+            .set(WORLDS.NODE_SIZE, 1)
+            .set(WORLDS.FREQUENCY, 1)
+            .returningResult(WORLDS.ID).fetchOne()!!.value1()!!
+
+        val regionIdValue = dsl.insertInto(REGIONS)
+            .set(REGIONS.WORLD_ID, worldIdValue)
+            .set(REGIONS.SPHERE_INDEX, 0)
+            .set(REGIONS.BIOME, "FOREST")
+            .set(REGIONS.CLIMATE, "OCEANIC")
+            .set(REGIONS.CENTROID_X, 0.0)
+            .set(REGIONS.CENTROID_Y, 0.0)
+            .set(REGIONS.CENTROID_Z, 1.0)
+            .set(REGIONS.FACE_VERTICES, JSON.valueOf("[]"))
+            .returningResult(REGIONS.ID).fetchOne()!!.value1()!!
+
+        val nodeIdValue = dsl.insertInto(NODES)
+            .set(NODES.REGION_ID, regionIdValue)
+            .set(NODES.Q, 0).set(NODES.R, 0)
+            .set(NODES.TERRAIN, "FOREST")
+            .returningResult(NODES.ID).fetchOne()!!.value1()!!
+
+        return SeededWorld(WorldId(worldIdValue), NodeId(nodeIdValue))
+    }
+
+    private fun newHandler(
+        queue: InMemoryCommandQueue,
+        publisher: ApplicationEventPublisher,
+        agentRegistry: AgentRegistry,
+        tick: Long,
+    ): WorldTickHandler {
+        val skills: AgentSkillsRegistry = NoopSkillsRegistry
+        val balance = HarvestBalanceLookup
+        val equipment = NoopEquipmentStore
+        val groundItems = NoopGroundItemStore
+        val deathProcessor = DeathProcessor(balance, agentRegistry, equipment, groundItems)
+        val rarity = RarityRoller(kotlin.random.Random(0))
+        val buildingsCatalog = BuildingsCatalog(BuildingDefinitionProperties(catalog = emptyMap()))
+        val profiles = object : AgentProfileLookup {
+            override fun find(id: AgentId): AgentProfile = AgentProfile(id, maxHp = 100, maxStamina = 50, maxMana = 0)
+        }
+        val tickClock = FixedTickClock(tick)
+        val level10 = Level10ChoiceEmitter(agentRegistry, NoOpClassLookup, InMemoryBehaviorTracker(), publisher)
+        val level50 = Level50EvolutionEmitter(agentRegistry, NoOpClassLookup, InMemoryBehaviorTracker(), publisher)
+        val characterXp = DefaultCharacterXpProgression(agentRegistry, level10, level50, tickClock, publisher)
+        return WorldTickHandler(
+            queue, repository, presence, publisher, balance, profiles, WoodItemLookup,
+            NoopRecipeLookup, dev.gvart.genesara.world.AgentKnownRecipesGateway.Empty,
+            SingleCellResourceStore(wood, quantity = 10), skills, agentRegistry, equipment,
+            NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingsLookup,
+            buildingsCatalog, NoopChestContentsStore, rarity, SkillProgression(skills, publisher),
+            characterXp, dev.gvart.genesara.world.RecipeLearning.NoOp, NoScaling, NoAura,
+            dev.gvart.genesara.world.EquipmentBonusAggregator.NoBonuses,
+            FixedSpawnResolver(NodeId(0L)), groundItems, deathProcessor,
+            NoOpTriggeredPassiveDispatcher, NoOpActivePerkLookup, InMemoryPerkCooldownStore(),
+            InMemoryPendingAttackScaleStore(), InMemoryBehaviorTracker(),
+            AlwaysHeldLeaseFence, Duration.ofSeconds(5L),
+        )
+    }
+
+    private object AlwaysHeldLeaseFence : WorldLeaseFence {
+        override fun requireHeldAndRenew(worldId: WorldId, tick: Long) = Unit
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+
+    private class FixedSpawnResolver(private val node: NodeId) : SpawnLocationResolver {
+        override fun resolveFor(agentId: AgentId): NodeId = node
+    }
+
+    private class FixedTickClock(private val tick: Long) : TickClock {
+        override fun currentTick(): Long = tick
+    }
+
+    private object NoopKillStreakStore : KillStreakStore {
+        override fun byAgents(agents: Set<AgentId>): Map<AgentId, AgentKillStreak> = emptyMap()
+        override fun save(agent: AgentId, streak: AgentKillStreak) = Unit
+        override fun delete(agent: AgentId) = Unit
+    }
+
+    private object HarvestBalanceLookup : BalanceLookup {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
+        override fun staminaRegenPerTick(climate: Climate) = 0
+        override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun carryGramsPerStrengthPoint(): Int = 5_000
+    }
+
+    private object WoodItemLookup : ItemLookup {
+        private val wood = Item(
+            id = ItemId("WOOD"),
+            displayName = "Wood",
+            description = "",
+            category = ItemCategory.RESOURCE,
+            weightPerUnit = 100,
+            maxStack = 100,
+            harvestSkill = null,
+        )
+        override fun byId(id: ItemId): Item? = if (id == wood.id) wood else null
+        override fun all(): List<Item> = listOf(wood)
+    }
+
+    private class SingleCellResourceStore(private val item: ItemId, quantity: Int) : NodeResourceStore {
+        private var qty = quantity
+        private val initial = quantity
+
+        override fun read(nodeId: NodeId, tick: Long) =
+            NodeResources(mapOf(item to NodeResourceView(item, qty, initial)))
+
+        override fun availability(nodeId: NodeId, item: ItemId, tick: Long): NodeResourceCell? {
+            if (item != this.item) return null
+            return NodeResourceCell(nodeId, item, qty, initial)
+        }
+
+        override fun decrement(nodeId: NodeId, item: ItemId, amount: Int, tick: Long) {
+            qty -= amount
+        }
+
+        override fun seed(rows: Collection<InitialResourceRow>, tick: Long) = Unit
+    }
+
+    private object NoopRecipeLookup : RecipeLookup {
+        override fun byId(id: RecipeId): Recipe? = null
+        override fun all(): List<Recipe> = emptyList()
+    }
+
+    private object NoopSkillsRegistry : AgentSkillsRegistry {
+        override fun snapshot(agent: AgentId) = AgentSkillsSnapshot(
+            perSkill = emptyMap(), slotCount = 8, slotsFilled = 0,
+        )
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int) = AddXpResult.Unslotted
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? = null
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int) = null
+    }
+
+    /**
+     * Single-agent in-memory registry that simulates [JooqAgentRegistry.addCharacterXp]'s
+     * level-cascade with the same linear `xp_to_next = level * 100` rule and 5 unspent
+     * points per level-up. Pre-L10 agents cap at level 10; the cap test path is exercised
+     * by the level-10 emitter inside [DefaultCharacterXpProgression].
+     */
+    private class InMemoryAgentRegistry(private val agentId: AgentId) : AgentRegistry {
+        private var level = 1
+        private var xpCurrent = 0
+        private var xpToNext = 100
+        private var unspent = 0
+        private var classId: dev.gvart.genesara.player.AgentClass? = null
+
+        override fun find(id: AgentId): Agent? = if (id == agentId) {
+            Agent(id = id, owner = PlayerId(UUID.randomUUID()), name = "harvester", classId = classId, level = level)
+        } else null
+
+        override fun listForOwner(owner: PlayerId): List<Agent> = listOf(find(agentId)!!)
+
+        override fun addCharacterXp(agentId: AgentId, delta: Int): AddCharacterXpOutcome? {
+            if (agentId != this.agentId) return null
+            if (delta < 0) return AddCharacterXpOutcome.NegativeDelta
+            val previousLevel = level
+            var capped = false
+            xpCurrent += delta
+            while (xpCurrent >= xpToNext) {
+                if (classId == null && level >= LEVEL_TEN_CAP) {
+                    xpCurrent = xpToNext
+                    capped = true
+                    break
+                }
+                xpCurrent -= xpToNext
+                level += 1
+                xpToNext = level * 100
+                unspent += 5
+            }
+            return AddCharacterXpOutcome.Granted(
+                previousLevel = previousLevel,
+                currentLevel = level,
+                xpCurrent = xpCurrent,
+                xpToNext = xpToNext,
+                unspentAttributePoints = unspent,
+                cappedAtPendingClassChoice = capped,
+            )
+        }
+
+        private companion object {
+            const val LEVEL_TEN_CAP = 10
+        }
+    }
+
+    private object NoopEquipmentStore : EquipmentInstanceStore {
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> = emptyMap()
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = error("not used")
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = error("not used")
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? =
+            error("not used")
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = error("not used")
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = error("not used")
+        override fun delete(instanceId: UUID): Boolean = error("not used")
+    }
+
+    private object NoopSafeNodeGateway : AgentSafeNodeGateway {
+        override fun set(agentId: AgentId, nodeId: NodeId, tick: Long) {}
+        override fun find(agentId: AgentId): NodeId? = null
+        override fun clear(agentId: AgentId) {}
+    }
+
+    private object NoopSafeNodeResolver : SafeNodeResolver {
+        override fun resolveFor(agentId: AgentId): SafeNodeResolution? = null
+    }
+
+    private object NoopBuildingsStore : BuildingsStore {
+        override fun insert(building: Building) = error("not used")
+        override fun findById(id: UUID): Building? = null
+        override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? = null
+        override fun listAtNode(node: NodeId): List<Building> = emptyList()
+        override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = emptyMap()
+        override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = null
+        override fun complete(id: UUID, asOfTick: Long): Building? = null
+    }
+
+    private object NoopBuildingsLookup : BuildingsLookup {
+        override fun byId(id: UUID): Building? = null
+        override fun byNode(node: NodeId): List<Building> = emptyList()
+        override fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = emptyMap()
+        override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> = emptyList()
+    }
+
+    private object NoopChestContentsStore : ChestContentsStore {
+        override fun quantityOf(buildingId: UUID, item: ItemId): Int = 0
+        override fun contentsOf(buildingId: UUID): Map<ItemId, Int> = emptyMap()
+        override fun add(buildingId: UUID, item: ItemId, quantity: Int) = error("not used")
+        override fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean = error("not used")
+    }
+
+    private object NoopGroundItemStore : GroundItemStore {
+        override fun deposit(node: NodeId, drop: DroppedItemView, droppedAtTick: Long) = error("not used")
+        override fun atNode(node: NodeId): List<GroundItemView> = emptyList()
+        override fun take(node: NodeId, dropId: UUID): GroundItemView? = null
+    }
+}


### PR DESCRIPTION
## Summary

Closes the P1 finding from the 2026-05-12 playtest sweep (`docs/playtest/findings.md` — "no `agent.xp_gained` event — character XP advances silently"). Successful harvest / consume were bumping `get_status.xp.current` but produced no character-ledger event, so autonomous agents could only react to their own progression by polling.

- `DefaultCharacterXpProgression.grant` now publishes `AgentEvent.CharacterXpGained` (every `AddCharacterXpOutcome.Granted`) and `AgentEvent.AgentLeveled` (every level-boundary crossing within the same cascade), both tagged with the originating `commandId` so they satisfy the queue-and-ack contract documented in `docs/mcp-api.md`.
- `AgentEventDispatcher` maps the two events to `agent.xp_gained` / `agent.leveled` on the per-agent stream, mirroring the existing `skill.recommended` / `skill.milestone` wiring.
- Harvest and consume reducers pass a `CharacterXpSource` (HARVEST, CONSUME) + `commandId` through the shared grant entry point. Class-choice events (`ClassChoiceOffered`, `EvolutionChoiceOffered`) were already wired at the L10 / L50 boundaries and continue to fire — this slice doesn't change them.

`class.choice_offered` / `class.offered` was already wired via `Level10ChoiceEmitter`; the playtest just didn't reach the 9→10 boundary, so I did not change its mapping.

## Spec citations

- `docs/lore/mechanics-reference.md` §3 — "A single action grants both character XP and skill XP. Independent ledgers, both trigger on the same event."
- `docs/mcp-api.md` queue-and-ack — every state-mutating command should surface `causedBy = commandId`.

## Out of scope

- Adding new XP sources (combat kills, craft completions, build completions). Today only harvest and consume grant character XP and the slice wires emission only at those existing sites.
- Renaming `class.offered` → `class.choice_offered` (pre-existing wiring; not part of this finding).

## Test plan

- [x] `:player:test`, `:world:test`, `:api:test`, `:app:test` — all green (`./gradlew check`)
- [x] `CharacterXpProgressionTest` — 9 cases covering happy path, NegativeDelta, null-agent, level-boundary crossing, capped-at-L10
- [x] `HarvestReducerTest` / `ConsumeReducerTest` — new focused cases asserting `characterXp.grant` is called with `source = HARVEST` / `CONSUME`, the correct delta, and the originating `commandId`
- [x] `AgentEventDispatcherTest` — asserts both new events surface on the agent stream with the right type strings and payload fields (`source`, `amount`, `total`, `toNext`, `level`, `causedBy`)
- [x] `WorldTickHandlerHarvestXpEventIntegrationTest` (Testcontainers Postgres) — drives a `WorldCommand.Harvest` through `WorldTickHandler.tickOne` and asserts `AgentEvent.CharacterXpGained` is published with the originating `commandId`