### PR TITLE
feat(world,api): defensive cluster + extraction infrastructure

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
@@ -17,6 +17,7 @@ import dev.gvart.genesara.api.internal.mcp.tools.craft.CraftTool
 import dev.gvart.genesara.api.internal.mcp.tools.drink.DrinkTool
 import dev.gvart.genesara.api.internal.mcp.tools.equipment.EquipItemTool
 import dev.gvart.genesara.api.internal.mcp.tools.equipment.UnequipSlotTool
+import dev.gvart.genesara.api.internal.mcp.tools.extract.ExtractTool
 import dev.gvart.genesara.api.internal.mcp.tools.getmap.GetMapTool
 import dev.gvart.genesara.api.internal.mcp.tools.getrecipes.GetRecipesTool
 import dev.gvart.genesara.api.internal.mcp.tools.getstatus.GetStatusTool
@@ -30,6 +31,7 @@ import dev.gvart.genesara.api.internal.mcp.tools.pickup.PickupTool
 import dev.gvart.genesara.api.internal.mcp.tools.respawn.RespawnTool
 import dev.gvart.genesara.api.internal.mcp.tools.safenode.SetSafeNodeTool
 import dev.gvart.genesara.api.internal.mcp.tools.say.SayTool
+import dev.gvart.genesara.api.internal.mcp.tools.togglegate.ToggleGateTool
 import dev.gvart.genesara.api.internal.mcp.tools.trade.TradeOfferTool
 import dev.gvart.genesara.api.internal.mcp.tools.trade.TradeRespondTool
 import dev.gvart.genesara.api.internal.mcp.tools.skills.EquipSkillTool
@@ -82,6 +84,8 @@ internal class McpServerConfiguration {
         say: SayTool,
         tradeOffer: TradeOfferTool,
         tradeRespond: TradeRespondTool,
+        toggleGate: ToggleGateTool,
+        extract: ExtractTool,
     ): ToolCallbackProvider {
         val methodProvider = MethodToolCallbackProvider.builder()
             .toolObjects(
@@ -91,6 +95,7 @@ internal class McpServerConfiguration {
                 setSafeNode, respawn, build, depositToChest, withdrawFromChest, craft, pickup, attack,
                 useAbility, selectClass, selectEvolution, selectPerk, getRecipes, say,
                 tradeOffer, tradeRespond,
+                toggleGate, extract,
             )
             .build()
         return EnumCaseInsensitiveToolCallbackProvider(methodProvider)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/craft/CraftTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/craft/CraftTool.kt
@@ -11,6 +11,7 @@ import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.annotation.Tool
 import org.springframework.ai.tool.annotation.ToolParam
 import org.springframework.stereotype.Component
+import java.util.UUID
 
 @Component
 internal class CraftTool(
@@ -25,16 +26,26 @@ internal class CraftTool(
             "matching crafting station active on the node, recipe inputs in inventory, the recipe's " +
             "required skill level, and stamina. Output rarity is rolled from the agent's skill + Luck. " +
             "Queues a CraftItem command; the resulting ItemCrafted event arrives on the agent's event " +
-            "stream once the tick lands.",
+            "stream once the tick lands. " +
+            "Some recipes require an existing per-instance item as a `source` template — e.g. " +
+            "GATE_KEY_COPY duplicates an existing GATE_KEY (the source stays; the new key inherits " +
+            "the source's gate-binding).",
     )
     fun invoke(
         @ToolParam(required = true, description = "Recipe id to craft at the agent's current node.")
         recipeId: String,
+        @ToolParam(
+            required = false,
+            description = "Instance UUID of an existing per-instance item the recipe operates on. " +
+                "Required only when the recipe declares `requiresSource` (e.g. GATE_KEY_COPY needs " +
+                "an existing GATE_KEY id). Omit for plain craft recipes.",
+        )
+        source: UUID? = null,
         toolContext: ToolContext,
     ): CraftResponse {
         touchActivity(toolContext, activity, "craft")
         val agent = AgentContextHolder.current()
-        val command = WorldCommand.CraftItem(agent = agent, recipe = RecipeId(recipeId))
+        val command = WorldCommand.CraftItem(agent = agent, recipe = RecipeId(recipeId), source = source)
         val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
         return CraftResponse(commandId = command.commandId, appliesAtTick = appliesAtTick, recipeId = recipeId)
     }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/craft/CraftTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/craft/CraftTool.kt
@@ -40,13 +40,16 @@ internal class CraftTool(
                 "Required only when the recipe declares `requiresSource` (e.g. GATE_KEY_COPY needs " +
                 "an existing GATE_KEY id). Omit for plain craft recipes.",
         )
-        source: UUID? = null,
+        source: String? = null,
         toolContext: ToolContext,
     ): CraftResponse {
         touchActivity(toolContext, activity, "craft")
+        val sourceUuid = if (source == null) null else
+            runCatching { UUID.fromString(source) }.getOrNull()
+                ?: return CraftResponse.rejected(recipeId, "bad_source_id", "source must be a UUID")
         val agent = AgentContextHolder.current()
-        val command = WorldCommand.CraftItem(agent = agent, recipe = RecipeId(recipeId), source = source)
+        val command = WorldCommand.CraftItem(agent = agent, recipe = RecipeId(recipeId), source = sourceUuid)
         val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
-        return CraftResponse(commandId = command.commandId, appliesAtTick = appliesAtTick, recipeId = recipeId)
+        return CraftResponse.queued(command.commandId, appliesAtTick, recipeId)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/craft/CraftToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/craft/CraftToolIo.kt
@@ -1,9 +1,23 @@
 package dev.gvart.genesara.api.internal.mcp.tools.craft
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import java.util.UUID
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class CraftResponse(
-    val commandId: UUID,
-    val appliesAtTick: Long,
+    val kind: CommandAckKind,
     val recipeId: String,
-)
+    val commandId: UUID? = null,
+    val appliesAtTick: Long? = null,
+    val reason: String? = null,
+    val detail: String? = null,
+) {
+    companion object {
+        fun queued(commandId: UUID, appliesAtTick: Long, recipeId: String) =
+            CraftResponse(CommandAckKind.QUEUED, recipeId, commandId, appliesAtTick)
+
+        fun rejected(recipeId: String, reason: String, detail: String) =
+            CraftResponse(CommandAckKind.REJECTED, recipeId, reason = reason, detail = detail)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/extract/ExtractTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/extract/ExtractTool.kt
@@ -1,0 +1,44 @@
+package dev.gvart.genesara.api.internal.mcp.tools.extract
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.world.ResourceItemId
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.ai.tool.annotation.ToolParam
+import org.springframework.stereotype.Component
+
+@Component
+internal class ExtractTool(
+    private val world: WorldCommandGateway,
+    private val engine: TickClock,
+    private val activity: AgentActivityTracker,
+) {
+
+    @Tool(
+        name = "extract",
+        description = "Pull one yield of an extraction-only resource (COAL, ORE, GOLD) from the agent's " +
+            "current node. Requires an ACTIVE MINE building on the node. Mirrors `harvest` but for " +
+            "items the bare gather verb rejects. Queues an Extract command; ResourceExtracted lands " +
+            "on the event stream once the tick applies. Costs stamina; trains MINING.",
+    )
+    fun invoke(
+        @ToolParam(
+            required = true,
+            description = "Extraction-only resource id (COAL, ORE, GOLD). Items not flagged extractionOnly " +
+                "are rejected with ResourceNotAvailableHere — use the `harvest` verb instead.",
+        )
+        itemId: ResourceItemId,
+        toolContext: ToolContext,
+    ): ExtractResponse {
+        touchActivity(toolContext, activity, "extract")
+        val agent = AgentContextHolder.current()
+        val command = WorldCommand.Extract(agent = agent, item = itemId.toItemId())
+        val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
+        return ExtractResponse.queued(command.commandId, appliesAtTick, itemId.name)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/extract/ExtractToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/extract/ExtractToolIo.kt
@@ -1,0 +1,16 @@
+package dev.gvart.genesara.api.internal.mcp.tools.extract
+
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
+import java.util.UUID
+
+data class ExtractResponse(
+    val kind: CommandAckKind,
+    val itemId: String,
+    val commandId: UUID? = null,
+    val appliesAtTick: Long? = null,
+) {
+    companion object {
+        fun queued(commandId: UUID, appliesAtTick: Long, itemId: String) =
+            ExtractResponse(CommandAckKind.QUEUED, itemId, commandId, appliesAtTick)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
@@ -14,6 +14,7 @@ import dev.gvart.genesara.world.Building
 import dev.gvart.genesara.world.BuildingBar
 import dev.gvart.genesara.world.BuildingBarsStore
 import dev.gvart.genesara.world.BuildingDefLookup
+import dev.gvart.genesara.world.BuildingGateStateStore
 import dev.gvart.genesara.world.BuildingStatus
 import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.BuildingsLookup
@@ -48,6 +49,7 @@ internal class InspectTool(
     private val chestContents: ChestContentsStore,
     private val equipmentInstances: EquipmentInstanceStore,
     private val equipmentSets: EquipmentSetLookup,
+    private val gateStates: BuildingGateStateStore,
 ) {
 
     @Tool(
@@ -342,6 +344,9 @@ internal class InspectTool(
                 )
             },
             chestContents = if (showChestContents) chestContents.contentsOf(building.instanceId).toMaterialViews() else null,
+            isOpen = if (building.type == BuildingType.GATE && building.isActive) {
+                gateStates.isOpen(building.instanceId)
+            } else null,
         )
     }
 

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.api.internal.mcp.tools.inspect
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import dev.gvart.genesara.api.internal.mcp.tools.equipment.views.EquipmentStatsView
 
 /**
@@ -161,6 +162,7 @@ data class InstanceStateView(
  * visible to the owner regardless of Perception, and to EXPERT-Perception non-owners.
  * Chest contents are strictly owner-only (Phase 1 personal stash).
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class BuildingInspectView(
     val instanceId: String,
     val type: String,
@@ -189,6 +191,8 @@ data class BuildingInspectView(
     val liveBars: List<BuildingBarProgressView>? = null,
     /** Owner-only: current chest contents. Null when not a chest, or the caller is not the builder. */
     val chestContents: List<BuildingMaterialView>? = null,
+    /** GATE-only: true when the gate is OPEN (passable), false when CLOSED (blocks like a wall). Null for non-gate buildings and not-yet-ACTIVE gates. Mirrors `look_around`. */
+    val isOpen: Boolean? = null,
 )
 
 data class BuildingSkillBarView(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/loadout/GetLoadoutTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/loadout/GetLoadoutTool.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.api.internal.mcp.tools.loadout
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.world.AgentKeysStore
 import dev.gvart.genesara.world.EquipSlot
 import dev.gvart.genesara.world.EquipmentInstance
 import dev.gvart.genesara.world.EquipmentInstanceStore
@@ -19,15 +20,19 @@ internal class GetLoadoutTool(
     private val world: WorldQueryGateway,
     private val items: ItemLookup,
     private val store: EquipmentInstanceStore,
+    private val keys: AgentKeysStore,
     private val activity: AgentActivityTracker,
 ) {
 
     @Tool(
         name = "get_loadout",
         description = "Return everything the agent is carrying: stackable inventory entries " +
-            "(itemId + quantity + catalog rarity) plus per-instance equipment. The equipment " +
-            "block lists every defined slot in stable order with the instance currently in it " +
-            "(or null if empty), plus a stash of per-instance gear owned but not slotted. Read-only.",
+            "(itemId + quantity + catalog rarity) plus per-instance equipment. Per-instance " +
+            "inventory items (e.g. GATE_KEY) appear as stackable entries with quantity=1 and " +
+            "carry their `instanceId`; GATE_KEY entries also carry `gateInstanceId` — the " +
+            "building instance id of the gate they open. The equipment block lists every " +
+            "defined slot in stable order with the instance currently in it (or null if " +
+            "empty), plus a stash of per-instance gear owned but not slotted. Read-only.",
     )
     fun invoke(toolContext: ToolContext): GetLoadoutResponse {
         touchActivity(toolContext, activity, "get_loadout")
@@ -39,14 +44,25 @@ internal class GetLoadoutTool(
         val (equippedList, stashList) = store.listByAgent(agentId).partition { it.equippedInSlot != null }
         val bySlot = equippedList.associateBy { it.equippedInSlot!! }
 
+        val stackableFromInventory = inventory.entries.map { entry ->
+            InventoryEntryView(
+                itemId = entry.itemId.value,
+                quantity = entry.quantity,
+                rarity = rarityFor(entry.itemId),
+            )
+        }
+        val stackableFromKeys = keys.listByAgent(agentId).map { key ->
+            InventoryEntryView(
+                itemId = key.itemId.value,
+                quantity = 1,
+                rarity = rarityFor(key.itemId),
+                instanceId = key.instanceId.toString(),
+                gateInstanceId = key.gateInstanceId.toString(),
+            )
+        }
+
         return GetLoadoutResponse(
-            stackable = inventory.entries.map { entry ->
-                InventoryEntryView(
-                    itemId = entry.itemId.value,
-                    quantity = entry.quantity,
-                    rarity = rarityFor(entry.itemId),
-                )
-            },
+            stackable = stackableFromInventory + stackableFromKeys,
             equipment = EquipmentView(
                 slots = EquipSlot.entries.map { slot ->
                     EquipmentSlotView(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/loadout/GetLoadoutToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/loadout/GetLoadoutToolIo.kt
@@ -1,17 +1,28 @@
 package dev.gvart.genesara.api.internal.mcp.tools.loadout
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import dev.gvart.genesara.world.Rarity
 
 data class GetLoadoutResponse(
-    /** Stackable carried items (food, materials, ammo, ground-pickup-able). */
+    /**
+     * Carried inventory: plain stackables (itemId + quantity + rarity) AND per-instance
+     * items (e.g. GATE_KEY) projected as quantity=1 entries carrying their own
+     * `instanceId` (and `gateInstanceId` for keys). Equipment lives separately under
+     * [equipment].
+     */
     val stackable: List<InventoryEntryView>,
     val equipment: EquipmentView,
 )
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class InventoryEntryView(
     val itemId: String,
     val quantity: Int,
     val rarity: Rarity,
+    /** Set for per-instance items (e.g. GATE_KEY); null for plain stackables. */
+    val instanceId: String? = null,
+    /** For GATE_KEY: the building instance id of the gate this key opens. */
+    val gateInstanceId: String? = null,
 )
 
 data class EquipmentView(

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundTool.kt
@@ -10,6 +10,7 @@ import dev.gvart.genesara.world.AgentMapMemoryGateway
 import dev.gvart.genesara.world.AgentPlot
 import dev.gvart.genesara.world.AgentPlotsStore
 import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingGateStateStore
 import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.CropLookup
@@ -38,6 +39,7 @@ internal class LookAroundTool(
     private val buildings: BuildingsLookup,
     private val plots: AgentPlotsStore,
     private val crops: CropLookup,
+    private val gateStates: BuildingGateStateStore,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -47,9 +49,10 @@ internal class LookAroundTool(
             "the ids of the hex-adjacent one-step `move` targets (`neighbours`). The current node " +
             "carries full resource counts, full per-building summaries, and `agents` — other agents " +
             "present on the same tile (id/name/race/level/hpBand), suitable for `attack` targeting. " +
-            "Visible non-current nodes carry only item ids and a fog-of-war building summary " +
-            "(type + status, no instance ids, no agents). `neighbours` is the canonical input for " +
-            "`move`; not every entry in `visible` is move-legal.",
+            "GATE buildings carry `isOpen` (true=passable, false=acts as a wall) on both current and " +
+            "adjacent tiles. Visible non-current nodes carry only item ids and a fog-of-war building " +
+            "summary (type + status + isOpen for gates, no instance ids, no agents). `neighbours` is " +
+            "the canonical input for `move`; not every entry in `visible` is move-legal.",
     )
     fun invoke(toolContext: ToolContext): LookAroundResponse {
         touchActivity(toolContext, activity, "look_around")
@@ -77,6 +80,15 @@ internal class LookAroundTool(
             .values
             .flatten()
             .associateBy { it.buildingInstanceId }
+        // Gate state surfaces on every visible tile: gates are large infrastructure, you
+        // can see open vs. shut from sight range. `toggle_gate` still requires co-location
+        // to ACT, only observation is at-distance.
+        val gateStateByInstance: Map<UUID, Boolean> = buildingsByNode.values
+            .asSequence()
+            .flatten()
+            .filter { it.type == BuildingType.GATE && it.isActive }
+            .mapNotNull { b -> gateStates.isOpen(b.instanceId)?.let { b.instanceId to it } }
+            .toMap()
 
         val currentNodeAgents = projectAgentsAt(current.id, excluding = agentId)
 
@@ -92,6 +104,7 @@ internal class LookAroundTool(
                 plotsByBuilding = plotsByBuilding,
                 cropLookup = crops,
                 currentTick = currentTick,
+                gateStateByInstance = gateStateByInstance,
             ),
             currentResources = currentResources.entries.values.map {
                 ResourceView(
@@ -105,6 +118,7 @@ internal class LookAroundTool(
                 n.toView(
                     r, res, buildingsByNode[n.id].orEmpty(), emptyList(), fogOfWar = true,
                     plotsByBuilding = plotsByBuilding, cropLookup = crops, currentTick = currentTick,
+                    gateStateByInstance = gateStateByInstance,
                 )
             },
             neighbours = current.adjacency.map { it.value }.sorted(),
@@ -182,6 +196,7 @@ private fun Node.toView(
     plotsByBuilding: Map<UUID, AgentPlot>,
     cropLookup: CropLookup,
     currentTick: Long,
+    gateStateByInstance: Map<UUID, Boolean>,
 ) = NodeView(
     id = id.value,
     q = q,
@@ -193,7 +208,7 @@ private fun Node.toView(
     resources = resources.entries.keys.map { it.value }.sorted(),
     buildings = buildings
         .sortedBy { it.instanceId }
-        .map { it.toSummary(fogOfWar, plotsByBuilding, cropLookup, currentTick) },
+        .map { it.toSummary(fogOfWar, plotsByBuilding, cropLookup, currentTick, gateStateByInstance) },
     agents = agents,
 )
 
@@ -223,17 +238,20 @@ private fun Building.toSummary(
     plotsByBuilding: Map<UUID, AgentPlot>,
     crops: CropLookup,
     currentTick: Long,
+    gateStateByInstance: Map<UUID, Boolean> = emptyMap(),
 ): BuildingSummaryView {
     val plot = if (type == BuildingType.FARM_PLOT) plotsByBuilding[instanceId] else null
     val plant = plot?.plant
     val crop = plant?.let { crops.byId(it.cropId) }
+    val isOpen = if (type == BuildingType.GATE) gateStateByInstance[instanceId] else null
 
     return if (fogOfWar) {
-        // Adjacent tiles see the planted-crop name but no timing details.
+        // Adjacent tiles see the planted-crop name + gate open/closed but no timing or per-instance details.
         BuildingSummaryView(
             type = type.name,
             status = status.name,
             plantedCrop = plant?.cropId?.value,
+            isOpen = isOpen,
         )
     } else {
         BuildingSummaryView(
@@ -252,6 +270,7 @@ private fun Building.toSummary(
             ticksUntilNeglect = if (plant != null && crop != null) {
                 ((plant.lastTendedAtTick + crop.neglectWindowTicks) - currentTick).coerceAtLeast(0L)
             } else null,
+            isOpen = isOpen,
         )
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolIo.kt
@@ -1,5 +1,6 @@
 package dev.gvart.genesara.api.internal.mcp.tools.lookaround
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import dev.gvart.genesara.world.Rarity
 
 data class LookAroundResponse(
@@ -94,6 +95,7 @@ enum class GroundItemKind { STACKABLE, EQUIPMENT }
  * intentionally omit `instanceId`, `progressSteps`, `totalSteps`, `hpBand`, and `builderAgentId`
  * — fog-of-war keeps remote tiles to type + status + a node-local count.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 data class BuildingSummaryView(
     val type: String,
     val status: String,
@@ -110,4 +112,6 @@ data class BuildingSummaryView(
     val ticksToRipe: Long? = null,
     /** Ticks remaining before the neglect sweep would clear the plot. 0 when neglected. */
     val ticksUntilNeglect: Long? = null,
+    /** GATE-only: true when the gate is OPEN (passable), false when CLOSED (blocks like a wall). Null for non-gate buildings. Surfaced on both current and adjacent tiles — a gate is large infrastructure, visibly open or shut from sight range. */
+    val isOpen: Boolean? = null,
 )

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/togglegate/ToggleGateTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/togglegate/ToggleGateTool.kt
@@ -1,0 +1,44 @@
+package dev.gvart.genesara.api.internal.mcp.tools.togglegate
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.WorldCommand
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.ai.tool.annotation.ToolParam
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+internal class ToggleGateTool(
+    private val world: WorldCommandGateway,
+    private val engine: TickClock,
+    private val activity: AgentActivityTracker,
+) {
+
+    @Tool(
+        name = "toggle_gate",
+        description = "Flip the OPEN/CLOSED state of a GATE building at the agent's current node. " +
+            "Requires the agent to be standing on the gate's node AND to hold a matching GATE_KEY " +
+            "in inventory. Passage through a CLOSED gate is blocked (DefensiveBlocks); passage " +
+            "through an OPEN gate is permitted to anyone — toggle with intent. Emits GateToggled.",
+    )
+    fun invoke(
+        @ToolParam(
+            required = true,
+            description = "Building instance id of the GATE to flip. Read it from `look_around().current.buildings` " +
+                "or the GateKeyMinted event that issued your key.",
+        )
+        gateId: UUID,
+        toolContext: ToolContext,
+    ): ToggleGateResponse {
+        touchActivity(toolContext, activity, "toggle_gate")
+        val agent = AgentContextHolder.current()
+        val command = WorldCommand.ToggleGate(agent = agent, gateId = gateId)
+        val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
+        return ToggleGateResponse.queued(command.commandId, appliesAtTick, gateId)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/togglegate/ToggleGateTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/togglegate/ToggleGateTool.kt
@@ -32,13 +32,15 @@ internal class ToggleGateTool(
             description = "Building instance id of the GATE to flip. Read it from `look_around().current.buildings` " +
                 "or the GateKeyMinted event that issued your key.",
         )
-        gateId: UUID,
+        gateId: String,
         toolContext: ToolContext,
     ): ToggleGateResponse {
         touchActivity(toolContext, activity, "toggle_gate")
+        val gateUuid = runCatching { UUID.fromString(gateId) }.getOrNull()
+            ?: return ToggleGateResponse.rejected(gateId, "bad_gate_id", "gateId must be a UUID")
         val agent = AgentContextHolder.current()
-        val command = WorldCommand.ToggleGate(agent = agent, gateId = gateId)
+        val command = WorldCommand.ToggleGate(agent = agent, gateId = gateUuid)
         val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
-        return ToggleGateResponse.queued(command.commandId, appliesAtTick, gateId)
+        return ToggleGateResponse.queued(command.commandId, appliesAtTick, gateUuid)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/togglegate/ToggleGateToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/togglegate/ToggleGateToolIo.kt
@@ -5,12 +5,17 @@ import java.util.UUID
 
 data class ToggleGateResponse(
     val kind: CommandAckKind,
-    val gateId: UUID,
+    val gateId: String,
     val commandId: UUID? = null,
     val appliesAtTick: Long? = null,
+    val reason: String? = null,
+    val detail: String? = null,
 ) {
     companion object {
         fun queued(commandId: UUID, appliesAtTick: Long, gateId: UUID) =
-            ToggleGateResponse(CommandAckKind.QUEUED, gateId, commandId, appliesAtTick)
+            ToggleGateResponse(CommandAckKind.QUEUED, gateId.toString(), commandId, appliesAtTick)
+
+        fun rejected(gateId: String, reason: String, detail: String) =
+            ToggleGateResponse(CommandAckKind.REJECTED, gateId, reason = reason, detail = detail)
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/togglegate/ToggleGateToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/togglegate/ToggleGateToolIo.kt
@@ -1,0 +1,16 @@
+package dev.gvart.genesara.api.internal.mcp.tools.togglegate
+
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
+import java.util.UUID
+
+data class ToggleGateResponse(
+    val kind: CommandAckKind,
+    val gateId: UUID,
+    val commandId: UUID? = null,
+    val appliesAtTick: Long? = null,
+) {
+    companion object {
+        fun queued(commandId: UUID, appliesAtTick: Long, gateId: UUID) =
+            ToggleGateResponse(CommandAckKind.QUEUED, gateId, commandId, appliesAtTick)
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/craft/CraftToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/craft/CraftToolTest.kt
@@ -36,7 +36,7 @@ class CraftToolTest {
     fun `queues a CraftItem command at the next tick and returns the ack`() {
         val tool = CraftTool(gateway, tickClock, activity)
 
-        val response = tool.invoke("IRON_SWORD_BASIC", toolContext)
+        val response = tool.invoke("IRON_SWORD_BASIC", toolContext = toolContext)
 
         assertEquals("IRON_SWORD_BASIC", response.recipeId)
         assertEquals(101L, response.appliesAtTick)
@@ -51,7 +51,7 @@ class CraftToolTest {
     @Test
     fun `touches activity registry on every successful invocation`() {
         val tool = CraftTool(gateway, tickClock, activity)
-        tool.invoke("IRON_INGOT_BASIC", toolContext)
+        tool.invoke("IRON_INGOT_BASIC", toolContext = toolContext)
         assertTrue(agent in activity.staleAgents(clock.instant().plusSeconds(60)))
     }
 

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/craft/CraftToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/craft/CraftToolTest.kt
@@ -7,6 +7,7 @@ import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.world.RecipeId
 import dev.gvart.genesara.world.WorldCommandGateway
 import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -18,6 +19,7 @@ import java.time.ZoneOffset
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class CraftToolTest {
@@ -53,6 +55,32 @@ class CraftToolTest {
         val tool = CraftTool(gateway, tickClock, activity)
         tool.invoke("IRON_INGOT_BASIC", toolContext = toolContext)
         assertTrue(agent in activity.staleAgents(clock.instant().plusSeconds(60)))
+    }
+
+    @Test
+    fun `forwards a valid source UUID into the queued command`() {
+        val tool = CraftTool(gateway, tickClock, activity)
+        val sourceId = UUID.randomUUID()
+
+        val response = tool.invoke("GATE_KEY_COPY", source = sourceId.toString(), toolContext = toolContext)
+
+        assertEquals(CommandAckKind.QUEUED, response.kind)
+        val craft = assertNotNull(gateway.submissions.single().first as? WorldCommand.CraftItem)
+        assertEquals(sourceId, craft.source)
+    }
+
+    @Test
+    fun `rejects a non-UUID source with bad_source_id and does not submit`() {
+        val tool = CraftTool(gateway, tickClock, activity)
+
+        val response = tool.invoke("GATE_KEY_COPY", source = "not-a-uuid", toolContext = toolContext)
+
+        assertEquals(CommandAckKind.REJECTED, response.kind)
+        assertEquals("bad_source_id", response.reason)
+        assertEquals("GATE_KEY_COPY", response.recipeId)
+        assertNull(response.commandId)
+        assertNull(response.appliesAtTick)
+        assertTrue(gateway.submissions.isEmpty())
     }
 
     private class RecordingGateway : WorldCommandGateway {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
@@ -328,6 +328,7 @@ class InspectBuildingTest {
             chestContents = chestContents,
             equipmentInstances = NoEquipmentInstances,
             equipmentSets = NoEquipmentSets,
+            gateStates = NoGates,
         )
     }
 
@@ -454,5 +455,11 @@ class InspectBuildingTest {
         override fun byId(id: EquipmentSetId): EquipmentSet? = null
         override fun all(): List<EquipmentSet> = emptyList()
         override fun setsContaining(itemId: ItemId): List<EquipmentSet> = emptyList()
+    }
+
+    private object NoGates : dev.gvart.genesara.world.BuildingGateStateStore {
+        override fun insertClosed(gateInstanceId: java.util.UUID) = error("not used")
+        override fun isOpen(gateInstanceId: java.util.UUID): Boolean? = null
+        override fun toggle(gateInstanceId: java.util.UUID): Boolean? = null
     }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectLookAroundParityTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectLookAroundParityTest.kt
@@ -122,13 +122,48 @@ class InspectLookAroundParityTest {
         )
         val registry = registryOf(caller, other)
         val inspect = inspectTool(world, registry)
-        val lookAround = LookAroundTool(world, registry, vision(1), activity, NoMapMemory, NoBuildings, NoOpPlots, NoOpCrops)
+        val lookAround = LookAroundTool(world, registry, vision(1), activity, NoMapMemory, NoBuildings, NoOpPlots, NoOpCrops, NoGates)
 
         val inspectBand = assertNotNull(inspect.dispatch("agent", otherId.id.toString())).agent?.hpBand
         val lookBand = lookAround.invoke(toolContext)
             .currentNode.agents.single { it.id == otherId.id.toString() }.hpBand
 
         assertEquals(lookBand, inspectBand, "inspect must return the same hpBand as look_around for same-node agents")
+    }
+
+    @Test
+    fun `inspect BUILDING and look_around agree on isOpen for an ACTIVE GATE on the same tile`() {
+        val gate = Building(
+            instanceId = UUID.randomUUID(),
+            nodeId = nodeId,
+            type = BuildingType.GATE,
+            status = BuildingStatus.ACTIVE,
+            builtByAgentId = callerId,
+            builtAtTick = 1L,
+            lastProgressTick = 1L,
+            progressSteps = 1,
+            totalSteps = 1,
+            hpCurrent = 120,
+            hpMax = 120,
+        )
+        val world = SharedWorld(
+            location = nodeId,
+            nodes = mapOf(nodeId to node),
+            regions = mapOf(regionId to region),
+            within = mapOf((nodeId to 1) to setOf(nodeId)),
+        )
+        val buildingsLookup = SharedBuildings(listOf(gate))
+        val gates = StubGates(mapOf(gate.instanceId to true))
+        val inspect = inspectTool(world, registryOf(caller), buildings = buildingsLookup, gateStates = gates)
+        val lookAround = LookAroundTool(world, registryOf(caller), vision(1), activity, NoMapMemory, buildingsLookup, NoOpPlots, NoOpCrops, gates)
+
+        val inspectView = assertNotNull(inspect.dispatch("building", gate.instanceId.toString())).building!!
+        val lookView = lookAround.invoke(toolContext)
+            .currentNode.buildings.single { it.instanceId == gate.instanceId.toString() }
+
+        assertEquals(true, inspectView.isOpen, "inspect must surface the gate's OPEN state")
+        assertEquals(true, lookView.isOpen, "look_around must surface the gate's OPEN state")
+        assertEquals(lookView.isOpen, inspectView.isOpen, "inspect and look_around must agree on isOpen")
     }
 
     @Test
@@ -155,7 +190,7 @@ class InspectLookAroundParityTest {
         val registry = registryOf(caller)
         val buildingsLookup = SharedBuildings(listOf(chest))
         val inspect = inspectTool(world, registry, buildings = buildingsLookup)
-        val lookAround = LookAroundTool(world, registry, vision(1), activity, NoMapMemory, buildingsLookup, NoOpPlots, NoOpCrops)
+        val lookAround = LookAroundTool(world, registry, vision(1), activity, NoMapMemory, buildingsLookup, NoOpPlots, NoOpCrops, NoGates)
 
         val inspectView = assertNotNull(inspect.dispatch("building", chest.instanceId.toString())).building!!
         val lookView = lookAround.invoke(toolContext)
@@ -176,6 +211,7 @@ class InspectLookAroundParityTest {
         world: WorldQueryGateway,
         registry: AgentRegistry,
         buildings: BuildingsLookup = NoBuildings,
+        gateStates: dev.gvart.genesara.world.BuildingGateStateStore = NoGates,
     ): InspectTool = InspectTool(
         world = world,
         agents = registry,
@@ -189,6 +225,7 @@ class InspectLookAroundParityTest {
         chestContents = NoChestContents,
         equipmentInstances = NoEquipmentInstances,
         equipmentSets = NoEquipmentSets,
+        gateStates = gateStates,
     )
 
     private fun registryOf(vararg present: Agent) = object : AgentRegistry {
@@ -304,6 +341,18 @@ class InspectLookAroundParityTest {
     private object NoOpCrops : dev.gvart.genesara.world.CropLookup {
         override fun byId(id: dev.gvart.genesara.world.CropId): dev.gvart.genesara.world.Crop? = null
         override fun all(): List<dev.gvart.genesara.world.Crop> = emptyList()
+    }
+
+    private object NoGates : dev.gvart.genesara.world.BuildingGateStateStore {
+        override fun insertClosed(gateInstanceId: UUID) = error("not used")
+        override fun isOpen(gateInstanceId: UUID): Boolean? = null
+        override fun toggle(gateInstanceId: UUID): Boolean? = null
+    }
+
+    private class StubGates(private val byId: Map<UUID, Boolean>) : dev.gvart.genesara.world.BuildingGateStateStore {
+        override fun insertClosed(gateInstanceId: UUID) = error("not used")
+        override fun isOpen(gateInstanceId: UUID): Boolean? = byId[gateInstanceId]
+        override fun toggle(gateInstanceId: UUID): Boolean? = error("not used")
     }
 
     private class MutableTestClock(private var now: Instant) : Clock() {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
@@ -273,6 +273,7 @@ class InspectToolTest {
             chestContents = NoChestContents,
             equipmentInstances = StubEquipmentInstanceStore(),
             equipmentSets = StubEquipmentSetLookup(),
+            gateStates = NoGates,
         )
 
         val resp = selfTool.dispatch("agent", agentId.id.toString(), toolContext)
@@ -565,6 +566,7 @@ class InspectToolTest {
             chestContents = NoChestContents,
             equipmentInstances = equipmentInstances,
             equipmentSets = equipmentSets,
+            gateStates = NoGates,
         )
     }
 
@@ -732,5 +734,11 @@ class InspectToolTest {
         override fun contentsOf(buildingId: java.util.UUID): Map<ItemId, Int> = emptyMap()
         override fun add(buildingId: java.util.UUID, item: ItemId, quantity: Int) = error("not used")
         override fun remove(buildingId: java.util.UUID, item: ItemId, quantity: Int): Boolean = error("not used")
+    }
+
+    internal object NoGates : dev.gvart.genesara.world.BuildingGateStateStore {
+        override fun insertClosed(gateInstanceId: java.util.UUID) = error("not used")
+        override fun isOpen(gateInstanceId: java.util.UUID): Boolean? = null
+        override fun toggle(gateInstanceId: java.util.UUID): Boolean? = null
     }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/loadout/GetLoadoutToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/loadout/GetLoadoutToolTest.kt
@@ -4,6 +4,8 @@ import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.world.AgentKeyInstance
+import dev.gvart.genesara.world.AgentKeysStore
 import dev.gvart.genesara.world.BodyView
 import dev.gvart.genesara.world.EquipSlot
 import dev.gvart.genesara.world.EquipmentInstance
@@ -191,14 +193,78 @@ class GetLoadoutToolTest {
         assertEquals(emptyList(), res.equipment.stash)
     }
 
+    @Test
+    fun `agent_keys rows are folded into stackable as quantity-1 entries with instanceId and gateInstanceId`() {
+        val keyInstanceId = UUID.randomUUID()
+        val gateInstanceId = UUID.randomUUID()
+        val tool = buildTool(
+            inventory = InventoryView(entries = listOf(InventoryEntry(ItemId("WOOD"), 3))),
+            items = StubItems(
+                mapOf(
+                    ItemId("WOOD") to itemFor(ItemId("WOOD"), Rarity.COMMON),
+                    ItemId("GATE_KEY") to itemFor(ItemId("GATE_KEY"), Rarity.COMMON),
+                ),
+            ),
+            keys = StubKeysStore(
+                listOf(
+                    AgentKeyInstance(
+                        instanceId = keyInstanceId,
+                        agentId = agent,
+                        itemId = ItemId("GATE_KEY"),
+                        gateInstanceId = gateInstanceId,
+                        createdAtTick = 1L,
+                    ),
+                ),
+            ),
+        )
+
+        val res = tool.invoke(toolContext)
+
+        assertEquals(2, res.stackable.size)
+        val wood = res.stackable.first { it.itemId == "WOOD" }
+        assertNull(wood.instanceId)
+        assertNull(wood.gateInstanceId)
+
+        val key = res.stackable.first { it.itemId == "GATE_KEY" }
+        assertEquals(1, key.quantity)
+        assertEquals(keyInstanceId.toString(), key.instanceId)
+        assertEquals(gateInstanceId.toString(), key.gateInstanceId)
+    }
+
+    @Test
+    fun `each agent_keys row yields its own InventoryEntryView — no merging across gates`() {
+        val gateA = UUID.randomUUID()
+        val gateB = UUID.randomUUID()
+        val keyA = UUID.randomUUID()
+        val keyB = UUID.randomUUID()
+        val tool = buildTool(
+            items = StubItems(mapOf(ItemId("GATE_KEY") to itemFor(ItemId("GATE_KEY"), Rarity.COMMON))),
+            keys = StubKeysStore(
+                listOf(
+                    AgentKeyInstance(keyA, agent, ItemId("GATE_KEY"), gateA, 1L),
+                    AgentKeyInstance(keyB, agent, ItemId("GATE_KEY"), gateB, 2L),
+                ),
+            ),
+        )
+
+        val keyEntries = tool.invoke(toolContext).stackable.filter { it.itemId == "GATE_KEY" }
+        assertEquals(2, keyEntries.size)
+        assertEquals(
+            setOf(gateA.toString(), gateB.toString()),
+            keyEntries.map { it.gateInstanceId }.toSet(),
+        )
+    }
+
     private fun buildTool(
         inventory: InventoryView = InventoryView(emptyList()),
         items: ItemLookup = StubItems(emptyMap()),
         store: EquipmentInstanceStore = StubStore(emptyList()),
+        keys: AgentKeysStore = StubKeysStore(emptyList()),
     ) = GetLoadoutTool(
         world = StubQuery(inventory),
         items = items,
         store = store,
+        keys = keys,
         activity = activity,
     )
 
@@ -241,6 +307,16 @@ class GetLoadoutToolTest {
         override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = null
         override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = null
         override fun delete(instanceId: UUID): Boolean = false
+    }
+
+    private class StubKeysStore(private val keys: List<AgentKeyInstance>) : AgentKeysStore {
+        override fun insert(key: AgentKeyInstance) = error("not used")
+        override fun findById(instanceId: UUID): AgentKeyInstance? =
+            keys.firstOrNull { it.instanceId == instanceId }
+        override fun agentHoldsKeyFor(agent: AgentId, gateInstanceId: UUID): Boolean =
+            keys.any { it.agentId == agent && it.gateInstanceId == gateInstanceId }
+        override fun listByAgent(agent: AgentId): List<AgentKeyInstance> =
+            keys.filter { it.agentId == agent }
     }
 
     private class StubQuery(private val inventory: InventoryView) : WorldQueryGateway {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/lookaround/LookAroundToolTest.kt
@@ -86,7 +86,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops, NoGates)
 
         val response = tool.invoke(toolContext)
 
@@ -107,7 +107,7 @@ class LookAroundToolTest {
             // Sight 2 surfaces `far` in `visible` but it is not move-adjacent to the current node.
             within = mapOf((currentNodeId to 2) to setOf(currentNodeId, northNodeId, farNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 2), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 2), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops, NoGates)
 
         val response = tool.invoke(toolContext)
 
@@ -124,7 +124,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops, NoGates)
 
         val response = tool.invoke(toolContext)
 
@@ -143,7 +143,7 @@ class LookAroundToolTest {
             currentTick = 7L,
         )
         val memory = RecordingMapMemory()
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, memory, NoBuildings, NoOpPlots, NoOpCrops)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, memory, NoBuildings, NoOpPlots, NoOpCrops, NoGates)
 
         tool.invoke(toolContext)
 
@@ -172,7 +172,7 @@ class LookAroundToolTest {
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
         val flaky = ThrowingMapMemory()
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, flaky, NoBuildings, NoOpPlots, NoOpCrops)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, flaky, NoBuildings, NoOpPlots, NoOpCrops, NoGates)
 
         // Should NOT throw — the read still returns successfully.
         val response = tool.invoke(toolContext)
@@ -188,7 +188,7 @@ class LookAroundToolTest {
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
             currentTick = 9_999L,
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops, NoGates)
 
         tool.invoke(toolContext)
 
@@ -204,7 +204,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops, NoGates)
 
         val response = tool.invoke(toolContext)
 
@@ -250,6 +250,7 @@ class LookAroundToolTest {
             buildings,
             plotsByNode,
             crops,
+            NoGates,
         )
 
         val view = tool.invoke(toolContext).currentNode.buildings.single()
@@ -289,7 +290,7 @@ class LookAroundToolTest {
         )
         val tool = LookAroundTool(
             world, registryWith(scoutAgent), vision(sight = 1), activity,
-            RecordingMapMemory(), buildings, plotsByNode, NoOpCrops,
+            RecordingMapMemory(), buildings, plotsByNode, NoOpCrops, NoGates,
         )
 
         val view = tool.invoke(toolContext).currentNode.buildings.single()
@@ -330,7 +331,7 @@ class LookAroundToolTest {
         )
         val tool = LookAroundTool(
             world, registryWith(scoutAgent), vision(sight = 1), activity,
-            RecordingMapMemory(), buildings, plotsByNode, StubCrops(wheatCrop),
+            RecordingMapMemory(), buildings, plotsByNode, StubCrops(wheatCrop), NoGates,
         )
 
         val view = tool.invoke(toolContext).visible.single { it.id == northNodeId.value }.buildings.single()
@@ -397,7 +398,7 @@ class LookAroundToolTest {
         )
         val campfire = activeBuilding(currentNodeId, dev.gvart.genesara.world.BuildingType.CAMPFIRE)
         val buildings = StubBuildingsLookup(byNode = mapOf(currentNodeId to listOf(campfire)))
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), buildings, NoOpPlots, NoOpCrops)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), buildings, NoOpPlots, NoOpCrops, NoGates)
 
         val response = tool.invoke(toolContext)
 
@@ -421,7 +422,7 @@ class LookAroundToolTest {
         )
         val workbench = activeBuilding(northNodeId, dev.gvart.genesara.world.BuildingType.WORKBENCH)
         val buildings = StubBuildingsLookup(byNode = mapOf(northNodeId to listOf(workbench)))
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), buildings, NoOpPlots, NoOpCrops)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), buildings, NoOpPlots, NoOpCrops, NoGates)
 
         val response = tool.invoke(toolContext)
 
@@ -433,6 +434,65 @@ class LookAroundToolTest {
         assertEquals(null, view.progressSteps)
         assertEquals(null, view.hpBand)
         assertEquals(null, view.builderAgentId)
+    }
+
+    @Test
+    fun `current-tile GATE surfaces isOpen=true when the gate state store reports OPEN`() {
+        val world = StubQuery(
+            location = currentNodeId,
+            nodes = mapOf(currentNodeId to current, northNodeId to north),
+            regions = mapOf(regionId to region),
+            within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
+        )
+        val gate = activeBuilding(currentNodeId, dev.gvart.genesara.world.BuildingType.GATE)
+        val buildings = StubBuildingsLookup(byNode = mapOf(currentNodeId to listOf(gate)))
+        val gates = StubGates(open = setOf(gate.instanceId))
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), buildings, NoOpPlots, NoOpCrops, gates)
+
+        val view = tool.invoke(toolContext).currentNode.buildings.single()
+
+        assertEquals("GATE", view.type)
+        assertEquals(true, view.isOpen)
+    }
+
+    @Test
+    fun `adjacent GATE surfaces isOpen too — gate visibility carries across sight range`() {
+        val world = StubQuery(
+            location = currentNodeId,
+            nodes = mapOf(currentNodeId to current, northNodeId to north),
+            regions = mapOf(regionId to region),
+            within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
+        )
+        val gate = activeBuilding(northNodeId, dev.gvart.genesara.world.BuildingType.GATE)
+        val buildings = StubBuildingsLookup(byNode = mapOf(northNodeId to listOf(gate)))
+        val gates = StubGates(closed = setOf(gate.instanceId))
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), buildings, NoOpPlots, NoOpCrops, gates)
+
+        val visible = tool.invoke(toolContext).visible.single { it.id == northNodeId.value }
+        val view = visible.buildings.single()
+
+        assertEquals("GATE", view.type)
+        assertEquals(false, view.isOpen)
+        // Fog-of-war contract still holds for everything else.
+        assertEquals(null, view.instanceId)
+        assertEquals(null, view.builderAgentId)
+    }
+
+    @Test
+    fun `non-GATE buildings never carry isOpen, even on the current tile`() {
+        val world = StubQuery(
+            location = currentNodeId,
+            nodes = mapOf(currentNodeId to current, northNodeId to north),
+            regions = mapOf(regionId to region),
+            within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
+        )
+        val workbench = activeBuilding(currentNodeId, dev.gvart.genesara.world.BuildingType.WORKBENCH)
+        val buildings = StubBuildingsLookup(byNode = mapOf(currentNodeId to listOf(workbench)))
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), buildings, NoOpPlots, NoOpCrops, NoGates)
+
+        val view = tool.invoke(toolContext).currentNode.buildings.single()
+
+        assertEquals(null, view.isOpen)
     }
 
     @Test
@@ -448,7 +508,7 @@ class LookAroundToolTest {
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId, northNodeId)),
         )
         val recordingBuildings = RecordingBuildingsLookup()
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), recordingBuildings, NoOpPlots, NoOpCrops)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), recordingBuildings, NoOpPlots, NoOpCrops, NoGates)
 
         tool.invoke(toolContext)
 
@@ -491,7 +551,7 @@ class LookAroundToolTest {
             activity,
             RecordingMapMemory(),
             NoBuildings,
-            NoOpPlots, NoOpCrops,
+            NoOpPlots, NoOpCrops, NoGates,
         )
 
         val response = tool.invoke(toolContext)
@@ -530,7 +590,7 @@ class LookAroundToolTest {
             activity,
             RecordingMapMemory(),
             NoBuildings,
-            NoOpPlots, NoOpCrops,
+            NoOpPlots, NoOpCrops, NoGates,
         )
 
         val response = tool.invoke(toolContext)
@@ -559,7 +619,7 @@ class LookAroundToolTest {
             activity,
             RecordingMapMemory(),
             NoBuildings,
-            NoOpPlots, NoOpCrops,
+            NoOpPlots, NoOpCrops, NoGates,
         )
 
         val response = tool.invoke(toolContext)
@@ -639,7 +699,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to unpainted),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops, NoGates)
 
         val response = tool.invoke(toolContext)
 
@@ -655,7 +715,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = emptyMap(),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops, NoGates)
 
         assertThrows<IllegalStateException> {
             tool.invoke(toolContext)
@@ -670,7 +730,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId)),
         )
-        val tool = LookAroundTool(world, EmptyRegistry, vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops)
+        val tool = LookAroundTool(world, EmptyRegistry, vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops, NoGates)
 
         assertThrows<IllegalStateException> {
             tool.invoke(toolContext)
@@ -685,7 +745,7 @@ class LookAroundToolTest {
             regions = mapOf(regionId to region),
             within = mapOf((currentNodeId to 1) to setOf(currentNodeId)),
         )
-        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops)
+        val tool = LookAroundTool(world, registryWith(scoutAgent), vision(sight = 1), activity, RecordingMapMemory(), NoBuildings, NoOpPlots, NoOpCrops, NoGates)
 
         tool.invoke(toolContext)
 
@@ -800,5 +860,22 @@ class LookAroundToolTest {
     internal object NoOpCrops : dev.gvart.genesara.world.CropLookup {
         override fun byId(id: dev.gvart.genesara.world.CropId): dev.gvart.genesara.world.Crop? = null
         override fun all(): List<dev.gvart.genesara.world.Crop> = emptyList()
+    }
+
+    internal object NoGates : dev.gvart.genesara.world.BuildingGateStateStore {
+        override fun insertClosed(gateInstanceId: java.util.UUID) = error("not used")
+        override fun isOpen(gateInstanceId: java.util.UUID): Boolean? = null
+        override fun toggle(gateInstanceId: java.util.UUID): Boolean? = null
+    }
+
+    internal class StubGates(
+        open: Set<java.util.UUID> = emptySet(),
+        closed: Set<java.util.UUID> = emptySet(),
+    ) : dev.gvart.genesara.world.BuildingGateStateStore {
+        private val state: Map<java.util.UUID, Boolean> =
+            open.associateWith { true } + closed.associateWith { false }
+        override fun insertClosed(gateInstanceId: java.util.UUID) = error("not used")
+        override fun isOpen(gateInstanceId: java.util.UUID): Boolean? = state[gateInstanceId]
+        override fun toggle(gateInstanceId: java.util.UUID): Boolean? = error("not used")
     }
 }

--- a/world/build.gradle.kts
+++ b/world/build.gradle.kts
@@ -23,5 +23,5 @@ dependencies {
 
 jooqModule {
     migrationsSubdir.set("world")
-    tableIncludes.set("worlds|regions|region_neighbors|nodes|node_adjacency|agent_positions|agent_bodies|starter_nodes|agent_inventory|non_renewable_resources|agent_node_memory|agent_equipment_instances|agent_safe_nodes|node_buildings|node_building_bars|building_chest_inventory|world_tick|agent_action_counters|agent_known_recipes|trade_offers|agent_plots")
+    tableIncludes.set("worlds|regions|region_neighbors|nodes|node_adjacency|agent_positions|agent_bodies|starter_nodes|agent_inventory|non_renewable_resources|agent_node_memory|agent_equipment_instances|agent_safe_nodes|node_buildings|node_building_bars|building_chest_inventory|building_gate_states|agent_keys|world_tick|agent_action_counters|agent_known_recipes|trade_offers|agent_plots")
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/AgentKeyInstance.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/AgentKeyInstance.kt
@@ -1,0 +1,21 @@
+package dev.gvart.genesara.world
+
+import dev.gvart.genesara.player.AgentId
+import java.util.UUID
+
+/**
+ * A single physical key in an agent's inventory. Mirrors [EquipmentInstance]'s
+ * shape: per-instance UUID PK, no stack semantics, soft refs to the holding
+ * agent and the gate it opens. Backed by `agent_keys`.
+ *
+ * Keys cannot merge because each instance encodes the gate it targets — two
+ * keys to two different gates can never be a stack of two, even when the
+ * underlying [ItemId] (GATE_KEY) is the same.
+ */
+data class AgentKeyInstance(
+    val instanceId: UUID,
+    val agentId: AgentId,
+    val itemId: ItemId,
+    val gateInstanceId: UUID,
+    val createdAtTick: Long,
+)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/AgentKeysStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/AgentKeysStore.kt
@@ -1,0 +1,25 @@
+package dev.gvart.genesara.world
+
+import dev.gvart.genesara.player.AgentId
+import java.util.UUID
+
+/**
+ * Persistent store for [AgentKeyInstance]s. Mirrors [EquipmentInstanceStore]:
+ * per-instance UUID PK, transactional reads/writes, no ORM caching. Side-channel
+ * writes during the build-complete / craft / toggle paths; the surrounding
+ * reducer transaction keeps the row insert and the world-state save atomic.
+ */
+interface AgentKeysStore {
+
+    /** Insert a freshly minted key. PK uniqueness on `instance_id` rejects double-insert. */
+    fun insert(key: AgentKeyInstance)
+
+    /** Single-instance lookup. Returns `null` when the row is gone. */
+    fun findById(instanceId: UUID): AgentKeyInstance?
+
+    /** Does [agent] hold any key bound to [gateInstanceId]? Hot-path predicate for toggle / passage. */
+    fun agentHoldsKeyFor(agent: AgentId, gateInstanceId: UUID): Boolean
+
+    /** Every key held by [agent]. Used by projections and admin tooling. */
+    fun listByAgent(agent: AgentId): List<AgentKeyInstance>
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/BuildingCategoryHint.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/BuildingCategoryHint.kt
@@ -25,4 +25,5 @@ enum class BuildingCategoryHint {
     VISION,
     COMMERCE,
     ANIMAL_HOUSING,
+    EXTRACTION_MINE;
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/BuildingGateStateStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/BuildingGateStateStore.kt
@@ -1,0 +1,22 @@
+package dev.gvart.genesara.world
+
+import java.util.UUID
+
+/**
+ * Persistent store for GATE per-instance OPEN/CLOSED state. Backed by
+ * `building_gate_states` — one row per ACTIVE gate, inserted on build-complete
+ * and cascade-deleted when the parent building row is removed.
+ *
+ * Non-gate buildings have no row; reads for unknown ids return `null`.
+ */
+interface BuildingGateStateStore {
+
+    /** Insert a fresh gate-state row, defaulting to CLOSED. Called on GATE build completion. */
+    fun insertClosed(gateInstanceId: UUID)
+
+    /** Read whether [gateInstanceId] is OPEN. `null` when no row exists for the id (non-gate or pre-completion). */
+    fun isOpen(gateInstanceId: UUID): Boolean?
+
+    /** Flip the gate's state. Returns the new state. Returns `null` when no row exists. */
+    fun toggle(gateInstanceId: UUID): Boolean?
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/BuildingType.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/BuildingType.kt
@@ -1,16 +1,14 @@
 package dev.gvart.genesara.world
 
 /**
- * The Tier-1 (non-base) building catalog. Five behavioral types are wired in
- * this slice; the rest are scaffolded with persistent state but their gameplay
- * effect waits on a downstream substrate (cooking + crafting recipes from #8,
- * cultivated resources from #18, PvP combat from Phase 2).
+ * The Tier-1/Tier-2 (non-base) building catalog. All entries carry persistent
+ * state and a wired gameplay effect except STABLE (waiting on #21 mounts).
  *
  * The base-tier ladder (T1 outpost → T5 city — see mechanics-reference §13)
  * is a separate concept and lands with the territory work in #23 Phase 3.
  */
 enum class BuildingType {
-    /** TODO(#8): consult as a cooking station once recipes land; today inert. */
+    /** Cooking station — gates `craft` recipes whose `requiredStation` is COOKING. */
     CAMPFIRE,
 
     /** Owner-only personal stash backed by `building_chest_inventory`. */
@@ -19,25 +17,25 @@ enum class BuildingType {
     /** On the build step that completes the shelter, the builder's safe-node is set to its node. */
     SHELTER,
 
-    /** TODO(#8): consult as a wood crafting station; today inert. */
+    /** Wood crafting station — gates recipes whose `requiredStation` is CRAFTING_STATION_WOOD. */
     WORKBENCH,
 
-    /** TODO(#8): consult as a metal crafting station; today inert. */
+    /** Metal crafting station — gates recipes whose `requiredStation` is CRAFTING_STATION_METAL. */
     FORGE,
 
-    /** TODO(#8): consult as a potion crafting station; today inert. */
+    /** Potion crafting station — gates recipes whose `requiredStation` is CRAFTING_STATION_POTION. */
     ALCHEMY_TABLE,
 
-    /** TODO(#18): anchor for plant / tend / harvest verbs; today inert. */
+    /** Anchor for plant / tend / harvest_crop verbs; the build-complete side-effect inserts an `agent_plots` row. */
     FARM_PLOT,
 
     /** Drink succeeds on this node even when terrain is not a water source. */
     WELL,
 
-    /** TODO(#22 Phase 2 PvP): block enemy entry; today inert. */
+    /** DEFENSIVE: blocks all movement onto its node when active. No friendly bypass; use GATE for permissioned passage. */
     WOODEN_WALL,
 
-    /** Halves outgoing-move stamina cost when an agent leaves the road's node. */
+    /** Halves move stamina cost in both directions (entering AND leaving a road's node). */
     ROAD,
 
     /** Overrides `TerrainNotTraversable` on the bridge's node. */
@@ -51,4 +49,20 @@ enum class BuildingType {
 
     /** TODO(#21): mount housing + taming anchor; today inert. */
     STABLE,
+
+    /**
+     * DEFENSIVE: like WOODEN_WALL, but passage is gated by per-instance OPEN/CLOSED
+     * state. Toggle requires holding a matching GATE_KEY at the gate's node;
+     * passage is allowed only while state is OPEN. The builder receives 1 key
+     * on completion; copies are minted via `copy_gate_key` at a WORKBENCH.
+     */
+    GATE,
+
+    /**
+     * Extraction infrastructure for `extract`-only resources (COAL, ORE, GOLD).
+     * Any agent on the node may extract while the MINE is ACTIVE; security
+     * comes from surrounding WALL / GATE structures, not from MINE access
+     * control. Terrain-coupled at build time: FOOTHILLS / MOUNTAIN / VOLCANIC.
+     */
+    MINE,
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/Item.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/Item.kt
@@ -137,6 +137,13 @@ data class Item(
      * [EquippedBonus] for the discriminated shape, ADR-0001 for the design.
      */
     val bonuses: List<EquippedBonus> = emptyList(),
+    /**
+     * If true, this resource is reachable only via the `extract` verb at an
+     * active MINE. The `harvest` verb rejects it with `ResourceNotAvailableHere`
+     * regardless of whether the underlying node has the spawn — building
+     * extraction infrastructure is the gate. Used for COAL / ORE / GOLD.
+     */
+    val extractionOnly: Boolean = false,
 ) {
     init {
         if (twoHanded) {

--- a/world/src/main/kotlin/dev/gvart/genesara/world/RecipeLookup.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/RecipeLookup.kt
@@ -37,6 +37,16 @@ data class Recipe(
     val requiredSkillLevel: Int,
     val staminaCost: Int,
     val unlockMode: RecipeUnlockMode = RecipeUnlockMode.Open,
+    /**
+     * Some recipes operate on an existing per-instance item (template-style):
+     * GATE_KEY_COPY consumes IRON_INGOT + an existing GATE_KEY, mints a new
+     * key bound to the same gate as the source. Future upgrade recipes will
+     * carry an existing EquipmentInstance for refinement. When non-null the
+     * `craft` command must supply `source` (the instance UUID); the reducer
+     * validates the source resolves to an owned instance of the named item
+     * type before consuming it (or not — keys are templates and stay).
+     */
+    val requiresSource: ItemId? = null,
 )
 
 interface RecipeLookup {

--- a/world/src/main/kotlin/dev/gvart/genesara/world/ResourceItemId.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/ResourceItemId.kt
@@ -31,11 +31,7 @@ enum class ResourceItemId {
     COAL,
     GEM,
     SALT,
-
-    // Cultivars (#18). Spawn rarely on PLAINS / MEADOW / HILLS / FOREST_EDGE so day-0
-    // agents can forage a starter unit; the renewable+reliable path is to plant them
-    // on a FARM_PLOT and reap many. Plot-first dispatch in HarvestTool prefers the
-    // ripe plot over the wild cell when both are present at the agent's node.
+    GOLD,
     WHEAT,
     POTATO,
     TOMATO,

--- a/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
@@ -462,4 +462,91 @@ sealed interface WorldRejection {
         val crop: CropId,
         val ticksRemaining: Long,
     ) : WorldRejection
+
+    /**
+     * `build` rejected because another DEFENSIVE-category structure already
+     * exists at the agent's node. WOODEN_WALL and GATE share the slot:
+     * stacking them is nonsensical (a gate is bypassable, a wall isn't).
+     * Carries the existing variant so the agent can decide whether to
+     * demolish-and-rebuild or pick a different node.
+     */
+    data class DefensiveAlreadyAtNode(
+        val agent: AgentId,
+        val type: BuildingType,
+        val node: NodeId,
+        val existingType: BuildingType,
+        val existingInstanceId: UUID,
+    ) : WorldRejection
+
+    /**
+     * `build` rejected because the requested [type] is terrain-coupled and
+     * the agent's node is not on the allowed list. Today only MINE is
+     * terrain-coupled (FOOTHILLS / MOUNTAIN / VOLCANIC); future variants
+     * will reuse this rejection.
+     */
+    data class BuildingTerrainMismatch(
+        val agent: AgentId,
+        val type: BuildingType,
+        val node: NodeId,
+        val terrain: Terrain,
+        val allowed: Set<Terrain>,
+    ) : WorldRejection
+
+    /**
+     * `toggle_gate` rejected because the gate id does not resolve, the
+     * building is not a GATE, or it is not ACTIVE. Surfaced as a single
+     * rejection so probing for "is X a gate?" via id enumeration cannot
+     * leak the building catalog.
+     */
+    data class GateNotFound(val agent: AgentId, val gateId: UUID) : WorldRejection
+
+    /**
+     * `toggle_gate` rejected because the agent does not hold any key bound
+     * to [gateId]. The reducer surfaces this without disclosing whether
+     * other agents hold keys — that knowledge is per-agent.
+     */
+    data class MissingGateKey(val agent: AgentId, val gateId: UUID) : WorldRejection
+
+    /**
+     * Movement onto a node with an ACTIVE wall (WOODEN_WALL) or a CLOSED
+     * GATE. The reducer collapses both to this single rejection so an agent
+     * probing via repeated moves cannot deduce the precise variant.
+     */
+    data class DefensiveBlocks(val agent: AgentId, val node: NodeId) : WorldRejection
+
+    /**
+     * `extract` rejected because no ACTIVE MINE is at the agent's node.
+     * Distinct from [RecipeRequiresStation] because extract is not a craft
+     * verb — it has its own surface area and rejection.
+     */
+    data class ExtractRequiresMine(val agent: AgentId, val node: NodeId) : WorldRejection
+
+    /**
+     * `harvest` rejected because the [item] is flagged `extractionOnly` —
+     * it requires the `extract` verb at a built MINE. Surfaced so an agent
+     * who learns of GOLD / ORE / COAL on a node can route to `extract`
+     * instead of retrying `harvest`.
+     */
+    data class HarvestRequiresExtraction(
+        val agent: AgentId,
+        val node: NodeId,
+        val item: ItemId,
+    ) : WorldRejection
+
+    /**
+     * `craft` rejected because the recipe declares `requiresSource` and one
+     * of the following holds:
+     *   - The command did not pass a `source` UUID.
+     *   - The supplied `source` does not resolve to an instance the agent owns.
+     *   - The supplied `source`'s item-id does not match the recipe's required type.
+     *
+     * Collapsed for anti-probe: an agent enumerating UUIDs cannot tell the
+     * three cases apart. [requiredItem] is the item type the recipe expects
+     * the source to be (e.g. GATE_KEY for GATE_KEY_COPY).
+     */
+    data class RecipeRequiresSource(
+        val agent: AgentId,
+        val recipe: RecipeId,
+        val requiredItem: ItemId,
+    ) : WorldRejection
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/commands/WorldCommand.kt
@@ -47,6 +47,8 @@ import java.util.UUID
     JsonSubTypes.Type(value = WorldCommand.PlantCrop::class, name = "plantCrop"),
     JsonSubTypes.Type(value = WorldCommand.TendCrop::class, name = "tendCrop"),
     JsonSubTypes.Type(value = WorldCommand.HarvestCrop::class, name = "harvestCrop"),
+    JsonSubTypes.Type(value = WorldCommand.ToggleGate::class, name = "toggleGate"),
+    JsonSubTypes.Type(value = WorldCommand.Extract::class, name = "extract"),
 )
 sealed interface WorldCommand {
     val agent: AgentId
@@ -154,10 +156,17 @@ sealed interface WorldCommand {
      * with the calling agent. Stackable outputs (potions, intermediates) skip
      * the rarity roll and the creator signature; the output is added to the
      * agent's inventory instead.
+     *
+     * [source] is required when the recipe declares `requiresSource`: a
+     * UUID identifying an existing per-instance item the recipe operates on
+     * (e.g. GATE_KEY_COPY references an existing GATE_KEY whose gate-binding
+     * the new key inherits). Future upgrade-style recipes will use this
+     * field to point at an existing EquipmentInstance to refine.
      */
     data class CraftItem(
         override val agent: AgentId,
         val recipe: RecipeId,
+        val source: UUID? = null,
         override val commandId: UUID = UUID.randomUUID(),
     ) : WorldCommand
 
@@ -306,4 +315,29 @@ sealed interface WorldCommand {
         val plotId: UUID,
         override val commandId: UUID = UUID.randomUUID(),
     ) : WorldCommand
+
+    /**
+     * Flip the OPEN/CLOSED state of GATE [gateId]. Requires the agent to be
+     * standing on the gate's node AND to hold a matching key. Passage through
+     * a GATE is gated by its state; passage through a WOODEN_WALL is always
+     * blocked.
+     */
+    data class ToggleGate(
+        override val agent: AgentId,
+        val gateId: UUID,
+        override val commandId: UUID = UUID.randomUUID(),
+    ) : WorldCommand
+
+    /**
+     * Pull a single yield of [item] from the agent's current node via a built
+     * MINE. Mirrors [Harvest] but filters to items flagged `extractionOnly`
+     * (COAL, ORE, GOLD) and requires an ACTIVE MINE building at the node.
+     * MINING is the trained skill (via [Item.harvestSkill]).
+     */
+    data class Extract(
+        override val agent: AgentId,
+        val item: ItemId,
+        override val commandId: UUID = UUID.randomUUID(),
+    ) : WorldCommand
+
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/events/WorldEvent.kt
@@ -447,4 +447,47 @@ sealed interface WorldEvent {
         val neglectedSinceTick: Long,
         override val tick: Long,
     ) : WorldEvent
+
+    /**
+     * Emitted on a successful `toggle_gate`. [isOpen] is the post-toggle
+     * state — agents in the same node can correlate by gate id to update
+     * their cached fog-of-war about the perimeter.
+     */
+    data class GateToggled(
+        val agent: AgentId,
+        val gateId: UUID,
+        val at: NodeId,
+        val isOpen: Boolean,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : WorldEvent
+
+    /**
+     * Emitted on a successful `extract`. Mirrors [ResourceHarvested] shape;
+     * separate event so consumers can distinguish MINE-gated pulls from bare
+     * gather (different XP / progression signal in the future).
+     */
+    data class ResourceExtracted(
+        val agent: AgentId,
+        val at: NodeId,
+        val item: ItemId,
+        val quantity: Int,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : WorldEvent
+
+    /**
+     * Emitted when the build reducer auto-issues a GATE_KEY on gate build
+     * completion, AND when the `copy_gate_key` reducer mints a duplicate.
+     * [byCopy] distinguishes the two — auto-issue is implicit on
+     * [BuildingConstructed]; copies are caused by [WorldCommand.CopyGateKey].
+     */
+    data class GateKeyMinted(
+        val agent: AgentId,
+        val keyInstanceId: UUID,
+        val gateId: UUID,
+        val byCopy: Boolean,
+        override val tick: Long,
+        val causedBy: UUID,
+    ) : WorldEvent
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -10,10 +10,12 @@ import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.PassiveAuraAggregator
 import dev.gvart.genesara.player.PerkCooldownStore
 import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.world.AgentKeysStore
 import dev.gvart.genesara.world.AgentKnownRecipesGateway
 import dev.gvart.genesara.world.AgentPlotsStore
 import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.BuildingBarsStore
+import dev.gvart.genesara.world.BuildingGateStateStore
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.BuildingsStore
 import dev.gvart.genesara.world.ChestContentsStore
@@ -38,8 +40,10 @@ import dev.gvart.genesara.world.internal.abilities.PendingAttackScaleStore
 import dev.gvart.genesara.world.internal.abilities.reduceUseAbility
 import dev.gvart.genesara.world.internal.buildings.reduceBuild
 import dev.gvart.genesara.world.internal.buildings.reduceDeposit
+import dev.gvart.genesara.world.internal.buildings.reduceToggleGate
 import dev.gvart.genesara.world.internal.buildings.reduceWithdraw
 import dev.gvart.genesara.world.internal.combat.reduceAttack
+import dev.gvart.genesara.world.internal.extract.reduceExtract
 import dev.gvart.genesara.world.internal.consume.reduceConsume
 import dev.gvart.genesara.world.internal.crafting.RarityRoller
 import dev.gvart.genesara.world.internal.crafting.reduceCraft
@@ -83,6 +87,8 @@ internal fun reduce(
     buildingBars: BuildingBarsStore,
     buildingsLookup: BuildingsLookup,
     buildingsCatalog: BuildingsCatalog,
+    gateStates: BuildingGateStateStore,
+    agentKeys: AgentKeysStore,
     chestContents: ChestContentsStore,
     plots: AgentPlotsStore,
     crops: CropLookup,
@@ -109,7 +115,7 @@ internal fun reduce(
     classes: ClassLookup = dev.gvart.genesara.player.NoOpClassLookup,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = when (command) {
     is WorldCommand.SpawnAgent -> reduceSpawn(state, command, profiles, spawnLocationResolver, tick)
-    is WorldCommand.MoveAgent -> reduceMove(state, command, balance, buildingsLookup, scaling, behaviorTracker, tick)
+    is WorldCommand.MoveAgent -> reduceMove(state, command, balance, buildingsLookup, gateStates, scaling, behaviorTracker, tick)
     is WorldCommand.UnspawnAgent -> reduceUnspawn(state, command, tick)
     is WorldCommand.Harvest ->
         reduceHarvest(
@@ -123,7 +129,7 @@ internal fun reduce(
     is WorldCommand.BuildStructure ->
         reduceBuild(
             state, command, buildingsCatalog, skills, buildings, buildingBars, safeNodes, plots,
-            progression, triggeredPassives, behaviorTracker, tick,
+            gateStates, agentKeys, progression, triggeredPassives, behaviorTracker, tick,
         )
     is WorldCommand.DepositToChest ->
         reduceDeposit(state, command, items, buildingsCatalog, buildings, chestContents, tick)
@@ -131,7 +137,7 @@ internal fun reduce(
         reduceWithdraw(state, command, buildings, chestContents, tick)
     is WorldCommand.CraftItem ->
         reduceCraft(
-            state, command, balance, items, recipes, knownRecipes, equipment, buildingsLookup,
+            state, command, balance, items, recipes, knownRecipes, equipment, agentKeys, buildingsLookup,
             skills, agents, rarityRoller, progression, scaling, triggeredPassives, behaviorTracker, tick,
         )
     is WorldCommand.Pickup ->
@@ -161,5 +167,12 @@ internal fun reduce(
         reduceHarvestCrop(
             state, command, crops, plots, items, agents, skills, equipment, balance,
             progression, characterXp, triggeredPassives, behaviorTracker, rng, tick,
+        )
+    is WorldCommand.ToggleGate ->
+        reduceToggleGate(state, command, buildings, gateStates, agentKeys, tick)
+    is WorldCommand.Extract ->
+        reduceExtract(
+            state, command, balance, items, resources, buildingsLookup, agents, equipment,
+            progression, characterXp, scaling, triggeredPassives, behaviorTracker, tick,
         )
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemLookupImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemLookupImpl.kt
@@ -47,5 +47,6 @@ internal class ItemLookupImpl(
         combatSkill = combatSkill?.let(::SkillId),
         range = range,
         bonuses = bonuses.map { it.bindToDomain(id.value) },
+        extractionOnly = extractionOnly,
     )
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemProperties.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/balance/ItemProperties.kt
@@ -53,6 +53,12 @@ internal data class ItemProperties(
      * app boot in the binder. See ADR-0001.
      */
     val bonuses: List<EquippedBonusProperties> = emptyList(),
+    /**
+     * Mirrors [dev.gvart.genesara.world.Item.extractionOnly]: when true the
+     * `harvest` verb rejects this item and the `extract` verb requires an
+     * active MINE on the agent's node.
+     */
+    val extractionOnly: Boolean = false,
 )
 
 internal data class EquippedBonusProperties(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducer.kt
@@ -9,16 +9,21 @@ import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import dev.gvart.genesara.world.AgentKeyInstance
+import dev.gvart.genesara.world.AgentKeysStore
 import dev.gvart.genesara.world.AgentPlot
 import dev.gvart.genesara.world.AgentPlotsStore
 import dev.gvart.genesara.world.AgentSafeNodeGateway
 import dev.gvart.genesara.world.Building
 import dev.gvart.genesara.world.BuildingBar
 import dev.gvart.genesara.world.BuildingBarsStore
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingGateStateStore
 import dev.gvart.genesara.world.BuildingStatus
 import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.BuildingsStore
 import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.Terrain
 import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
@@ -39,6 +44,8 @@ internal fun reduceBuild(
     bars: BuildingBarsStore,
     safeNodes: AgentSafeNodeGateway,
     plots: AgentPlotsStore,
+    gateStates: BuildingGateStateStore,
+    keys: AgentKeysStore,
     progression: SkillProgression,
     triggeredPassives: TriggeredPassiveDispatcher,
     behaviorTracker: BehaviorTracker,
@@ -47,6 +54,7 @@ internal fun reduceBuild(
     val nodeId = ensureNotNull(state.positions[command.agent]) {
         WorldRejection.NotInWorld(command.agent)
     }
+    val node = ensureNotNull(state.nodes[nodeId]) { WorldRejection.UnknownNode(nodeId) }
     val def = catalog.def(command.type)
     val targetBar = resolveTargetBar(def, command)
 
@@ -71,6 +79,23 @@ internal fun reduceBuild(
 
     val existing = buildings.findInProgress(nodeId, command.agent, command.type)
     if (existing == null) {
+        // Terrain coupling: MINE can only be founded on rocky terrain. The
+        // restriction lives in the reducer (not the catalog YAML) because today
+        // only MINE is terrain-coupled; if more types join we will lift this
+        // into the catalog as a per-def `allowedTerrains` set.
+        val allowed = terrainGate(command.type)
+        if (allowed != null && node.terrain !in allowed) {
+            raise(
+                WorldRejection.BuildingTerrainMismatch(
+                    agent = command.agent,
+                    type = command.type,
+                    node = nodeId,
+                    terrain = node.terrain,
+                    allowed = allowed,
+                ),
+            )
+        }
+
         val occupant = buildings.findAnyAtNodeOfType(nodeId, command.type)
         if (occupant != null) {
             raise(
@@ -81,6 +106,25 @@ internal fun reduceBuild(
                     existingInstanceId = occupant.instanceId,
                 ),
             )
+        }
+
+        // DEFENSIVE slot is shared across WOODEN_WALL + GATE: stacking a wall
+        // on top of a gate (or vice versa) is nonsensical (gate is bypassable,
+        // wall isn't). At most one DEFENSIVE-category structure per node.
+        if (def.categoryHint == BuildingCategoryHint.DEFENSIVE) {
+            val occupyingDefensive = buildings.listAtNode(nodeId)
+                .firstOrNull { catalog.def(it.type).categoryHint == BuildingCategoryHint.DEFENSIVE }
+            if (occupyingDefensive != null) {
+                raise(
+                    WorldRejection.DefensiveAlreadyAtNode(
+                        agent = command.agent,
+                        type = command.type,
+                        node = nodeId,
+                        existingType = occupyingDefensive.type,
+                        existingInstanceId = occupyingDefensive.instanceId,
+                    ),
+                )
+            }
         }
     }
 
@@ -151,7 +195,11 @@ internal fun reduceBuild(
         }
     }
 
-    if (event is WorldEvent.BuildingConstructed) applyCompletionSideEffects(resultBuilding, safeNodes, plots, tick)
+    val completionEvents = if (event is WorldEvent.BuildingConstructed) {
+        applyCompletionSideEffects(resultBuilding, safeNodes, plots, gateStates, keys, command.commandId, tick)
+    } else {
+        emptyList()
+    }
 
     progression.accrueXp(command.agent, targetBar.skill, delta = 1, tick, command.commandId)
     behaviorTracker.record(command.agent, ActionCategory.BUILD, tick)
@@ -170,7 +218,14 @@ internal fun reduceBuild(
     } else {
         emptyList()
     }
-    next to (listOf(event) + triggered)
+    next to (listOf(event) + completionEvents + triggered)
+}
+
+private val MINE_ALLOWED_TERRAINS: Set<Terrain> = setOf(Terrain.FOOTHILLS, Terrain.MOUNTAIN, Terrain.VOLCANIC)
+
+private fun terrainGate(type: BuildingType): Set<Terrain>? = when (type) {
+    BuildingType.MINE -> MINE_ALLOWED_TERRAINS
+    else -> null
 }
 
 private fun Raise<WorldRejection>.resolveTargetBar(
@@ -219,11 +274,17 @@ private fun applyCompletionSideEffects(
     building: Building,
     safeNodes: AgentSafeNodeGateway,
     plots: AgentPlotsStore,
+    gateStates: BuildingGateStateStore,
+    keys: AgentKeysStore,
+    commandId: UUID,
     tick: Long,
-) {
-    when (building.type) {
-        BuildingType.SHELTER -> safeNodes.set(building.builtByAgentId, building.nodeId, tick)
-        BuildingType.FARM_PLOT -> plots.insertEmpty(
+): List<WorldEvent> = when (building.type) {
+    BuildingType.SHELTER -> {
+        safeNodes.set(building.builtByAgentId, building.nodeId, tick)
+        emptyList()
+    }
+    BuildingType.FARM_PLOT -> {
+        plots.insertEmpty(
             AgentPlot(
                 plotId = UUID.randomUUID(),
                 buildingInstanceId = building.instanceId,
@@ -231,6 +292,30 @@ private fun applyCompletionSideEffects(
                 plant = null,
             ),
         )
-        else -> Unit
+        emptyList()
     }
+    BuildingType.GATE -> {
+        gateStates.insertClosed(building.instanceId)
+        val keyId = UUID.randomUUID()
+        keys.insert(
+            AgentKeyInstance(
+                instanceId = keyId,
+                agentId = building.builtByAgentId,
+                itemId = ItemId("GATE_KEY"),
+                gateInstanceId = building.instanceId,
+                createdAtTick = tick,
+            ),
+        )
+        listOf(
+            WorldEvent.GateKeyMinted(
+                agent = building.builtByAgentId,
+                keyInstanceId = keyId,
+                gateId = building.instanceId,
+                byCopy = false,
+                tick = tick,
+                causedBy = commandId,
+            ),
+        )
+    }
+    else -> emptyList()
 }

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/JooqAgentKeysStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/JooqAgentKeysStore.kt
@@ -1,0 +1,60 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.AgentKeyInstance
+import dev.gvart.genesara.world.AgentKeysStore
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_KEYS
+import org.jooq.DSLContext
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Component
+internal class JooqAgentKeysStore(
+    private val dsl: DSLContext,
+) : AgentKeysStore {
+
+    @Transactional
+    override fun insert(key: AgentKeyInstance) {
+        dsl.insertInto(AGENT_KEYS)
+            .set(AGENT_KEYS.INSTANCE_ID, key.instanceId)
+            .set(AGENT_KEYS.AGENT_ID, key.agentId.id)
+            .set(AGENT_KEYS.ITEM_ID, key.itemId.value)
+            .set(AGENT_KEYS.GATE_INSTANCE_ID, key.gateInstanceId)
+            .set(AGENT_KEYS.CREATED_AT_TICK, key.createdAtTick)
+            .execute()
+    }
+
+    @Transactional(readOnly = true)
+    override fun findById(instanceId: UUID): AgentKeyInstance? =
+        dsl.selectFrom(AGENT_KEYS)
+            .where(AGENT_KEYS.INSTANCE_ID.eq(instanceId))
+            .fetchOne(::toDomain)
+
+    @Transactional(readOnly = true)
+    override fun agentHoldsKeyFor(agent: AgentId, gateInstanceId: UUID): Boolean =
+        dsl.fetchExists(
+            dsl.selectOne()
+                .from(AGENT_KEYS)
+                .where(AGENT_KEYS.AGENT_ID.eq(agent.id))
+                .and(AGENT_KEYS.GATE_INSTANCE_ID.eq(gateInstanceId)),
+        )
+
+    @Transactional(readOnly = true)
+    override fun listByAgent(agent: AgentId): List<AgentKeyInstance> =
+        dsl.selectFrom(AGENT_KEYS)
+            .where(AGENT_KEYS.AGENT_ID.eq(agent.id))
+            .orderBy(AGENT_KEYS.CREATED_AT_TICK.asc(), AGENT_KEYS.INSTANCE_ID.asc())
+            .fetch(::toDomain)
+
+    private fun toDomain(
+        record: dev.gvart.genesara.world.internal.jooq.tables.records.AgentKeysRecord,
+    ): AgentKeyInstance = AgentKeyInstance(
+        instanceId = record.instanceId,
+        agentId = AgentId(record.agentId),
+        itemId = ItemId(record.itemId),
+        gateInstanceId = record.gateInstanceId,
+        createdAtTick = record.createdAtTick,
+    )
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/JooqBuildingGateStateStore.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/JooqBuildingGateStateStore.kt
@@ -1,0 +1,42 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.world.BuildingGateStateStore
+import dev.gvart.genesara.world.internal.jooq.tables.references.BUILDING_GATE_STATES
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Component
+internal class JooqBuildingGateStateStore(
+    private val dsl: DSLContext,
+) : BuildingGateStateStore {
+
+    @Transactional
+    override fun insertClosed(gateInstanceId: UUID) {
+        dsl.insertInto(BUILDING_GATE_STATES)
+            .set(BUILDING_GATE_STATES.BUILDING_INSTANCE_ID, gateInstanceId)
+            .set(BUILDING_GATE_STATES.IS_OPEN, false)
+            .execute()
+    }
+
+    @Transactional(readOnly = true)
+    override fun isOpen(gateInstanceId: UUID): Boolean? =
+        dsl.select(BUILDING_GATE_STATES.IS_OPEN)
+            .from(BUILDING_GATE_STATES)
+            .where(BUILDING_GATE_STATES.BUILDING_INSTANCE_ID.eq(gateInstanceId))
+            .fetchOne(BUILDING_GATE_STATES.IS_OPEN)
+
+    @Transactional
+    override fun toggle(gateInstanceId: UUID): Boolean? {
+        val flipped = DSL.case_()
+            .`when`(BUILDING_GATE_STATES.IS_OPEN.eq(true), DSL.value(false))
+            .otherwise(DSL.value(true))
+        return dsl.update(BUILDING_GATE_STATES)
+            .set(BUILDING_GATE_STATES.IS_OPEN, flipped)
+            .where(BUILDING_GATE_STATES.BUILDING_INSTANCE_ID.eq(gateInstanceId))
+            .returningResult(BUILDING_GATE_STATES.IS_OPEN)
+            .fetchOne(BUILDING_GATE_STATES.IS_OPEN)
+    }
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/ToggleGateReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/buildings/ToggleGateReducer.kt
@@ -1,0 +1,68 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import arrow.core.Either
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import arrow.core.raise.ensureNotNull
+import dev.gvart.genesara.world.AgentKeysStore
+import dev.gvart.genesara.world.BuildingGateStateStore
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+
+/**
+ * Reducer for [WorldCommand.ToggleGate]. Validates the agent is co-located
+ * with the gate, the gate is ACTIVE, and the agent holds a matching key.
+ * Toggles state and emits [WorldEvent.GateToggled] carrying the post-flip
+ * state.
+ *
+ * No stamina cost: a key-holding agent at the gate's node is presumed to
+ * have walked up to it; the toggle itself is a near-zero action.
+ */
+internal fun reduceToggleGate(
+    state: WorldState,
+    command: WorldCommand.ToggleGate,
+    buildings: BuildingsStore,
+    gateStates: BuildingGateStateStore,
+    keys: AgentKeysStore,
+    tick: Long,
+): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = either {
+    val agentNode = ensureNotNull(state.positions[command.agent]) {
+        WorldRejection.NotInWorld(command.agent)
+    }
+    val gate = ensureNotNull(buildings.findById(command.gateId)) {
+        WorldRejection.GateNotFound(command.agent, command.gateId)
+    }
+    ensure(gate.type == BuildingType.GATE) {
+        WorldRejection.GateNotFound(command.agent, command.gateId)
+    }
+    ensure(gate.status == BuildingStatus.ACTIVE) {
+        WorldRejection.BuildingNotActive(command.gateId, gate.status)
+    }
+    ensure(gate.nodeId == agentNode) {
+        WorldRejection.NotOnBuildingNode(command.agent, command.gateId)
+    }
+    ensure(keys.agentHoldsKeyFor(command.agent, command.gateId)) {
+        WorldRejection.MissingGateKey(command.agent, command.gateId)
+    }
+    val newOpen = ensureNotNull(gateStates.toggle(command.gateId)) {
+        // Defensive: gate row exists but its state row is missing. The
+        // build-complete side-effect inserts both atomically, so this is a
+        // schema-invariant break, not a user-facing case. Collapse to
+        // GateNotFound so we don't leak the storage layout.
+        WorldRejection.GateNotFound(command.agent, command.gateId)
+    }
+    val event = WorldEvent.GateToggled(
+        agent = command.agent,
+        gateId = command.gateId,
+        at = gate.nodeId,
+        isOpen = newOpen,
+        tick = tick,
+        causedBy = command.commandId,
+    )
+    state to listOf(event)
+}

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducer.kt
@@ -12,12 +12,15 @@ import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import dev.gvart.genesara.world.AgentKeyInstance
+import dev.gvart.genesara.world.AgentKeysStore
 import dev.gvart.genesara.world.AgentKnownRecipesGateway
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.EquipmentInstance
 import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.Item
 import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.Recipe
@@ -53,6 +56,7 @@ internal fun reduceCraft(
     recipes: RecipeLookup,
     knownRecipes: AgentKnownRecipesGateway,
     equipment: EquipmentInstanceStore,
+    agentKeys: AgentKeysStore,
     buildingsLookup: BuildingsLookup,
     skills: AgentSkillsRegistry,
     agents: AgentRegistry,
@@ -113,6 +117,10 @@ internal fun reduceCraft(
         WorldRejection.UnknownItem(recipe.output.item)
     }
 
+    val source = recipe.requiresSource?.let { requiredItem ->
+        resolveSource(command, recipe, requiredItem, agentKeys)
+    }
+
     val qualityBonus = scaling.bonusFor(command.agent, ScalingEffect.CRAFT_QUALITY_BONUS)
     val effectiveSkillLevel = (skillLevel * (1.0 + qualityBonus)).toInt().coerceAtLeast(skillLevel)
 
@@ -128,10 +136,12 @@ internal fun reduceCraft(
         items = items,
         rarityRoller = rarityRoller,
         nodeId = nodeId,
+        source = source,
         tick = tick,
     )
 
     mutation.equipmentToInsert?.let(equipment::insert)
+    mutation.keyToInsert?.let(agentKeys::insert)
 
     progression.accrueXp(command.agent, recipe.requiredSkill, delta = 1, tick, command.commandId, agents.find(command.agent)?.classId)
     behaviorTracker.record(command.agent, ActionCategory.CRAFT, tick)
@@ -146,7 +156,42 @@ internal fun reduceCraft(
         tick = tick,
         causedBy = command.commandId,
     )
-    next to (listOf(mutation.event) + triggered)
+    next to (listOf(mutation.event) + mutation.extraEvents + triggered)
+}
+
+/**
+ * Resolve and validate the per-instance `source` for recipes that declare
+ * `requiresSource`. Today only GATE_KEY sources are supported (the
+ * GATE_KEY_COPY recipe). Future upgrade-style recipes will branch here on
+ * other item-ids. The three failure modes (missing source, source not owned,
+ * source wrong type) collapse to a single rejection so an agent enumerating
+ * UUIDs cannot probe the per-instance stores.
+ */
+private fun Raise<WorldRejection>.resolveSource(
+    command: WorldCommand.CraftItem,
+    recipe: Recipe,
+    requiredItem: ItemId,
+    agentKeys: AgentKeysStore,
+): SourceInstance {
+    val sourceId = command.source
+        ?: raise(WorldRejection.RecipeRequiresSource(command.agent, recipe.id, requiredItem))
+    return when (requiredItem.value) {
+        "GATE_KEY" -> {
+            val key = agentKeys.findById(sourceId)
+                ?: raise(WorldRejection.RecipeRequiresSource(command.agent, recipe.id, requiredItem))
+            if (key.agentId != command.agent || key.itemId != requiredItem) {
+                raise(WorldRejection.RecipeRequiresSource(command.agent, recipe.id, requiredItem))
+            }
+            SourceInstance.Key(key)
+        }
+        else -> error(
+            "Recipe ${recipe.id} declares requires-source=${requiredItem.value} but no resolver is wired.",
+        )
+    }
+}
+
+private sealed interface SourceInstance {
+    data class Key(val key: AgentKeyInstance) : SourceInstance
 }
 
 private fun Raise<WorldRejection>.requireMaterials(
@@ -174,6 +219,8 @@ private data class CraftMutation(
     val nextInventory: AgentInventory,
     val event: WorldEvent.ItemCrafted,
     val equipmentToInsert: EquipmentInstance?,
+    val keyToInsert: AgentKeyInstance? = null,
+    val extraEvents: List<WorldEvent> = emptyList(),
 )
 
 private fun Raise<WorldRejection>.produceOutput(
@@ -188,10 +235,14 @@ private fun Raise<WorldRejection>.produceOutput(
     items: ItemLookup,
     rarityRoller: RarityRoller,
     nodeId: NodeId,
+    source: SourceInstance?,
     tick: Long,
 ): CraftMutation {
     val afterInputs = recipe.inputs.entries.fold(inventory) { acc, (item, qty) ->
         acc.remove(item, qty)
+    }
+    if (source is SourceInstance.Key && outputItem.id.value == "GATE_KEY") {
+        return keyMutation(command, recipe, outputItem, afterInputs, source.key, nodeId, tick)
     }
     return when (outputItem.category) {
         ItemCategory.EQUIPMENT -> equipmentMutation(
@@ -200,6 +251,58 @@ private fun Raise<WorldRejection>.produceOutput(
         )
         ItemCategory.RESOURCE -> stackableMutation(command, recipe, outputItem, afterInputs, nodeId, tick)
     }
+}
+
+/**
+ * Output-branch for recipes that mint a per-instance key bound to the same
+ * gate as the source template. The source is NOT consumed — the inputs map
+ * already carries the consumed materials (e.g. IRON_INGOT). Emits BOTH the
+ * canonical `ItemCrafted` (so craft-listening consumers see it) AND a
+ * `GateKeyMinted(byCopy=true)` (so key-tracking consumers correlate).
+ */
+private fun keyMutation(
+    command: WorldCommand.CraftItem,
+    recipe: Recipe,
+    outputItem: Item,
+    afterInputs: AgentInventory,
+    sourceKey: AgentKeyInstance,
+    nodeId: NodeId,
+    tick: Long,
+): CraftMutation {
+    val mintedId = java.util.UUID.randomUUID()
+    val newKey = AgentKeyInstance(
+        instanceId = mintedId,
+        agentId = command.agent,
+        itemId = outputItem.id,
+        gateInstanceId = sourceKey.gateInstanceId,
+        createdAtTick = tick,
+    )
+    val crafted = WorldEvent.ItemCrafted(
+        agent = command.agent,
+        at = nodeId,
+        recipe = recipe.id,
+        output = outputItem.id,
+        quantity = 1,
+        instanceId = mintedId,
+        rarity = null,
+        tick = tick,
+        causedBy = command.commandId,
+    )
+    val minted = WorldEvent.GateKeyMinted(
+        agent = command.agent,
+        keyInstanceId = mintedId,
+        gateId = sourceKey.gateInstanceId,
+        byCopy = true,
+        tick = tick,
+        causedBy = command.commandId,
+    )
+    return CraftMutation(
+        nextInventory = afterInputs,
+        event = crafted,
+        equipmentToInsert = null,
+        keyToInsert = newKey,
+        extraEvents = listOf(minted),
+    )
 }
 
 private fun Raise<WorldRejection>.equipmentMutation(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/RecipeLookupImpl.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/RecipeLookupImpl.kt
@@ -36,6 +36,7 @@ internal class RecipeLookupImpl(
         requiredSkillLevel = requiredSkillLevel,
         staminaCost = staminaCost,
         unlockMode = unlockMode.toDomain(id),
+        requiresSource = requiresSource?.let(::ItemId),
     )
 
     private fun RecipeUnlockModeProperties?.toDomain(id: RecipeId): RecipeUnlockMode {

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/RecipeProperties.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/RecipeProperties.kt
@@ -19,6 +19,12 @@ internal data class RecipeProperties(
     val requiredSkillLevel: Int = 0,
     val staminaCost: Int,
     val unlockMode: RecipeUnlockModeProperties? = null,
+    /**
+     * String item-id required as the `craft` command's `source` instance.
+     * Mapped to [dev.gvart.genesara.world.Recipe.requiresSource] at catalog
+     * load; null = recipe does not consume a per-instance template.
+     */
+    val requiresSource: String? = null,
 )
 
 internal data class RecipeOutputProperties(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/extract/ExtractReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/extract/ExtractReducer.kt
@@ -1,4 +1,4 @@
-package dev.gvart.genesara.world.internal.harvest
+package dev.gvart.genesara.world.internal.extract
 
 import arrow.core.Either
 import arrow.core.raise.Raise
@@ -12,6 +12,8 @@ import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.EquipmentInstanceStore
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.ItemLookup
@@ -33,18 +35,22 @@ import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 
 /**
- * Reducer for [WorldCommand.Harvest].
+ * Reducer for [WorldCommand.Extract]. Mirrors `reduceHarvest` but with two
+ * additional gates:
+ *   - `item.extractionOnly` must be `true` (the verb is invalid for harvest-able items).
+ *   - An ACTIVE MINE must be at the agent's node (`BuildingCategoryHint.EXTRACTION_MINE`).
  *
- * Mutates [NodeResourceStore.decrement] outside [WorldState] because per-node cells
- * are too large to load into the aggregate every tick. The caller (`WorldTickHandler`)
- * owns the surrounding transaction; if its tx rolls back, the decrement rolls back too.
+ * Resource consumption goes through [NodeResourceStore] exactly like harvest —
+ * the spawn rules in `terrains.yaml` are shared between both verbs; only the
+ * access path differs.
  */
-internal fun reduceHarvest(
+internal fun reduceExtract(
     state: WorldState,
-    command: WorldCommand.Harvest,
+    command: WorldCommand.Extract,
     balance: BalanceLookup,
     items: ItemLookup,
     resources: NodeResourceStore,
+    buildings: BuildingsLookup,
     agents: AgentRegistry,
     equipment: EquipmentInstanceStore,
     progression: SkillProgression,
@@ -62,9 +68,13 @@ internal fun reduceHarvest(
     val itemDef = ensureNotNull(items.byId(command.item)) {
         WorldRejection.UnknownItem(command.item)
     }
-    ensure(!itemDef.extractionOnly) {
-        WorldRejection.HarvestRequiresExtraction(command.agent, nodeId, command.item)
+    ensure(itemDef.extractionOnly) {
+        WorldRejection.ResourceNotAvailableHere(command.agent, nodeId, command.item)
     }
+    ensure(buildings.activeStationsAt(nodeId, BuildingCategoryHint.EXTRACTION_MINE).isNotEmpty()) {
+        WorldRejection.ExtractRequiresMine(command.agent, nodeId)
+    }
+
     val cell = requireAvailableDeposit(command.agent, nodeId, command.item, resources, tick)
 
     val body = state.bodyOf(command.agent)
@@ -93,14 +103,11 @@ internal fun reduceHarvest(
     characterXp.grant(command.agent, CharacterXpSource.HARVEST, delta = quantity, tick = tick, commandId = command.commandId)
     behaviorTracker.record(command.agent, ActionCategory.GATHER, tick)
 
-    // TODO(max-stack): reject (StackFull) when adding `quantity` would exceed maxStack.
-    // TODO(events): emit WorldEvent.NodeResourceDepleted alongside ResourceHarvested when
-    //               this harvest takes the cell to zero — needs multi-event reducer return.
     val nextInventory = state.inventoryOf(command.agent).add(command.item, quantity)
     val next = state
         .updateBody(command.agent, body.spendStamina(cost))
         .updateInventory(command.agent, nextInventory)
-    val event = WorldEvent.ResourceHarvested(
+    val event = WorldEvent.ResourceExtracted(
         agent = command.agent,
         at = nodeId,
         item = command.item,
@@ -118,11 +125,6 @@ internal fun reduceHarvest(
     next to (listOf(event) + triggered)
 }
 
-/**
- * Splits the cell-lookup into two distinct rejections so the agent can tell "wrong place"
- * (no row — no spawn rule on this terrain, or the spawn-chance roll failed at paint time)
- * from "deposit gone" (row at zero — harvested out). Strategic responses differ.
- */
 private fun Raise<WorldRejection>.requireAvailableDeposit(
     agent: AgentId,
     nodeId: NodeId,

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
@@ -7,7 +7,10 @@ import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingGateStateStore
+import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.BuildingsLookup
+import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.WorldCommand
 import dev.gvart.genesara.world.events.WorldEvent
@@ -21,6 +24,7 @@ internal fun reduceMove(
     command: WorldCommand.MoveAgent,
     balance: BalanceLookup,
     buildings: BuildingsLookup,
+    gateStates: BuildingGateStateStore,
     scaling: LevelScalingAggregator,
     behaviorTracker: BehaviorTracker,
     tick: Long,
@@ -40,12 +44,19 @@ internal fun reduceMove(
     ensure(balance.isTraversable(toNode.terrain) || hasActiveBuilding(buildings, command.to, BuildingCategoryHint.INFRASTRUCTURE_BRIDGE)) {
         WorldRejection.TerrainNotTraversable(command.agent, command.to, toNode.terrain)
     }
+    val defensive = buildings.activeStationsAt(command.to, BuildingCategoryHint.DEFENSIVE)
+    if (defensive.isNotEmpty()) {
+        val allOpenGates = defensive.all { it.type == BuildingType.GATE && gateStates.isOpen(it.instanceId) == true }
+        ensure(allOpenGates) { WorldRejection.DefensiveBlocks(command.agent, command.to) }
+    }
     val biome = ensureNotNull(toRegion.biome) { WorldRejection.UnpaintedRegion(toRegion.id) }
     val climate = ensureNotNull(toRegion.climate) { WorldRejection.UnpaintedRegion(toRegion.id) }
 
     val body = state.bodyOf(command.agent)!!
     val baseCost = balance.moveStaminaCost(biome, climate, toNode.terrain)
-    val onRoad = hasActiveBuilding(buildings, from, BuildingCategoryHint.INFRASTRUCTURE_ROAD)
+
+    val onRoad = hasActiveBuilding(buildings, from, BuildingCategoryHint.INFRASTRUCTURE_ROAD) ||
+        hasActiveBuilding(buildings, command.to, BuildingCategoryHint.INFRASTRUCTURE_ROAD)
     // Floor at 1 so road-hopping still costs stamina.
     val roadAdjusted = if (onRoad) (baseCost * balance.roadStaminaMultiplier()).toInt().coerceAtLeast(1) else baseCost
     val speedBonus = scaling.bonusFor(command.agent, ScalingEffect.MOVEMENT_SPEED)
@@ -71,6 +82,6 @@ internal fun reduceMove(
 
 private fun hasActiveBuilding(
     buildings: BuildingsLookup,
-    node: dev.gvart.genesara.world.NodeId,
+    node: NodeId,
     hint: BuildingCategoryHint,
 ): Boolean = buildings.activeStationsAt(node, hint).isNotEmpty()

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -10,9 +10,11 @@ import dev.gvart.genesara.player.NoOpClassLookup
 import dev.gvart.genesara.player.PassiveAuraAggregator
 import dev.gvart.genesara.player.PerkCooldownStore
 import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.world.AgentKeysStore
 import dev.gvart.genesara.world.AgentKnownRecipesGateway
 import dev.gvart.genesara.world.AgentPlotsStore
 import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.BuildingGateStateStore
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.BuildingBarsStore
 import dev.gvart.genesara.world.BuildingsStore
@@ -74,6 +76,8 @@ internal class WorldTickHandler(
     private val buildingBars: BuildingBarsStore,
     private val buildingsLookup: BuildingsLookup,
     private val buildingsCatalog: BuildingsCatalog,
+    private val gateStates: BuildingGateStateStore,
+    private val agentKeys: AgentKeysStore,
     private val chestContents: ChestContentsStore,
     private val plots: AgentPlotsStore,
     private val crops: CropLookup,
@@ -152,7 +156,8 @@ internal class WorldTickHandler(
         val (next, commandEvents) = commands.fold(afterDeaths to emptyList<WorldEvent>()) { (state, acc), command ->
             reduce(
                 state, command, balance, profiles, items, recipes, knownRecipes, resources, skills, agents, equipment,
-                safeNodes, safeNodeResolver, buildings, buildingBars, buildingsLookup, buildingsCatalog, chestContents,
+                safeNodes, safeNodeResolver, buildings, buildingBars, buildingsLookup, buildingsCatalog,
+                gateStates, agentKeys, chestContents,
                 plots, crops,
                 tradeStore, relationships,
                 rarityRoller, progression, characterXp, recipeLearning, scaling, passiveAura, equipmentBonuses, spawnLocationResolver, groundItems,

--- a/world/src/main/resources/db/migration/world/V24__gates_and_keys.sql
+++ b/world/src/main/resources/db/migration/world/V24__gates_and_keys.sql
@@ -1,0 +1,45 @@
+-- Phase 2 defensive cluster + extraction infrastructure: gate state and per-agent keys.
+--
+-- GATE buildings carry an OPEN/CLOSED state independent of their construction
+-- lifecycle. Stored in a 1:1 sidecar table rather than a column on
+-- `node_buildings` so non-gate building rows pay no storage cost and the
+-- shared `Building` domain type stays gate-agnostic.
+--
+-- A row is inserted on GATE build completion (status flips to ACTIVE) and
+-- removed via ON DELETE CASCADE when the parent building row is destroyed.
+-- Default state is FALSE (CLOSED) — a freshly-built gate locks itself; the
+-- builder uses `toggle_gate` (key in hand) to open it.
+CREATE TABLE building_gate_states
+(
+    building_instance_id UUID    PRIMARY KEY
+                                 REFERENCES node_buildings (instance_id) ON DELETE CASCADE,
+    is_open              BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+-- Per-instance GATE_KEY storage. Mirrors `agent_equipment_instances`: one row
+-- per physical key, bound to the gate it opens. Keys are stackless inventory
+-- items — they cannot merge because each instance is identified by the
+-- (gate_instance_id) it targets.
+--
+-- The builder receives 1 key automatically on gate build completion. Copies
+-- are minted via the `copy_gate_key` verb at a WORKBENCH (requires holding a
+-- matching template key, not consumed). Lost / stolen keys are recoverable
+-- only by destroying the gate and rebuilding it.
+--
+-- agent_id has no cross-module FK to player.agents (matches the convention
+-- used by node_buildings / agent_equipment_instances / agent_node_memory).
+-- gate_instance_id is a soft FK to node_buildings; orphan cleanup is the
+-- responsibility of the future destroy/repair flow.
+CREATE TABLE agent_keys
+(
+    instance_id      UUID         NOT NULL,
+    agent_id         UUID         NOT NULL,
+    item_id          VARCHAR(32)  NOT NULL,
+    gate_instance_id UUID         NOT NULL,
+    created_at_tick  BIGINT       NOT NULL,
+    PRIMARY KEY (instance_id)
+);
+
+CREATE INDEX idx_agent_keys_agent ON agent_keys (agent_id);
+CREATE INDEX idx_agent_keys_gate  ON agent_keys (gate_instance_id);
+CREATE INDEX idx_agent_keys_agent_gate ON agent_keys (agent_id, gate_instance_id);

--- a/world/src/main/resources/world-definition/buildings.yaml
+++ b/world/src/main/resources/world-definition/buildings.yaml
@@ -69,6 +69,27 @@ buildings:
           materials-per-step:
             WOOD: 5
 
+    # GATE: T1 defensive variant of WOODEN_WALL. Carries OPEN/CLOSED state and a
+    # per-instance GATE_KEY. Toggle requires holding a matching key while on the
+    # gate's node; passage is allowed only while state is OPEN. The build
+    # consumes both wood (structure) and iron (hinges + lock mechanism) — the
+    # IRON_INGOT requirement is what gates GATE construction behind metal-tier
+    # crafting infrastructure (MINE → IRON_INGOT_BASIC → GATE).
+
+    GATE:
+      stamina-per-step: 11
+      hp: 120
+      category-hint: DEFENSIVE
+      skill-bars:
+        CARPENTRY:
+          steps: 6
+          materials-per-step:
+            WOOD: 4
+        SMITHING:
+          steps: 4
+          materials-per-step:
+            IRON_INGOT: 1
+
     # ───────────────────────── Behavioral (Phase 1 wired) ─────────────────────────
 
     STORAGE_CHEST:
@@ -184,3 +205,20 @@ buildings:
           steps: 6
           materials-per-step:
             STONE: 2
+
+    # ───────────────────────── Extraction infrastructure (T1) ─────────────────────────
+    # MINE gates access to `extract`-only resources (COAL, ORE, GOLD). Buildable only
+    # on rocky terrain (FOOTHILLS / MOUNTAIN / VOLCANIC) — enforced at the reducer.
+    # Build materials are intentionally IRON-free so a fresh agent on a virgin world
+    # can bootstrap metal-tier crafting: WOOD + STONE are bare-gatherable.
+
+    MINE:
+      stamina-per-step: 12
+      hp: 80
+      category-hint: EXTRACTION_MINE
+      skill-bars:
+        CARPENTRY:
+          steps: 10
+          materials-per-step:
+            WOOD: 3
+            STONE: 4

--- a/world/src/main/resources/world-definition/equipment-jewelry.yaml
+++ b/world/src/main/resources/world-definition/equipment-jewelry.yaml
@@ -82,3 +82,51 @@ items:
       bonuses:
         - { target: SLASH, magnitude: 1 }
         - { target: PIERCE, magnitude: 1 }
+
+    # ──────────────────────── Gold tier ────────────────────────
+
+    GOLD_RING:
+      display-name: Gold Ring
+      description: >-
+        Polished gold band. Luxury alternative to the iron ring — higher
+        durability and a luck nudge.
+      category: EQUIPMENT
+      weight-per-unit: 110
+      max-stack: 1
+      regenerating: false
+      max-durability: 120
+      valid-slots: [RING_LEFT, RING_RIGHT]
+      two-handed: false
+      bonuses:
+        - { target: LUCK, magnitude: 2 }
+
+    GOLD_BRACELET:
+      display-name: Gold Bracelet
+      description: >-
+        Tooled gold wristband. Luxury substrate for the bracelet slot.
+      category: EQUIPMENT
+      weight-per-unit: 420
+      max-stack: 1
+      regenerating: false
+      max-durability: 120
+      valid-slots: [BRACELET_LEFT, BRACELET_RIGHT]
+      two-handed: false
+      bonuses:
+        - { target: PERCEPTION, magnitude: 1 }
+        - { target: LUCK, magnitude: 2 }
+
+    GOLD_AMULET:
+      display-name: Gold Amulet
+      description: >-
+        Gemstone set in a gold mounting. Premium amulet with stronger
+        constitution and stamina regen bonuses than the iron-mount version.
+      category: EQUIPMENT
+      weight-per-unit: 220
+      max-stack: 1
+      regenerating: false
+      max-durability: 100
+      valid-slots: [AMULET]
+      two-handed: false
+      bonuses:
+        - { target: CONSTITUTION, magnitude: 3 }
+        - { target: STAMINA_REGEN, magnitude: 2 }

--- a/world/src/main/resources/world-definition/items.yaml
+++ b/world/src/main/resources/world-definition/items.yaml
@@ -159,23 +159,40 @@ items:
       display-name: Ore
       description: >-
         Raw metal-bearing ore. Smelts into ingots at a forge. Mountain and volcanic
-        biomes. Non-renewable: rich nodes are a finite advantage.
+        biomes. Non-renewable: rich nodes are a finite advantage. Reachable only
+        via the `extract` verb at a built MINE (bare gather no longer yields ORE).
       category: RESOURCE
       weight-per-unit: 2000
       max-stack: 50
       regenerating: false
       harvest-skill: MINING
+      extraction-only: true
 
     COAL:
       display-name: Coal
       description: >-
         Bituminous fuel from mountain seams and volcanic flows. Required for
-        higher-tier forges. Non-renewable.
+        higher-tier forges. Non-renewable. Reachable only via the `extract`
+        verb at a built MINE.
       category: RESOURCE
       weight-per-unit: 1800
       max-stack: 80
       regenerating: false
       harvest-skill: MINING
+      extraction-only: true
+
+    GOLD:
+      display-name: Gold Nugget
+      description: >-
+        Raw gold ore. Smelts into a gold ingot at a forge. Found in trace
+        quantities on MOUNTAIN / VOLCANIC / CRYSTAL_CAVES nodes — but only
+        reachable via the `extract` verb at a built MINE.
+      category: RESOURCE
+      weight-per-unit: 2200
+      max-stack: 50
+      regenerating: false
+      harvest-skill: MINING
+      extraction-only: true
 
     GEM:
       display-name: Gemstone
@@ -213,6 +230,29 @@ items:
       category: RESOURCE
       weight-per-unit: 1500
       max-stack: 50
+      regenerating: false
+
+    GOLD_INGOT:
+      display-name: Gold Ingot
+      description: >-
+        Smelted gold bar from nugget + coal at a forge. Luxury substrate for
+        gold-tier jewelry. Not engine currency — agents may use it as a trade
+        good if they choose.
+      category: RESOURCE
+      weight-per-unit: 1800
+      max-stack: 50
+      regenerating: false
+
+    GATE_KEY:
+      display-name: Gate Key
+      description: >-
+        Per-instance physical key bound to one specific GATE building. Required
+        to toggle that gate's OPEN/CLOSED state. Auto-issued to the builder on
+        gate completion; copies are minted at a WORKBENCH via `copy_gate_key`
+        (template required, not consumed).
+      category: RESOURCE
+      weight-per-unit: 100
+      max-stack: 1
       regenerating: false
 
     LEATHER:

--- a/world/src/main/resources/world-definition/recipes-intermediates.yaml
+++ b/world/src/main/resources/world-definition/recipes-intermediates.yaml
@@ -19,6 +19,31 @@ recipes:
       required-skill-level: 0
       stamina-cost: 12
 
+    GOLD_INGOT_BASIC:
+      output: { item: GOLD_INGOT, quantity: 1 }
+      inputs:
+        GOLD: 2
+        COAL: 1
+      required-station: CRAFTING_STATION_METAL
+      required-skill: SMITHING
+      required-skill-level: 3
+      stamina-cost: 14
+
+    # Per-instance copy recipe: the `craft` command must supply `source` =
+    # an existing GATE_KEY instance the caller holds. The source is NOT
+    # consumed; the new key inherits the source's gate-binding. Inputs
+    # (IRON_INGOT) are consumed normally. Output goes to agent_keys, not
+    # the stackable inventory.
+    GATE_KEY_COPY:
+      output: { item: GATE_KEY, quantity: 1 }
+      inputs:
+        IRON_INGOT: 1
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: CARPENTRY
+      required-skill-level: 0
+      stamina-cost: 10
+      requires-source: GATE_KEY
+
     LEATHER_BASIC:
       output: { item: LEATHER, quantity: 1 }
       inputs:

--- a/world/src/main/resources/world-definition/recipes-jewelry.yaml
+++ b/world/src/main/resources/world-definition/recipes-jewelry.yaml
@@ -54,3 +54,32 @@ recipes:
       required-skill: JEWELRYCRAFTING
       required-skill-level: 4
       stamina-cost: 14
+
+    GOLD_RING_BASIC:
+      output: { item: GOLD_RING, quantity: 1 }
+      inputs:
+        GOLD_INGOT: 1
+      required-station: CRAFTING_STATION_METAL
+      required-skill: JEWELRYCRAFTING
+      required-skill-level: 5
+      stamina-cost: 14
+
+    GOLD_BRACELET_BASIC:
+      output: { item: GOLD_BRACELET, quantity: 1 }
+      inputs:
+        GOLD_INGOT: 1
+        LEATHER: 1
+      required-station: CRAFTING_STATION_METAL
+      required-skill: JEWELRYCRAFTING
+      required-skill-level: 6
+      stamina-cost: 16
+
+    GOLD_AMULET_BASIC:
+      output: { item: GOLD_AMULET, quantity: 1 }
+      inputs:
+        GEM: 1
+        GOLD_INGOT: 1
+      required-station: CRAFTING_STATION_METAL
+      required-skill: JEWELRYCRAFTING
+      required-skill-level: 7
+      stamina-cost: 20

--- a/world/src/main/resources/world-definition/terrains.yaml
+++ b/world/src/main/resources/world-definition/terrains.yaml
@@ -99,6 +99,7 @@ world:
         - { item: ORE,   spawn-chance: 0.4, quantity-range: [30, 100] }
         - { item: COAL,  spawn-chance: 0.3, quantity-range: [30, 80] }
         - { item: GEM,   spawn-chance: 0.05, quantity-range: [3, 12] }
+        - { item: GOLD,  spawn-chance: 0.07, quantity-range: [4, 16] }
     ALPINE:
       display-name: Alpine
       movement-cost-multiplier: 1.4
@@ -138,6 +139,7 @@ world:
         - { item: STONE, spawn-chance: 0.6, quantity-range: [50, 150] }
         - { item: ORE,   spawn-chance: 0.4, quantity-range: [30, 90] }
         - { item: COAL,  spawn-chance: 0.4, quantity-range: [30, 90] }
+        - { item: GOLD,  spawn-chance: 0.08, quantity-range: [4, 18] }
 
     # ───────────── Coastal / wet ─────────────
     COASTAL:
@@ -199,6 +201,7 @@ world:
         - { item: STONE, spawn-chance: 0.6, quantity-range: [50, 150] }
         - { item: ORE,   spawn-chance: 0.4, quantity-range: [30, 90] }
         - { item: GEM,   spawn-chance: 0.15, quantity-range: [5, 20] }
+        - { item: GOLD,  spawn-chance: 0.12, quantity-range: [6, 22] }
     BLIGHTED:
       display-name: Blighted
 

--- a/world/src/test/kotlin/dev/gvart/genesara/world/commands/WorldCommandSerializationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/commands/WorldCommandSerializationTest.kt
@@ -69,6 +69,20 @@ class WorldCommandSerializationTest {
                 accept = true,
                 commandId = cid,
             ),
+            "toggleGate" to WorldCommand.ToggleGate(
+                agent = agent,
+                gateId = UUID.fromString("88888888-8888-8888-8888-888888888888"),
+                commandId = cid,
+            ),
+            "extract" to WorldCommand.Extract(agent, ItemId("GOLD"), cid),
+            // Source-bearing craft variant — the `source` field is optional but
+            // must round-trip for recipes that declare `requires-source` (e.g. GATE_KEY_COPY).
+            "craft" to WorldCommand.CraftItem(
+                agent = agent,
+                recipe = RecipeId("GATE_KEY_COPY"),
+                source = UUID.fromString("99999999-9999-9999-9999-999999999999"),
+                commandId = cid,
+            ),
         )
 
         for ((discriminator, command) in expectations) {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/BuildReducerTest.kt
@@ -115,7 +115,7 @@ class BuildReducerTest {
         val (next, events) = assertNotNull(
             reduceBuild(
                 state, command,
-                catalog, skills, store, barsStore, safeNodes, NoOpAgentPlotsStore, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
+                catalog, skills, store, barsStore, safeNodes, NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
             ).getOrNull(),
         )
 
@@ -150,7 +150,7 @@ class BuildReducerTest {
         val (next, events) = assertNotNull(
             reduceBuild(
                 state, command,
-                catalog, skills, store, barsStore, safeNodes, NoOpAgentPlotsStore, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 9,
+                catalog, skills, store, barsStore, safeNodes, NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 9,
             ).getOrNull(),
         )
 
@@ -179,7 +179,7 @@ class BuildReducerTest {
         val (_, events) = assertNotNull(
             reduceBuild(
                 state, command,
-                catalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 11,
+                catalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 11,
             ).getOrNull(),
         )
 
@@ -206,7 +206,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.SHELTER),
-            catalog, skills, store, barsStore, safeNodes, NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 11,
+            catalog, skills, store, barsStore, safeNodes, NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 11,
         )
 
         assertEquals(nodeId, safeNodes.set[agent])
@@ -223,7 +223,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, store, barsStore, safeNodes, NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 11,
+            catalog, skills, store, barsStore, safeNodes, NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 11,
         )
 
         assertEquals(emptyMap(), safeNodes.set)
@@ -254,13 +254,122 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.FARM_PLOT),
-            plotCatalog, skills, store, barsStore, StubSafeNodes(), plots, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 11,
+            plotCatalog, skills, store, barsStore, StubSafeNodes(), plots, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 11,
         )
 
         val inserted = plots.inserted.single()
         assertEquals(nearlyDone.instanceId, inserted.buildingInstanceId)
         assertEquals(nodeId, inserted.nodeId)
         assertNull(inserted.plant)
+    }
+
+    @Test
+    fun `GATE completion inserts a CLOSED gate state row, issues one key to the builder, and emits GateKeyMinted`() {
+        val gateDef = BuildingProperties(
+            staminaPerStep = 1,
+            hp = 120,
+            categoryHint = BuildingCategoryHint.DEFENSIVE,
+            skillBars = mapOf(
+                "CARPENTRY" to BarProperties(steps = 2, materialsPerStep = mapOf("WOOD" to 1)),
+            ),
+        )
+        val gateCatalog = BuildingsCatalog(
+            BuildingDefinitionProperties(catalog = mapOf("GATE" to gateDef)),
+        )
+        val state = stateWith(inventory = mapOf(wood to 5))
+        // Pre-place a near-complete gate row so the next step finishes it.
+        val nearlyDone = sampleBuilding(type = BuildingType.GATE, progress = 1, totalSteps = 2, hp = 120)
+        val store = StubBuildingsStore(rows = mutableListOf(nearlyDone))
+        val barsStore = StubBuildingBarsStore().also {
+            it.storeRef = store
+            it.catalogRef = gateCatalog
+        }
+        val gateStates = RecordingGateStates()
+        val keys = RecordingAgentKeys()
+
+        val (_, events) = assertNotNull(
+            reduceBuild(
+                state, WorldCommand.BuildStructure(agent, BuildingType.GATE),
+                gateCatalog, StubSkillsRegistry(), store, barsStore, StubSafeNodes(),
+                NoOpAgentPlotsStore, gateStates, keys,
+                SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+                triggeredPassives = NoOpTriggeredPassiveDispatcher,
+                behaviorTracker = tracker, tick = 12L,
+            ).getOrNull(),
+        )
+
+        val placed = store.rows.single()
+        assertEquals(BuildingStatus.ACTIVE, placed.status)
+        assertEquals(BuildingType.GATE, placed.type)
+        assertEquals(listOf(placed.instanceId), gateStates.insertedClosed)
+        val issuedKey = keys.inserted.single()
+        assertEquals(placed.instanceId, issuedKey.gateInstanceId)
+        assertEquals(agent, issuedKey.agentId)
+        val minted = events.filterIsInstance<WorldEvent.GateKeyMinted>().single()
+        assertEquals(issuedKey.instanceId, minted.keyInstanceId)
+        assertEquals(placed.instanceId, minted.gateId)
+        assertEquals(false, minted.byCopy)
+    }
+
+    @Test
+    fun `building a DEFENSIVE structure on a node that already has one is rejected`() {
+        val gateDef = BuildingProperties(
+            staminaPerStep = 11, hp = 120, categoryHint = BuildingCategoryHint.DEFENSIVE,
+            skillBars = mapOf("CARPENTRY" to BarProperties(steps = 2, materialsPerStep = mapOf("WOOD" to 1))),
+        )
+        val wallDef = BuildingProperties(
+            staminaPerStep = 10, hp = 120, categoryHint = BuildingCategoryHint.DEFENSIVE,
+            skillBars = mapOf("CARPENTRY" to BarProperties(steps = 2, materialsPerStep = mapOf("WOOD" to 1))),
+        )
+        val defensiveCatalog = BuildingsCatalog(
+            BuildingDefinitionProperties(catalog = mapOf("GATE" to gateDef, "WOODEN_WALL" to wallDef)),
+        )
+        val state = stateWith(inventory = mapOf(wood to 5))
+        val existingWall = sampleBuilding(type = BuildingType.WOODEN_WALL, totalSteps = 2, progress = 2).copy(
+            status = BuildingStatus.ACTIVE,
+        )
+        val store = StubBuildingsStore(rows = mutableListOf(existingWall))
+        val barsStore = StubBuildingBarsStore().also { it.storeRef = store; it.catalogRef = defensiveCatalog }
+        val skills = StubSkillsRegistry()
+
+        val result = reduceBuild(
+            state, WorldCommand.BuildStructure(agent, BuildingType.GATE),
+            defensiveCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore,
+            NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()),
+            triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+        )
+
+        val rejection = assertIs<WorldRejection.DefensiveAlreadyAtNode>(result.leftOrNull())
+        assertEquals(BuildingType.WOODEN_WALL, rejection.existingType)
+        assertEquals(existingWall.instanceId, rejection.existingInstanceId)
+    }
+
+    @Test
+    fun `MINE on a non-rocky terrain is rejected with BuildingTerrainMismatch`() {
+        val mineDef = BuildingProperties(
+            staminaPerStep = 12, hp = 80, categoryHint = BuildingCategoryHint.EXTRACTION_MINE,
+            skillBars = mapOf("CARPENTRY" to BarProperties(steps = 2, materialsPerStep = mapOf("WOOD" to 1))),
+        )
+        val mineCatalog = BuildingsCatalog(
+            BuildingDefinitionProperties(catalog = mapOf("MINE" to mineDef)),
+        )
+        val state = stateWith(inventory = mapOf(wood to 5))
+        // Default stateWith() puts the agent on a PLAINS node — outside the allowed set.
+        val store = StubBuildingsStore()
+        val barsStore = StubBuildingBarsStore().also { it.storeRef = store; it.catalogRef = mineCatalog }
+        val skills = StubSkillsRegistry()
+
+        val result = reduceBuild(
+            state, WorldCommand.BuildStructure(agent, BuildingType.MINE),
+            mineCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore,
+            NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()),
+            triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+        )
+
+        val rejection = assertIs<WorldRejection.BuildingTerrainMismatch>(result.leftOrNull())
+        assertEquals(BuildingType.MINE, rejection.type)
+        assertEquals(Terrain.FOREST, rejection.terrain)
+        assertTrue(Terrain.MOUNTAIN in rejection.allowed)
     }
 
     @Test
@@ -274,7 +383,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, store, barsStore, StubSafeNodes(), plots, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 11,
+            catalog, skills, store, barsStore, StubSafeNodes(), plots, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 11,
         )
 
         assertTrue(plots.inserted.isEmpty())
@@ -298,7 +407,7 @@ class BuildReducerTest {
         val skills = StubSkillsRegistry()
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            catalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
@@ -310,7 +419,7 @@ class BuildReducerTest {
         val skills = StubSkillsRegistry()
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            catalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(WorldRejection.NotEnoughStamina(agent, required = 8, available = 3), result.leftOrNull())
@@ -327,7 +436,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            catalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val rejection = assertIs<WorldRejection.InsufficientMaterials>(result.leftOrNull())
@@ -376,7 +485,7 @@ class BuildReducerTest {
         val (afterA, eventsA) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.STORAGE_CHEST),
-                chestCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()),
+                chestCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()),
                 triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 100,
             ).getOrNull(),
         )
@@ -384,7 +493,7 @@ class BuildReducerTest {
 
         val rejection = reduceBuild(
             afterA, WorldCommand.BuildStructure(agentB, BuildingType.STORAGE_CHEST),
-            chestCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()),
+            chestCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()),
             triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 100,
         ).leftOrNull()
 
@@ -419,7 +528,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agentB, BuildingType.CAMPFIRE),
-            catalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 5,
+            catalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 5,
         )
 
         val rejection = assertIs<WorldRejection.DuplicateBuildingAtNode>(result.leftOrNull())
@@ -440,7 +549,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 12,
+            catalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 12,
         )
 
         val rejection = assertIs<WorldRejection.DuplicateBuildingAtNode>(result.leftOrNull())
@@ -460,7 +569,7 @@ class BuildReducerTest {
         val (_, events) = assertNotNull(
             reduceBuild(
                 state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                catalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
+                catalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 7,
             ).getOrNull(),
         )
 
@@ -489,7 +598,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            gatedCatalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            gatedCatalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         val rejection = assertIs<WorldRejection.BuildingSkillTooLow>(result.leftOrNull())
@@ -514,7 +623,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            gatedCatalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            gatedCatalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertNotNull(result.getOrNull())
@@ -553,7 +662,7 @@ class BuildReducerTest {
             val (next, events) = assertNotNull(
                 reduceBuild(
                     state, command, customCatalog, skills, store, barsStore, StubSafeNodes(),
-                    NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()),
+                    NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()),
                     triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker,
                     tick = (100 + i).toLong(),
                 ).getOrNull(),
@@ -600,7 +709,7 @@ class BuildReducerTest {
             val (next, events) = assertNotNull(
                 reduceBuild(
                     state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-                    catalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = (10 + i).toLong(),
+                    catalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = (10 + i).toLong(),
                 ).getOrNull(),
             )
             state = next
@@ -623,7 +732,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+            catalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
         )
 
         assertEquals(listOf(carpentry to 1), skills.xpAddCalls)
@@ -657,7 +766,7 @@ class BuildReducerTest {
 
         val (_, events) = assertNotNull(
             reduceBuild(
-                state, command, watchtowerCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore,
+                state, command, watchtowerCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys,
                 SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher,
                 behaviorTracker = tracker, tick = 1,
             ).getOrNull(),
@@ -687,7 +796,7 @@ class BuildReducerTest {
             val cmd = WorldCommand.BuildStructure(agent, BuildingType.WATCHTOWER, skill = carpentry)
             val (next, events) = assertNotNull(
                 reduceBuild(
-                    currentState, cmd, watchtowerCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore,
+                    currentState, cmd, watchtowerCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys,
                     SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher,
                     behaviorTracker = tracker, tick = (1 + i).toLong(),
                 ).getOrNull(),
@@ -700,7 +809,7 @@ class BuildReducerTest {
             val cmd = WorldCommand.BuildStructure(agent, BuildingType.WATCHTOWER, skill = survival)
             val (next, events) = assertNotNull(
                 reduceBuild(
-                    currentState, cmd, watchtowerCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore,
+                    currentState, cmd, watchtowerCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys,
                     SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher,
                     behaviorTracker = tracker, tick = (9 + i).toLong(),
                 ).getOrNull(),
@@ -720,7 +829,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.WATCHTOWER, skill = null),
-            watchtowerCatalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore,
+            watchtowerCatalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys,
             SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher,
             behaviorTracker = tracker, tick = 1,
         )
@@ -738,7 +847,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.WATCHTOWER, skill = alchemy),
-            watchtowerCatalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore,
+            watchtowerCatalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys,
             SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher,
             behaviorTracker = tracker, tick = 1,
         )
@@ -776,7 +885,7 @@ class BuildReducerTest {
 
         val result = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.WATCHTOWER, skill = carpentry),
-            watchtowerCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore,
+            watchtowerCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys,
             SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher,
             behaviorTracker = tracker, tick = 5,
         )
@@ -796,7 +905,7 @@ class BuildReducerTest {
 
         val survivalResult = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.WATCHTOWER, skill = survival),
-            watchtowerCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore,
+            watchtowerCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys,
             SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher,
             behaviorTracker = tracker, tick = 1,
         )
@@ -808,7 +917,7 @@ class BuildReducerTest {
 
         val carpentryResult = reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.WATCHTOWER, skill = carpentry),
-            watchtowerCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore,
+            watchtowerCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys,
             SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher,
             behaviorTracker = tracker, tick = 2,
         )
@@ -825,7 +934,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.WATCHTOWER, skill = survival),
-            watchtowerCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore,
+            watchtowerCatalog, skills, store, barsStore, StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys,
             SkillProgression(skills, RecordingPublisher()), triggeredPassives = NoOpTriggeredPassiveDispatcher,
             behaviorTracker = tracker, tick = 1,
         )
@@ -841,7 +950,7 @@ class BuildReducerTest {
 
         reduceBuild(
             state, WorldCommand.BuildStructure(agent, BuildingType.CAMPFIRE),
-            catalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 5,
+            catalog, skills, StubBuildingsStore(), StubBuildingBarsStore(), StubSafeNodes(), NoOpAgentPlotsStore, NoGateStates, NoAgentKeys, SkillProgression(skills, publisher), triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 5,
         )
 
         val rec = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>().single()
@@ -969,6 +1078,34 @@ class BuildReducerTest {
         override fun tend(plotId: java.util.UUID, tick: Long): dev.gvart.genesara.world.AgentPlot? = null
         override fun clearPlanting(plotId: java.util.UUID): dev.gvart.genesara.world.AgentPlot? = null
         override fun listPlantedSnapshot(): List<dev.gvart.genesara.world.AgentPlot> = emptyList()
+    }
+
+    private object NoGateStates : dev.gvart.genesara.world.BuildingGateStateStore {
+        override fun insertClosed(gateInstanceId: java.util.UUID) = Unit
+        override fun isOpen(gateInstanceId: java.util.UUID): Boolean? = null
+        override fun toggle(gateInstanceId: java.util.UUID): Boolean? = null
+    }
+
+    private object NoAgentKeys : dev.gvart.genesara.world.AgentKeysStore {
+        override fun insert(key: dev.gvart.genesara.world.AgentKeyInstance) = Unit
+        override fun findById(instanceId: java.util.UUID): dev.gvart.genesara.world.AgentKeyInstance? = null
+        override fun agentHoldsKeyFor(agent: AgentId, gateInstanceId: java.util.UUID): Boolean = false
+        override fun listByAgent(agent: AgentId): List<dev.gvart.genesara.world.AgentKeyInstance> = emptyList()
+    }
+
+    private class RecordingGateStates : dev.gvart.genesara.world.BuildingGateStateStore {
+        val insertedClosed = mutableListOf<java.util.UUID>()
+        override fun insertClosed(gateInstanceId: java.util.UUID) { insertedClosed += gateInstanceId }
+        override fun isOpen(gateInstanceId: java.util.UUID): Boolean? = false
+        override fun toggle(gateInstanceId: java.util.UUID): Boolean? = true
+    }
+
+    private class RecordingAgentKeys : dev.gvart.genesara.world.AgentKeysStore {
+        val inserted = mutableListOf<dev.gvart.genesara.world.AgentKeyInstance>()
+        override fun insert(key: dev.gvart.genesara.world.AgentKeyInstance) { inserted += key }
+        override fun findById(instanceId: java.util.UUID): dev.gvart.genesara.world.AgentKeyInstance? = null
+        override fun agentHoldsKeyFor(agent: AgentId, gateInstanceId: java.util.UUID): Boolean = false
+        override fun listByAgent(agent: AgentId): List<dev.gvart.genesara.world.AgentKeyInstance> = emptyList()
     }
 
     private class StubSkillsRegistry : AgentSkillsRegistry {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/DefensiveExtractionFlowTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/DefensiveExtractionFlowTest.kt
@@ -1,0 +1,612 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
+import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AgentSkillState
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.world.AgentKeyInstance
+import dev.gvart.genesara.world.AgentKeysStore
+import dev.gvart.genesara.world.AgentKnownRecipesGateway
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingBar
+import dev.gvart.genesara.world.BuildingBarsStore
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingGateStateStore
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsLookup
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.Gauge
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Rarity
+import dev.gvart.genesara.world.Recipe
+import dev.gvart.genesara.world.RecipeId
+import dev.gvart.genesara.world.RecipeLookup
+import dev.gvart.genesara.world.RecipeOutput
+import dev.gvart.genesara.world.RecipeUnlockMode
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.ResourceSpawnRule
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.classes.CharacterXpProgression
+import dev.gvart.genesara.world.internal.crafting.RarityRoller
+import dev.gvart.genesara.world.internal.crafting.reduceCraft
+import dev.gvart.genesara.world.internal.extract.reduceExtract
+import dev.gvart.genesara.world.internal.harvest.reduceHarvest
+import dev.gvart.genesara.world.internal.inventory.AgentInventory
+import dev.gvart.genesara.world.internal.movement.reduceMove
+import dev.gvart.genesara.world.internal.resources.InitialResourceRow
+import dev.gvart.genesara.world.internal.resources.NodeResourceCell
+import dev.gvart.genesara.world.internal.resources.NodeResourceStore
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DefensiveExtractionFlowTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val ownerId = PlayerId(UUID.randomUUID())
+    private val tracker = InMemoryBehaviorTracker()
+    private val publisher = RecordingPublisher()
+
+    private val regionId = RegionId(1L)
+    private val mountainNode = NodeId(1L)
+    private val gateNode = NodeId(2L)
+
+    private val wood = ItemId("WOOD")
+    private val stone = ItemId("STONE")
+    private val ironIngot = ItemId("IRON_INGOT")
+    private val coal = ItemId("COAL")
+    private val gateKey = ItemId("GATE_KEY")
+
+    private val carpentry = SkillId("CARPENTRY")
+    private val smithing = SkillId("SMITHING")
+
+    private val region = Region(
+        id = regionId, worldId = WorldId(1L), sphereIndex = 0,
+        biome = Biome.MOUNTAIN, climate = Climate.OCEANIC,
+        centroid = Vec3(0.0, 0.0, 1.0), faceVertices = emptyList(), neighbors = emptySet(),
+    )
+
+    private val mineDef = BuildingProperties(
+        staminaPerStep = 8, hp = 80,
+        categoryHint = BuildingCategoryHint.EXTRACTION_MINE,
+        skillBars = mapOf("CARPENTRY" to BarProperties(steps = 2, materialsPerStep = mapOf("WOOD" to 1))),
+    )
+    private val gateDef = BuildingProperties(
+        staminaPerStep = 8, hp = 120,
+        categoryHint = BuildingCategoryHint.DEFENSIVE,
+        skillBars = mapOf(
+            "CARPENTRY" to BarProperties(steps = 2, materialsPerStep = mapOf("WOOD" to 1)),
+            "SMITHING" to BarProperties(steps = 2, materialsPerStep = mapOf("IRON_INGOT" to 1)),
+        ),
+    )
+    private val catalog = BuildingsCatalog(
+        BuildingDefinitionProperties(catalog = mapOf("MINE" to mineDef, "GATE" to gateDef)),
+    )
+
+    private val gateKeyCopyRecipe = Recipe(
+        id = RecipeId("GATE_KEY_COPY"),
+        output = RecipeOutput(item = gateKey, quantity = 1),
+        inputs = mapOf(ironIngot to 1),
+        requiredStation = BuildingCategoryHint.CRAFTING_STATION_WOOD,
+        requiredSkill = carpentry,
+        requiredSkillLevel = 0,
+        staminaCost = 10,
+        unlockMode = RecipeUnlockMode.Open,
+        requiresSource = gateKey,
+    )
+
+    private val itemLookup = FlowItemLookup(
+        mapOf(
+            wood to resource(wood),
+            stone to resource(stone),
+            ironIngot to resource(ironIngot),
+            coal to resource(coal, extractionOnly = true),
+            gateKey to resource(gateKey),
+        ),
+    )
+
+    private val balance = FlowBalance(harvestCost = 5)
+
+    @Test
+    fun `mine-gate-extract-block-toggle-move-keycopy-harvest-block flow`() {
+        val buildStore = FlowBuildingsStore()
+        val barsStore = FlowBuildingBarsStore(buildStore, catalog)
+        val gateStates = FlowGateStates()
+        val agentKeys = FlowAgentKeysStore()
+        val skills = FlowSkillsRegistry().apply { slot(carpentry); slot(smithing) }
+        val safeNodes = FlowSafeNodes()
+        val resources = FlowResourceStore(mapOf(coal to 50))
+        val agentRegistry = FlowAgentRegistry(agent, ownerId)
+        val equipment = FlowEquipmentStore()
+        val recipeLookup = FlowRecipeLookup(listOf(gateKeyCopyRecipe))
+
+        fun buildingsLookupFromStore(): BuildingsLookup = FlowBuildingsLookup(buildStore)
+
+        var state = WorldState(
+            regions = mapOf(regionId to region),
+            nodes = mapOf(
+                mountainNode to Node(mountainNode, regionId, q = 0, r = 0, terrain = Terrain.MOUNTAIN, adjacency = setOf(gateNode)),
+                gateNode to Node(gateNode, regionId, q = 1, r = 0, terrain = Terrain.MOUNTAIN, adjacency = setOf(mountainNode)),
+            ),
+            positions = mapOf(agent to mountainNode),
+            bodies = mapOf(agent to AgentBody(hp = 100, maxHp = 100, stamina = 500, maxStamina = 500, mana = 0, maxMana = 0)),
+            inventories = mapOf(agent to AgentInventory()
+                .add(wood, 50).add(stone, 50).add(ironIngot, 20)),
+        )
+
+        // --- Step 1: Build MINE (2 steps) ---
+        repeat(2) { i ->
+            val (next, events) = assertNotNull(
+                reduceBuild(
+                    state, WorldCommand.BuildStructure(agent, BuildingType.MINE, skill = carpentry),
+                    catalog, skills, buildStore, barsStore, safeNodes,
+                    NoOpAgentPlotsStore, NoGateStates, NoAgentKeys,
+                    SkillProgression(skills, publisher),
+                    triggeredPassives = NoOpTriggeredPassiveDispatcher,
+                    behaviorTracker = tracker, tick = (1 + i).toLong(),
+                ).getOrNull(),
+                "Step 1.${i + 1}: MINE build step ${i + 1} failed",
+            )
+            state = next
+            if (i == 1) assertIs<WorldEvent.BuildingConstructed>(events.single(), "Step 1: final build step must emit BuildingConstructed")
+        }
+        val mineInstance = buildStore.rows.single { it.type == BuildingType.MINE }
+        assertEquals(BuildingStatus.ACTIVE, mineInstance.status, "Step 1: MINE must be ACTIVE")
+        assertEquals(Terrain.MOUNTAIN, state.nodes[mountainNode]!!.terrain, "Step 1: terrain-coupling passed — MOUNTAIN is in the allowed set")
+
+        // --- Step 2: Extract COAL ---
+        val (afterExtract, extractEvents) = assertNotNull(
+            reduceExtract(
+                state,
+                WorldCommand.Extract(agent, coal),
+                balance,
+                itemLookup,
+                resources,
+                buildingsLookupFromStore(),
+                agentRegistry,
+                equipment,
+                SkillProgression(skills, publisher),
+                characterXp = CharacterXpProgression.NoOp,
+                scaling = NoScaling,
+                triggeredPassives = NoOpTriggeredPassiveDispatcher,
+                behaviorTracker = tracker,
+                tick = 10,
+            ).getOrNull(),
+            "Step 2: Extract COAL must succeed",
+        )
+        state = afterExtract
+        val extracted = assertIs<WorldEvent.ResourceExtracted>(extractEvents.single(), "Step 2: must emit ResourceExtracted")
+        assertEquals(coal, extracted.item, "Step 2: extracted item must be COAL")
+        assertTrue(state.inventoryOf(agent).quantityOf(coal) > 0, "Step 2: COAL must be in inventory")
+
+        // --- Step 3: Build GATE on mountainNode (same node as MINE, 4 steps: 2 carpentry + 2 smithing) ---
+        // Agent stays on mountainNode so the toggle (step 5) can be issued from the gate's own node.
+        // The movement block test (step 4) uses a separate agent position copy.
+
+        repeat(2) { i ->
+            val (next, _) = assertNotNull(
+                reduceBuild(
+                    state, WorldCommand.BuildStructure(agent, BuildingType.GATE, skill = carpentry),
+                    catalog, skills, buildStore, barsStore, safeNodes,
+                    NoOpAgentPlotsStore, gateStates, agentKeys,
+                    SkillProgression(skills, publisher),
+                    triggeredPassives = NoOpTriggeredPassiveDispatcher,
+                    behaviorTracker = tracker, tick = (20 + i).toLong(),
+                ).getOrNull(),
+                "Step 3: GATE carpentry step ${i + 1} failed",
+            )
+            state = next
+        }
+        var gateCompletionEvents: List<WorldEvent> = emptyList()
+        repeat(2) { i ->
+            val (next, events) = assertNotNull(
+                reduceBuild(
+                    state, WorldCommand.BuildStructure(agent, BuildingType.GATE, skill = smithing),
+                    catalog, skills, buildStore, barsStore, safeNodes,
+                    NoOpAgentPlotsStore, gateStates, agentKeys,
+                    SkillProgression(skills, publisher),
+                    triggeredPassives = NoOpTriggeredPassiveDispatcher,
+                    behaviorTracker = tracker, tick = (22 + i).toLong(),
+                ).getOrNull(),
+                "Step 3: GATE smithing step ${i + 1} failed",
+            )
+            state = next
+            if (i == 1) { gateCompletionEvents = events }
+        }
+        assertIs<WorldEvent.BuildingConstructed>(gateCompletionEvents.first(), "Step 3: final GATE step must emit BuildingConstructed")
+        val gateInstance = buildStore.rows.single { it.type == BuildingType.GATE }
+        assertEquals(BuildingStatus.ACTIVE, gateInstance.status, "Step 3: GATE must be ACTIVE")
+        assertEquals(listOf(gateInstance.instanceId), gateStates.closedInserted, "Step 3: gate state row must be inserted as CLOSED")
+        val issuedKey = agentKeys.inserted.single()
+        assertEquals(gateInstance.instanceId, issuedKey.gateInstanceId, "Step 3: auto-issued key must reference the gate")
+        assertEquals(agent, issuedKey.agentId, "Step 3: key must be issued to the builder")
+        val mintedEvent = assertIs<WorldEvent.GateKeyMinted>(
+            gateCompletionEvents.filterIsInstance<WorldEvent.GateKeyMinted>().single(),
+            "Step 3: GateKeyMinted must be in completion events",
+        )
+        assertEquals(false, mintedEvent.byCopy, "Step 3: GateKeyMinted must have byCopy=false")
+        assertEquals(gateInstance.instanceId, mintedEvent.gateId, "Step 3: GateKeyMinted must reference the gate")
+
+        // --- Step 4: Attempt to move from gateNode into mountainNode while gate is CLOSED ---
+        // Simulate an outsider on gateNode trying to enter the fortified mountainNode.
+        val outsiderState = state.copy(positions = mapOf(agent to gateNode))
+        val moveBlockResult = reduceMove(
+            outsiderState,
+            WorldCommand.MoveAgent(agent, mountainNode),
+            balance,
+            buildingsLookupFromStore(),
+            gateStates = gateStates,
+            scaling = NoScaling,
+            behaviorTracker = tracker,
+            tick = 30,
+        )
+        val blockRejection = assertIs<WorldRejection.DefensiveBlocks>(
+            moveBlockResult.leftOrNull(),
+            "Step 4: closed GATE must block movement into mountainNode",
+        )
+        assertEquals(agent, blockRejection.agent, "Step 4: rejection must name our agent")
+        assertEquals(mountainNode, blockRejection.node, "Step 4: rejection must name the destination node")
+
+        // --- Step 5: Toggle the gate open (agent is already on mountainNode — the gate's node) ---
+        val (afterToggle, toggleEvents) = assertNotNull(
+            reduceToggleGate(
+                state,
+                WorldCommand.ToggleGate(agent, gateInstance.instanceId),
+                buildStore,
+                gateStates,
+                agentKeys,
+                tick = 31,
+            ).getOrNull(),
+            "Step 5: ToggleGate must succeed with the auto-issued key",
+        )
+        state = afterToggle
+        val toggled = assertIs<WorldEvent.GateToggled>(toggleEvents.single(), "Step 5: must emit GateToggled")
+        assertTrue(toggled.isOpen, "Step 5: gate must be OPEN after toggle")
+
+        // --- Step 6: Move through the now-open gate (outsider can now enter) ---
+        val (afterMove, moveEvents) = assertNotNull(
+            reduceMove(
+                outsiderState,
+                WorldCommand.MoveAgent(agent, mountainNode),
+                balance,
+                buildingsLookupFromStore(),
+                gateStates = gateStates,
+                scaling = NoScaling,
+                behaviorTracker = tracker,
+                tick = 32,
+            ).getOrNull(),
+            "Step 6: movement through open GATE must succeed",
+        )
+        state = afterMove
+        assertIs<WorldEvent.AgentMoved>(moveEvents.single(), "Step 6: must emit AgentMoved")
+        assertEquals(mountainNode, state.positions[agent], "Step 6: agent must be on mountainNode after move")
+
+        // --- Step 7: Craft GATE_KEY_COPY at WORKBENCH (on mountainNode) ---
+        state = state.copy(positions = mapOf(agent to mountainNode))
+        val workbenchBuilding = Building(
+            instanceId = UUID.randomUUID(),
+            nodeId = mountainNode,
+            type = BuildingType.WORKBENCH,
+            status = BuildingStatus.ACTIVE,
+            builtByAgentId = agent,
+            builtAtTick = 1L, lastProgressTick = 1L,
+            progressSteps = 1, totalSteps = 1,
+            hpCurrent = 50, hpMax = 50,
+        )
+        buildStore.rows += workbenchBuilding
+
+        val ironIngotBefore = state.inventoryOf(agent).quantityOf(ironIngot)
+        val (afterCraft, craftEvents) = assertNotNull(
+            reduceCraft(
+                state,
+                WorldCommand.CraftItem(agent, gateKeyCopyRecipe.id, source = issuedKey.instanceId),
+                balance,
+                itemLookup,
+                recipeLookup,
+                AgentKnownRecipesGateway.Empty,
+                equipment,
+                agentKeys,
+                buildingsLookupFromStore(),
+                skills,
+                agentRegistry,
+                fixedRoller(),
+                SkillProgression(skills, publisher),
+                scaling = NoScaling,
+                triggeredPassives = NoOpTriggeredPassiveDispatcher,
+                behaviorTracker = tracker,
+                tick = 40,
+            ).getOrNull(),
+            "Step 7: GATE_KEY_COPY craft must succeed",
+        )
+        state = afterCraft
+        assertIs<WorldEvent.ItemCrafted>(craftEvents.filterIsInstance<WorldEvent.ItemCrafted>().single(), "Step 7: must emit ItemCrafted")
+        val copyMinted = assertIs<WorldEvent.GateKeyMinted>(
+            craftEvents.filterIsInstance<WorldEvent.GateKeyMinted>().single(),
+            "Step 7: must emit GateKeyMinted",
+        )
+        assertTrue(copyMinted.byCopy, "Step 7: GateKeyMinted byCopy must be true")
+        assertEquals(gateInstance.instanceId, copyMinted.gateId, "Step 7: copied key must reference same gate")
+        val copiedKey = agentKeys.inserted.last()
+        assertEquals(gateInstance.instanceId, copiedKey.gateInstanceId, "Step 7: copied key in store must point at original gate")
+        assertEquals(ironIngotBefore - 1, state.inventoryOf(agent).quantityOf(ironIngot), "Step 7: IRON_INGOT must be consumed")
+
+        // --- Step 8: Bare harvest of COAL is rejected (extractionOnly guard) ---
+        val harvestResult = reduceHarvest(
+            state,
+            WorldCommand.Harvest(agent, coal),
+            balance,
+            itemLookup,
+            resources,
+            agentRegistry,
+            equipment,
+            SkillProgression(skills, publisher),
+            characterXp = CharacterXpProgression.NoOp,
+            scaling = NoScaling,
+            triggeredPassives = NoOpTriggeredPassiveDispatcher,
+            behaviorTracker = tracker,
+            tick = 50,
+        )
+        val harvestRejection = assertIs<WorldRejection.HarvestRequiresExtraction>(
+            harvestResult.leftOrNull(),
+            "Step 8: bare Harvest on extractionOnly COAL must be rejected",
+        )
+        assertEquals(coal, harvestRejection.item, "Step 8: rejection must name COAL")
+    }
+
+    // ---- stubs ----
+
+    private fun resource(id: ItemId, extractionOnly: Boolean = false) = Item(
+        id = id, displayName = id.value, description = "",
+        category = ItemCategory.RESOURCE, weightPerUnit = 100, maxStack = 500,
+        harvestSkill = null, extractionOnly = extractionOnly,
+    )
+
+    private fun fixedRoller() = object : RarityRoller(Random(0)) {
+        override fun roll(skillLevel: Int, luck: Int) = Rarity.COMMON
+    }
+
+    private object NoOpAgentPlotsStore : dev.gvart.genesara.world.AgentPlotsStore {
+        override fun insertEmpty(plot: dev.gvart.genesara.world.AgentPlot) = Unit
+        override fun findById(plotId: UUID): dev.gvart.genesara.world.AgentPlot? = null
+        override fun findByBuilding(buildingInstanceId: UUID): dev.gvart.genesara.world.AgentPlot? = null
+        override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<dev.gvart.genesara.world.AgentPlot>> = emptyMap()
+        override fun plant(plotId: UUID, crop: dev.gvart.genesara.world.PlantedCrop): dev.gvart.genesara.world.AgentPlot? = null
+        override fun tend(plotId: UUID, tick: Long): dev.gvart.genesara.world.AgentPlot? = null
+        override fun clearPlanting(plotId: UUID): dev.gvart.genesara.world.AgentPlot? = null
+        override fun listPlantedSnapshot(): List<dev.gvart.genesara.world.AgentPlot> = emptyList()
+    }
+
+    private object NoGateStates : BuildingGateStateStore {
+        override fun insertClosed(gateInstanceId: UUID) = Unit
+        override fun isOpen(gateInstanceId: UUID): Boolean? = null
+        override fun toggle(gateInstanceId: UUID): Boolean? = null
+    }
+
+    private object NoAgentKeys : AgentKeysStore {
+        override fun insert(key: AgentKeyInstance) = Unit
+        override fun findById(instanceId: UUID): AgentKeyInstance? = null
+        override fun agentHoldsKeyFor(agent: AgentId, gateInstanceId: UUID): Boolean = false
+        override fun listByAgent(agent: AgentId): List<AgentKeyInstance> = emptyList()
+    }
+
+    private class FlowBuildingsStore(val rows: MutableList<Building> = mutableListOf()) : BuildingsStore {
+        override fun insert(building: Building) { rows += building }
+        override fun findById(id: UUID): Building? = rows.firstOrNull { it.instanceId == id }
+        override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? =
+            rows.firstOrNull { it.nodeId == node && it.builtByAgentId == agent && it.type == type && it.status == BuildingStatus.UNDER_CONSTRUCTION }
+        override fun findAnyAtNodeOfType(node: NodeId, type: BuildingType): Building? =
+            rows.firstOrNull { it.nodeId == node && it.type == type }
+        override fun listAtNode(node: NodeId): List<Building> = rows.filter { it.nodeId == node }
+        override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
+            rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }
+        override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? {
+            val idx = rows.indexOfFirst { it.instanceId == id }.takeIf { it >= 0 } ?: return null
+            val updated = rows[idx].copy(progressSteps = newProgress, lastProgressTick = asOfTick)
+            rows[idx] = updated
+            return updated
+        }
+        override fun complete(id: UUID, asOfTick: Long): Building? {
+            val idx = rows.indexOfFirst { it.instanceId == id }.takeIf { it >= 0 } ?: return null
+            val original = rows[idx]
+            val updated = original.copy(status = BuildingStatus.ACTIVE, progressSteps = original.totalSteps, lastProgressTick = asOfTick)
+            rows[idx] = updated
+            return updated
+        }
+    }
+
+    private class FlowBuildingBarsStore(
+        private val store: FlowBuildingsStore,
+        private val catalog: BuildingsCatalog,
+    ) : BuildingBarsStore {
+        val rows: MutableMap<Pair<UUID, String>, BuildingBar> = mutableMapOf()
+
+        override fun insertAll(bars: List<BuildingBar>) { bars.forEach { rows[it.instanceId to it.skill.value] = it } }
+        override fun barsByInstance(instanceId: UUID): List<BuildingBar> =
+            rows.values.filter { it.instanceId == instanceId }.sortedBy { it.skill.value }
+        override fun barsByInstances(instanceIds: Set<UUID>): Map<UUID, List<BuildingBar>> =
+            rows.values.filter { it.instanceId in instanceIds }.groupBy { it.instanceId }
+        override fun advanceBar(instanceId: UUID, skill: SkillId): BuildingBar? {
+            val key = instanceId to skill.value
+            val existing = rows[key]
+            if (existing != null) {
+                if (existing.progressSteps >= existing.totalSteps) return null
+                val updated = existing.copy(progressSteps = existing.progressSteps + 1)
+                rows[key] = updated
+                return updated
+            }
+            val building = store.rows.firstOrNull { it.instanceId == instanceId } ?: return null
+            val def = try { catalog.def(building.type) } catch (_: Throwable) { return null }
+            val barDef = def.bar(skill) ?: return null
+            val advanced = (building.progressSteps).coerceAtMost(barDef.steps - 1) + 1
+            val seeded = BuildingBar(instanceId, skill, progressSteps = advanced, totalSteps = barDef.steps)
+            rows[key] = seeded
+            return seeded
+        }
+    }
+
+    private class FlowGateStates : BuildingGateStateStore {
+        val closedInserted = mutableListOf<UUID>()
+        private val states = mutableMapOf<UUID, Boolean>()
+        override fun insertClosed(gateInstanceId: UUID) {
+            closedInserted += gateInstanceId
+            states[gateInstanceId] = false
+        }
+        override fun isOpen(gateInstanceId: UUID): Boolean? = states[gateInstanceId]
+        override fun toggle(gateInstanceId: UUID): Boolean? {
+            val current = states[gateInstanceId] ?: return null
+            val next = !current
+            states[gateInstanceId] = next
+            return next
+        }
+    }
+
+    private class FlowAgentKeysStore : AgentKeysStore {
+        val inserted = mutableListOf<AgentKeyInstance>()
+        private val byId = mutableMapOf<UUID, AgentKeyInstance>()
+        override fun insert(key: AgentKeyInstance) { inserted += key; byId[key.instanceId] = key }
+        override fun findById(instanceId: UUID): AgentKeyInstance? = byId[instanceId]
+        override fun agentHoldsKeyFor(agent: AgentId, gateInstanceId: UUID): Boolean =
+            byId.values.any { it.agentId == agent && it.gateInstanceId == gateInstanceId }
+        override fun listByAgent(agent: AgentId): List<AgentKeyInstance> =
+            byId.values.filter { it.agentId == agent }
+    }
+
+    private class FlowSkillsRegistry : AgentSkillsRegistry {
+        private val slotted = mutableSetOf<SkillId>()
+        fun slot(skill: SkillId) { slotted += skill }
+        override fun snapshot(agent: AgentId) = AgentSkillsSnapshot(
+            perSkill = slotted.associateWith { AgentSkillState(it, xp = 0, level = 0, slotIndex = 0, recommendCount = 0) },
+            slotCount = 8, slotsFilled = slotted.size,
+        )
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int): AddXpResult = AddXpResult.Unslotted
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? = null
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? = null
+    }
+
+    private class FlowSafeNodes : dev.gvart.genesara.world.AgentSafeNodeGateway {
+        override fun set(agentId: AgentId, nodeId: NodeId, tick: Long) = Unit
+        override fun find(agentId: AgentId): NodeId? = null
+        override fun clear(agentId: AgentId) = Unit
+    }
+
+    private class FlowResourceStore(initial: Map<ItemId, Int>) : NodeResourceStore {
+        private val cells = initial.toMutableMap()
+        override fun availability(nodeId: NodeId, item: ItemId, tick: Long): NodeResourceCell? =
+            cells[item]?.let { NodeResourceCell(nodeId, item, it, it.coerceAtLeast(1)) }
+        override fun decrement(nodeId: NodeId, item: ItemId, amount: Int, tick: Long) {
+            val have = cells[item] ?: error("no cell for $item")
+            cells[item] = have - amount
+        }
+        override fun read(nodeId: NodeId, tick: Long) = dev.gvart.genesara.world.NodeResources(
+            cells.mapValues { (k, v) -> dev.gvart.genesara.world.NodeResourceView(k, v, v.coerceAtLeast(1)) },
+        )
+        override fun seed(rows: Collection<InitialResourceRow>, tick: Long) = Unit
+    }
+
+    private class FlowAgentRegistry(private val id: AgentId, private val owner: PlayerId) : AgentRegistry {
+        override fun find(agentId: AgentId): Agent? = if (agentId == id) Agent(
+            id = id, owner = owner, name = "test",
+            attributes = AgentAttributes(strength = 100, dexterity = 10, constitution = 10, perception = 10, intelligence = 10, luck = 5),
+        ) else null
+        override fun listForOwner(owner: PlayerId): List<Agent> = emptyList()
+    }
+
+    private class FlowEquipmentStore : EquipmentInstanceStore {
+        override fun insert(instance: EquipmentInstance) = Unit
+        override fun findById(instanceId: UUID): EquipmentInstance? = null
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = emptyList()
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> = emptyMap()
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? = null
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = null
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = null
+        override fun delete(instanceId: UUID): Boolean = false
+    }
+
+    private class FlowRecipeLookup(recipes: List<Recipe>) : RecipeLookup {
+        private val byId = recipes.associateBy { it.id }
+        override fun byId(id: RecipeId): Recipe? = byId[id]
+        override fun all(): List<Recipe> = byId.values.toList()
+    }
+
+    private class FlowItemLookup(private val items: Map<ItemId, Item>) : ItemLookup {
+        override fun byId(id: ItemId): Item? = items[id]
+        override fun all(): List<Item> = items.values.toList()
+    }
+
+    private class FlowBuildingsLookup(private val store: FlowBuildingsStore) : BuildingsLookup {
+        override fun byId(id: UUID): Building? = store.findById(id)
+        override fun byNode(node: NodeId): List<Building> = store.listAtNode(node)
+        override fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = store.listByNodes(nodes)
+        override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> =
+            store.listAtNode(node).filter { it.status == BuildingStatus.ACTIVE && hintOf(it.type) == hint }
+        private fun hintOf(type: BuildingType): BuildingCategoryHint? = when (type) {
+            BuildingType.MINE -> BuildingCategoryHint.EXTRACTION_MINE
+            BuildingType.GATE -> BuildingCategoryHint.DEFENSIVE
+            BuildingType.WOODEN_WALL -> BuildingCategoryHint.DEFENSIVE
+            BuildingType.WORKBENCH -> BuildingCategoryHint.CRAFTING_STATION_WOOD
+            BuildingType.FORGE -> BuildingCategoryHint.CRAFTING_STATION_METAL
+            else -> null
+        }
+    }
+
+    private class FlowBalance(private val harvestCost: Int) : BalanceLookup {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain): Int = 1
+        override fun staminaRegenPerTick(climate: Climate): Int = 0
+        override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = harvestCost
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun roadStaminaMultiplier(): Double = 0.5
+        override fun carryGramsPerStrengthPoint(): Int = 1_000_000
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) { events += event }
+    }
+}
+
+private fun <L, R> arrow.core.Either<L, R>.leftOrNull(): L? = (this as? arrow.core.Either.Left<L>)?.value

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/JooqAgentKeysStoreIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/JooqAgentKeysStoreIntegrationTest.kt
@@ -1,0 +1,132 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.AgentKeyInstance
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_KEYS
+import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.exception.DataAccessException
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@Testcontainers
+class JooqAgentKeysStoreIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("agent_keys_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = WorldFlyway.pooledDataSource(postgres)
+            WorldFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private lateinit var store: JooqAgentKeysStore
+    private val agent = AgentId(UUID.randomUUID())
+    private val otherAgent = AgentId(UUID.randomUUID())
+    private val gateId = UUID.randomUUID()
+
+    @BeforeEach
+    fun reset() {
+        dsl.truncate(AGENT_KEYS).cascade().execute()
+        store = JooqAgentKeysStore(dsl)
+    }
+
+    @Test
+    fun `insert and findById round-trip all fields`() {
+        val key = sampleKey()
+        store.insert(key)
+
+        assertEquals(key, store.findById(key.instanceId))
+    }
+
+    @Test
+    fun `findById returns null for a missing instance`() {
+        assertNull(store.findById(UUID.randomUUID()))
+    }
+
+    @Test
+    fun `listByAgent returns only the calling agent's keys`() {
+        val mine1 = sampleKey()
+        val mine2 = sampleKey(gateInstanceId = UUID.randomUUID())
+        val theirs = sampleKey(agentId = otherAgent)
+        listOf(mine1, mine2, theirs).forEach { store.insert(it) }
+
+        val result = store.listByAgent(agent)
+
+        assertEquals(setOf(mine1.instanceId, mine2.instanceId), result.map { it.instanceId }.toSet())
+    }
+
+    @Test
+    fun `agentHoldsKeyFor returns true when the agent holds a key for that gate`() {
+        store.insert(sampleKey())
+
+        assertTrue(store.agentHoldsKeyFor(agent, gateId))
+    }
+
+    @Test
+    fun `agentHoldsKeyFor returns false for the wrong agent`() {
+        store.insert(sampleKey())
+
+        assertFalse(store.agentHoldsKeyFor(otherAgent, gateId))
+    }
+
+    @Test
+    fun `agentHoldsKeyFor returns false for the wrong gate`() {
+        store.insert(sampleKey())
+
+        assertFalse(store.agentHoldsKeyFor(agent, UUID.randomUUID()))
+    }
+
+    @Test
+    fun `duplicate instance_id raises DataAccessException on PK conflict`() {
+        val key = sampleKey()
+        store.insert(key)
+
+        assertFailsWith<DataAccessException> { store.insert(key) }
+    }
+
+    private fun sampleKey(
+        instanceId: UUID = UUID.randomUUID(),
+        agentId: AgentId = agent,
+        gateInstanceId: UUID = gateId,
+    ) = AgentKeyInstance(
+        instanceId = instanceId,
+        agentId = agentId,
+        itemId = ItemId("GATE_KEY"),
+        gateInstanceId = gateInstanceId,
+        createdAtTick = 1L,
+    )
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/JooqBuildingGateStateStoreIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/JooqBuildingGateStateStoreIntegrationTest.kt
@@ -1,0 +1,134 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.world.internal.jooq.tables.references.BUILDING_GATE_STATES
+import dev.gvart.genesara.world.internal.jooq.tables.references.NODE_BUILDINGS
+import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@Testcontainers
+class JooqBuildingGateStateStoreIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("gate_state_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = WorldFlyway.pooledDataSource(postgres)
+            WorldFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private lateinit var store: JooqBuildingGateStateStore
+
+    @BeforeEach
+    fun reset() {
+        dsl.truncate(BUILDING_GATE_STATES).cascade().execute()
+        dsl.truncate(NODE_BUILDINGS).cascade().execute()
+        store = JooqBuildingGateStateStore(dsl)
+    }
+
+    @Test
+    fun `insertClosed sets is_open to false`() {
+        val gateId = insertNodeBuilding()
+        store.insertClosed(gateId)
+
+        assertFalse(store.isOpen(gateId)!!)
+    }
+
+    @Test
+    fun `toggle flips false to true`() {
+        val gateId = insertNodeBuilding()
+        store.insertClosed(gateId)
+
+        val afterFirst = store.toggle(gateId)
+
+        assertTrue(afterFirst!!)
+        assertTrue(store.isOpen(gateId)!!)
+    }
+
+    @Test
+    fun `toggle flips true back to false on second call`() {
+        val gateId = insertNodeBuilding()
+        store.insertClosed(gateId)
+        store.toggle(gateId)
+
+        val afterSecond = store.toggle(gateId)
+
+        assertFalse(afterSecond!!)
+        assertFalse(store.isOpen(gateId)!!)
+    }
+
+    @Test
+    fun `isOpen returns null for an unknown gate id`() {
+        assertNull(store.isOpen(UUID.randomUUID()))
+    }
+
+    @Test
+    fun `toggle returns null for an unknown gate id without inserting a row`() {
+        val unknown = UUID.randomUUID()
+
+        assertNull(store.toggle(unknown))
+        assertNull(store.isOpen(unknown))
+    }
+
+    @Test
+    fun `deleting the node_buildings row cascades and removes the gate state row`() {
+        val gateId = insertNodeBuilding()
+        store.insertClosed(gateId)
+
+        dsl.deleteFrom(NODE_BUILDINGS)
+            .where(NODE_BUILDINGS.INSTANCE_ID.eq(gateId))
+            .execute()
+
+        assertNull(store.isOpen(gateId))
+    }
+
+    private fun insertNodeBuilding(): UUID {
+        val id = UUID.randomUUID()
+        dsl.insertInto(NODE_BUILDINGS)
+            .set(NODE_BUILDINGS.INSTANCE_ID, id)
+            .set(NODE_BUILDINGS.NODE_ID, 1L)
+            .set(NODE_BUILDINGS.BUILDING_TYPE, "GATE")
+            .set(NODE_BUILDINGS.STATUS, "ACTIVE")
+            .set(NODE_BUILDINGS.BUILT_BY_AGENT_ID, UUID.randomUUID())
+            .set(NODE_BUILDINGS.BUILT_AT_TICK, 1L)
+            .set(NODE_BUILDINGS.LAST_PROGRESS_TICK, 1L)
+            .set(NODE_BUILDINGS.PROGRESS_STEPS, 5)
+            .set(NODE_BUILDINGS.TOTAL_STEPS, 5)
+            .set(NODE_BUILDINGS.HP_CURRENT, 100)
+            .set(NODE_BUILDINGS.HP_MAX, 100)
+            .execute()
+        return id
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/ToggleGateReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/ToggleGateReducerTest.kt
@@ -1,0 +1,142 @@
+package dev.gvart.genesara.world.internal.buildings
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.AgentKeyInstance
+import dev.gvart.genesara.world.AgentKeysStore
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingGateStateStore
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ToggleGateReducerTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val regionId = RegionId(1L)
+    private val node = NodeId(1L)
+    private val gateId = UUID.randomUUID()
+
+    private val world = WorldState(
+        regions = mapOf(
+            regionId to Region(
+                id = regionId, worldId = WorldId(1L), sphereIndex = 0,
+                biome = Biome.PLAINS, climate = Climate.OCEANIC,
+                centroid = Vec3(0.0, 0.0, 1.0), faceVertices = emptyList(), neighbors = emptySet(),
+            ),
+        ),
+        nodes = mapOf(node to Node(node, regionId, q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())),
+        positions = mapOf(agent to node),
+        bodies = mapOf(agent to AgentBody(hp = 50, maxHp = 50, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0)),
+        inventories = emptyMap(),
+    )
+
+    private val gate = Building(
+        instanceId = gateId, nodeId = node, type = BuildingType.GATE, status = BuildingStatus.ACTIVE,
+        builtByAgentId = agent, builtAtTick = 1L, lastProgressTick = 5L,
+        progressSteps = 10, totalSteps = 10, hpCurrent = 120, hpMax = 120,
+    )
+
+    @Test
+    fun `happy path — key-holder on gate node toggles closed gate to open`() {
+        val keys = StubAgentKeys(holdings = mapOf(agent to setOf(gateId)))
+        val states = StubGateStates(initiallyOpen = false)
+
+        val result = reduceToggleGate(world, WorldCommand.ToggleGate(agent, gateId), StubBuildingsStore(gate), states, keys, tick = 7L)
+
+        val (_, events) = assertNotNull(result.getOrNull())
+        val event = assertIs<WorldEvent.GateToggled>(events.single())
+        assertEquals(gateId, event.gateId)
+        assertTrue(event.isOpen)
+        assertEquals(true, states.lastFlip)
+    }
+
+    @Test
+    fun `rejects when agent does not hold a matching key`() {
+        val keys = StubAgentKeys(holdings = emptyMap())
+        val states = StubGateStates(initiallyOpen = true)
+
+        val result = reduceToggleGate(world, WorldCommand.ToggleGate(agent, gateId), StubBuildingsStore(gate), states, keys, tick = 7L)
+
+        assertEquals(WorldRejection.MissingGateKey(agent, gateId), result.leftOrNull())
+        assertEquals(null, states.lastFlip)
+    }
+
+    @Test
+    fun `rejects when agent stands on a different node than the gate`() {
+        val keys = StubAgentKeys(holdings = mapOf(agent to setOf(gateId)))
+        val states = StubGateStates(initiallyOpen = false)
+        val otherNode = NodeId(99L)
+        val displaced = world.copy(positions = mapOf(agent to otherNode), nodes = world.nodes + (otherNode to Node(otherNode, regionId, q = 1, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())))
+
+        val result = reduceToggleGate(displaced, WorldCommand.ToggleGate(agent, gateId), StubBuildingsStore(gate), states, keys, tick = 7L)
+
+        assertEquals(WorldRejection.NotOnBuildingNode(agent, gateId), result.leftOrNull())
+    }
+
+    @Test
+    fun `rejects when the building id does not resolve to an ACTIVE GATE`() {
+        val keys = StubAgentKeys(holdings = mapOf(agent to setOf(gateId)))
+        val states = StubGateStates(initiallyOpen = false)
+        val chestBuilding = gate.copy(type = BuildingType.STORAGE_CHEST)
+
+        val result = reduceToggleGate(world, WorldCommand.ToggleGate(agent, gateId), StubBuildingsStore(chestBuilding), states, keys, tick = 7L)
+
+        assertEquals(WorldRejection.GateNotFound(agent, gateId), result.leftOrNull())
+    }
+
+    private class StubBuildingsStore(private val one: Building?) : BuildingsStore {
+        override fun insert(building: Building) = error("not used")
+        override fun findById(id: UUID): Building? = one?.takeIf { it.instanceId == id }
+        override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? = null
+        override fun findAnyAtNodeOfType(node: NodeId, type: BuildingType): Building? = null
+        override fun listAtNode(node: NodeId): List<Building> = listOfNotNull(one)
+        override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = emptyMap()
+        override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = null
+        override fun complete(id: UUID, asOfTick: Long): Building? = null
+    }
+
+    private class StubGateStates(initiallyOpen: Boolean) : BuildingGateStateStore {
+        private var open: Boolean = initiallyOpen
+        var lastFlip: Boolean? = null
+            private set
+
+        override fun insertClosed(gateInstanceId: UUID) = Unit
+        override fun isOpen(gateInstanceId: UUID): Boolean? = open
+        override fun toggle(gateInstanceId: UUID): Boolean? {
+            open = !open
+            lastFlip = open
+            return open
+        }
+    }
+
+    private class StubAgentKeys(private val holdings: Map<AgentId, Set<UUID>>) : AgentKeysStore {
+        override fun insert(key: AgentKeyInstance) = Unit
+        override fun findById(instanceId: UUID): AgentKeyInstance? = null
+        override fun agentHoldsKeyFor(agent: AgentId, gateInstanceId: UUID): Boolean =
+            holdings[agent].orEmpty().contains(gateInstanceId)
+        override fun listByAgent(agent: AgentId): List<AgentKeyInstance> = emptyList()
+    }
+}
+
+private val UNUSED_ITEM_ID = ItemId("UNUSED")

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/CraftReducerTest.kt
@@ -160,6 +160,7 @@ class CraftReducerTest {
                 recipes,
                 AgentKnownRecipesGateway.Empty,
                 store,
+                StubAgentKeysStore(),
                 StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_METAL))),
                 skills,
                 StubAgents(luckyAgent(luck = 5)),
@@ -204,6 +205,7 @@ class CraftReducerTest {
                 recipes,
                 AgentKnownRecipesGateway.Empty,
                 store,
+                StubAgentKeysStore(),
                 StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_POTION))),
                 skills,
                 StubAgents(luckyAgent(luck = 1)),
@@ -245,6 +247,7 @@ class CraftReducerTest {
             recipes,
             AgentKnownRecipesGateway.Empty,
             StubEquipmentStore(),
+            StubAgentKeysStore(),
             StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_POTION))),
             skills,
             StubAgents(luckyAgent()),
@@ -290,6 +293,7 @@ class CraftReducerTest {
             lockedRecipes,
             AgentKnownRecipesGateway.Empty,
             StubEquipmentStore(),
+            StubAgentKeysStore(),
             StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_METAL))),
             skills,
             StubAgents(luckyAgent()),
@@ -339,6 +343,7 @@ class CraftReducerTest {
             recipes,
             AgentKnownRecipesGateway.Empty,
             StubEquipmentStore(),
+            StubAgentKeysStore(),
             StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_METAL))),
             skills,
             StubAgents(luckyAgent()),
@@ -388,7 +393,8 @@ class CraftReducerTest {
             recipes,
             AgentKnownRecipesGateway.Empty,
             store,
-            StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_METAL))),
+            StubAgentKeysStore(),
+                StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_METAL))),
             skills,
             StubAgents(weakAgent),
             fixedRoller(Rarity.COMMON),
@@ -419,6 +425,7 @@ class CraftReducerTest {
             recipes,
             AgentKnownRecipesGateway.Empty,
             StubEquipmentStore(),
+            StubAgentKeysStore(),
             StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_POTION))),
             skills,
             StubAgents(luckyAgent()),
@@ -452,7 +459,8 @@ class CraftReducerTest {
                     recipes,
                     AgentKnownRecipesGateway.Empty,
                     store,
-                    StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_METAL))),
+                    StubAgentKeysStore(),
+                StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_METAL))),
                     skills,
                     StubAgents(luckyAgent()),
                     fixedRoller(rarity),
@@ -478,6 +486,7 @@ class CraftReducerTest {
             recipes,
             AgentKnownRecipesGateway.Empty,
             StubEquipmentStore(),
+            StubAgentKeysStore(),
             StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_METAL))),
             skills,
             StubAgents(luckyAgent(luck = 7)),
@@ -487,6 +496,148 @@ class CraftReducerTest {
         )
         assertEquals(25, capturingRoller.lastSkill)
         assertEquals(7, capturingRoller.lastLuck)
+    }
+
+    @Test
+    fun `GATE_KEY_COPY mints a new key bound to the source's gate, consumes IRON_INGOT, emits ItemCrafted + GateKeyMinted`() {
+        val gateKey = ItemId("GATE_KEY")
+        val carpentry = SkillId("CARPENTRY")
+        val sourceGate = UUID.randomUUID()
+        val templateKey = dev.gvart.genesara.world.AgentKeyInstance(
+            instanceId = UUID.randomUUID(), agentId = agent, itemId = gateKey,
+            gateInstanceId = sourceGate, createdAtTick = 1L,
+        )
+        val gateKeyCopy = Recipe(
+            id = RecipeId("GATE_KEY_COPY"),
+            output = RecipeOutput(item = gateKey, quantity = 1),
+            inputs = mapOf(ironIngot to 1),
+            requiredStation = BuildingCategoryHint.CRAFTING_STATION_WOOD,
+            requiredSkill = carpentry,
+            requiredSkillLevel = 0,
+            staminaCost = 10,
+            requiresSource = gateKey,
+        )
+        val keyItems = StubItemLookup(
+            mapOf(
+                ironIngot to itemDef(ironIngot, ItemCategory.RESOURCE, weightPerUnit = 1500),
+                gateKey to itemDef(gateKey, ItemCategory.RESOURCE, weightPerUnit = 100),
+            ),
+        )
+        val keyRecipes = StubRecipeLookup(listOf(gateKeyCopy))
+        val skills = StubSkillsRegistry()
+        val keys = StubAgentKeysStore().also { it.seed(templateKey) }
+
+        val (_, events) = assertNotNull(
+            reduceCraft(
+                stateWith(inventory = mapOf(ironIngot to 3)),
+                WorldCommand.CraftItem(agent, gateKeyCopy.id, source = templateKey.instanceId),
+                stubBalance(),
+                keyItems,
+                keyRecipes,
+                AgentKnownRecipesGateway.Empty,
+                StubEquipmentStore(),
+                keys,
+                StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_WOOD))),
+                skills,
+                StubAgents(luckyAgent()),
+                fixedRoller(Rarity.COMMON),
+                SkillProgression(skills, RecordingPublisher()),
+                scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 8,
+            ).getOrNull(),
+        )
+
+        val crafted = assertIs<WorldEvent.ItemCrafted>(events.filterIsInstance<WorldEvent.ItemCrafted>().single())
+        val minted = assertIs<WorldEvent.GateKeyMinted>(events.filterIsInstance<WorldEvent.GateKeyMinted>().single())
+        assertEquals(gateKey, crafted.output)
+        assertNotNull(crafted.instanceId)
+        assertEquals(crafted.instanceId, minted.keyInstanceId)
+        assertEquals(sourceGate, minted.gateId)
+        assertTrue(minted.byCopy)
+        // Source survives, new key is the only inserted entry.
+        val newKey = keys.inserted.single()
+        assertEquals(sourceGate, newKey.gateInstanceId)
+        assertEquals(agent, newKey.agentId)
+    }
+
+    @Test
+    fun `recipe with requiresSource rejects when source is null on the command`() {
+        val gateKey = ItemId("GATE_KEY")
+        val carpentry = SkillId("CARPENTRY")
+        val gateKeyCopy = Recipe(
+            id = RecipeId("GATE_KEY_COPY"),
+            output = RecipeOutput(item = gateKey, quantity = 1),
+            inputs = mapOf(ironIngot to 1),
+            requiredStation = BuildingCategoryHint.CRAFTING_STATION_WOOD,
+            requiredSkill = carpentry,
+            requiredSkillLevel = 0,
+            staminaCost = 10,
+            requiresSource = gateKey,
+        )
+        val keyItems = StubItemLookup(
+            mapOf(
+                ironIngot to itemDef(ironIngot, ItemCategory.RESOURCE, weightPerUnit = 1500),
+                gateKey to itemDef(gateKey, ItemCategory.RESOURCE, weightPerUnit = 100),
+            ),
+        )
+        val keyRecipes = StubRecipeLookup(listOf(gateKeyCopy))
+        val skills = StubSkillsRegistry()
+
+        val result = reduceCraft(
+            stateWith(inventory = mapOf(ironIngot to 3)),
+            WorldCommand.CraftItem(agent, gateKeyCopy.id, source = null),
+            stubBalance(), keyItems, keyRecipes, AgentKnownRecipesGateway.Empty,
+            StubEquipmentStore(), StubAgentKeysStore(),
+            StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_WOOD))),
+            skills, StubAgents(luckyAgent()), fixedRoller(Rarity.COMMON),
+            SkillProgression(skills, RecordingPublisher()),
+            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+        )
+
+        val rejection = assertIs<WorldRejection.RecipeRequiresSource>(result.leftOrNull())
+        assertEquals(gateKey, rejection.requiredItem)
+        assertEquals(gateKeyCopy.id, rejection.recipe)
+    }
+
+    @Test
+    fun `recipe with requiresSource rejects when source resolves to a different agent`() {
+        val gateKey = ItemId("GATE_KEY")
+        val carpentry = SkillId("CARPENTRY")
+        val otherAgent = AgentId(UUID.randomUUID())
+        val foreignKey = dev.gvart.genesara.world.AgentKeyInstance(
+            instanceId = UUID.randomUUID(), agentId = otherAgent, itemId = gateKey,
+            gateInstanceId = UUID.randomUUID(), createdAtTick = 1L,
+        )
+        val gateKeyCopy = Recipe(
+            id = RecipeId("GATE_KEY_COPY"),
+            output = RecipeOutput(item = gateKey, quantity = 1),
+            inputs = mapOf(ironIngot to 1),
+            requiredStation = BuildingCategoryHint.CRAFTING_STATION_WOOD,
+            requiredSkill = carpentry, requiredSkillLevel = 0, staminaCost = 10,
+            requiresSource = gateKey,
+        )
+        val keyItems = StubItemLookup(
+            mapOf(
+                ironIngot to itemDef(ironIngot, ItemCategory.RESOURCE, weightPerUnit = 1500),
+                gateKey to itemDef(gateKey, ItemCategory.RESOURCE, weightPerUnit = 100),
+            ),
+        )
+        val keyRecipes = StubRecipeLookup(listOf(gateKeyCopy))
+        val skills = StubSkillsRegistry()
+        val keys = StubAgentKeysStore().also { it.seed(foreignKey) }
+
+        val result = reduceCraft(
+            stateWith(inventory = mapOf(ironIngot to 3)),
+            WorldCommand.CraftItem(agent, gateKeyCopy.id, source = foreignKey.instanceId),
+            stubBalance(), keyItems, keyRecipes, AgentKnownRecipesGateway.Empty,
+            StubEquipmentStore(), keys,
+            StubBuildingsLookup(stationsAt = mapOf(nodeId to setOf(BuildingCategoryHint.CRAFTING_STATION_WOOD))),
+            skills, StubAgents(luckyAgent()), fixedRoller(Rarity.COMMON),
+            SkillProgression(skills, RecordingPublisher()),
+            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+        )
+
+        assertIs<WorldRejection.RecipeRequiresSource>(result.leftOrNull())
+        assertTrue(keys.inserted.isEmpty())
     }
 
     private fun runReducer(
@@ -504,6 +655,7 @@ class CraftReducerTest {
         recipes,
         AgentKnownRecipesGateway.Empty,
         StubEquipmentStore(),
+        StubAgentKeysStore(),
         buildings,
         skills,
         StubAgents(luckyAgent()),
@@ -590,6 +742,23 @@ class CraftReducerTest {
         override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = null
         override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = null
         override fun delete(instanceId: UUID): Boolean = false
+    }
+
+    private class StubAgentKeysStore : dev.gvart.genesara.world.AgentKeysStore {
+        val inserted = mutableListOf<dev.gvart.genesara.world.AgentKeyInstance>()
+        val byId = mutableMapOf<UUID, dev.gvart.genesara.world.AgentKeyInstance>()
+        fun seed(key: dev.gvart.genesara.world.AgentKeyInstance) {
+            byId[key.instanceId] = key
+        }
+        override fun insert(key: dev.gvart.genesara.world.AgentKeyInstance) {
+            inserted += key
+            byId[key.instanceId] = key
+        }
+        override fun findById(instanceId: UUID): dev.gvart.genesara.world.AgentKeyInstance? = byId[instanceId]
+        override fun agentHoldsKeyFor(agent: AgentId, gateInstanceId: UUID): Boolean =
+            byId.values.any { it.agentId == agent && it.gateInstanceId == gateInstanceId }
+        override fun listByAgent(agent: AgentId): List<dev.gvart.genesara.world.AgentKeyInstance> =
+            byId.values.filter { it.agentId == agent }
     }
 
     private class StubBuildingsLookup(

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/extract/ExtractReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/extract/ExtractReducerTest.kt
@@ -1,0 +1,288 @@
+package dev.gvart.genesara.world.internal.extract
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AddCharacterXpOutcome
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AgentSkillState
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.CharacterXpSource
+import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsLookup
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentInstance
+import dev.gvart.genesara.world.EquipmentInstanceStore
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Rarity
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.commands.WorldCommand
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.classes.CharacterXpProgression
+import dev.gvart.genesara.world.internal.resources.InitialResourceRow
+import dev.gvart.genesara.world.internal.resources.NodeResourceCell
+import dev.gvart.genesara.world.internal.resources.NodeResourceStore
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
+import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ExtractReducerTest {
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val regionId = RegionId(1L)
+    private val nodeId = NodeId(1L)
+    private val coal = ItemId("COAL")
+    private val wood = ItemId("WOOD")
+    private val tracker = InMemoryBehaviorTracker()
+
+    private val region = Region(
+        id = regionId, worldId = WorldId(1L), sphereIndex = 0,
+        biome = Biome.MOUNTAIN, climate = Climate.OCEANIC,
+        centroid = Vec3(0.0, 0.0, 1.0), faceVertices = emptyList(), neighbors = emptySet(),
+    )
+
+    private val balance = balance(staminaCost = 5)
+    private val items = StubItemLookup(
+        mapOf(
+            coal to itemFor(coal, harvestSkill = "MINING", extractionOnly = true),
+            wood to itemFor(wood, harvestSkill = "LUMBERJACKING", extractionOnly = false),
+        ),
+    )
+    private val agents: AgentRegistry = StubAgentRegistry(strength = 100)
+    private val equipment: EquipmentInstanceStore = StubEquipmentStore()
+
+    private fun stateWith(stamina: Int = 30): WorldState = WorldState(
+        regions = mapOf(regionId to region),
+        nodes = mapOf(nodeId to Node(nodeId, regionId, q = 0, r = 0, terrain = Terrain.MOUNTAIN, adjacency = emptySet())),
+        positions = mapOf(agent to nodeId),
+        bodies = mapOf(agent to AgentBody(hp = 50, maxHp = 50, stamina = stamina, maxStamina = 50, mana = 0, maxMana = 0)),
+        inventories = emptyMap(),
+    )
+
+    @Test
+    fun `happy path — agent at MINE extracts one COAL, spends stamina, emits ResourceExtracted`() {
+        val state = stateWith()
+        val store = StubResourceStore(initial = mapOf(coal to 20))
+        val mine = StubBuildingsLookup(activeStationsByHint = mapOf(BuildingCategoryHint.EXTRACTION_MINE to listOf(activeMine())))
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+
+        val result = reduceExtract(
+            state, WorldCommand.Extract(agent, coal), balance, items, store, mine, agents, equipment,
+            SkillProgression(skills, publisher),
+            characterXp = CharacterXpProgression.NoOp,
+            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher,
+            behaviorTracker = tracker, tick = 7,
+        )
+
+        val (next, events) = assertNotNull(result.getOrNull(), "Expected success but got: ${result.leftOrNull()}")
+        val event = assertIs<WorldEvent.ResourceExtracted>(events.single())
+        assertEquals(coal, event.item)
+        assertEquals(1, event.quantity)
+        assertEquals(1, next.inventoryOf(agent).quantityOf(coal))
+        assertEquals(25, next.bodyOf(agent)!!.stamina)
+        assertEquals(19, store.quantity(coal))
+    }
+
+    @Test
+    fun `rejects when no active MINE on the node`() {
+        val state = stateWith()
+        val store = StubResourceStore(initial = mapOf(coal to 20))
+        val empty = StubBuildingsLookup(activeStationsByHint = emptyMap())
+
+        val result = reduceExtract(
+            state, WorldCommand.Extract(agent, coal), balance, items, store, empty, agents, equipment,
+            SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            characterXp = CharacterXpProgression.NoOp, scaling = NoScaling,
+            triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+        )
+
+        assertEquals(WorldRejection.ExtractRequiresMine(agent, nodeId), result.leftOrNull())
+        assertEquals(20, store.quantity(coal))
+    }
+
+    @Test
+    fun `rejects when target item is not flagged extractionOnly — use harvest instead`() {
+        val state = stateWith()
+        val store = StubResourceStore(initial = mapOf(wood to 50))
+        val mine = StubBuildingsLookup(activeStationsByHint = mapOf(BuildingCategoryHint.EXTRACTION_MINE to listOf(activeMine())))
+
+        val result = reduceExtract(
+            state, WorldCommand.Extract(agent, wood), balance, items, store, mine, agents, equipment,
+            SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            characterXp = CharacterXpProgression.NoOp, scaling = NoScaling,
+            triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+        )
+
+        assertEquals(WorldRejection.ResourceNotAvailableHere(agent, nodeId, wood), result.leftOrNull())
+        assertEquals(50, store.quantity(wood))
+    }
+
+    @Test
+    fun `rejects when node has no deposit of the requested extraction-only item`() {
+        val state = stateWith()
+        val store = StubResourceStore(initial = emptyMap())
+        val mine = StubBuildingsLookup(activeStationsByHint = mapOf(BuildingCategoryHint.EXTRACTION_MINE to listOf(activeMine())))
+
+        val result = reduceExtract(
+            state, WorldCommand.Extract(agent, coal), balance, items, store, mine, agents, equipment,
+            SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            characterXp = CharacterXpProgression.NoOp, scaling = NoScaling,
+            triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+        )
+
+        assertEquals(WorldRejection.ResourceNotAvailableHere(agent, nodeId, coal), result.leftOrNull())
+    }
+
+    @Test
+    fun `rejects when agent has insufficient stamina`() {
+        val state = stateWith(stamina = 2)
+        val store = StubResourceStore(initial = mapOf(coal to 20))
+        val mine = StubBuildingsLookup(activeStationsByHint = mapOf(BuildingCategoryHint.EXTRACTION_MINE to listOf(activeMine())))
+
+        val result = reduceExtract(
+            state, WorldCommand.Extract(agent, coal), balance, items, store, mine, agents, equipment,
+            SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            characterXp = CharacterXpProgression.NoOp, scaling = NoScaling,
+            triggeredPassives = NoOpTriggeredPassiveDispatcher, behaviorTracker = tracker, tick = 1,
+        )
+
+        val rejection = assertIs<WorldRejection.NotEnoughStamina>(result.leftOrNull())
+        assertEquals(5, rejection.required)
+        assertEquals(2, rejection.available)
+    }
+
+    private fun activeMine(): Building = Building(
+        instanceId = UUID.randomUUID(), nodeId = nodeId, type = BuildingType.MINE,
+        status = BuildingStatus.ACTIVE, builtByAgentId = agent,
+        builtAtTick = 1L, lastProgressTick = 1L, progressSteps = 10, totalSteps = 10,
+        hpCurrent = 80, hpMax = 80,
+    )
+
+    private fun itemFor(
+        id: ItemId,
+        harvestSkill: String? = null,
+        extractionOnly: Boolean = false,
+    ) = Item(
+        id = id, displayName = id.value, description = "",
+        category = ItemCategory.RESOURCE, weightPerUnit = 100, maxStack = 100,
+        harvestSkill = harvestSkill?.let(::SkillId),
+        extractionOnly = extractionOnly,
+    )
+
+    private class StubItemLookup(private val byId: Map<ItemId, Item>) : ItemLookup {
+        override fun byId(id: ItemId): Item? = byId[id]
+        override fun all(): List<Item> = byId.values.toList()
+    }
+
+    private class StubBuildingsLookup(
+        private val activeStationsByHint: Map<BuildingCategoryHint, List<Building>>,
+    ) : BuildingsLookup {
+        override fun byId(id: UUID): Building? = null
+        override fun byNode(node: NodeId): List<Building> = emptyList()
+        override fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = emptyMap()
+        override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> =
+            activeStationsByHint[hint].orEmpty()
+    }
+
+    private inner class StubResourceStore(initial: Map<ItemId, Int>) : NodeResourceStore {
+        private val cells = initial.toMutableMap()
+        override fun read(nodeId: NodeId, tick: Long) = dev.gvart.genesara.world.NodeResources(
+            cells.mapValues { (k, v) -> dev.gvart.genesara.world.NodeResourceView(k, v, v.coerceAtLeast(1)) },
+        )
+        override fun availability(nodeId: NodeId, item: ItemId, tick: Long): NodeResourceCell? =
+            cells[item]?.let { NodeResourceCell(nodeId, item, it, it.coerceAtLeast(1)) }
+        override fun decrement(nodeId: NodeId, item: ItemId, amount: Int, tick: Long) {
+            val have = cells[item] ?: error("no cell for $item")
+            check(have >= amount)
+            cells[item] = have - amount
+        }
+        override fun seed(rows: Collection<InitialResourceRow>, tick: Long) = error("not used")
+        fun quantity(item: ItemId): Int = cells[item] ?: 0
+    }
+
+    private class StubAgentRegistry(private val strength: Int) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = Agent(
+            id = id, owner = PlayerId(UUID.randomUUID()), name = "test",
+            attributes = AgentAttributes(strength = strength, dexterity = 10, constitution = 10, perception = 10, intelligence = 10, luck = 10),
+        )
+        override fun listForOwner(owner: PlayerId): List<Agent> = emptyList()
+    }
+
+    private class StubEquipmentStore : EquipmentInstanceStore {
+        override fun insert(instance: EquipmentInstance) = error("not used")
+        override fun findById(instanceId: UUID): EquipmentInstance? = null
+        override fun listByAgent(agentId: AgentId): List<EquipmentInstance> = emptyList()
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, EquipmentInstance> = emptyMap()
+        override fun assignToSlot(instanceId: UUID, agentId: AgentId, slot: EquipSlot): EquipmentInstance? = null
+        override fun clearSlot(agentId: AgentId, slot: EquipSlot): EquipmentInstance? = null
+        override fun decrementDurability(instanceId: UUID, amount: Int): EquipmentInstance? = null
+        override fun delete(instanceId: UUID): Boolean = false
+    }
+
+    private class StubSkillsRegistry : AgentSkillsRegistry {
+        override fun snapshot(agent: AgentId): AgentSkillsSnapshot =
+            AgentSkillsSnapshot(perSkill = emptyMap(), slotCount = 8, slotsFilled = 0)
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int): AddXpResult =
+            AddXpResult.Unslotted
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? = null
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? = null
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+    }
+
+    private fun balance(staminaCost: Int) = object : BalanceLookup {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
+        override fun staminaRegenPerTick(climate: Climate) = 0
+        override fun resourceSpawnsFor(terrain: Terrain) = emptyList<dev.gvart.genesara.world.ResourceSpawnRule>()
+        override fun harvestStaminaCost(item: ItemId): Int = staminaCost
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: dev.gvart.genesara.world.Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: dev.gvart.genesara.world.Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun roadStaminaMultiplier(): Double = 0.5
+        override fun carryGramsPerStrengthPoint(): Int = 1_000_000
+    }
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/harvest/HarvestReducerTest.kt
@@ -175,6 +175,30 @@ class HarvestReducerTest {
     }
 
     @Test
+    fun `harvest rejects items flagged extractionOnly — they require the extract verb at a MINE`() {
+        val ore = ItemId("ORE")
+        val state = stateWith(terrain = Terrain.MOUNTAIN)
+        val extractionItems = StubItemLookup(
+            mapOf(ore to itemFor(ore, harvestSkill = "MINING", extractionOnly = true)),
+        )
+        val store = StubResourceStore(initial = mapOf(ore to 30))
+
+        val result = reduceHarvest(
+            state, WorldCommand.Harvest(agent, ore), balance, extractionItems, store,
+            agents, equipment, SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            characterXp = dev.gvart.genesara.world.internal.classes.CharacterXpProgression.NoOp,
+            scaling = NoScaling, triggeredPassives = NoOpTriggeredPassiveDispatcher,
+            behaviorTracker = tracker, tick = 1,
+        )
+
+        val rejection = assertIs<WorldRejection.HarvestRequiresExtraction>(result.leftOrNull())
+        assertEquals(agent, rejection.agent)
+        assertEquals(nodeId, rejection.node)
+        assertEquals(ore, rejection.item)
+        assertEquals(30, store.quantity(ore))
+    }
+
+    @Test
     fun `harvest works for a MINING-skill item — the verb is no longer split`() {
         val state = stateWith()
         val command = WorldCommand.Harvest(agent, stone)
@@ -550,7 +574,11 @@ class HarvestReducerTest {
         override fun carryGramsPerStrengthPoint(): Int = carryGramsPerStrengthPoint
     }
 
-    private fun itemFor(id: ItemId, harvestSkill: String? = null) = Item(
+    private fun itemFor(
+        id: ItemId,
+        harvestSkill: String? = null,
+        extractionOnly: Boolean = false,
+    ) = Item(
         id = id,
         displayName = id.value,
         description = "",
@@ -558,6 +586,7 @@ class HarvestReducerTest {
         weightPerUnit = 100,
         maxStack = 100,
         harvestSkill = harvestSkill?.let(::SkillId),
+        extractionOnly = extractionOnly,
     )
 
     private class StubItemLookup(private val byId: Map<ItemId, Item>) : ItemLookup {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
@@ -65,7 +65,7 @@ class MovementReducerTest {
     @Test
     fun `accepts move to adjacent node, deducts stamina, and emits AgentMoved`() {
         val command = WorldCommand.MoveAgent(agent, b)
-        val result = reduceMove(world, command, flatCost, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val result = reduceMove(world, command, flatCost, NoBuildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
@@ -84,7 +84,7 @@ class MovementReducerTest {
     @Test
     fun `rejects move when agent is not in the world`() {
         val unknown = AgentId(UUID.randomUUID())
-        val result = reduceMove(world, WorldCommand.MoveAgent(unknown, b), flatCost, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(unknown, b), flatCost, NoBuildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         assertTrue(result.isLeft())
         assertEquals(WorldRejection.NotInWorld(unknown), result.leftOrNull())
@@ -93,14 +93,14 @@ class MovementReducerTest {
     @Test
     fun `rejects move to unknown node`() {
         val ghost = NodeId(99L)
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, ghost), flatCost, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, ghost), flatCost, NoBuildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         assertEquals(WorldRejection.UnknownNode(ghost), result.leftOrNull())
     }
 
     @Test
     fun `rejects move to non-adjacent node`() {
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, c), flatCost, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, c), flatCost, NoBuildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         assertEquals(WorldRejection.NotAdjacent(a, c), result.leftOrNull())
     }
@@ -108,7 +108,7 @@ class MovementReducerTest {
     @Test
     fun `rejects move when stamina is below cost`() {
         val expensive = balanceLookup(cost = 99)
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), expensive, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), expensive, NoBuildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         assertEquals(
             WorldRejection.NotEnoughStamina(agent, required = 99, available = 10),
@@ -121,7 +121,7 @@ class MovementReducerTest {
         val unpainted = world.copy(
             regions = world.regions.mapValues { (_, r) -> r.copy(biome = null) },
         )
-        val result = reduceMove(unpainted, WorldCommand.MoveAgent(agent, b), flatCost, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val result = reduceMove(unpainted, WorldCommand.MoveAgent(agent, b), flatCost, NoBuildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         assertEquals(WorldRejection.UnpaintedRegion(region), result.leftOrNull())
     }
@@ -136,7 +136,7 @@ class MovementReducerTest {
         val balance = object : BalanceLookup by flatCost {
             override fun isTraversable(terrain: Terrain): Boolean = terrain != Terrain.OCEAN
         }
-        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, NoBuildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         assertEquals(
             WorldRejection.TerrainNotTraversable(agent, b, Terrain.OCEAN),
@@ -149,7 +149,7 @@ class MovementReducerTest {
         val perTerrain = perTerrainBalance(
             mapOf(Terrain.PLAINS to 1, Terrain.MOUNTAIN to 6),
         )
-        val plainsResult = reduceMove(world, WorldCommand.MoveAgent(agent, b), perTerrain, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val plainsResult = reduceMove(world, WorldCommand.MoveAgent(agent, b), perTerrain, NoBuildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
         val plainsMoved = plainsResult.getOrNull()!!.second.filterIsInstance<WorldEvent.AgentMoved>().single()
         assertEquals(1, plainsMoved.staminaSpent)
         assertEquals(9, plainsResult.getOrNull()!!.first.bodyOf(agent)!!.stamina)
@@ -159,7 +159,7 @@ class MovementReducerTest {
                 if (id == b) n.copy(terrain = Terrain.MOUNTAIN) else n
             },
         )
-        val mountainResult = reduceMove(mountainous, WorldCommand.MoveAgent(agent, b), perTerrain, NoBuildings, scaling = NoScaling, behaviorTracker = tracker, tick = 2)
+        val mountainResult = reduceMove(mountainous, WorldCommand.MoveAgent(agent, b), perTerrain, NoBuildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 2)
         val mountainMoved = mountainResult.getOrNull()!!.second.filterIsInstance<WorldEvent.AgentMoved>().single()
         assertEquals(6, mountainMoved.staminaSpent)
         assertEquals(4, mountainResult.getOrNull()!!.first.bodyOf(agent)!!.stamina)
@@ -171,7 +171,7 @@ class MovementReducerTest {
         val road = activeBuilding(node = a, hint = BuildingCategoryHint.INFRASTRUCTURE_ROAD)
         val buildings = StubBuildingsLookup(byNode = mapOf(a to listOf(road)))
 
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost10, buildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost10, buildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
         val moved = result.getOrNull()!!.second.filterIsInstance<WorldEvent.AgentMoved>().single()
 
         assertEquals(5, moved.staminaSpent)
@@ -211,11 +211,58 @@ class MovementReducerTest {
         val road = activeBuilding(node = a, hint = BuildingCategoryHint.INFRASTRUCTURE_ROAD)
         val buildings = StubBuildingsLookup(byNode = mapOf(a to listOf(road)))
 
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost10, buildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost10, buildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
             ifRight = { (next, _) -> assertEquals(5, 10 - next.bodyOf(agent)!!.stamina) },
+        )
+    }
+
+    @Test
+    fun `road discount also applies when entering a road node from a non-road origin (symmetric)`() {
+        val cost10 = balanceLookup(cost = 10)
+        val road = activeBuilding(node = b, hint = BuildingCategoryHint.INFRASTRUCTURE_ROAD)
+        val buildings = StubBuildingsLookup(byNode = mapOf(b to listOf(road)))
+
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost10, buildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+
+        val moved = result.getOrNull()!!.second.filterIsInstance<WorldEvent.AgentMoved>().single()
+        assertEquals(5, moved.staminaSpent)
+    }
+
+    @Test
+    fun `WOODEN_WALL on the destination blocks movement with DefensiveBlocks`() {
+        val wall = activeBuilding(node = b, hint = BuildingCategoryHint.DEFENSIVE, type = dev.gvart.genesara.world.BuildingType.WOODEN_WALL)
+        val buildings = StubBuildingsLookup(byNode = mapOf(b to listOf(wall)))
+
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), flatCost, buildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+
+        assertEquals(WorldRejection.DefensiveBlocks(agent, b), result.leftOrNull())
+    }
+
+    @Test
+    fun `CLOSED GATE on the destination blocks movement with DefensiveBlocks`() {
+        val gate = activeBuilding(node = b, hint = BuildingCategoryHint.DEFENSIVE, type = dev.gvart.genesara.world.BuildingType.GATE)
+        val buildings = StubBuildingsLookup(byNode = mapOf(b to listOf(gate)))
+        val gateStates = StubGateStates(open = false, forGate = gate.instanceId)
+
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), flatCost, buildings, gateStates = gateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+
+        assertEquals(WorldRejection.DefensiveBlocks(agent, b), result.leftOrNull())
+    }
+
+    @Test
+    fun `OPEN GATE on the destination lets movement through`() {
+        val gate = activeBuilding(node = b, hint = BuildingCategoryHint.DEFENSIVE, type = dev.gvart.genesara.world.BuildingType.GATE)
+        val buildings = StubBuildingsLookup(byNode = mapOf(b to listOf(gate)))
+        val gateStates = StubGateStates(open = true, forGate = gate.instanceId)
+
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), flatCost, buildings, gateStates = gateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+
+        result.fold(
+            ifLeft = { error("expected Right but got $it") },
+            ifRight = { (next, _) -> assertEquals(b, next.positions[agent]) },
         )
     }
 
@@ -225,7 +272,7 @@ class MovementReducerTest {
         val road = activeBuilding(node = a, hint = BuildingCategoryHint.INFRASTRUCTURE_ROAD)
         val buildings = StubBuildingsLookup(byNode = mapOf(a to listOf(road)))
 
-        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost1, buildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val result = reduceMove(world, WorldCommand.MoveAgent(agent, b), cost1, buildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
@@ -246,7 +293,7 @@ class MovementReducerTest {
         val bridge = activeBuilding(node = b, hint = BuildingCategoryHint.INFRASTRUCTURE_BRIDGE)
         val buildings = StubBuildingsLookup(byNode = mapOf(b to listOf(bridge)))
 
-        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, buildings, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val result = reduceMove(sea, WorldCommand.MoveAgent(agent, b), balance, buildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
@@ -254,14 +301,18 @@ class MovementReducerTest {
         )
     }
 
-    private fun activeBuilding(node: NodeId, hint: BuildingCategoryHint): Building = Building(
-        instanceId = UUID.randomUUID(),
-        nodeId = node,
-        type = when (hint) {
+    private fun activeBuilding(
+        node: NodeId,
+        hint: BuildingCategoryHint,
+        type: dev.gvart.genesara.world.BuildingType = when (hint) {
             BuildingCategoryHint.INFRASTRUCTURE_ROAD -> dev.gvart.genesara.world.BuildingType.ROAD
             BuildingCategoryHint.INFRASTRUCTURE_BRIDGE -> dev.gvart.genesara.world.BuildingType.BRIDGE
             else -> error("unsupported hint for this stub")
         },
+    ): Building = Building(
+        instanceId = UUID.randomUUID(),
+        nodeId = node,
+        type = type,
         status = dev.gvart.genesara.world.BuildingStatus.ACTIVE,
         builtByAgentId = agent,
         builtAtTick = 1L,
@@ -279,6 +330,21 @@ class MovementReducerTest {
         override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> = emptyList()
     }
 
+    private object NoGateStates : dev.gvart.genesara.world.BuildingGateStateStore {
+        override fun insertClosed(gateInstanceId: UUID) = Unit
+        override fun isOpen(gateInstanceId: UUID): Boolean? = null
+        override fun toggle(gateInstanceId: UUID): Boolean? = null
+    }
+
+    private class StubGateStates(
+        private val open: Boolean,
+        private val forGate: UUID,
+    ) : dev.gvart.genesara.world.BuildingGateStateStore {
+        override fun insertClosed(gateInstanceId: UUID) = Unit
+        override fun isOpen(gateInstanceId: UUID): Boolean? = if (gateInstanceId == forGate) open else null
+        override fun toggle(gateInstanceId: UUID): Boolean? = null
+    }
+
     private class StubBuildingsLookup(
         private val byNode: Map<NodeId, List<Building>>,
     ) : BuildingsLookup {
@@ -287,6 +353,16 @@ class MovementReducerTest {
         override fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
             nodes.associateWith { byNode[it].orEmpty() }.filterValues { it.isNotEmpty() }
         override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> =
-            byNode[node].orEmpty().filter { it.status == dev.gvart.genesara.world.BuildingStatus.ACTIVE }
+            byNode[node].orEmpty()
+                .filter { it.status == dev.gvart.genesara.world.BuildingStatus.ACTIVE }
+                .filter { hintFor(it.type) == hint }
+
+        private fun hintFor(type: dev.gvart.genesara.world.BuildingType): BuildingCategoryHint = when (type) {
+            dev.gvart.genesara.world.BuildingType.ROAD -> BuildingCategoryHint.INFRASTRUCTURE_ROAD
+            dev.gvart.genesara.world.BuildingType.BRIDGE -> BuildingCategoryHint.INFRASTRUCTURE_BRIDGE
+            dev.gvart.genesara.world.BuildingType.WOODEN_WALL,
+            dev.gvart.genesara.world.BuildingType.GATE -> BuildingCategoryHint.DEFENSIVE
+            else -> error("StubBuildingsLookup hintFor needs a case for $type")
+        }
     }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
@@ -295,7 +295,7 @@ class WorldTickHandlerHarvestXpEventIntegrationTest {
             NoopRecipeLookup, dev.gvart.genesara.world.AgentKnownRecipesGateway.Empty,
             SingleCellResourceStore(wood, quantity = 10), skills, agentRegistry, equipment,
             NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingBarsStore, NoopBuildingsLookup,
-            buildingsCatalog, NoopChestContentsStore,
+            buildingsCatalog, NoopBuildingGateStateStore, NoopAgentKeysStore, NoopChestContentsStore,
             NoopAgentPlotsStore, NoopCropLookup,
             dev.gvart.genesara.world.internal.cultivation.CropDecaySweep(NoopAgentPlotsStore, NoopCropLookup),
             dev.gvart.genesara.world.TradeStore.NoOp, dev.gvart.genesara.world.RelationshipLookup.NoOp,
@@ -307,6 +307,23 @@ class WorldTickHandlerHarvestXpEventIntegrationTest {
             InMemoryPendingAttackScaleStore(), InMemoryBehaviorTracker(),
             AlwaysHeldLeaseFence, Duration.ofSeconds(5L),
         )
+    }
+
+    private object NoopBuildingGateStateStore : dev.gvart.genesara.world.BuildingGateStateStore {
+        override fun insertClosed(gateInstanceId: java.util.UUID) = Unit
+        override fun isOpen(gateInstanceId: java.util.UUID): Boolean? = null
+        override fun toggle(gateInstanceId: java.util.UUID): Boolean? = null
+    }
+
+    private object NoopAgentKeysStore : dev.gvart.genesara.world.AgentKeysStore {
+        override fun insert(key: dev.gvart.genesara.world.AgentKeyInstance) = Unit
+        override fun findById(instanceId: java.util.UUID): dev.gvart.genesara.world.AgentKeyInstance? = null
+        override fun agentHoldsKeyFor(
+            agent: dev.gvart.genesara.player.AgentId,
+            gateInstanceId: java.util.UUID,
+        ): Boolean = false
+        override fun listByAgent(agent: dev.gvart.genesara.player.AgentId): List<dev.gvart.genesara.world.AgentKeyInstance> =
+            emptyList()
     }
 
     private object AlwaysHeldLeaseFence : WorldLeaseFence {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerSpawnResumeIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerSpawnResumeIntegrationTest.kt
@@ -233,6 +233,7 @@ class WorldTickHandlerSpawnResumeIntegrationTest {
             NoopRecipeLookup, dev.gvart.genesara.world.AgentKnownRecipesGateway.Empty,
             NoopResourceStore, skills, agents, equipment, NoopSafeNodeGateway,
             NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingBarsStore, NoopBuildingsLookup, buildingsCatalog,
+            NoopBuildingGateStateStore, NoopAgentKeysStore,
             NoopChestContentsStore,
             NoopAgentPlotsStore, NoopCropLookup,
             dev.gvart.genesara.world.internal.cultivation.CropDecaySweep(NoopAgentPlotsStore, NoopCropLookup),
@@ -245,6 +246,23 @@ class WorldTickHandlerSpawnResumeIntegrationTest {
             InMemoryPerkCooldownStore(), InMemoryPendingAttackScaleStore(),
             InMemoryBehaviorTracker(), AlwaysHeldLeaseFence, Duration.ofSeconds(5L),
         )
+    }
+
+    private object NoopBuildingGateStateStore : dev.gvart.genesara.world.BuildingGateStateStore {
+        override fun insertClosed(gateInstanceId: java.util.UUID) = Unit
+        override fun isOpen(gateInstanceId: java.util.UUID): Boolean? = null
+        override fun toggle(gateInstanceId: java.util.UUID): Boolean? = null
+    }
+
+    private object NoopAgentKeysStore : dev.gvart.genesara.world.AgentKeysStore {
+        override fun insert(key: dev.gvart.genesara.world.AgentKeyInstance) = Unit
+        override fun findById(instanceId: java.util.UUID): dev.gvart.genesara.world.AgentKeyInstance? = null
+        override fun agentHoldsKeyFor(
+            agent: dev.gvart.genesara.player.AgentId,
+            gateInstanceId: java.util.UUID,
+        ): Boolean = false
+        override fun listByAgent(agent: dev.gvart.genesara.player.AgentId): List<dev.gvart.genesara.world.AgentKeyInstance> =
+            emptyList()
     }
 
     private object AlwaysHeldLeaseFence : WorldLeaseFence {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -255,6 +255,7 @@ class WorldTickHandlerTest {
         dev.gvart.genesara.world.AgentKnownRecipesGateway.Empty, NoopResourceStore,
         NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway,
         NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingBarsStore, NoopBuildingsLookup, EmptyBuildingsCatalog,
+        NoopBuildingGateStateStore, NoopAgentKeysStore,
         NoopChestContentsStore,
         NoopAgentPlotsStore, NoopCropLookup,
         dev.gvart.genesara.world.internal.cultivation.CropDecaySweep(NoopAgentPlotsStore, NoopCropLookup),
@@ -435,6 +436,23 @@ class WorldTickHandlerTest {
             error("not used")
         override fun remove(buildingId: java.util.UUID, item: dev.gvart.genesara.world.ItemId, quantity: Int): Boolean =
             error("not used")
+    }
+
+    private object NoopBuildingGateStateStore : dev.gvart.genesara.world.BuildingGateStateStore {
+        override fun insertClosed(gateInstanceId: java.util.UUID) = error("not used")
+        override fun isOpen(gateInstanceId: java.util.UUID): Boolean? = null
+        override fun toggle(gateInstanceId: java.util.UUID): Boolean? = null
+    }
+
+    private object NoopAgentKeysStore : dev.gvart.genesara.world.AgentKeysStore {
+        override fun insert(key: dev.gvart.genesara.world.AgentKeyInstance) = error("not used")
+        override fun findById(instanceId: java.util.UUID): dev.gvart.genesara.world.AgentKeyInstance? = null
+        override fun agentHoldsKeyFor(
+            agent: dev.gvart.genesara.player.AgentId,
+            gateInstanceId: java.util.UUID,
+        ): Boolean = false
+        override fun listByAgent(agent: dev.gvart.genesara.player.AgentId): List<dev.gvart.genesara.world.AgentKeyInstance> =
+            emptyList()
     }
 
     private object NoopAgentPlotsStore : dev.gvart.genesara.world.AgentPlotsStore {


### PR DESCRIPTION
## Summary

Bundles two related design pieces into one slice (per direction during grilling — see conversation context).

### Defensive cluster
- `WOODEN_WALL` now blocks movement onto its node (DEFENSIVE-category check in `MovementReducer`). Wall+gate combos block via `all` (defense-in-depth against admin-induced collisions).
- New `GATE` building (T1, dual-bar CARPENTRY+SMITHING, materials WOOD + IRON_INGOT). State `OPEN`/`CLOSED` persisted in new `building_gate_states` table. Build-complete side-effect inserts a CLOSED state row AND auto-issues one `GATE_KEY` to the builder.
- New `GATE_KEY` item type, per-instance via new `agent_keys` table (mirrors equipment-instances shape). Each key bound to one gate's UUID.
- New `toggle_gate` MCP verb: requires on-node + matching key in inventory.
- `ROAD` symmetric: half-stamina applies on both entering AND leaving a road node.
- `BuildReducer` rejects a second DEFENSIVE-category structure on a node (`DefensiveAlreadyAtNode`).
- KDoc cleanup on `BuildingType.kt` — stale "today inert" comments removed.

### Extraction infrastructure
- New `MINE` building (T1, single CARPENTRY bar, WOOD + STONE — no IRON to avoid chicken/egg). Terrain-coupled at build time: FOOTHILLS / MOUNTAIN / VOLCANIC (`BuildingTerrainMismatch` rejection).
- New `extract` MCP verb — requires `Item.extractionOnly == true` AND active MINE on the node.
- **B2 regressive change**: `COAL` + `ORE` now flagged `extractionOnly: true`. Bare `harvest` rejects them with `HarvestRequiresExtraction`. Reachable only via `extract` at a built MINE.
- **B1 new GOLD chain**: raw `GOLD` (spawns on MOUNTAIN/VOLCANIC/CRYSTAL_CAVES, extract-only) → `GOLD_INGOT` (FORGE recipe) → `GOLD_RING` / `GOLD_BRACELET` / `GOLD_AMULET` jewelry recipes mirroring the IRON tier.
- Reuses existing `MINING` skill from `player-definition/skills/gathering.yaml` — no new skill catalog entry.

### Generalized craft + source (replaces dedicated copy_gate_key)
- `WorldCommand.CraftItem` gains an optional `source: UUID?`.
- `Recipe.requiresSource: ItemId?` declares which per-instance item type the recipe operates on. Mapped from `recipes-*.yaml`'s `requires-source: <itemId>` field.
- `GATE_KEY_COPY` recipe in `recipes-intermediates.yaml`: consumes 1 IRON_INGOT + template GATE_KEY (NOT consumed), mints a new key bound to the same gate. Emits both `ItemCrafted` (canonical) and `GateKeyMinted(byCopy=true)` (per-instance signal).
- Future upgrade-style equipment recipes plug into the same hook — no new verb needed per per-instance copy/refine pattern.

### Playtest-driven follow-ups (commit `ef9e6c4`)

End-to-end playtest of the new MCP surface (`docs/playtest/sessions/s10-defensive-extraction.log`) surfaced two real bugs and two observability gaps, fixed in the same branch:

- **MCP UUID `@ToolParam` deserialization bug.** Spring AI MCP cannot map a JSON string to a raw `java.util.UUID` parameter (Jackson `Unexpected character`). `ToggleGateTool.gateId` and `CraftTool.source` both failed at the tool boundary. Fixed by switching to `String` + manual `UUID.fromString` + a synchronous `REJECTED` ack with `bad_*_id` reason. `CraftResponse` and `ToggleGateResponse` now share the `kind/reason/detail` factory shape.
- **`look_around` + `inspect` now surface gate `isOpen`** on the current tile AND on adjacent fog-of-war tiles. Gates are large infrastructure visible from sight range; `toggle_gate`'s co-location requirement still gates the action, not the observation. Mirrors the s2b playtest finding.
- **`get_loadout` folds `agent_keys` rows into the stackable inventory list** as quantity=1 entries carrying their own `instanceId` and `gateInstanceId`. Keys are no longer invisible to agents. Per the user's call: keys are regular inventory items.
- **`@JsonInclude(NON_NULL)`** on every IO type that gained nullable fields, so payloads don't bloat with `"isOpen": null` on every non-gate building or `"instanceId": null` on every plain stackable.

Tests added: `CraftTool` bad-source rejection + valid-source pass-through; `GetLoadoutTool` key folding (single + multi-gate distinctness); `LookAroundTool` gate `isOpen` on current and adjacent tiles + non-gate exclusion; `InspectLookAroundParityTest` asserts `inspect` + `look_around` agree on a gate's `isOpen`.

## Follow-up

- #179 — consolidate per-instance item tables into `agent_item_instances` (refactor; not blocking).

## Persistence
- `V24__gates_and_keys.sql`: `building_gate_states` (1:1 with `node_buildings`, cascade delete) + `agent_keys` (per-instance, indexed by agent and by gate).
- `Item.extractionOnly` flag flows from `ItemProperties` through `ItemLookupImpl`.

## Test plan
- [x] `:world:test` green (full suite, including 5 new test files and ~15 new test cases)
- [x] `:api:test` green (incl. the 6 new MCP-surface tests from the playtest pass)
- [x] `ToggleGateReducerTest` covers: happy + missing key + off-node + not-a-gate
- [x] `ExtractReducerTest` covers: happy + no-mine + non-extractionOnly + no-deposit + low-stamina
- [x] `CraftReducerTest` extended: GATE_KEY_COPY happy + missing source + wrong-owner source
- [x] `BuildReducerTest` extended: GATE auto-issues key, DEFENSIVE-stack rejection, MINE terrain mismatch
- [x] `HarvestReducerTest` extended: extractionOnly filter rejection
- [x] `MovementReducerTest` extended: wall block, gate-closed block, gate-open pass, road symmetric on entry
- [x] `WorldCommandSerializationTest` extended: toggleGate / extract / craft-with-source wire-contract discriminators
- [x] `CraftToolTest` / `GetLoadoutToolTest` / `LookAroundToolTest` / `InspectLookAroundParityTest` extended for MCP-surface fixes
- [x] `code-quality-reviewer` agent pass on both the initial slice and the playtest follow-up — all critical findings addressed in-branch

## Notes for reviewers
- The two-commit shape (`808125d` original feature + `ef9e6c4` playtest fixes) is intentional. The second commit is small and surgical and addresses MCP-surface bugs that only show up against the live tool layer, not against `:world` reducer tests.
- GOLD is **not** engine currency — it's a crafting input for the jewelry tier. Agents may use it as a trade good if they choose, per the "agents invent coins" rule in the economy design.