### PR TITLE
fix(api): populate inspect(AGENT,BUILDING) band/effect/owner fields

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
@@ -50,7 +50,9 @@ internal class InspectTool(
         name = "inspect",
         description = "Inspect a single target (node, agent, item, or building) in detail. " +
             "Vision-gated: nodes and buildings must be within sight, agents must be in the same node, " +
-            "items must be in the agent's own inventory. Response depth scales with Perception.",
+            "items must be in the agent's own inventory. There is no caller-supplied depth — the level " +
+            "of detail is derived from the calling agent's Perception attribute and reflected in the " +
+            "response's `depth` field.",
     )
     fun invoke(
         @ToolParam(required = true, description = "Kind of target to inspect. One of NODE, AGENT, ITEM, BUILDING.")
@@ -250,14 +252,7 @@ internal class InspectTool(
     )
 
     private fun projectAgent(target: Agent, body: BodyView, depth: InspectDepth): AgentInspectView {
-        val classId = if (depth != InspectDepth.SHALLOW) target.classId?.name else null
-        val hpBand = if (depth != InspectDepth.SHALLOW) bandOf(body.hp, body.maxHp) else null
-        val staminaBand = if (depth != InspectDepth.SHALLOW) bandOf(body.stamina, body.maxStamina) else null
-        // Mana is psionic-only: non-psionic classes have `maxMana == 0` and we hide the
-        // pool entirely (canon: `Agent.mana` is null for non-psionic).
-        val manaBand = if (depth != InspectDepth.SHALLOW && body.maxMana > 0) {
-            bandOf(body.mana, body.maxMana)
-        } else null
+        val manaBand = if (body.maxMana > 0) bandOf(body.mana, body.maxMana) else null
         // TODO(combat): populate Bleed/Burn/Stun/Poison once Phase 2 status effects ship.
         val activeEffects = if (depth == InspectDepth.EXPERT) emptyList<String>() else null
         return AgentInspectView(
@@ -265,9 +260,9 @@ internal class InspectTool(
             name = target.name,
             race = target.race.value,
             level = target.level,
-            classId = classId,
-            hpBand = hpBand,
-            staminaBand = staminaBand,
+            classId = target.classId?.name,
+            hpBand = bandOf(body.hp, body.maxHp),
+            staminaBand = bandOf(body.stamina, body.maxStamina),
             manaBand = manaBand,
             activeEffects = activeEffects,
         )
@@ -298,9 +293,8 @@ internal class InspectTool(
     ): BuildingInspectView {
         val def = buildingDefs.byType(building.type)
         val isOwner = building.builtByAgentId == agentId
-        val isExpert = depth == InspectDepth.EXPERT
-        val isDetailedPlus = depth != InspectDepth.SHALLOW
-        val showChestContents = isExpert && isOwner && building.type == BuildingType.STORAGE_CHEST
+        val showCatalogDetail = isOwner || depth == InspectDepth.EXPERT
+        val showChestContents = isOwner && building.type == BuildingType.STORAGE_CHEST
         return BuildingInspectView(
             instanceId = building.instanceId.toString(),
             type = building.type.name,
@@ -308,16 +302,16 @@ internal class InspectTool(
             progressSteps = building.progressSteps,
             totalSteps = building.totalSteps,
             hpBand = vitalBand(building.hpCurrent, building.hpMax, zeroLabel = "destroyed"),
-            nodeId = if (isDetailedPlus) building.nodeId.value else null,
-            builderAgentId = if (isDetailedPlus) building.builtByAgentId.id.toString() else null,
-            hpCurrent = if (isDetailedPlus) building.hpCurrent else null,
-            hpMax = if (isDetailedPlus) building.hpMax else null,
-            lastProgressTick = if (isDetailedPlus) building.lastProgressTick else null,
-            builtAtTick = if (isExpert) building.builtAtTick else null,
-            requiredSkill = if (isExpert) def?.requiredSkill?.value else null,
-            requiredSkillLevel = if (isExpert) def?.requiredSkillLevel else null,
-            totalMaterials = if (isExpert) def?.totalMaterials?.toMaterialViews() else null,
-            stepMaterials = if (isExpert) def?.stepMaterials?.map { it.toMaterialViews() } else null,
+            nodeId = building.nodeId.value,
+            builderAgentId = building.builtByAgentId.id.toString(),
+            hpCurrent = building.hpCurrent,
+            hpMax = building.hpMax,
+            lastProgressTick = building.lastProgressTick,
+            builtAtTick = if (showCatalogDetail) building.builtAtTick else null,
+            requiredSkill = if (showCatalogDetail) def?.requiredSkill?.value else null,
+            requiredSkillLevel = if (showCatalogDetail) def?.requiredSkillLevel else null,
+            totalMaterials = if (showCatalogDetail) def?.totalMaterials?.toMaterialViews() else null,
+            stepMaterials = if (showCatalogDetail) def?.stepMaterials?.map { it.toMaterialViews() } else null,
             chestContents = if (showChestContents) chestContents.contentsOf(building.instanceId).toMaterialViews() else null,
         )
     }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
@@ -77,15 +77,15 @@ data class AgentInspectView(
     val name: String,
     val race: String,
     val level: Int,
-    /** Class id once assigned at level 10; null for unclassed agents. DETAILED+. */
+    /** Class id once assigned at level 10; null for unclassed agents. */
     val classId: String? = null,
-    /** Banded HP: "low" / "mid" / "high" (or "dead" if 0). DETAILED+. */
+    /** Banded HP: "low" / "mid" / "high" (or "dead" if 0). Always populated for same-node agents — matches `look_around`. */
     val hpBand: String? = null,
-    /** Banded Stamina: same banding as HP. DETAILED+. */
+    /** Banded Stamina: same banding as HP. Always populated for same-node agents. */
     val staminaBand: String? = null,
     /**
      * Banded Mana: only set for psionic agents (`maxMana > 0`); null otherwise.
-     * Non-psionic agents have no mana pool by canon. DETAILED+.
+     * Non-psionic agents have no mana pool by canon.
      */
     val manaBand: String? = null,
     /** EXPERT-only list of visible status effect ids (Bleed, Burn, Stun, Poison...). */
@@ -154,12 +154,12 @@ data class InstanceStateView(
 )
 
 /**
- * Per-building inspect projection. Type, status, hp band, and progress (`progressSteps` /
- * `totalSteps`) are always present — agents need progress to know whether to keep building.
- * DETAILED+ adds the precise hp values, the node id, the builder agent id, and a tick-based
- * `lastProgressTick`. EXPERT adds the per-step materials breakdown from the catalog and the
- * required skill / level. Chest contents are EXPERT-only AND owner-only (Phase 1 personal
- * stash).
+ * Per-building inspect projection. For any building within sight, every per-instance field
+ * (type, status, progress, hp band, exact hp, node id, builder agent id, `lastProgressTick`)
+ * is always populated — matching what `look_around` already exposes for same-node buildings.
+ * Catalog/recipe details (required skill, total / per-step materials, `builtAtTick`) are
+ * visible to the owner regardless of Perception, and to EXPERT-Perception non-owners.
+ * Chest contents are strictly owner-only (Phase 1 personal stash).
  */
 data class BuildingInspectView(
     val instanceId: String,
@@ -178,7 +178,7 @@ data class BuildingInspectView(
     val requiredSkillLevel: Int? = null,
     val totalMaterials: List<BuildingMaterialView>? = null,
     val stepMaterials: List<List<BuildingMaterialView>>? = null,
-    /** EXPERT + owner-only: current chest contents. Null when not a chest, not owner, or below EXPERT. */
+    /** Owner-only: current chest contents. Null when not a chest, or the caller is not the builder. */
     val chestContents: List<BuildingMaterialView>? = null,
 )
 

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
@@ -71,8 +71,8 @@ class InspectBuildingTest {
     @AfterEach fun tearDown() = AgentContextHolder.clear()
 
     @Test
-    fun `SHALLOW perception surfaces type, status, progress, hpBand only`() {
-        val chest = building(builder = agentId, type = BuildingType.STORAGE_CHEST)
+    fun `SHALLOW perception still surfaces per-instance fields — parity with look_around`() {
+        val chest = building(builder = builderId, type = BuildingType.STORAGE_CHEST)
         val tool = tool(perception = 0, buildings = listOf(chest))
 
         val resp = tool.dispatch("building", chest.instanceId.toString(), toolContext)
@@ -84,37 +84,22 @@ class InspectBuildingTest {
         assertEquals(8, view.progressSteps)
         assertEquals(8, view.totalSteps)
         assertEquals("high", view.hpBand)
-        assertNull(view.nodeId)
-        assertNull(view.builderAgentId)
-        assertNull(view.hpCurrent)
-        assertNull(view.totalMaterials)
-        assertNull(view.chestContents)
-    }
-
-    @Test
-    fun `DETAILED perception adds nodeId, builderAgentId, exact hp, lastProgressTick`() {
-        val chest = building(builder = builderId, type = BuildingType.STORAGE_CHEST)
-        val tool = tool(perception = 50, buildings = listOf(chest))
-
-        val resp = tool.dispatch("building", chest.instanceId.toString(), toolContext)
-
-        val view = assertNotNull(resp.building)
         assertEquals(nodeId.value, view.nodeId)
         assertEquals(builderId.id.toString(), view.builderAgentId)
         assertEquals(40, view.hpCurrent)
         assertEquals(40, view.hpMax)
         assertEquals(7L, view.lastProgressTick)
-        // EXPERT-only fields stay null at DETAILED.
+        // Non-owner at SHALLOW still has catalog detail gated.
         assertNull(view.totalMaterials)
         assertNull(view.requiredSkill)
         assertNull(view.chestContents)
     }
 
     @Test
-    fun `EXPERT perception adds catalog materials breakdown and required skill`() {
-        val chest = building(builder = builderId, type = BuildingType.STORAGE_CHEST)
+    fun `owner sees catalog detail at any Perception`() {
+        val chest = building(builder = agentId, type = BuildingType.STORAGE_CHEST)
         val def = stubChestDef()
-        val tool = tool(perception = 90, buildings = listOf(chest), defs = mapOf(BuildingType.STORAGE_CHEST to def))
+        val tool = tool(perception = 0, buildings = listOf(chest), defs = mapOf(BuildingType.STORAGE_CHEST to def))
 
         val resp = tool.dispatch("building", chest.instanceId.toString(), toolContext)
 
@@ -125,18 +110,32 @@ class InspectBuildingTest {
         assertEquals(1, totals.size)
         assertEquals("WOOD", totals.single().itemId)
         assertEquals(20, totals.single().quantity)
+        assertEquals(1L, view.builtAtTick)
+    }
+
+    @Test
+    fun `EXPERT-Perception non-owner sees catalog detail`() {
+        val chest = building(builder = builderId, type = BuildingType.STORAGE_CHEST)
+        val def = stubChestDef()
+        val tool = tool(perception = 90, buildings = listOf(chest), defs = mapOf(BuildingType.STORAGE_CHEST to def))
+
+        val resp = tool.dispatch("building", chest.instanceId.toString(), toolContext)
+
+        val view = assertNotNull(resp.building)
+        assertEquals("CARPENTRY", view.requiredSkill)
+        assertEquals(0, view.requiredSkillLevel)
         val steps = assertNotNull(view.stepMaterials)
         assertEquals(8, steps.size)
     }
 
     @Test
-    fun `EXPERT-and-owner sees chest contents — non-owner does not`() {
+    fun `owner sees chest contents regardless of Perception — non-owner never does`() {
         val chest = building(builder = agentId, type = BuildingType.STORAGE_CHEST)
         val contents = StubChestContents().apply {
             add(chest.instanceId, ItemId("WOOD"), 5)
             add(chest.instanceId, ItemId("STONE"), 2)
         }
-        val ownerTool = tool(perception = 90, buildings = listOf(chest), chestContents = contents)
+        val ownerTool = tool(perception = 0, buildings = listOf(chest), chestContents = contents)
         val nonOwnerChest = chest.copy(builtByAgentId = builderId)
         val nonOwnerTool = tool(perception = 90, buildings = listOf(nonOwnerChest), chestContents = contents)
 
@@ -149,9 +148,9 @@ class InspectBuildingTest {
     }
 
     @Test
-    fun `EXPERT does NOT surface chestContents for non-chest types — only STORAGE_CHEST`() {
+    fun `owner does NOT see chestContents for non-chest types — only STORAGE_CHEST`() {
         val workbench = building(builder = agentId, type = BuildingType.WORKBENCH)
-        val tool = tool(perception = 90, buildings = listOf(workbench))
+        val tool = tool(perception = 0, buildings = listOf(workbench))
 
         val resp = tool.dispatch("building", workbench.instanceId.toString(), toolContext)
         assertNull(resp.building?.chestContents)

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectLookAroundParityTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectLookAroundParityTest.kt
@@ -1,0 +1,287 @@
+package dev.gvart.genesara.api.internal.mcp.tools.inspect
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.tools.lookaround.LookAroundTool
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.world.AgentMapMemoryGateway
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.BodyView
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingDefLookup
+import dev.gvart.genesara.world.BuildingDefView
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsLookup
+import dev.gvart.genesara.world.ChestContentsStore
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.EquipmentSet
+import dev.gvart.genesara.world.EquipmentSetId
+import dev.gvart.genesara.world.EquipmentSetLookup
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.InventoryView
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NodeMemoryUpdate
+import dev.gvart.genesara.world.NodeResources
+import dev.gvart.genesara.world.RecalledNode
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.VisionRadius
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldQueryGateway
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class InspectLookAroundParityTest {
+
+    private val callerId = AgentId(UUID.randomUUID())
+    private val otherId = AgentId(UUID.fromString("00000000-0000-0000-0000-000000000aaa"))
+    private val regionId = RegionId(1L)
+    private val nodeId = NodeId(1L)
+
+    private val region = Region(
+        id = regionId,
+        worldId = WorldId(1L),
+        sphereIndex = 0,
+        biome = Biome.FOREST,
+        climate = Climate.CONTINENTAL,
+        centroid = Vec3(0.0, 0.0, 1.0),
+        faceVertices = emptyList(),
+        neighbors = emptySet(),
+    )
+    private val node = Node(nodeId, regionId, q = 0, r = 0, terrain = Terrain.FOREST, adjacency = emptySet())
+
+    private val clock = MutableTestClock(Instant.parse("2026-01-01T00:00:00Z"))
+    private val activity = AgentActivityRegistry(clock)
+    private val toolContext = ToolContext(emptyMap())
+
+    private val caller = Agent(
+        id = callerId,
+        owner = PlayerId(UUID.randomUUID()),
+        name = "caller",
+        attributes = AgentAttributes(perception = 1),
+    )
+    private val other = Agent(
+        id = otherId,
+        owner = PlayerId(UUID.randomUUID()),
+        name = "wanderer",
+        classId = AgentClass.SCOUT,
+        race = RaceId("human_warden"),
+        level = 4,
+    )
+
+    @BeforeEach fun setUp() = AgentContextHolder.set(callerId)
+    @AfterEach fun tearDown() = AgentContextHolder.clear()
+
+    @Test
+    fun `inspect AGENT and look_around agree on hpBand for the same target at the same tick`() {
+        val body = BodyView(
+            hp = 80, maxHp = 100,
+            stamina = 30, maxStamina = 100,
+            mana = 0, maxMana = 0,
+            hunger = 50, maxHunger = 100,
+            thirst = 50, maxThirst = 100,
+            sleep = 50, maxSleep = 100,
+        )
+        val world = SharedWorld(
+            location = nodeId,
+            nodes = mapOf(nodeId to node),
+            regions = mapOf(regionId to region),
+            within = mapOf((nodeId to 1) to setOf(nodeId)),
+            occupants = mapOf(nodeId to listOf(callerId, otherId)),
+            bodies = mapOf(callerId to body, otherId to body),
+        )
+        val registry = registryOf(caller, other)
+        val inspect = inspectTool(world, registry)
+        val lookAround = LookAroundTool(world, registry, vision(1), activity, NoMapMemory, NoBuildings)
+
+        val inspectBand = assertNotNull(inspect.dispatch("agent", otherId.id.toString())).agent?.hpBand
+        val lookBand = lookAround.invoke(toolContext)
+            .currentNode.agents.single { it.id == otherId.id.toString() }.hpBand
+
+        assertEquals(lookBand, inspectBand, "inspect must return the same hpBand as look_around for same-node agents")
+    }
+
+    @Test
+    fun `inspect BUILDING and look_around agree on per-instance fields for the agent's own chest`() {
+        val chest = Building(
+            instanceId = UUID.randomUUID(),
+            nodeId = nodeId,
+            type = BuildingType.STORAGE_CHEST,
+            status = BuildingStatus.ACTIVE,
+            builtByAgentId = callerId,
+            builtAtTick = 1L,
+            lastProgressTick = 7L,
+            progressSteps = 8,
+            totalSteps = 8,
+            hpCurrent = 40,
+            hpMax = 40,
+        )
+        val world = SharedWorld(
+            location = nodeId,
+            nodes = mapOf(nodeId to node),
+            regions = mapOf(regionId to region),
+            within = mapOf((nodeId to 1) to setOf(nodeId)),
+        )
+        val registry = registryOf(caller)
+        val buildingsLookup = SharedBuildings(listOf(chest))
+        val inspect = inspectTool(world, registry, buildings = buildingsLookup)
+        val lookAround = LookAroundTool(world, registry, vision(1), activity, NoMapMemory, buildingsLookup)
+
+        val inspectView = assertNotNull(inspect.dispatch("building", chest.instanceId.toString())).building!!
+        val lookView = lookAround.invoke(toolContext)
+            .currentNode.buildings.single { it.instanceId == chest.instanceId.toString() }
+
+        assertEquals(lookView.type, inspectView.type)
+        assertEquals(lookView.status, inspectView.status)
+        assertEquals(lookView.progressSteps, inspectView.progressSteps)
+        assertEquals(lookView.totalSteps, inspectView.totalSteps)
+        assertEquals(lookView.hpBand, inspectView.hpBand)
+        assertEquals(lookView.builderAgentId, inspectView.builderAgentId)
+    }
+
+    private fun InspectTool.dispatch(targetType: String, targetId: String) =
+        invoke(InspectTargetType.valueOf(targetType.uppercase()), targetId, toolContext)
+
+    private fun inspectTool(
+        world: WorldQueryGateway,
+        registry: AgentRegistry,
+        buildings: BuildingsLookup = NoBuildings,
+    ): InspectTool = InspectTool(
+        world = world,
+        agents = registry,
+        vision = vision(1),
+        items = NoItems,
+        activity = activity,
+        tick = FixedTickClock(0L),
+        buildings = buildings,
+        buildingDefs = NoBuildingDefs,
+        chestContents = NoChestContents,
+        equipmentInstances = NoEquipmentInstances,
+        equipmentSets = NoEquipmentSets,
+    )
+
+    private fun registryOf(vararg present: Agent) = object : AgentRegistry {
+        private val byId = present.associateBy { it.id }
+        override fun find(id: AgentId): Agent? = byId[id]
+        override fun listForOwner(owner: PlayerId): List<Agent> = present.filter { it.owner == owner }
+    }
+
+    private fun vision(sight: Int) = object : VisionRadius {
+        override fun radiusFor(agent: Agent, currentNode: NodeId): Int = sight
+    }
+
+    private class SharedWorld(
+        private val location: NodeId,
+        private val nodes: Map<NodeId, Node>,
+        private val regions: Map<RegionId, Region>,
+        private val within: Map<Pair<NodeId, Int>, Set<NodeId>>,
+        private val occupants: Map<NodeId, List<AgentId>> = emptyMap(),
+        private val bodies: Map<AgentId, BodyView> = emptyMap(),
+    ) : WorldQueryGateway {
+        override fun locationOf(agent: AgentId): NodeId? = location
+        override fun activePositionOf(agent: AgentId): NodeId? = location
+        override fun node(id: NodeId): Node? = nodes[id]
+        override fun region(id: RegionId): Region? = regions[id]
+        override fun nodesWithin(origin: NodeId, radius: Int): Set<NodeId> = within[origin to radius] ?: emptySet()
+        override fun randomSpawnableNode(): NodeId? = null
+        override fun starterNodeFor(race: RaceId): NodeId? = null
+        override fun bodyOf(agent: AgentId): BodyView? = bodies[agent]
+        override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
+        override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId): List<GroundItemView> = emptyList()
+        override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> =
+            nodeIds.associateWith { occupants[it].orEmpty() }.filterValues { it.isNotEmpty() }
+    }
+
+    private class SharedBuildings(private val rows: List<Building>) : BuildingsLookup {
+        override fun byId(id: UUID): Building? = rows.firstOrNull { it.instanceId == id }
+        override fun byNode(node: NodeId): List<Building> = rows.filter { it.nodeId == node }
+        override fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
+            rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }
+        override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> = emptyList()
+    }
+
+    private object NoItems : ItemLookup {
+        override fun byId(id: ItemId): Item? = null
+        override fun all(): List<Item> = emptyList()
+    }
+
+    private object NoBuildings : BuildingsLookup {
+        override fun byId(id: UUID): Building? = null
+        override fun byNode(node: NodeId): List<Building> = emptyList()
+        override fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = emptyMap()
+        override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> = emptyList()
+    }
+
+    private object NoBuildingDefs : BuildingDefLookup {
+        override fun byType(type: BuildingType): BuildingDefView? = null
+        override fun all(): List<BuildingDefView> = emptyList()
+    }
+
+    private object NoChestContents : ChestContentsStore {
+        override fun quantityOf(buildingId: UUID, item: ItemId): Int = 0
+        override fun contentsOf(buildingId: UUID): Map<ItemId, Int> = emptyMap()
+        override fun add(buildingId: UUID, item: ItemId, quantity: Int) = error("not used")
+        override fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean = error("not used")
+    }
+
+    private object NoEquipmentInstances : EquipmentInstanceStore {
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = null
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = emptyList()
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> = emptyMap()
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? = null
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = null
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = null
+        override fun delete(instanceId: UUID): Boolean = false
+    }
+
+    private object NoEquipmentSets : EquipmentSetLookup {
+        override fun byId(id: EquipmentSetId): EquipmentSet? = null
+        override fun all(): List<EquipmentSet> = emptyList()
+        override fun setsContaining(itemId: ItemId): List<EquipmentSet> = emptyList()
+    }
+
+    private object NoMapMemory : AgentMapMemoryGateway {
+        override fun recordVisible(agentId: AgentId, updates: Collection<NodeMemoryUpdate>, tick: Long) = Unit
+        override fun recall(agentId: AgentId): List<RecalledNode> = emptyList()
+    }
+
+    private class MutableTestClock(private var now: Instant) : Clock() {
+        override fun instant(): Instant = now
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+
+    private class FixedTickClock(private val current: Long) : TickClock {
+        override fun currentTick(): Long = current
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
@@ -202,14 +202,15 @@ class InspectToolTest {
     }
 
     @Test
-    fun `inspect agent at SHALLOW Perception hides class and bands`() {
+    fun `inspect agent at SHALLOW Perception still surfaces class and bands — parity with look_around`() {
         val tool = tool(perception = 1, otherAgentNode = currentNodeId, body = body(hp = 50, maxHp = 100))
         val resp = tool.dispatch("agent", otherAgentId.id.toString(), toolContext)
 
         val view = assertNotNull(resp.agent)
-        assertNull(view.classId)
-        assertNull(view.hpBand)
-        assertNull(view.staminaBand)
+        assertEquals("SCOUT", view.classId)
+        assertEquals("mid", view.hpBand)
+        assertEquals("mid", view.staminaBand)
+        assertNull(view.activeEffects, "EXPERT-only field still gated")
     }
 
     @Test


### PR DESCRIPTION
## Summary

Two related playtest bugs in `inspect` were dropping data that `look_around` already publishes for the same situation:

- **`inspect(AGENT, …)`** returned `hpBand`, `staminaBand`, `manaBand`, and `classId` as `null` whenever the calling agent's Perception was below 5 (i.e. SHALLOW depth). Meanwhile `look_around.currentNode.agents` happily exposes the same `hpBand` for any same-node agent with zero Perception cost. New characters (Perception = 1 by default) saw the inconsistency immediately.
- **`inspect(BUILDING, <own-chest-uuid>)`** returned `nodeId`, `builderAgentId`, `hpCurrent`, `hpMax`, `lastProgressTick`, `requiredSkill`, `chestContents`, etc. as `null` even on the agent's own active STORAGE_CHEST. Again, `look_around`'s current-node entry already exposes `instanceId`, `progressSteps`, `totalSteps`, `hpBand`, `builderAgentId` for free.

The fix narrows the Perception ladder to only the fields `look_around` does **not** expose:

- `projectAgent` always populates `hpBand`, `staminaBand`, `manaBand` (psionic-only via `maxMana > 0`), and `classId`. `activeEffects` stays EXPERT-only (still not surfaced anywhere else, and will land when Phase-2 status effects ship).
- `projectBuilding` always populates `nodeId`, `builderAgentId`, `hpCurrent`, `hpMax`, `lastProgressTick`. Catalog/recipe detail (`requiredSkill`, `requiredSkillLevel`, `totalMaterials`, `stepMaterials`, `builtAtTick`) is now visible to the owner **regardless of Perception**, and to EXPERT-Perception non-owners — previously gated to EXPERT for everyone. `chestContents` is now owner-only at any Perception (was EXPERT + owner), still strictly hidden from non-owners.

Both projections continue to reuse the shared `vitalBand` helper that `look_around` uses, so the two tools stay band-consistent by construction.

### `depth` parameter

`InspectTool` never exposed a caller-supplied `depth` parameter — the response's `depth` field is derived from the agent's Perception attribute. The playtest sent `depth="deep"` as an extra unknown param which the framework silently dropped, then read the response's `depth: "shallow"` and concluded the param was downgraded. Nothing to remove; tool description updated to make the derivation explicit.

## Test plan

- [x] Updated `InspectToolTest` `inspect agent at SHALLOW Perception …` to pin the new contract (bands and classId always surface for same-node targets; `activeEffects` stays EXPERT-only).
- [x] Updated `InspectBuildingTest` `SHALLOW perception …` to pin per-instance fields always present; new `owner sees catalog detail at any Perception` test; reshaped chest-contents tests to drop the EXPERT requirement for owners; `EXPERT-Perception non-owner sees catalog detail` keeps the recipe gate working for strangers.
- [x] New `InspectLookAroundParityTest` shares a single `WorldQueryGateway` stub between both tools and asserts `inspect(AGENT, …).agent.hpBand == look_around.currentNode.agents.single().hpBand`, and that `inspect(BUILDING, ownChest)` agrees with `look_around.currentNode.buildings.single()` on `type`/`status`/`progressSteps`/`totalSteps`/`hpBand`/`builderAgentId`.
- [x] `./gradlew :api:test` green.
- [x] `./gradlew :world:test` green.