### PR TITLE
feat(api,ci): publish MCP tool schema as a release asset

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -71,3 +71,39 @@ jobs:
           docker tag "$IMAGE:${VERSION}" "$IMAGE:latest"
           docker push "$IMAGE:${VERSION}"
           docker push "$IMAGE:latest"
+
+  publish-schema:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ needs.release-please.outputs.version }}
+      TAG: ${{ needs.release-please.outputs.tag_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Export MCP schema
+        run: ./gradlew :api:exportMcpSchema -Pversion=${{ env.VERSION }}
+
+      - name: Validate JSON
+        run: jq empty schema/schema.json
+
+      - name: Attach schema.json to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # `--clobber` keeps the job idempotent — re-running for the same tag overwrites
+        # the asset rather than failing. The asset name is fixed: docs.genesara.com pulls
+        # from `releases/latest/download/schema.json`, so renaming this is a breaking change.
+        run: gh release upload "$TAG" schema/schema.json --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ logs/
 
 ### Plans ###
 plans/
+
+### MCP schema export — release artifact, not source. ###
+### Source of truth is the @Tool annotations in :api. ###
+/schema/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,72 @@
+# Releasing
+
+This repository uses [release-please](https://github.com/googleapis/release-please)
+to cut releases automatically from Conventional Commits on `main`. There is no
+manual `git tag && git push` step.
+
+## Mechanism
+
+1. Every push to `main` triggers `.github/workflows/release-please.yml`.
+2. The action maintains a long-lived "release PR" (`chore: release X.Y.Z`)
+   whose body lists every `feat:` / `fix:` / `perf:` commit since the last tag
+   and bumps the version in `.release-please-manifest.json`.
+3. Merging the release PR causes release-please to:
+   - tag the merge commit `v<X.Y.Z>` (configured via `include-v-in-tag: true`),
+   - create the corresponding GitHub Release with auto-generated notes.
+4. The release PR merge also triggers the `publish-image` and `publish-schema`
+   jobs in the same workflow file, gated on `release_created == 'true'`.
+
+## What gets published per release
+
+| Artifact | Where | URL contract |
+| --- | --- | --- |
+| OCI image | GHCR | `ghcr.io/genesara/genesara-engine:<version>` and `:latest` |
+| MCP tool schema | Release asset | `https://github.com/Genesara/genesara-engine/releases/latest/download/schema.json` |
+
+The schema asset is consumed by `docs.genesara.com`
+(`Genesara/genesara-docs:scripts/build-tools-json.ts`). Its shape is a
+**cross-repo contract** — see `api/src/test/.../mcp/schema/McpSchemaExporter.kt`
+KDoc and the `McpSchemaExporterTest` guards.
+
+## To cut a release
+
+1. Ensure your commits since the last tag follow Conventional Commits
+   (`feat:`, `fix:`, `perf:`, etc. — see `.github/workflows/semantic-pr.yml`).
+2. Find the open release-please PR titled `chore: release X.Y.Z` on GitHub.
+3. Review the changelog block, edit if you want to amend, then **squash-merge**.
+4. Wait ~2–5 minutes for the workflow to:
+   - tag + create the release,
+   - build & push the OCI image,
+   - run `./gradlew :api:exportMcpSchema` and upload `schema.json`.
+5. Confirm:
+
+   ```sh
+   curl -sL https://github.com/Genesara/genesara-engine/releases/latest/download/schema.json \
+     | jq '.version, (.tools | length)'
+   ```
+
+## Updating the MCP schema locally
+
+The exporter doesn't need a database or Redis — it walks the `@Tool`-annotated
+classes by reflection and serialises Spring AI's resolved `ToolDefinition`s.
+
+```sh
+./gradlew :api:exportMcpSchema
+jq '.tools | map(.name)' schema/schema.json
+```
+
+The output (`schema/schema.json`) is git-ignored; it is a build artifact, not
+source. The authoritative description of every tool lives on its `@Tool` /
+`@ToolParam` annotations in `:api`.
+
+## Schema-contract rules
+
+`schema.json` is the wire contract with the docs repository. **Do not** silently:
+
+- rename the file (`releases/latest/download/schema.json` is hard-coded by docs),
+- add top-level fields beyond `version`, `generatedAt`, `tools`,
+- add per-tool fields beyond `name`, `description`, `inputSchema`, `errors`,
+- change `inputSchema` from JSON Schema Draft 2020-12.
+
+Any of these is a breaking change and needs a coordinated update in
+`Genesara/genesara-docs` first.

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -24,3 +24,15 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter")
     testImplementation("org.testcontainers:testcontainers")
 }
+
+tasks.register<JavaExec>("exportMcpSchema") {
+    group = "documentation"
+    description = "Export the MCP tool catalog to schema/schema.json. Attached as a release " +
+        "asset by .github/workflows/release-schema.yml; consumed by docs.genesara.com."
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("dev.gvart.genesara.api.internal.mcp.schema.McpSchemaExporterKt")
+    val outputFile = rootProject.layout.projectDirectory.file("schema/schema.json")
+    val projectVersion = project.version.toString()
+    args(outputFile.asFile.absolutePath, projectVersion)
+    outputs.file(outputFile)
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/schema/McpSchemaExporter.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/schema/McpSchemaExporter.kt
@@ -1,0 +1,96 @@
+package dev.gvart.genesara.api.internal.mcp.schema
+
+import org.mockito.Mockito.mock
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.ai.tool.method.MethodToolCallbackProvider
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.type.filter.AnnotationTypeFilter
+import org.springframework.stereotype.Component
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+
+/**
+ * Build-time emitter for the catalog of `@Tool`-annotated MCP tools exposed by `:api`.
+ *
+ * Produces the JSON contract consumed by `docs.genesara.com`
+ * (`Genesara/genesara-docs:scripts/build-tools-json.ts`). The shape — top-level
+ * `version` + `generatedAt` + alphabetical `tools` array, each entry with
+ * `name` / `description` / `inputSchema` — is a stable cross-repo contract;
+ * extending it requires coordinating with docs first.
+ *
+ * Tool beans are discovered via Spring's classpath scanner over
+ * `dev.gvart.genesara.api.internal.mcp.tools`. Each candidate is instantiated as a
+ * Mockito mock so the tool's constructor dependencies (`WorldCommandGateway`, `TickClock`,
+ * etc.) need not be wired — Spring AI only reflects on the `@Tool` methods to build the
+ * schema; the bean instances themselves are never invoked.
+ */
+internal object McpSchemaExporter {
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+
+    data class ToolSchema(
+        val name: String,
+        val description: String,
+        val inputSchema: JsonNode,
+    )
+
+    data class SchemaDocument(
+        val version: String,
+        val generatedAt: String,
+        val tools: List<ToolSchema>,
+    )
+
+    fun export(version: String = SNAPSHOT_VERSION, generatedAt: Instant = Instant.now()): SchemaDocument {
+        val toolClasses = discoverToolClasses()
+        check(toolClasses.isNotEmpty()) { "no @Tool beans discovered under mcp.tools — package layout drifted?" }
+        val mocks: Array<Any> = toolClasses.map { mock(it) }.toTypedArray()
+        val provider = MethodToolCallbackProvider.builder().toolObjects(*mocks).build()
+        val tools = provider.toolCallbacks
+            .map { callback ->
+                val def = callback.toolDefinition
+                ToolSchema(
+                    name = def.name(),
+                    description = def.description(),
+                    inputSchema = mapper.readTree(def.inputSchema()),
+                )
+            }
+            .sortedBy { it.name }
+        return SchemaDocument(version = version, generatedAt = generatedAt.toString(), tools = tools)
+    }
+
+    fun writeTo(output: Path, version: String): SchemaDocument {
+        val doc = export(version = version)
+        Files.createDirectories(output.parent)
+        val payload = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(doc)
+        output.toFile().writeText(payload + "\n")
+        return doc
+    }
+
+    private fun discoverToolClasses(): List<Class<*>> {
+        val scanner = ClassPathScanningCandidateComponentProvider(false).apply {
+            addIncludeFilter(AnnotationTypeFilter(Component::class.java))
+        }
+        return scanner.findCandidateComponents(TOOL_PACKAGE)
+            .map { Class.forName(it.beanClassName!!) }
+            // Defensive: a stray @Component under tools.* with no @Tool method must not
+            // sneak into the catalog (Spring AI would crash later, with a worse trace).
+            .filter { clazz -> clazz.methods.any { it.isAnnotationPresent(Tool::class.java) } }
+            .sortedBy { it.name }
+    }
+
+    private const val TOOL_PACKAGE = "dev.gvart.genesara.api.internal.mcp.tools"
+    internal const val SNAPSHOT_VERSION = "0.0.0-SNAPSHOT"
+}
+
+fun main(args: Array<String>) {
+    val outputPath = args.getOrNull(0)?.let(::File)
+        ?: error("usage: McpSchemaExporterKt <output-path> [version]")
+    val version = args.getOrNull(1).orEmpty().ifBlank { McpSchemaExporter.SNAPSHOT_VERSION }
+    val doc = McpSchemaExporter.writeTo(outputPath.toPath(), version)
+    println("mcp-schema: wrote ${doc.tools.size} tools (version=${doc.version}) to ${outputPath.absolutePath}")
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/schema/McpSchemaExporterTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/schema/McpSchemaExporterTest.kt
@@ -1,0 +1,54 @@
+package dev.gvart.genesara.api.internal.mcp.schema
+
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Guards the build-time export. A regression here means the docs site would
+ * publish a broken catalog or break its parse step, which is worse than not
+ * publishing at all.
+ */
+class McpSchemaExporterTest {
+
+    @Test
+    fun `every discovered tool has a usable schema`() {
+        val doc = McpSchemaExporter.export()
+
+        assertTrue(doc.tools.isNotEmpty(), "no tools exported — classpath scan misconfigured?")
+        for (tool in doc.tools) {
+            assertTrue(tool.name.isNotBlank(), "tool has blank name: $tool")
+            assertTrue(tool.description.isNotBlank(), "${tool.name} has blank description")
+            val type = tool.inputSchema.get("type")
+            assertTrue(
+                type != null && type.asString() == "object",
+                "${tool.name} inputSchema missing top-level type=object: ${tool.inputSchema}",
+            )
+        }
+    }
+
+    @Test
+    fun `tools are sorted alphabetically by name`() {
+        val names = McpSchemaExporter.export().tools.map { it.name }
+        assertEquals(names.sorted(), names, "tool list must be sorted for stable diffs across releases")
+    }
+
+    @Test
+    fun `well-known tools are present in the catalog`() {
+        // Smoke check against tools that have shipped and are unlikely to ever be removed
+        // wholesale. Catches the case where the classpath scan misses a registration root.
+        val names = McpSchemaExporter.export().tools.map { it.name }.toSet()
+        listOf("spawn", "move", "look_around", "say", "trade_offer", "trade_respond").forEach {
+            assertTrue(it in names, "expected '$it' in exported catalog, got $names")
+        }
+    }
+
+    @Test
+    fun `document carries version and ISO-8601 generatedAt`() {
+        val doc = McpSchemaExporter.export(version = "1.2.3")
+        assertEquals("1.2.3", doc.version)
+        // Round-trip via Instant.parse to assert the string is well-formed UTC ISO-8601.
+        Instant.parse(doc.generatedAt)
+    }
+}


### PR DESCRIPTION
## Summary
- Exporter walks `@Tool`-annotated tool beans by classpath scan, hands Mockito-mocked instances to Spring AI's `MethodToolCallbackProvider`, and dumps the resolved `ToolDefinition`s to `schema/schema.json`. No database / Redis / Spring boot needed — the mocks are never invoked.
- Output matches the cross-repo contract: `version` + `generatedAt` + alphabetically-sorted `tools[]`, each entry with `name` / `description` / `inputSchema`. 31 tools on this branch.
- Workflow change is additive: a `publish-schema` job in `release-please.yml`, gated on `release_created == 'true'`, mirrors the existing `publish-image` shape. Runs the exporter with `-Pversion=<version>`, validates with `jq empty`, and uploads with `gh release upload --clobber` so re-runs are idempotent.
- `schema/schema.json` is git-ignored; source of truth is the `@Tool` annotations in `:api`.

## Hard contract
- Asset name **must** stay `schema.json` — `docs.genesara.com` hard-codes `releases/latest/download/schema.json`.
- Top-level + per-tool field set is frozen; extending it is a coordinated change with `Genesara/genesara-docs`.
- `RELEASING.md` documents the rules.

## Verification
- [x] `./gradlew :api:exportMcpSchema -Pversion=0.1.0` → `schema/schema.json` with version 0.1.0, 31 tools.
- [x] `jq empty schema/schema.json` parses clean.
- [x] `./gradlew :api:test --tests McpSchemaExporterTest` passes (4 tests: catalog non-empty + usable schemas + sorted-by-name + ISO-8601 generatedAt + smoke check on well-known tool names).
- [x] YAML syntax of the updated workflow validates.

## Manual smoke after merge
After the next release-please PR merges, confirm:
```sh
curl -sL https://github.com/Genesara/genesara-engine/releases/latest/download/schema.json \
  | jq '.version, (.tools | length)'
```

## Non-goals
- No npm package — spec explicitly excludes that path.
- No commit of `schema/schema.json` to the repo.
- No rename of the asset.