### PR TITLE
fix(world): reject duplicate building of same type at same node

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/build/BuildTool.kt
@@ -23,6 +23,9 @@ internal class BuildTool(
         name = "build",
         description = "Spend one work step on a building type at the agent's current node. " +
             "First call lays the foundation; subsequent calls advance the same in-progress build until it completes. " +
+            "At most one instance per (buildingType, node) is allowed: laying a fresh foundation is rejected with " +
+            "DuplicateBuildingAtNode when another non-destroyed instance of the same type already occupies the node " +
+            "(yours or another agent's). Different types may share a node; build elsewhere to add a second of the same type. " +
             "Queues a BuildStructure command; the resulting building.progressed event (or building.constructed " +
             "on the terminal step) arrives on the agent's event stream once the tick lands. Costs per-step " +
             "stamina + materials.",

--- a/world/src/main/kotlin/dev/gvart/genesara/world/BuildingsStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/BuildingsStore.kt
@@ -41,6 +41,16 @@ interface BuildingsStore {
     fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building?
 
     /**
+     * Find any existing instance of [type] at [node] regardless of builder agent or
+     * lifecycle stage (UNDER_CONSTRUCTION or ACTIVE — destruction will drop the row).
+     * Drives the duplicate-at-node precondition in the build reducer: a second agent
+     * (or the same agent) attempting to lay a fresh foundation of the same type at
+     * an already-occupied node is rejected. Returns `null` when no such instance
+     * exists.
+     */
+    fun findAnyAtNodeOfType(node: NodeId, type: BuildingType): Building?
+
+    /**
      * Every building (any status) attached to [node], ordered by `instance_id`
      * for stability. Used by the inspect / look_around projections when only
      * one node is needed.

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
@@ -118,6 +118,20 @@ sealed interface WorldRejection {
         val current: Int,
     ) : WorldRejection
 
+    /**
+     * Agent tried to lay a fresh foundation for [type] at [node], but another
+     * non-destroyed instance of the same type already exists there (either
+     * UNDER_CONSTRUCTION by any agent or ACTIVE). At most one instance per
+     * (buildingType, node) pair is allowed. Surfaced only on the foundation step;
+     * advancing an agent's own existing in-progress build is unaffected.
+     */
+    data class DuplicateBuildingAtNode(
+        val agent: AgentId,
+        val type: BuildingType,
+        val node: NodeId,
+        val existingInstanceId: java.util.UUID,
+    ) : WorldRejection
+
     /** Chest reducer target id does not resolve to any building row. */
     data class BuildingNotFound(val building: java.util.UUID) : WorldRejection
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
@@ -67,6 +67,19 @@ internal fun reduceBuild(
     }
 
     val existing = buildings.findInProgress(nodeId, command.agent, command.type)
+    if (existing == null) {
+        val occupant = buildings.findAnyAtNodeOfType(nodeId, command.type)
+        if (occupant != null) {
+            raise(
+                WorldRejection.DuplicateBuildingAtNode(
+                    agent = command.agent,
+                    type = command.type,
+                    node = nodeId,
+                    existingInstanceId = occupant.instanceId,
+                ),
+            )
+        }
+    }
     val nextProgress = (existing?.progressSteps ?: 0) + 1
     val stepCost = def.stepMaterials[nextProgress - 1]
     val inventory = state.inventoryOf(command.agent)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/JooqBuildingsStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/JooqBuildingsStore.kt
@@ -50,6 +50,15 @@ internal class JooqBuildingsStore(
             .fetchOne(::toDomain)
 
     @Transactional(readOnly = true)
+    override fun findAnyAtNodeOfType(node: NodeId, type: BuildingType): Building? =
+        dsl.selectFrom(NODE_BUILDINGS)
+            .where(NODE_BUILDINGS.NODE_ID.eq(node.value))
+            .and(NODE_BUILDINGS.BUILDING_TYPE.eq(type.name))
+            .orderBy(NODE_BUILDINGS.BUILT_AT_TICK.asc(), NODE_BUILDINGS.INSTANCE_ID.asc())
+            .limit(1)
+            .fetchOne(::toDomain)
+
+    @Transactional(readOnly = true)
     override fun listAtNode(node: NodeId): List<Building> =
         dsl.selectFrom(NODE_BUILDINGS)
             .where(NODE_BUILDINGS.NODE_ID.eq(node.value))

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
@@ -292,7 +292,65 @@ class BuildReducerTest {
     }
 
     @Test
-    fun `agent B starting a build of the same type does NOT advance agent A's in-progress row`() {
+    fun `two agents submitting build of the same type at the same node within one tick — first wins, second is rejected with DuplicateBuildingAtNode`() {
+        val agentB = AgentId(UUID.randomUUID())
+        val state = WorldState(
+            regions = mapOf(regionId to region),
+            nodes = mapOf(nodeId to Node(nodeId, regionId, q = 0, r = 0, terrain = Terrain.FOREST, adjacency = emptySet())),
+            positions = mapOf(agent to nodeId, agentB to nodeId),
+            bodies = mapOf(
+                agent to AgentBody(50, 50, 50, 50, 0, 0),
+                agentB to AgentBody(50, 50, 50, 50, 0, 0),
+            ),
+            inventories = mapOf(
+                agent to AgentInventory().add(wood, 100).add(stone, 100),
+                agentB to AgentInventory().add(wood, 100).add(stone, 100),
+            ),
+        )
+        val chestCatalog = BuildingsCatalog(
+            BuildingDefinitionProperties(
+                catalog = mapOf(
+                    "STORAGE_CHEST" to BuildingProperties(
+                        requiredSkill = "CARPENTRY",
+                        totalSteps = 8,
+                        staminaPerStep = 1,
+                        hp = 40,
+                        categoryHint = BuildingCategoryHint.STORAGE,
+                        totalMaterials = mapOf("WOOD" to 16),
+                        chestCapacityGrams = 50_000,
+                    ),
+                ),
+            ),
+        )
+        val store = StubBuildingsStore()
+        val skills = StubSkillsRegistry()
+
+        val (afterA, eventsA) = assertNotNull(
+            reduceBuild(
+                state, WorldCommand.BuildStructure(agent, BuildingType.STORAGE_CHEST),
+                chestCatalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()),
+                triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 100,
+            ).getOrNull(),
+        )
+        assertIs<WorldEvent.BuildingProgressed>(eventsA.single())
+
+        val rejection = reduceBuild(
+            afterA, WorldCommand.BuildStructure(agentB, BuildingType.STORAGE_CHEST),
+            chestCatalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()),
+            triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 100,
+        ).leftOrNull()
+
+        val duplicate = assertIs<WorldRejection.DuplicateBuildingAtNode>(rejection)
+        assertEquals(agentB, duplicate.agent)
+        assertEquals(BuildingType.STORAGE_CHEST, duplicate.type)
+        assertEquals(nodeId, duplicate.node)
+        assertEquals(store.rows.single().instanceId, duplicate.existingInstanceId)
+        assertEquals(1, store.rows.size)
+        assertEquals(agent, store.rows.single().builtByAgentId)
+    }
+
+    @Test
+    fun `agent B is rejected with DuplicateBuildingAtNode when A has an in-progress same-type build at the node`() {
         val agentB = AgentId(UUID.randomUUID())
         val state = WorldState(
             regions = mapOf(regionId to region),
@@ -310,37 +368,55 @@ class BuildReducerTest {
         val store = StubBuildingsStore(rows = mutableListOf(agentARow))
         val skills = StubSkillsRegistry()
 
-        val (_, events) = assertNotNull(
-            reduceBuild(
-                state, WorldCommand.BuildStructure(agentB, BuildingType.CAMPFIRE),
-                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 5,
-            ).getOrNull(),
+        val result = reduceBuild(
+            state, WorldCommand.BuildStructure(agentB, BuildingType.CAMPFIRE),
+            catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 5,
         )
 
-        val firstStep = assertIs<WorldEvent.BuildingProgressed>(events.single())
-        assertEquals(1, firstStep.step)
-        assertEquals(2, store.rows.size)
-        assertEquals(2, store.rows.first { it.builtByAgentId == agent }.progressSteps)
+        val rejection = assertIs<WorldRejection.DuplicateBuildingAtNode>(result.leftOrNull())
+        assertEquals(BuildingType.CAMPFIRE, rejection.type)
+        assertEquals(nodeId, rejection.node)
+        assertEquals(agentARow.instanceId, rejection.existingInstanceId)
+        assertEquals(1, store.rows.size)
+        assertEquals(2, store.rows.single().progressSteps)
     }
 
     @Test
-    fun `after completion a follow-up build call starts a fresh UNDER_CONSTRUCTION instance`() {
+    fun `rejects with DuplicateBuildingAtNode when an ACTIVE same-type instance already occupies the node`() {
         val state = stateWith()
         val finished = sampleBuilding(progress = 5, totalSteps = 5)
         val store = StubBuildingsStore(rows = mutableListOf(finished))
         val skills = StubSkillsRegistry()
 
+        val result = reduceBuild(
+            state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
+            catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 12,
+        )
+
+        val rejection = assertIs<WorldRejection.DuplicateBuildingAtNode>(result.leftOrNull())
+        assertEquals(BuildingType.CAMPFIRE, rejection.type)
+        assertEquals(finished.instanceId, rejection.existingInstanceId)
+        assertEquals(1, store.rows.size)
+    }
+
+    @Test
+    fun `accepts the foundation step when only a different-type instance occupies the node`() {
+        val state = stateWith()
+        val shelter = sampleBuilding(type = BuildingType.SHELTER, progress = 2, totalSteps = 2, hp = 80)
+        val store = StubBuildingsStore(rows = mutableListOf(shelter))
+        val skills = StubSkillsRegistry()
+
         val (_, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 12,
+                catalog, skills, store, StubSafeNodes(), SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
             ).getOrNull(),
         )
 
         val firstStep = assertIs<WorldEvent.BuildingProgressed>(events.single())
         assertEquals(1, firstStep.step)
+        assertEquals(BuildingType.CAMPFIRE, firstStep.type)
         assertEquals(2, store.rows.size)
-        assertEquals(0, store.completed.size)
     }
 
     @Test
@@ -545,6 +621,8 @@ class BuildReducerTest {
                 it.nodeId == node && it.builtByAgentId == agent && it.type == type &&
                     it.status == BuildingStatus.UNDER_CONSTRUCTION
             }
+        override fun findAnyAtNodeOfType(node: NodeId, type: BuildingType): Building? =
+            rows.firstOrNull { it.nodeId == node && it.type == type }
         override fun listAtNode(node: NodeId): List<Building> = rows.filter { it.nodeId == node }
         override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
             rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsLookupImplTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildingsLookupImplTest.kt
@@ -84,6 +84,7 @@ class BuildingsLookupImplTest {
         override fun insert(building: Building) = error("unused")
         override fun findById(id: UUID): Building? = rows.firstOrNull { it.instanceId == id }
         override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? = error("unused")
+        override fun findAnyAtNodeOfType(node: NodeId, type: BuildingType): Building? = error("unused")
         override fun listAtNode(node: NodeId): List<Building> = rows.filter { it.nodeId == node }
         override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
             rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/ChestReducersTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/ChestReducersTest.kt
@@ -399,6 +399,8 @@ class ChestReducersTest {
                 it.nodeId == node && it.builtByAgentId == agent && it.type == type &&
                     it.status == BuildingStatus.UNDER_CONSTRUCTION
             }
+        override fun findAnyAtNodeOfType(node: NodeId, type: BuildingType): Building? =
+            rows.firstOrNull { it.nodeId == node && it.type == type }
         override fun listAtNode(node: NodeId): List<Building> = rows.filter { it.nodeId == node }
         override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
             rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/JooqBuildingsStoreIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/JooqBuildingsStoreIntegrationTest.kt
@@ -128,6 +128,50 @@ class JooqBuildingsStoreIntegrationTest {
     }
 
     @Test
+    fun `findAnyAtNodeOfType returns an ACTIVE same-type instance regardless of which agent built it`() {
+        val theirs = sampleBuilding(
+            agent = otherAgent,
+            type = BuildingType.STORAGE_CHEST,
+            progress = 8,
+            totalSteps = 8,
+            status = BuildingStatus.ACTIVE,
+        )
+        store.insert(theirs)
+
+        assertEquals(theirs, store.findAnyAtNodeOfType(node1, BuildingType.STORAGE_CHEST))
+    }
+
+    @Test
+    fun `findAnyAtNodeOfType returns an UNDER_CONSTRUCTION same-type instance built by anyone`() {
+        val theirs = sampleBuilding(
+            agent = otherAgent,
+            type = BuildingType.STORAGE_CHEST,
+            progress = 3,
+            totalSteps = 8,
+            status = BuildingStatus.UNDER_CONSTRUCTION,
+        )
+        store.insert(theirs)
+
+        assertEquals(theirs, store.findAnyAtNodeOfType(node1, BuildingType.STORAGE_CHEST))
+    }
+
+    @Test
+    fun `findAnyAtNodeOfType is scoped per type — different types do not collide`() {
+        val campfire = sampleBuilding(type = BuildingType.CAMPFIRE, progress = 5, totalSteps = 5, status = BuildingStatus.ACTIVE)
+        store.insert(campfire)
+
+        assertNull(store.findAnyAtNodeOfType(node1, BuildingType.STORAGE_CHEST))
+    }
+
+    @Test
+    fun `findAnyAtNodeOfType is scoped per node — same type at a different node does not collide`() {
+        val elsewhere = sampleBuilding(nodeId = node2, type = BuildingType.STORAGE_CHEST, progress = 8, totalSteps = 8, status = BuildingStatus.ACTIVE)
+        store.insert(elsewhere)
+
+        assertNull(store.findAnyAtNodeOfType(node1, BuildingType.STORAGE_CHEST))
+    }
+
+    @Test
     fun `listAtNode returns every status, ordered by instance_id for stability`() {
         val ids = listOf(
             UUID.fromString("00000000-0000-0000-0000-000000000003"),

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
@@ -446,6 +446,7 @@ class WorldTickHandlerHarvestXpEventIntegrationTest {
         override fun insert(building: Building) = error("not used")
         override fun findById(id: UUID): Building? = null
         override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? = null
+        override fun findAnyAtNodeOfType(node: NodeId, type: BuildingType): Building? = null
         override fun listAtNode(node: NodeId): List<Building> = emptyList()
         override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = emptyMap()
         override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = null

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerSpawnResumeIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerSpawnResumeIntegrationTest.kt
@@ -338,6 +338,7 @@ class WorldTickHandlerSpawnResumeIntegrationTest {
         override fun insert(building: Building) = error("not used")
         override fun findById(id: UUID): Building? = null
         override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? = null
+        override fun findAnyAtNodeOfType(node: NodeId, type: BuildingType): Building? = null
         override fun listAtNode(node: NodeId): List<Building> = emptyList()
         override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = emptyMap()
         override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = null

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -388,6 +388,10 @@ class WorldTickHandlerTest {
             agent: AgentId,
             type: dev.gvart.genesara.world.BuildingType,
         ): dev.gvart.genesara.world.Building? = null
+        override fun findAnyAtNodeOfType(
+            node: NodeId,
+            type: dev.gvart.genesara.world.BuildingType,
+        ): dev.gvart.genesara.world.Building? = null
         override fun listAtNode(node: NodeId): List<dev.gvart.genesara.world.Building> = emptyList()
         override fun listByNodes(
             nodes: Set<NodeId>,


### PR DESCRIPTION
## Summary

Adds a foundation-step precondition to `reduceBuild` that rejects laying a fresh foundation when another non-destroyed instance of the same `BuildingType` already occupies the target node (any builder agent, `UNDER_CONSTRUCTION` or `ACTIVE`). Multi-step progression of an agent's own in-progress build is unaffected — the new check fires only when no in-progress row exists for the caller, so the find-or-create-then-advance path keeps working.

New rejection: `WorldRejection.DuplicateBuildingAtNode { agent, type, node, existingInstanceId }`. Agents see it on the event stream as `command.rejected { kind:"DuplicateBuildingAtNode" }` through the existing `WorldTickHandler` mapping (`kind` is auto-derived from the rejection's class simple name, no extra wiring needed). The `build` MCP tool description now mentions the constraint.

## Wave-2 playtest evidence

Alice and Bob both at node 539 — current engine accepts three coexisting `STORAGE_CHEST` instances:

- Alice's first `834537a8-...` `ACTIVE`
- Bob's `610b283e-...` `ACTIVE`
- Alice's second `831f4989-...` `UNDER_CONSTRUCTION`

With this PR, Bob's command and Alice's second command are rejected with `DuplicateBuildingAtNode` carrying `existingInstanceId = 834537a8-...`.

## Spec citation

`docs/lore/mechanics-reference.md` §13 "Nodes & Territory" — "the base building's tier governs the node — which other buildings can exist..." The spec is silent on the explicit duplicate guard at the engine level, so this lands the task-default rule: at most one instance per `(buildingType, node)`. Different types may still share a node.

## Files touched

- `world/.../BuildingsStore.kt` — new `findAnyAtNodeOfType(node, type)`.
- `world/.../JooqBuildingsStore.kt` — jOOQ implementation (one-row `SELECT ... WHERE node_id=? AND building_type=? LIMIT 1`).
- `world/.../BuildReducer.kt` — precondition gated on `existing == null` (foundation step only).
- `world/.../WorldRejection.kt` — new `DuplicateBuildingAtNode` data class.
- `api/.../BuildTool.kt` — tool description mentions the constraint.
- Test stubs updated in `BuildReducerTest`, `BuildingsLookupImplTest`, `ChestReducersTest`, `WorldTickHandlerTest`, `WorldTickHandlerHarvestXpEventIntegrationTest`, `WorldTickHandlerSpawnResumeIntegrationTest`.

## Test plan

- [x] Unit: rejects when an `ACTIVE` same-type instance occupies the node.
- [x] Unit: rejects when an `UNDER_CONSTRUCTION` same-type instance (any agent) occupies the node.
- [x] Unit: accepts a fresh foundation when only a *different*-type instance occupies the node.
- [x] Unit: agent's own multi-step progression is not tripped by the new precondition (covered by the existing 8-step `STORAGE_CHEST` and 5-step `CAMPFIRE` walkthrough tests, now exercising the guard naturally).
- [x] Integration (reducer-level, two-agent state-threaded): A submits → progresses; B submits next on the post-A state → rejected with `DuplicateBuildingAtNode`, store has exactly one row built by A.
- [x] Integration (jOOQ): `findAnyAtNodeOfType` finds an `ACTIVE` row built by any agent, finds an `UNDER_CONSTRUCTION` row built by any agent, is scoped per type, is scoped per node.
- [x] `./gradlew :world:test :api:test` — green.

## Out of scope

- Building destruction isn't implemented yet, so the "previously destroyed → can rebuild" case isn't exercised. The guard is structured to allow it once destruction lands (`findAnyAtNodeOfType` only matches surviving rows; a destroyed row would be deleted).