### PR TITLE
fix(world): align agent.xp_gained.tick with the world clock

### DIFF
--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgression.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgression.kt
@@ -1,6 +1,5 @@
 package dev.gvart.genesara.world.internal.classes
 
-import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AddCharacterXpOutcome
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
@@ -16,9 +15,19 @@ import java.util.UUID
  * (when the grant cascade crossed at least one level boundary), and routes level-milestone
  * transitions through the matching emitter so future XP-source slices (quest rewards, NPC
  * kills) only need to call this method.
+ *
+ * Callers pass [tick] from the reducer they fire in — the same value that tags the
+ * originating world event (e.g. `ResourceHarvested.tick`) — so sibling events sharing
+ * a `causedBy` correlate on the same world clock.
  */
 internal interface CharacterXpProgression {
-    fun grant(agentId: AgentId, source: CharacterXpSource, delta: Int, commandId: UUID): AddCharacterXpOutcome?
+    fun grant(
+        agentId: AgentId,
+        source: CharacterXpSource,
+        delta: Int,
+        tick: Long,
+        commandId: UUID,
+    ): AddCharacterXpOutcome?
 
     companion object {
         /** Drop-in no-op for tests that exercise reducers but don't care about XP propagation. */
@@ -27,6 +36,7 @@ internal interface CharacterXpProgression {
                 agentId: AgentId,
                 source: CharacterXpSource,
                 delta: Int,
+                tick: Long,
                 commandId: UUID,
             ): AddCharacterXpOutcome? = null
         }
@@ -38,7 +48,6 @@ internal class DefaultCharacterXpProgression(
     private val agents: AgentRegistry,
     private val level10: Level10ChoiceEmitter,
     private val level50: Level50EvolutionEmitter,
-    private val tickClock: TickClock,
     private val publisher: ApplicationEventPublisher,
 ) : CharacterXpProgression {
 
@@ -46,11 +55,11 @@ internal class DefaultCharacterXpProgression(
         agentId: AgentId,
         source: CharacterXpSource,
         delta: Int,
+        tick: Long,
         commandId: UUID,
     ): AddCharacterXpOutcome? {
         val outcome = agents.addCharacterXp(agentId, delta) ?: return null
         if (outcome is AddCharacterXpOutcome.Granted) {
-            val tick = tickClock.currentTick()
             publisher.publishEvent(
                 AgentEvent.CharacterXpGained(
                     agent = agentId,

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducer.kt
@@ -65,7 +65,7 @@ internal fun reduceConsume(
             ?: error("Invariant violated: agent ${command.agent} has a position but no registry row")
         progression.accrueXp(command.agent, skill, delta = 1, tick, command.commandId, agentRecord.classId)
     }
-    characterXp.grant(command.agent, CharacterXpSource.CONSUME, delta = 1, commandId = command.commandId)
+    characterXp.grant(command.agent, CharacterXpSource.CONSUME, delta = 1, tick = tick, commandId = command.commandId)
     recipeLearning.learnFromItem(command.agent, command.item, tick)
     val next = state
         .updateBody(command.agent, nextBody)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducer.kt
@@ -87,7 +87,7 @@ internal fun reduceHarvest(
     itemDef.harvestSkill?.let { skill ->
         progression.accrueXp(command.agent, skill, delta = quantity, tick, command.commandId, agentRecord.classId)
     }
-    characterXp.grant(command.agent, CharacterXpSource.HARVEST, delta = quantity, commandId = command.commandId)
+    characterXp.grant(command.agent, CharacterXpSource.HARVEST, delta = quantity, tick = tick, commandId = command.commandId)
     behaviorTracker.record(command.agent, ActionCategory.GATHER, tick)
 
     // TODO(max-stack): reject (StackFull) when adding `quantity` would exceed maxStack.

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgressionTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/classes/CharacterXpProgressionTest.kt
@@ -1,7 +1,6 @@
 package dev.gvart.genesara.world.internal.classes
 
 import dev.gvart.genesara.account.PlayerId
-import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AddCharacterXpOutcome
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentId
@@ -39,9 +38,9 @@ class CharacterXpProgressionTest {
         )
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick), RecordingPublisher())
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, RecordingPublisher())
 
-        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 100, commandId = commandId)
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 100, tick = tick, commandId = commandId)
 
         assertEquals(1, l10.invocations)
         assertEquals(tick, l10.lastTick)
@@ -64,9 +63,9 @@ class CharacterXpProgressionTest {
         )
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick), RecordingPublisher())
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, RecordingPublisher())
 
-        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 100, commandId = commandId)
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 100, tick = tick, commandId = commandId)
 
         assertEquals(0, l10.invocations)
         assertEquals(0, l50.invocations)
@@ -88,9 +87,9 @@ class CharacterXpProgressionTest {
         )
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick), RecordingPublisher())
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, RecordingPublisher())
 
-        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 1100, commandId = commandId)
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 1100, tick = tick, commandId = commandId)
 
         assertEquals(0, l10.invocations, "the offer fires only once, on the 9→10 boundary")
         assertEquals(0, l50.invocations)
@@ -113,9 +112,9 @@ class CharacterXpProgressionTest {
         )
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
-        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick), RecordingPublisher())
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, RecordingPublisher())
 
-        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 100, commandId = commandId)
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 100, tick = tick, commandId = commandId)
 
         assertEquals(0, l10.invocations, "L10 emitter only fires on the 9→10 boundary")
         assertEquals(1, l50.invocations)
@@ -128,9 +127,9 @@ class CharacterXpProgressionTest {
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
         val publisher = RecordingPublisher()
-        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick), publisher)
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, publisher)
 
-        val outcome = progression.grant(agentId, CharacterXpSource.HARVEST, delta = -5, commandId = commandId)
+        val outcome = progression.grant(agentId, CharacterXpSource.HARVEST, delta = -5, tick = tick, commandId = commandId)
 
         assertEquals(AddCharacterXpOutcome.NegativeDelta, outcome)
         assertEquals(0, l10.invocations)
@@ -144,9 +143,9 @@ class CharacterXpProgressionTest {
         val l10 = RecordingL10Emitter(agents)
         val l50 = RecordingL50Emitter(agents)
         val publisher = RecordingPublisher()
-        val progression = DefaultCharacterXpProgression(agents, l10, l50, FixedTickClock(tick), publisher)
+        val progression = DefaultCharacterXpProgression(agents, l10, l50, publisher)
 
-        val outcome = progression.grant(agentId, CharacterXpSource.HARVEST, delta = 100, commandId = commandId)
+        val outcome = progression.grant(agentId, CharacterXpSource.HARVEST, delta = 100, tick = tick, commandId = commandId)
 
         assertNull(outcome)
         assertEquals(0, l10.invocations)
@@ -173,11 +172,10 @@ class CharacterXpProgressionTest {
             agents,
             RecordingL10Emitter(agents),
             RecordingL50Emitter(agents),
-            FixedTickClock(tick),
             publisher,
         )
 
-        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 1, commandId = commandId)
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 1, tick = tick, commandId = commandId)
 
         val gained = publisher.published.single() as AgentEvent.CharacterXpGained
         assertEquals(agentId, gained.agent)
@@ -189,6 +187,34 @@ class CharacterXpProgressionTest {
         assertEquals(0, gained.unspentAttributePoints)
         assertEquals(tick, gained.tick)
         assertEquals(commandId, gained.causedBy)
+    }
+
+    @Test
+    fun `CharacterXpGained tick mirrors the caller-supplied tick verbatim`() {
+        val agents = SequencedRegistry(
+            grant = AddCharacterXpOutcome.Granted(
+                previousLevel = 1,
+                currentLevel = 1,
+                xpCurrent = 1,
+                xpToNext = 100,
+                unspentAttributePoints = 0,
+                accruedDelta = 1,
+                cappedAtPendingClassChoice = false,
+            ),
+            stateAfter = level10Unclassed().copy(level = 1),
+        )
+        val publisher = RecordingPublisher()
+        val progression = DefaultCharacterXpProgression(
+            agents,
+            RecordingL10Emitter(agents),
+            RecordingL50Emitter(agents),
+            publisher,
+        )
+
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 1, tick = 14306L, commandId = commandId)
+
+        val gained = publisher.published.single() as AgentEvent.CharacterXpGained
+        assertEquals(14306L, gained.tick)
     }
 
     @Test
@@ -210,11 +236,10 @@ class CharacterXpProgressionTest {
             agents,
             RecordingL10Emitter(agents),
             RecordingL50Emitter(agents),
-            FixedTickClock(tick),
             publisher,
         )
 
-        progression.grant(agentId, CharacterXpSource.CONSUME, delta = 600, commandId = commandId)
+        progression.grant(agentId, CharacterXpSource.CONSUME, delta = 600, tick = tick, commandId = commandId)
 
         val (gained, leveled) = publisher.published.let { it[0] to it[1] }
         gained as AgentEvent.CharacterXpGained
@@ -248,11 +273,10 @@ class CharacterXpProgressionTest {
             agents,
             RecordingL10Emitter(agents),
             RecordingL50Emitter(agents),
-            FixedTickClock(tick),
             publisher,
         )
 
-        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 5, commandId = commandId)
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 5, tick = tick, commandId = commandId)
 
         assertEquals(1, publisher.published.size, "only CharacterXpGained fires; level did not change")
         assertTrue(publisher.published.single() is AgentEvent.CharacterXpGained)
@@ -277,11 +301,10 @@ class CharacterXpProgressionTest {
             agents,
             RecordingL10Emitter(agents),
             RecordingL50Emitter(agents),
-            FixedTickClock(tick),
             publisher,
         )
 
-        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 1100, commandId = commandId)
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 1100, tick = tick, commandId = commandId)
 
         val types = publisher.published.map { it::class.simpleName }
         assertEquals(listOf("CharacterXpGained", "AgentLeveled"), types)
@@ -308,11 +331,10 @@ class CharacterXpProgressionTest {
             agents,
             RecordingL10Emitter(agents),
             RecordingL50Emitter(agents),
-            FixedTickClock(tick),
             publisher,
         )
 
-        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 5, commandId = commandId)
+        progression.grant(agentId, CharacterXpSource.HARVEST, delta = 5, tick = tick, commandId = commandId)
 
         val gained = publisher.published.single() as AgentEvent.CharacterXpGained
         assertEquals(0, gained.amount, "no headroom at the cap; the requested 5 XP is fully dropped")
@@ -378,7 +400,4 @@ class CharacterXpProgressionTest {
         }
     }
 
-    private class FixedTickClock(private val tick: Long) : TickClock {
-        override fun currentTick(): Long = tick
-    }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/consume/ConsumeReducerTest.kt
@@ -332,6 +332,7 @@ class ConsumeReducerTest {
             val agentId: AgentId,
             val source: CharacterXpSource,
             val delta: Int,
+            val tick: Long,
             val commandId: UUID,
         )
 
@@ -341,9 +342,10 @@ class ConsumeReducerTest {
             agentId: AgentId,
             source: CharacterXpSource,
             delta: Int,
+            tick: Long,
             commandId: UUID,
         ): AddCharacterXpOutcome? {
-            calls += Call(agentId, source, delta, commandId)
+            calls += Call(agentId, source, delta, tick, commandId)
             return null
         }
     }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
@@ -154,6 +154,27 @@ class HarvestReducerTest {
     }
 
     @Test
+    fun `character XP grant carries the reducer's tick — the same value that tags ResourceHarvested`() {
+        val state = stateWith()
+        val command = WorldCommand.Harvest(agent, wood)
+        val store = StubResourceStore(initial = mapOf(wood to 100))
+        val characterXp = RecordingCharacterXpProgression()
+
+        val result = reduceHarvest(
+            state, command, balance, items, store, agents, equipment,
+            SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            characterXp = characterXp, scaling = NoScaling,
+            triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 14306L,
+        )
+
+        val (_, events) = assertNotNull(result.getOrNull())
+        val harvested = events.filterIsInstance<WorldEvent.ResourceHarvested>().single()
+        val xpCall = characterXp.calls.single()
+        assertEquals(harvested.tick, xpCall.tick)
+        assertEquals(14306L, xpCall.tick)
+    }
+
+    @Test
     fun `harvest works for a MINING-skill item — the verb is no longer split`() {
         val state = stateWith()
         val command = WorldCommand.Harvest(agent, stone)
@@ -641,6 +662,7 @@ class HarvestReducerTest {
             val agentId: AgentId,
             val source: CharacterXpSource,
             val delta: Int,
+            val tick: Long,
             val commandId: UUID,
         )
 
@@ -650,9 +672,10 @@ class HarvestReducerTest {
             agentId: AgentId,
             source: CharacterXpSource,
             delta: Int,
+            tick: Long,
             commandId: UUID,
         ): AddCharacterXpOutcome? {
-            calls += Call(agentId, source, delta, commandId)
+            calls += Call(agentId, source, delta, tick, commandId)
             return null
         }
     }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
@@ -2,7 +2,6 @@ package dev.gvart.genesara.world.internal.tick
 
 import com.zaxxer.hikari.HikariDataSource
 import dev.gvart.genesara.account.PlayerId
-import dev.gvart.genesara.engine.TickClock
 import dev.gvart.genesara.player.AddCharacterXpOutcome
 import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.Agent
@@ -170,7 +169,6 @@ class WorldTickHandlerHarvestXpEventIntegrationTest {
             queue = queue,
             publisher = publisher,
             agentRegistry = agentRegistry,
-            tick = 1,
         )
 
         handler.tickOne(worldId, 1)
@@ -189,6 +187,38 @@ class WorldTickHandlerHarvestXpEventIntegrationTest {
             publisher.events.none { it is AgentEvent.AgentLeveled },
             "single-unit harvest must not cross a level boundary",
         )
+    }
+
+    @Test
+    fun `CharacterXpGained tick matches the ResourceHarvested tick — same causedBy, same world clock`() {
+        val (worldId, nodeId) = seedSingleNodeWorld("world-harvest-xp-tick")
+        staticConfig.reload()
+
+        val agent = AgentId(UUID.randomUUID())
+        seedPersistedBody(agent, hp = 50, stamina = 50)
+        seedPositionedAgent(agent, worldId, nodeId)
+
+        val command = WorldCommand.Harvest(agent, wood)
+        val queue = InMemoryCommandQueue()
+        val driftedTick = 14306L
+        queue.submitTo(worldId, command, appliesAtTick = driftedTick)
+
+        val publisher = RecordingPublisher()
+        val agentRegistry = InMemoryAgentRegistry(agent)
+        val handler = newHandler(
+            queue = queue,
+            publisher = publisher,
+            agentRegistry = agentRegistry,
+        )
+
+        handler.tickOne(worldId, driftedTick)
+
+        val harvested = publisher.events.filterIsInstance<dev.gvart.genesara.world.events.WorldEvent.ResourceHarvested>().single()
+        val xp = publisher.events.filterIsInstance<AgentEvent.CharacterXpGained>().single()
+        assertEquals(command.commandId, harvested.causedBy)
+        assertEquals(command.commandId, xp.causedBy)
+        assertEquals(driftedTick, harvested.tick)
+        assertEquals(harvested.tick, xp.tick)
     }
 
     private fun seedPersistedBody(agent: AgentId, hp: Int, stamina: Int) {
@@ -246,7 +276,6 @@ class WorldTickHandlerHarvestXpEventIntegrationTest {
         queue: InMemoryCommandQueue,
         publisher: ApplicationEventPublisher,
         agentRegistry: AgentRegistry,
-        tick: Long,
     ): WorldTickHandler {
         val skills: AgentSkillsRegistry = NoopSkillsRegistry
         val balance = HarvestBalanceLookup
@@ -258,10 +287,9 @@ class WorldTickHandlerHarvestXpEventIntegrationTest {
         val profiles = object : AgentProfileLookup {
             override fun find(id: AgentId): AgentProfile = AgentProfile(id, maxHp = 100, maxStamina = 50, maxMana = 0)
         }
-        val tickClock = FixedTickClock(tick)
         val level10 = Level10ChoiceEmitter(agentRegistry, NoOpClassLookup, InMemoryBehaviorTracker(), publisher)
         val level50 = Level50EvolutionEmitter(agentRegistry, NoOpClassLookup, InMemoryBehaviorTracker(), publisher)
-        val characterXp = DefaultCharacterXpProgression(agentRegistry, level10, level50, tickClock, publisher)
+        val characterXp = DefaultCharacterXpProgression(agentRegistry, level10, level50, publisher)
         return WorldTickHandler(
             queue, repository, presence, publisher, balance, profiles, WoodItemLookup,
             NoopRecipeLookup, dev.gvart.genesara.world.AgentKnownRecipesGateway.Empty,
@@ -290,10 +318,6 @@ class WorldTickHandlerHarvestXpEventIntegrationTest {
 
     private class FixedSpawnResolver(private val node: NodeId) : SpawnLocationResolver {
         override fun resolveFor(agentId: AgentId): NodeId = node
-    }
-
-    private class FixedTickClock(private val tick: Long) : TickClock {
-        override fun currentTick(): Long = tick
     }
 
     private object NoopKillStreakStore : KillStreakStore {


### PR DESCRIPTION
## Summary

Closes a P1 regression introduced by #168.

`DefaultCharacterXpProgression.grant()` was reading `TickClock.currentTick()` (a
process-wide `AtomicLong`) when tagging `CharacterXpGained` and `AgentLeveled`
events, instead of the per-world tick the calling reducer was already
processing. The two counters drift: playtest sessions consistently observed
~13.3k delta between `resource.harvested.tick` and `agent.xp_gained.tick` on
events sharing the same `causedBy`.

Fix threads the reducer's `tick: Long` through `grant()` and uses it verbatim
in the published events, removing the `TickClock` dependency entirely.

## Playtest evidence

| Source | World tick | `agent.xp_gained.tick` | Δ |
| --- | --- | --- | --- |
| Bob session 1 | 13736 | 387 | 13349 |
| Bob session 1 | 13848 | 499 | 13349 |
| Alice wave 2 | 14306 | 957 | 13349 |
| Bob wave 2 | (multiple) | (multiple) | 13288–13349 (drifts) |

## Test plan

- [x] `CharacterXpProgressionTest`: new `CharacterXpGained tick mirrors the caller-supplied tick verbatim` — passes 14306L explicitly, asserts event tick == 14306L.
- [x] `HarvestReducerTest`: new regression `character XP grant carries the reducer's tick — the same value that tags ResourceHarvested`.
- [x] `WorldTickHandlerHarvestXpEventIntegrationTest`: new `CharacterXpGained tick matches the ResourceHarvested tick — same causedBy, same world clock` drives a real harvest at tick 14306 through `tickOne` and asserts both events on the agent stream carry that tick.
- [x] `:world:test :player:test :api:test` all green.