### PR TITLE
feat(world,api): say MCP tool for proximity chat (#12)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
@@ -29,6 +29,7 @@ import dev.gvart.genesara.api.internal.mcp.tools.perks.SelectPerkTool
 import dev.gvart.genesara.api.internal.mcp.tools.pickup.PickupTool
 import dev.gvart.genesara.api.internal.mcp.tools.respawn.RespawnTool
 import dev.gvart.genesara.api.internal.mcp.tools.safenode.SetSafeNodeTool
+import dev.gvart.genesara.api.internal.mcp.tools.say.SayTool
 import dev.gvart.genesara.api.internal.mcp.tools.skills.EquipSkillTool
 import dev.gvart.genesara.api.internal.mcp.tools.spawn.SpawnTool
 import dev.gvart.genesara.api.internal.mcp.tools.unspawn.UnspawnTool
@@ -76,6 +77,7 @@ internal class McpServerConfiguration {
         selectEvolution: SelectEvolutionTool,
         selectPerk: SelectPerkTool,
         getRecipes: GetRecipesTool,
+        say: SayTool,
     ): ToolCallbackProvider {
         val methodProvider = MethodToolCallbackProvider.builder()
             .toolObjects(
@@ -83,7 +85,7 @@ internal class McpServerConfiguration {
                 consume, drink, equipSkill, allocatePoints, inspect, getMap,
                 equipItem, unequipSlot,
                 setSafeNode, respawn, build, depositToChest, withdrawFromChest, craft, pickup, attack,
-                useAbility, selectClass, selectEvolution, selectPerk, getRecipes,
+                useAbility, selectClass, selectEvolution, selectPerk, getRecipes, say,
             )
             .build()
         return EnumCaseInsensitiveToolCallbackProvider(methodProvider)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -146,6 +146,11 @@ internal class AgentEventDispatcher(
     @EventListener
     fun on(event: WorldEvent.DerivedPoolsRefreshed) = publish(event.agent, "pools.refreshed", event)
 
+    @EventListener
+    fun on(event: WorldEvent.AgentSpoke) {
+        event.listeners.forEach { listener -> publish(listener, "agent.spoke", event) }
+    }
+
     private fun publish(agent: AgentId, type: String, payload: Any) {
         val tick = (payload as? WorldEvent)?.tick
             ?: (payload as? AgentEvent)?.tick

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/say/SayTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/say/SayTool.kt
@@ -1,0 +1,53 @@
+package dev.gvart.genesara.api.internal.mcp.tools.say
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.world.SayChannel
+import dev.gvart.genesara.world.SpeechMode
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.ai.tool.annotation.ToolParam
+import org.springframework.stereotype.Component
+
+@Component
+internal class SayTool(
+    private val world: WorldCommandGateway,
+    private val engine: TickClock,
+    private val activity: AgentActivityTracker,
+) {
+
+    @Tool(
+        name = "say",
+        description = "Speak aloud. Every agent within node-hop range hears you and receives an " +
+            "agent.spoke event — including yourself. Volume sets the reach: WHISPER (1 hop), " +
+            "NORMAL (3 hops, default), SCREAM (5 hops). Channel is LOCAL in v1. Queues a Say " +
+            "command; the agent.spoke event arrives on listeners' streams once the tick lands. " +
+            "Messages longer than the balance cap are rejected with MessageTooLong.",
+    )
+    fun invoke(
+        @ToolParam(required = true, description = "Message text to broadcast to listeners in range.")
+        message: String,
+        @ToolParam(required = false, description = "Volume — WHISPER (1 hop), NORMAL (3 hops, default), SCREAM (5 hops).")
+        mode: SpeechMode?,
+        @ToolParam(required = false, description = "Routing channel; v1 supports LOCAL only.")
+        channel: SayChannel?,
+        toolContext: ToolContext,
+    ): SayResponse {
+        touchActivity(toolContext, activity, "say")
+        val resolvedMode = mode ?: SpeechMode.NORMAL
+        val resolvedChannel = channel ?: SayChannel.LOCAL
+        val agent = AgentContextHolder.current()
+        val command = WorldCommand.Say(
+            agent = agent,
+            message = message,
+            mode = resolvedMode,
+            channel = resolvedChannel,
+        )
+        val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
+        return SayResponse.queued(command.commandId, appliesAtTick, resolvedMode, resolvedChannel)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/say/SayToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/say/SayToolIo.kt
@@ -1,0 +1,19 @@
+package dev.gvart.genesara.api.internal.mcp.tools.say
+
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
+import dev.gvart.genesara.world.SayChannel
+import dev.gvart.genesara.world.SpeechMode
+import java.util.UUID
+
+data class SayResponse(
+    val kind: CommandAckKind,
+    val mode: SpeechMode,
+    val channel: SayChannel,
+    val commandId: UUID? = null,
+    val appliesAtTick: Long? = null,
+) {
+    companion object {
+        fun queued(commandId: UUID, appliesAtTick: Long, mode: SpeechMode, channel: SayChannel) =
+            SayResponse(CommandAckKind.QUEUED, mode, channel, commandId, appliesAtTick)
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
@@ -413,6 +413,37 @@ class AgentEventDispatcherTest {
     }
 
     @Test
+    fun `AgentSpoke fans out one envelope per listener with full payload intact`() {
+        val speaker = AgentId(UUID.randomUUID())
+        val listener1 = AgentId(UUID.randomUUID())
+        val listener2 = AgentId(UUID.randomUUID())
+        val cmdId = UUID.randomUUID()
+        val event = WorldEvent.AgentSpoke(
+            speaker = speaker,
+            at = NodeId(1L),
+            message = "hello",
+            mode = dev.gvart.genesara.world.SpeechMode.NORMAL,
+            channel = dev.gvart.genesara.world.SayChannel.LOCAL,
+            listeners = setOf(speaker, listener1, listener2),
+            tick = 7L,
+            causedBy = cmdId,
+        )
+
+        dispatcher.on(event)
+
+        listOf(speaker, listener1, listener2).forEach { recipient ->
+            val entry = log.since(recipient, 0).single()
+            assertEquals("agent.spoke", entry.type)
+            assertEquals(7L, entry.tick)
+            assertEquals("hello", entry.payload.get("message").asString())
+            assertEquals("NORMAL", entry.payload.get("mode").asString())
+            assertEquals("LOCAL", entry.payload.get("channel").asString())
+            assertEquals(cmdId.toString(), entry.payload.get("causedBy").asString())
+            verify(bus).publish(InvalidationMessage.AgentNotify(recipient))
+        }
+    }
+
+    @Test
     fun `PassivesApplied fans out one envelope per affected agent`() {
         val a1 = AgentId(UUID.randomUUID())
         val a2 = AgentId(UUID.randomUUID())

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/say/SayToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/say/SayToolTest.kt
@@ -1,0 +1,95 @@
+package dev.gvart.genesara.api.internal.mcp.tools.say
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.SayChannel
+import dev.gvart.genesara.world.SpeechMode
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class SayToolTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val clock = MutableTestClock(Instant.parse("2026-01-01T00:00:00Z"))
+    private val activity = AgentActivityRegistry(clock)
+    private val gateway = RecordingGateway()
+    private val tickClock = StubTickClock(currentTick = 50L)
+    private val toolContext = ToolContext(emptyMap())
+
+    @BeforeEach fun setUp() = AgentContextHolder.set(agent)
+    @AfterEach fun tearDown() = AgentContextHolder.clear()
+
+    @Test
+    fun `queues a Say command at next tick with explicit mode and channel`() {
+        val tool = SayTool(gateway, tickClock, activity)
+
+        val response = tool.invoke("hi there", SpeechMode.SCREAM, SayChannel.LOCAL, toolContext)
+
+        assertEquals(CommandAckKind.QUEUED, response.kind)
+        assertEquals(SpeechMode.SCREAM, response.mode)
+        assertEquals(SayChannel.LOCAL, response.channel)
+        assertEquals(51L, response.appliesAtTick)
+        val (cmd, appliesAt) = gateway.submissions.single()
+        val say = assertNotNull(cmd as? WorldCommand.Say)
+        assertEquals(agent, say.agent)
+        assertEquals("hi there", say.message)
+        assertEquals(SpeechMode.SCREAM, say.mode)
+        assertEquals(SayChannel.LOCAL, say.channel)
+        assertEquals(51L, appliesAt)
+        assertEquals(say.commandId, response.commandId)
+    }
+
+    @Test
+    fun `null mode defaults to NORMAL`() {
+        val tool = SayTool(gateway, tickClock, activity)
+
+        val response = tool.invoke("hi", null, SayChannel.LOCAL, toolContext)
+
+        assertEquals(SpeechMode.NORMAL, response.mode)
+        val say = assertNotNull(gateway.submissions.single().first as? WorldCommand.Say)
+        assertEquals(SpeechMode.NORMAL, say.mode)
+    }
+
+    @Test
+    fun `null channel defaults to LOCAL`() {
+        val tool = SayTool(gateway, tickClock, activity)
+
+        val response = tool.invoke("hi", SpeechMode.WHISPER, null, toolContext)
+
+        assertEquals(SayChannel.LOCAL, response.channel)
+        val say = assertNotNull(gateway.submissions.single().first as? WorldCommand.Say)
+        assertEquals(SayChannel.LOCAL, say.channel)
+    }
+
+    private class RecordingGateway : WorldCommandGateway {
+        val submissions = mutableListOf<Pair<WorldCommand, Long>>()
+        override fun submit(command: WorldCommand, appliesAtTick: Long): Long {
+            submissions += command to appliesAtTick
+            return appliesAtTick
+        }
+    }
+
+    private class StubTickClock(private val currentTick: Long) : TickClock {
+        override fun currentTick(): Long = currentTick
+    }
+
+    private class MutableTestClock(private var now: Instant) : Clock() {
+        override fun instant(): Instant = now
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/SayChannel.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/SayChannel.kt
@@ -1,0 +1,11 @@
+package dev.gvart.genesara.world
+
+/**
+ * Routing channel of a [dev.gvart.genesara.world.commands.WorldCommand.Say]. v1 ships
+ * [LOCAL] only — clan and trade channels land alongside Phase 3 clans and trade
+ * infrastructure (issues #22 / #13) by extending this enum and the reducer's recipient
+ * resolution.
+ */
+enum class SayChannel {
+    LOCAL,
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/SpeechMode.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/SpeechMode.kt
@@ -1,0 +1,12 @@
+package dev.gvart.genesara.world
+
+/**
+ * Volume of a [dev.gvart.genesara.world.commands.WorldCommand.Say]. The reducer maps
+ * this to a node-hop radius via [dev.gvart.genesara.world.internal.balance.BalanceLookup.sayRangeFor]
+ * — wider modes reach further listeners. Default at the API edge is [NORMAL].
+ */
+enum class SpeechMode {
+    WHISPER,
+    NORMAL,
+    SCREAM,
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
@@ -313,4 +313,15 @@ sealed interface WorldRejection {
         val ability: AbilityId,
         val target: AgentId,
     ) : WorldRejection
+
+    /**
+     * Speaker's message length exceeds [max]. Surfaced by the `say` reducer so an agent
+     * who pasted a wall of text gets a deterministic, actionable error rather than a
+     * silent truncation.
+     */
+    data class MessageTooLong(
+        val agent: AgentId,
+        val length: Int,
+        val max: Int,
+    ) : WorldRejection
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
@@ -6,6 +6,8 @@ import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.RecipeId
+import dev.gvart.genesara.world.SayChannel
+import dev.gvart.genesara.world.SpeechMode
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import java.util.UUID
@@ -37,6 +39,7 @@ import java.util.UUID
     JsonSubTypes.Type(value = WorldCommand.AttackTarget::class, name = "attack"),
     JsonSubTypes.Type(value = WorldCommand.UseAbility::class, name = "useAbility"),
     JsonSubTypes.Type(value = WorldCommand.RefreshDerivedPools::class, name = "refreshDerivedPools"),
+    JsonSubTypes.Type(value = WorldCommand.Say::class, name = "say"),
 )
 sealed interface WorldCommand {
     val agent: AgentId
@@ -207,6 +210,21 @@ sealed interface WorldCommand {
         val maxHp: Int,
         val maxStamina: Int,
         val maxMana: Int,
+        override val commandId: UUID = UUID.randomUUID(),
+    ) : WorldCommand
+
+    /**
+     * Speak [message] aloud. The reducer resolves listeners by BFS over node adjacency
+     * out to [SpeechMode]'s configured radius and emits a single
+     * [dev.gvart.genesara.world.events.WorldEvent.AgentSpoke] carrying the listener set;
+     * the speaker is always included (self-hearing). v1 supports only [SayChannel.LOCAL]
+     * — clan/trade channels land with Phase 3.
+     */
+    data class Say(
+        override val agent: AgentId,
+        val message: String,
+        val mode: SpeechMode,
+        val channel: SayChannel,
         override val commandId: UUID = UUID.randomUUID(),
     ) : WorldCommand
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
@@ -16,6 +16,8 @@ import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.Rarity
 import dev.gvart.genesara.world.RecipeId
+import dev.gvart.genesara.world.SayChannel
+import dev.gvart.genesara.world.SpeechMode
 import dev.gvart.genesara.world.WorldRejection
 import java.util.UUID
 
@@ -319,6 +321,24 @@ sealed interface WorldEvent {
         val maxHp: Int,
         val maxStamina: Int,
         val maxMana: Int,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : WorldEvent
+
+    /**
+     * Emitted by the [dev.gvart.genesara.world.commands.WorldCommand.Say] reducer with
+     * the deterministic set of [listeners] resolved at the reducer's tick (every agent
+     * within [mode]'s hop radius of [at], including the speaker for self-hearing). The
+     * dispatcher fans this single event out by iterating [listeners] and writing one
+     * `agent.spoke` envelope per listener — same shape as [PassivesApplied].
+     */
+    data class AgentSpoke(
+        val speaker: AgentId,
+        val at: NodeId,
+        val message: String,
+        val mode: SpeechMode,
+        val channel: SayChannel,
+        val listeners: Set<AgentId>,
         override val tick: Long,
         val causedBy: UUID,
     ) : WorldEvent

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -48,6 +48,7 @@ import dev.gvart.genesara.world.internal.movement.reduceMove
 import dev.gvart.genesara.world.internal.perks.TriggeredPassiveDispatcher
 import dev.gvart.genesara.world.internal.pickup.reducePickup
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
+import dev.gvart.genesara.world.internal.say.reduceSay
 import dev.gvart.genesara.world.internal.spawn.SpawnLocationResolver
 import dev.gvart.genesara.world.internal.spawn.reduceSpawn
 import dev.gvart.genesara.world.internal.spawn.reduceUnspawn
@@ -132,4 +133,5 @@ internal fun reduce(
             progression, balance, behaviorTracker, tickIntervalSeconds, tick,
         )
     is WorldCommand.RefreshDerivedPools -> reduceRefreshDerivedPools(state, command, tick)
+    is WorldCommand.Say -> reduceSay(state, command, balance, tick)
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -9,6 +9,7 @@ import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.Rarity
 import dev.gvart.genesara.world.ResourceSpawnRule
+import dev.gvart.genesara.world.SpeechMode
 import dev.gvart.genesara.world.Terrain
 import org.springframework.stereotype.Component
 import kotlin.math.roundToInt
@@ -203,6 +204,27 @@ internal interface BalanceLookup {
         Rarity.RARE -> 1.5
         Rarity.EPIC -> 1.75
         Rarity.LEGENDARY -> 2.0
+    }
+
+    /**
+     * Maximum character count of a [dev.gvart.genesara.world.commands.WorldCommand.Say]
+     * message. Longer messages are rejected with
+     * [dev.gvart.genesara.world.WorldRejection.MessageTooLong]. Cap is per-message;
+     * an agent can still spam by calling `say` repeatedly — back-pressure for that
+     * lands as a tuning slice (stamina cost, cooldown) later.
+     */
+    fun maxSayMessageLength(): Int = 500
+
+    /**
+     * Node-hop radius reached by a [dev.gvart.genesara.world.commands.WorldCommand.Say]
+     * at the given [mode]. The reducer BFS-walks node adjacency out to this depth and
+     * routes the event to every agent positioned within. Defaults: WHISPER=1, NORMAL=3,
+     * SCREAM=5. Tunable later for psionic / perk-driven amplifiers.
+     */
+    fun sayRangeFor(mode: SpeechMode): Int = when (mode) {
+        SpeechMode.WHISPER -> 1
+        SpeechMode.NORMAL -> 3
+        SpeechMode.SCREAM -> 5
     }
 
     /** XP delta granted to the weapon's combat-skill per successful attack. Mirrors craft/build at 1. */

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/say/SayReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/say/SayReducer.kt
@@ -1,0 +1,68 @@
+package dev.gvart.genesara.world.internal.say
+
+import arrow.core.Either
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import arrow.core.raise.ensureNotNull
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+
+internal fun reduceSay(
+    state: WorldState,
+    command: WorldCommand.Say,
+    balance: BalanceLookup,
+    tick: Long,
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
+    val origin = ensureNotNull(state.positions[command.agent]) {
+        WorldRejection.NotInWorld(command.agent)
+    }
+    val max = balance.maxSayMessageLength()
+    ensure(command.message.length <= max) {
+        WorldRejection.MessageTooLong(command.agent, command.message.length, max)
+    }
+
+    val radius = balance.sayRangeFor(command.mode)
+    val reachable = nodesWithin(state.nodes, origin, radius)
+    // Speaker's own node is always in `reachable`, so the speaker is always in `listeners` —
+    // self-hearing falls out of the BFS without a dispatcher-side special case.
+    val listeners = state.positions
+        .asSequence()
+        .filter { (_, node) -> node in reachable }
+        .map { it.key }
+        .toSet()
+
+    val event = WorldEvent.AgentSpoke(
+        speaker = command.agent,
+        at = origin,
+        message = command.message,
+        mode = command.mode,
+        channel = command.channel,
+        listeners = listeners,
+        tick = tick,
+        causedBy = command.commandId,
+    )
+    state to listOf(event)
+}
+
+private fun nodesWithin(nodes: Map<NodeId, Node>, origin: NodeId, radius: Int): Set<NodeId> {
+    if (radius < 0) return emptySet()
+    val visited = mutableSetOf(origin)
+    var frontier: Set<NodeId> = setOf(origin)
+    repeat(radius) {
+        val next = mutableSetOf<NodeId>()
+        for (id in frontier) {
+            val adj = nodes[id]?.adjacency ?: continue
+            for (neighbour in adj) {
+                if (visited.add(neighbour)) next += neighbour
+            }
+        }
+        if (next.isEmpty()) return visited
+        frontier = next
+    }
+    return visited
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/commands/WorldCommandSerializationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/commands/WorldCommandSerializationTest.kt
@@ -6,6 +6,8 @@ import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.RecipeId
+import dev.gvart.genesara.world.SayChannel
+import dev.gvart.genesara.world.SpeechMode
 import org.junit.jupiter.api.Test
 import tools.jackson.databind.json.JsonMapper
 import tools.jackson.module.kotlin.kotlinModule
@@ -52,6 +54,7 @@ class WorldCommandSerializationTest {
             "pickup" to WorldCommand.Pickup(agent, drop, cid),
             "attack" to WorldCommand.AttackTarget(agent, target, cid),
             "useAbility" to WorldCommand.UseAbility(agent, AbilityId("SWORD_POWER_STRIKE"), target, cid),
+            "say" to WorldCommand.Say(agent, "hi", SpeechMode.NORMAL, SayChannel.LOCAL, cid),
         )
 
         for ((discriminator, command) in expectations) {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/say/SayReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/say/SayReducerTest.kt
@@ -1,0 +1,246 @@
+package dev.gvart.genesara.world.internal.say
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.Gauge
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.ResourceSpawnRule
+import dev.gvart.genesara.world.SayChannel
+import dev.gvart.genesara.world.SpeechMode
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+
+class SayReducerTest {
+
+    private val regionId = dev.gvart.genesara.world.RegionId(1L)
+    private val speaker = agent("speaker")
+
+    private val nA = NodeId(1L)
+    private val nB = NodeId(2L)
+    private val nC = NodeId(3L)
+    private val nD = NodeId(4L)
+    private val nE = NodeId(5L)
+    private val nF = NodeId(6L)
+    private val nG = NodeId(7L)
+
+    @Test
+    fun `WHISPER fan-out reaches only the speaker's node and direct neighbours`() {
+        val nearA = agent("a")
+        val nearB = agent("b")
+        val twoAway = agent("c")
+        val state = lineState(positions = mapOf(
+            speaker to nA, nearA to nA, nearB to nB, twoAway to nC,
+        ))
+
+        val result = reduceSay(state, sayCommand(SpeechMode.WHISPER), defaultBalance(), tick = 1)
+
+        val event = singleSpoke(result)
+        assertEquals(setOf(speaker, nearA, nearB), event.listeners)
+    }
+
+    @Test
+    fun `NORMAL fan-out reaches three hops out, excludes node four away`() {
+        val atC = agent("c")
+        val atD = agent("d")
+        val atE = agent("e")
+        val state = lineState(positions = mapOf(
+            speaker to nA, atC to nC, atD to nD, atE to nE,
+        ))
+
+        val result = reduceSay(state, sayCommand(SpeechMode.NORMAL), defaultBalance(), tick = 1)
+
+        val event = singleSpoke(result)
+        assertEquals(setOf(speaker, atC, atD), event.listeners)
+    }
+
+    @Test
+    fun `SCREAM fan-out reaches five hops out, excludes node six away`() {
+        val atE = agent("e")
+        val atF = agent("f")
+        val atG = agent("g")
+        val state = lineState(positions = mapOf(
+            speaker to nA, atE to nE, atF to nF, atG to nG,
+        ))
+
+        val result = reduceSay(state, sayCommand(SpeechMode.SCREAM), defaultBalance(), tick = 1)
+
+        val event = singleSpoke(result)
+        assertEquals(setOf(speaker, atE, atF), event.listeners)
+    }
+
+    @Test
+    fun `speaker hears themselves even when alone in the world`() {
+        val state = lineState(positions = mapOf(speaker to nA))
+
+        val result = reduceSay(state, sayCommand(SpeechMode.NORMAL), defaultBalance(), tick = 1)
+
+        val event = singleSpoke(result)
+        assertEquals(setOf(speaker), event.listeners)
+    }
+
+    @Test
+    fun `event carries the message, mode, channel, origin node, tick and causedBy`() {
+        val state = lineState(positions = mapOf(speaker to nA))
+        val command = WorldCommand.Say(speaker, "hello world", SpeechMode.WHISPER, SayChannel.LOCAL)
+
+        val result = reduceSay(state, command, defaultBalance(), tick = 42)
+
+        val event = singleSpoke(result)
+        assertEquals(speaker, event.speaker)
+        assertEquals(nA, event.at)
+        assertEquals("hello world", event.message)
+        assertEquals(SpeechMode.WHISPER, event.mode)
+        assertEquals(SayChannel.LOCAL, event.channel)
+        assertEquals(42L, event.tick)
+        assertEquals(command.commandId, event.causedBy)
+    }
+
+    @Test
+    fun `state is unchanged on success - say is observation, not mutation`() {
+        val state = lineState(positions = mapOf(speaker to nA, agent("b") to nB))
+
+        val (next, _) = assertNotNull(
+            reduceSay(state, sayCommand(SpeechMode.NORMAL), defaultBalance(), tick = 1).getOrNull()
+        )
+
+        assertSame(state, next)
+    }
+
+    @Test
+    fun `rejects with MessageTooLong when length exceeds the balance cap`() {
+        val state = lineState(positions = mapOf(speaker to nA))
+        val balance = balance(maxLength = 10)
+        val command = WorldCommand.Say(speaker, "x".repeat(11), SpeechMode.NORMAL, SayChannel.LOCAL)
+
+        val result = reduceSay(state, command, balance, tick = 1)
+
+        assertEquals(WorldRejection.MessageTooLong(speaker, length = 11, max = 10), result.leftOrNull())
+    }
+
+    @Test
+    fun `accepts exactly the balance cap length without rejecting`() {
+        val state = lineState(positions = mapOf(speaker to nA))
+        val balance = balance(maxLength = 10)
+        val command = WorldCommand.Say(speaker, "x".repeat(10), SpeechMode.NORMAL, SayChannel.LOCAL)
+
+        val result = reduceSay(state, command, balance, tick = 1)
+
+        assertNotNull(result.getOrNull())
+    }
+
+    @Test
+    fun `rejects with NotInWorld when speaker has no position`() {
+        val state = lineState(positions = emptyMap())
+
+        val result = reduceSay(state, sayCommand(SpeechMode.NORMAL), defaultBalance(), tick = 1)
+
+        assertEquals(WorldRejection.NotInWorld(speaker), result.leftOrNull())
+    }
+
+    @Test
+    fun `not-in-world rejection wins over message-too-long when both fail`() {
+        val state = lineState(positions = emptyMap())
+        val balance = balance(maxLength = 5)
+        val command = WorldCommand.Say(speaker, "too long", SpeechMode.NORMAL, SayChannel.LOCAL)
+
+        val result = reduceSay(state, command, balance, tick = 1)
+
+        assertEquals(WorldRejection.NotInWorld(speaker), result.leftOrNull())
+    }
+
+    @Test
+    fun `diamond graph dedups listeners reached via multiple paths`() {
+        val center = NodeId(100L)
+        val northeast = NodeId(101L)
+        val northwest = NodeId(102L)
+        val far = NodeId(103L)
+        val atFar = agent("at-far")
+        val nodes = mapOf(
+            center to Node(center, regionId, 0, 0, Terrain.PLAINS, adjacency = setOf(northeast, northwest)),
+            northeast to Node(northeast, regionId, 1, 0, Terrain.PLAINS, adjacency = setOf(center, far)),
+            northwest to Node(northwest, regionId, -1, 0, Terrain.PLAINS, adjacency = setOf(center, far)),
+            far to Node(far, regionId, 0, 2, Terrain.PLAINS, adjacency = setOf(northeast, northwest)),
+        )
+        val state = WorldState.EMPTY.copy(
+            nodes = nodes,
+            positions = mapOf(speaker to center, atFar to far),
+        )
+
+        val result = reduceSay(state, sayCommand(SpeechMode.WHISPER), defaultBalance(), tick = 1)
+
+        val event = singleSpoke(result)
+        // far is 2 hops away on either path — must NOT leak in via the join.
+        assertEquals(setOf(speaker), event.listeners)
+    }
+
+    @Test
+    fun `speaker positioned on a node missing from state nodes hears only themselves`() {
+        // Orphan position contract: a position pointing at a node not in state.nodes is a
+        // data-inconsistency we degrade gracefully rather than crash on.
+        val orphan = NodeId(999L)
+        val onlooker = agent("onlooker")
+        val state = WorldState.EMPTY.copy(
+            nodes = mapOf(nA to Node(nA, regionId, 0, 0, Terrain.PLAINS, adjacency = emptySet())),
+            positions = mapOf(speaker to orphan, onlooker to nA),
+        )
+
+        val result = reduceSay(state, sayCommand(SpeechMode.SCREAM), defaultBalance(), tick = 1)
+
+        val event = singleSpoke(result)
+        assertEquals(setOf(speaker), event.listeners)
+        assertEquals(orphan, event.at)
+    }
+
+    private fun singleSpoke(
+        result: arrow.core.Either<WorldRejection, Pair<WorldState, List<WorldEvent>>>,
+    ): WorldEvent.AgentSpoke {
+        val (_, events) = assertNotNull(result.getOrNull())
+        return assertIs<WorldEvent.AgentSpoke>(events.single())
+    }
+
+    private fun sayCommand(mode: SpeechMode) =
+        WorldCommand.Say(speaker, "hi", mode, SayChannel.LOCAL)
+
+    private fun lineState(positions: Map<AgentId, NodeId>): WorldState {
+        val ids = listOf(nA, nB, nC, nD, nE, nF, nG)
+        val nodes = ids.mapIndexed { idx, id ->
+            val neighbours = listOfNotNull(ids.getOrNull(idx - 1), ids.getOrNull(idx + 1)).toSet()
+            id to Node(id, regionId, q = idx, r = 0, terrain = Terrain.PLAINS, adjacency = neighbours)
+        }.toMap()
+        return WorldState.EMPTY.copy(nodes = nodes, positions = positions)
+    }
+
+    private fun agent(label: String) = AgentId(UUID.nameUUIDFromBytes(label.toByteArray()))
+
+    private fun defaultBalance(): BalanceLookup = balance(maxLength = 500)
+
+    private fun balance(maxLength: Int): BalanceLookup = object : BalanceLookup {
+        override fun maxSayMessageLength(): Int = maxLength
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain): Int = 0
+        override fun staminaRegenPerTick(climate: Climate): Int = 0
+        override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = 0
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: Gauge): Int = 0
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 0
+        override fun drinkThirstRefill(): Int = 0
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+    }
+}


### PR DESCRIPTION
## Summary
- New `say` MCP tool: an agent speaks; every other agent positioned within node-hop range receives an `agent.spoke` event (speaker included for self-hearing).
- Volume modes — `WHISPER` (1 hop), `NORMAL` (3 hops, default), `SCREAM` (5 hops) — sourced from `BalanceLookup.sayRangeFor(mode)` so future buffs/perks can tune ranges without touching the reducer.
- `SayChannel.LOCAL` only in v1; enum is extensible so clan / trade channels (Phase 3, #22 / #13) ship as additions, not rewrites.
- `BalanceLookup.maxSayMessageLength()` caps message length at 500; longer rejected with `WorldRejection.MessageTooLong`.
- Reducer is pure (BFS over `state.nodes` adjacency); event carries the resolved listener set and the dispatcher iterates it onto each per-agent SSE log — same fan-out shape as `PassivesApplied`.

Closes #12.

## Test plan
- [x] `./gradlew :world:test :api:test` — green
- [x] `./gradlew compileKotlin compileTestKotlin` across every module — green
- [x] `SayReducerTest` covers WHISPER/NORMAL/SCREAM range matrix, self-hearing, diamond-graph BFS dedup, orphan-position graceful degrade, message-length cap (boundary + over-cap), `NotInWorld` rejection, and the both-fail priority (presence wins over length, matching sibling reducers)
- [x] `SayToolTest` covers queue ack, `mode`/`channel` defaulting to `NORMAL`/`LOCAL` when null
- [x] `AgentEventDispatcherTest` covers per-listener `agent.spoke` fan-out and payload integrity
- [x] `WorldCommandSerializationTest` extended — wire-format `@type:"say"` discriminator stability is locked
- [x] Two `code-quality-reviewer` passes; second pass clean