### PR TITLE
feat(world): fauna expansion recipes — 34 new + 13 equipment items

### DIFF
--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/RecipeBalanceConfiguration.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/RecipeBalanceConfiguration.kt
@@ -14,6 +14,7 @@ import org.springframework.context.annotation.PropertySource
         "classpath:world-definition/recipes-jewelry.yaml",
         "classpath:world-definition/recipes-consumables.yaml",
         "classpath:world-definition/recipes-cooking.yaml",
+        "classpath:world-definition/recipes-brewing.yaml",
     ],
     factory = YamlPropertySourceFactory::class,
 )

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/RecipeCatalogValidator.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/crafting/RecipeCatalogValidator.kt
@@ -45,6 +45,12 @@ internal class RecipeCatalogValidator(
                     // never let an EQUIPMENT-output recipe reach the reducer with no durability.
                     problems += "$rid: equipment output ${outputItem.id.value} has no max-durability"
                 }
+                if (outputItem.category == ItemCategory.EQUIPMENT && recipe.output.quantity > 1) {
+                    // `equipmentMutation` mints exactly one ItemInstance per craft; a recipe
+                    // with output.quantity > 1 looks like a batch-craft on paper but only one
+                    // row lands. Catch the mismatch at startup before it ships to agents.
+                    problems += "$rid: equipment output ${outputItem.id.value} quantity ${recipe.output.quantity} > 1 — batch crafts are RESOURCE-only"
+                }
                 if (outputItem.category == ItemCategory.KEY && recipe.requiresSource == null) {
                     problems += "$rid: key output ${outputItem.id.value} requires a requires-source declaration"
                 }

--- a/world/src/main/resources/world-definition/equipment-armor.yaml
+++ b/world/src/main/resources/world-definition/equipment-armor.yaml
@@ -216,3 +216,100 @@ items:
         - { target: ENERGY, magnitude: 3 }
         - { target: MAGICAL, magnitude: 3 }
         - { target: INTELLIGENCE, magnitude: 2 }
+
+    # ───────────── Fauna-tier armor (fur / horn / scale / chitin) ─────────────
+
+    FUR_CLOAK:
+      display-name: Fur Cloak
+      description: >-
+        Heavy pelt cloak draped over the shoulders. Soaks light blows
+        and breaks the wind; the warmth bonus is conceptual until a
+        weather-buff system lands.
+      category: EQUIPMENT
+      weight-per-unit: 1500
+      max-stack: 1
+      regenerating: false
+      max-durability: 40
+      valid-slots: [CHEST]
+      two-handed: false
+      bonuses:
+        - { target: BLUNT, magnitude: 2 }
+        - { target: PIERCE, magnitude: 1 }
+
+    FUR_HOOD:
+      display-name: Fur Hood
+      description: >-
+        Trimmed fur hood. Light scalp protection; pairs with the cloak.
+      category: EQUIPMENT
+      weight-per-unit: 400
+      max-stack: 1
+      regenerating: false
+      max-durability: 25
+      valid-slots: [HELMET]
+      two-handed: false
+      bonuses:
+        - { target: BLUNT, magnitude: 1 }
+
+    HORN_HELMET:
+      display-name: Horn Helmet
+      description: >-
+        Leather-strapped helmet capped with curved horn ridges. Deflects
+        blades and blunt strikes; favored by skirmish hunters.
+      category: EQUIPMENT
+      weight-per-unit: 1800
+      max-stack: 1
+      regenerating: false
+      max-durability: 60
+      valid-slots: [HELMET]
+      two-handed: false
+      bonuses:
+        - { target: SLASH, magnitude: 4 }
+        - { target: BLUNT, magnitude: 3 }
+
+    SCALE_VEST:
+      display-name: Scale Vest
+      description: >-
+        Overlapping reptile scales stitched to a leather backing.
+        Pierce-resistant medium chest armor.
+      category: EQUIPMENT
+      weight-per-unit: 5000
+      max-stack: 1
+      regenerating: false
+      max-durability: 80
+      valid-slots: [CHEST]
+      two-handed: false
+      bonuses:
+        - { target: SLASH, magnitude: 6 }
+        - { target: PIERCE, magnitude: 4 }
+
+    CHITIN_SHIELD:
+      display-name: Chitin Shield
+      description: >-
+        Lightweight buckler shaped from a single chitin plate. Light
+        on the arm, surprisingly stout against edged weapons.
+      category: EQUIPMENT
+      weight-per-unit: 2500
+      max-stack: 1
+      regenerating: false
+      max-durability: 50
+      valid-slots: [OFF_HAND]
+      two-handed: false
+      bonuses:
+        - { target: SLASH, magnitude: 5 }
+        - { target: BLUNT, magnitude: 3 }
+
+    CHITIN_GAUNTLETS:
+      display-name: Chitin Gauntlets
+      description: >-
+        Hand-fitted chitin plates over leather palm linings. Keeps the
+        knuckles intact without sacrificing grip.
+      category: EQUIPMENT
+      weight-per-unit: 800
+      max-stack: 1
+      regenerating: false
+      max-durability: 40
+      valid-slots: [GLOVES]
+      two-handed: false
+      bonuses:
+        - { target: SLASH, magnitude: 3 }
+        - { target: PIERCE, magnitude: 2 }

--- a/world/src/main/resources/world-definition/equipment-jewelry.yaml
+++ b/world/src/main/resources/world-definition/equipment-jewelry.yaml
@@ -130,3 +130,33 @@ items:
       bonuses:
         - { target: CONSTITUTION, magnitude: 3 }
         - { target: STAMINA_REGEN, magnitude: 2 }
+
+    # ──────────────────────── Fauna-tier amulets ────────────────────────
+
+    BONE_AMULET:
+      display-name: Bone Amulet
+      description: >-
+        Carved bone pendant on a sinew cord. A placeholder ornament —
+        no wearer bonus until a totem-buff system lands.
+      category: EQUIPMENT
+      weight-per-unit: 100
+      max-stack: 1
+      regenerating: false
+      max-durability: 50
+      valid-slots: [AMULET]
+      two-handed: false
+
+    FANG_NECKLACE:
+      display-name: Fang Necklace
+      description: >-
+        Predator fangs threaded onto a leather cord. A small but
+        steady nudge to the wearer's strength.
+      category: EQUIPMENT
+      weight-per-unit: 150
+      max-stack: 1
+      regenerating: false
+      max-durability: 60
+      valid-slots: [AMULET]
+      two-handed: false
+      bonuses:
+        - { target: STRENGTH, magnitude: 1 }

--- a/world/src/main/resources/world-definition/equipment-weapons.yaml
+++ b/world/src/main/resources/world-definition/equipment-weapons.yaml
@@ -201,3 +201,57 @@ items:
       two-handed: false
       required-attributes:
         STRENGTH: 10
+
+    # ───────────── Fauna-tier weapons (bone / fang / horn) ─────────────
+
+    BONE_DAGGER:
+      display-name: Bone Dagger
+      description: >-
+        Sharpened bone shard lashed to a wooden grip. Entry-tier pierce
+        weapon for hunters working away from forges.
+      category: EQUIPMENT
+      weight-per-unit: 600
+      max-stack: 1
+      regenerating: false
+      max-durability: 25
+      valid-slots: [MAIN_HAND]
+      two-handed: false
+      damage-type: PIERCE
+      weapon-power: 5
+      combat-skill: DAGGER
+      range: 1
+
+    FANG_DAGGER:
+      display-name: Fang Dagger
+      description: >-
+        Predator fang wrapped in cured leather. Sharper and longer-lived
+        than the bone dagger; demands a kill to source.
+      category: EQUIPMENT
+      weight-per-unit: 600
+      max-stack: 1
+      regenerating: false
+      max-durability: 30
+      valid-slots: [MAIN_HAND]
+      two-handed: false
+      damage-type: PIERCE
+      weapon-power: 8
+      combat-skill: DAGGER
+      range: 1
+
+    HORN_CLUB:
+      display-name: Horn Club
+      description: >-
+        Hardwood haft crowned with a curved horn head. Heavier strike
+        than a plain wooden club; slots between WOODEN_CLUB and IRON tiers.
+      category: EQUIPMENT
+      weight-per-unit: 2000
+      max-stack: 1
+      regenerating: false
+      max-durability: 35
+      valid-slots: [MAIN_HAND]
+      two-handed: false
+      damage-type: BLUNT
+      weapon-power: 8
+      combat-skill: CLUB
+      range: 1
+

--- a/world/src/main/resources/world-definition/items.yaml
+++ b/world/src/main/resources/world-definition/items.yaml
@@ -656,7 +656,7 @@ items:
       display-name: Ale
       description: Grain ale from a brewery.
       category: RESOURCE
-      weight-per-unit: 500
+      weight-per-unit: 80
       max-stack: 10
       regenerating: false
       consumable:
@@ -667,7 +667,7 @@ items:
       display-name: Berry Wine
       description: Fermented wild berries.
       category: RESOURCE
-      weight-per-unit: 500
+      weight-per-unit: 80
       max-stack: 10
       regenerating: false
       consumable:
@@ -678,7 +678,7 @@ items:
       display-name: Herbal Tonic
       description: Steeped wild herbs. Bitter but refreshing.
       category: RESOURCE
-      weight-per-unit: 500
+      weight-per-unit: 80
       max-stack: 10
       regenerating: false
       consumable:
@@ -689,7 +689,7 @@ items:
       display-name: Mead
       description: Honey-fermented brew.
       category: RESOURCE
-      weight-per-unit: 500
+      weight-per-unit: 80
       max-stack: 10
       regenerating: false
       consumable:
@@ -700,7 +700,7 @@ items:
       display-name: Mushroom Liquor
       description: Distilled from fermented fungi.
       category: RESOURCE
-      weight-per-unit: 500
+      weight-per-unit: 80
       max-stack: 10
       regenerating: false
       consumable:
@@ -771,6 +771,34 @@ items:
       category: RESOURCE
       weight-per-unit: 100
       max-stack: 99
+      regenerating: false
+
+    # TODO(bow-recipe): BOWSTRING is currently orphan — no recipe consumes it.
+    # Crafted via BOWSTRING_WEAVE; will be consumed by a bow recipe in the
+    # ranged-weapon expansion slice. Until then, agents can craft it but it
+    # has no functional use beyond being a substrate.
+    BOWSTRING:
+      display-name: Bowstring
+      description: Woven sinew cord. Substrate for bows and fletching.
+      category: RESOURCE
+      weight-per-unit: 50
+      max-stack: 50
+      regenerating: false
+
+    # TODO(ammo-system): BONE_ARROW ships as a stackable RESOURCE today — the
+    # crafting system mints exactly one ItemInstance per EQUIPMENT recipe, so a
+    # quantity-5 batch only works for stackables. When a real ammo / quiver
+    # system lands, BONE_ARROW migrates to EQUIPMENT with the appropriate slot,
+    # weapon-power, combat-skill, and range fields.
+    BONE_ARROW:
+      display-name: Bone Arrow
+      description: >-
+        Wood-shafted arrow tipped with a knapped bone point and fletched with
+        feathers. Stackable ammunition substrate; no functional use until the
+        ammo system lands.
+      category: RESOURCE
+      weight-per-unit: 30
+      max-stack: 50
       regenerating: false
 
 # Equipment-class items live in equipment-{weapons,armor,jewelry}.yaml (same `items.catalog` key).

--- a/world/src/main/resources/world-definition/recipes-armor.yaml
+++ b/world/src/main/resources/world-definition/recipes-armor.yaml
@@ -119,3 +119,70 @@ recipes:
       required-skill: TAILORING
       required-skill-level: 5
       stamina-cost: 12
+
+    # ───────────── Fauna-tier tailoring (fur) ─────────────
+
+    FUR_HOOD_BASIC:
+      output: { item: FUR_HOOD, quantity: 1 }
+      inputs:
+        FUR: 2
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: TAILORING
+      required-skill-level: 0
+      stamina-cost: 10
+
+    FUR_CLOAK_BASIC:
+      output: { item: FUR_CLOAK, quantity: 1 }
+      inputs:
+        FUR: 4
+        CLOTH: 2
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: TAILORING
+      required-skill-level: 20
+      stamina-cost: 14
+
+    # ───────────── Fauna-tier leatherworking (horn / chitin) ─────────────
+
+    HORN_HELMET_BASIC:
+      output: { item: HORN_HELMET, quantity: 1 }
+      inputs:
+        HORN: 2
+        LEATHER: 1
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: LEATHERWORKING
+      required-skill-level: 30
+      stamina-cost: 12
+
+    CHITIN_GAUNTLETS_BASIC:
+      output: { item: CHITIN_GAUNTLETS, quantity: 1 }
+      inputs:
+        CHITIN: 3
+        LEATHER: 1
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: LEATHERWORKING
+      required-skill-level: 30
+      stamina-cost: 11
+
+    # ───────────── Fauna-tier carpentry (chitin shield) ─────────────
+
+    CHITIN_SHIELD_BASIC:
+      output: { item: CHITIN_SHIELD, quantity: 1 }
+      inputs:
+        CHITIN: 4
+        WOOD: 1
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: CARPENTRY
+      required-skill-level: 30
+      stamina-cost: 13
+
+    # ───────────── Fauna-tier smithing (scale) ─────────────
+
+    SCALE_VEST_BASIC:
+      output: { item: SCALE_VEST, quantity: 1 }
+      inputs:
+        SCALE: 6
+        LEATHER: 2
+      required-station: CRAFTING_STATION_METAL
+      required-skill: SMITHING
+      required-skill-level: 40
+      stamina-cost: 16

--- a/world/src/main/resources/world-definition/recipes-brewing.yaml
+++ b/world/src/main/resources/world-definition/recipes-brewing.yaml
@@ -1,0 +1,50 @@
+# Brewing recipes — fermented drinks crafted at a brewery. Outputs are
+# THIRST consumables; all share CRAFTING_STATION_BREW + BREWING skill.
+
+recipes:
+  catalog:
+
+    ALE:
+      output: { item: ALE, quantity: 1 }
+      inputs:
+        WHEAT: 3
+      required-station: CRAFTING_STATION_BREW
+      required-skill: BREWING
+      required-skill-level: 0
+      stamina-cost: 8
+
+    HERBAL_TONIC:
+      output: { item: HERBAL_TONIC, quantity: 1 }
+      inputs:
+        HERB: 3
+      required-station: CRAFTING_STATION_BREW
+      required-skill: BREWING
+      required-skill-level: 10
+      stamina-cost: 7
+
+    BERRY_WINE:
+      output: { item: BERRY_WINE, quantity: 1 }
+      inputs:
+        BERRY: 5
+      required-station: CRAFTING_STATION_BREW
+      required-skill: BREWING
+      required-skill-level: 20
+      stamina-cost: 10
+
+    MEAD:
+      output: { item: MEAD, quantity: 1 }
+      inputs:
+        HONEY: 2
+      required-station: CRAFTING_STATION_BREW
+      required-skill: BREWING
+      required-skill-level: 30
+      stamina-cost: 11
+
+    MUSHROOM_LIQUOR:
+      output: { item: MUSHROOM_LIQUOR, quantity: 1 }
+      inputs:
+        MUSHROOM: 4
+      required-station: CRAFTING_STATION_BREW
+      required-skill: BREWING
+      required-skill-level: 50
+      stamina-cost: 13

--- a/world/src/main/resources/world-definition/recipes-consumables.yaml
+++ b/world/src/main/resources/world-definition/recipes-consumables.yaml
@@ -12,3 +12,38 @@ recipes:
       required-skill: ALCHEMY
       required-skill-level: 0
       stamina-cost: 12
+
+    # ───────────── Fauna-tier alchemy ─────────────
+    # All three alchemy outputs (STAMINA_TONIC, ANTIDOTE, POISON_VIAL) ship
+    # inert in this slice — their consume / on-hit effects light up alongside
+    # the status-effect engine slice. Recipes are craftable today so the
+    # alchemy chain is exercisable end-to-end.
+
+    STAMINA_TONIC_BREW:
+      output: { item: STAMINA_TONIC, quantity: 1 }
+      inputs:
+        HONEY: 1
+        HERB: 2
+      required-station: CRAFTING_STATION_POTION
+      required-skill: ALCHEMY
+      required-skill-level: 10
+      stamina-cost: 8
+
+    ANTIDOTE_BREW:
+      output: { item: ANTIDOTE, quantity: 1 }
+      inputs:
+        GLAND: 1
+        HERB: 2
+      required-station: CRAFTING_STATION_POTION
+      required-skill: ALCHEMY
+      required-skill-level: 20
+      stamina-cost: 10
+
+    POISON_VIAL_BREW:
+      output: { item: POISON_VIAL, quantity: 1 }
+      inputs:
+        VENOM_EXTRACT: 2
+      required-station: CRAFTING_STATION_POTION
+      required-skill: ALCHEMY
+      required-skill-level: 30
+      stamina-cost: 11

--- a/world/src/main/resources/world-definition/recipes-cooking.yaml
+++ b/world/src/main/resources/world-definition/recipes-cooking.yaml
@@ -44,3 +44,96 @@ recipes:
       required-skill: COOKING
       required-skill-level: 50
       stamina-cost: 11
+
+    # ───────────────────────── Fauna cuisine (campfire) ─────────────────────────
+
+    ROAST_MEAT:
+      output: { item: ROAST_MEAT, quantity: 1 }
+      inputs:
+        MEAT: 1
+      required-station: COOKING
+      required-skill: COOKING
+      required-skill-level: 0
+      stamina-cost: 4
+
+    HEARTY_BROTH:
+      output: { item: HEARTY_BROTH, quantity: 1 }
+      inputs:
+        BONE: 1
+        HERB: 1
+      required-station: COOKING
+      required-skill: COOKING
+      required-skill-level: 10
+      stamina-cost: 7
+
+    MEAT_STEW:
+      output: { item: MEAT_STEW, quantity: 1 }
+      inputs:
+        MEAT: 1
+        POTATO: 1
+        HERB: 1
+      required-station: COOKING
+      required-skill: COOKING
+      required-skill-level: 20
+      stamina-cost: 9
+
+    BONE_MARROW_SOUP:
+      output: { item: BONE_MARROW_SOUP, quantity: 1 }
+      inputs:
+        BONE: 2
+        HERB: 1
+      required-station: COOKING
+      required-skill: COOKING
+      required-skill-level: 30
+      stamina-cost: 10
+
+    GAME_PIE:
+      output: { item: GAME_PIE, quantity: 1 }
+      inputs:
+        MEAT: 2
+        WHEAT: 2
+      required-station: COOKING
+      required-skill: COOKING
+      required-skill-level: 40
+      stamina-cost: 12
+
+    VENISON_ROAST:
+      output: { item: VENISON_ROAST, quantity: 1 }
+      inputs:
+        MEAT: 3
+        HERB: 2
+        SALT: 1
+      required-station: COOKING
+      required-skill: COOKING
+      required-skill-level: 60
+      stamina-cost: 14
+
+    # ───────────────────────── Fauna preserves (smokehouse) ─────────────────────
+
+    SMOKED_MEAT:
+      output: { item: SMOKED_MEAT, quantity: 1 }
+      inputs:
+        MEAT: 2
+      required-station: CRAFTING_STATION_PRESERVE
+      required-skill: COOKING
+      required-skill-level: 15
+      stamina-cost: 8
+
+    SMOKED_FISH:
+      output: { item: SMOKED_FISH, quantity: 1 }
+      inputs:
+        FISH: 2
+      required-station: CRAFTING_STATION_PRESERVE
+      required-skill: COOKING
+      required-skill-level: 15
+      stamina-cost: 8
+
+    JERKY:
+      output: { item: JERKY, quantity: 1 }
+      inputs:
+        MEAT: 1
+        SALT: 1
+      required-station: CRAFTING_STATION_PRESERVE
+      required-skill: COOKING
+      required-skill-level: 25
+      stamina-cost: 10

--- a/world/src/main/resources/world-definition/recipes-intermediates.yaml
+++ b/world/src/main/resources/world-definition/recipes-intermediates.yaml
@@ -98,3 +98,51 @@ recipes:
       required-skill: ALCHEMY
       required-skill-level: 0
       stamina-cost: 10
+
+    # ───────────── Fauna-tier intermediates ─────────────
+
+    BONE_MEAL_GRIND:
+      output: { item: BONE_MEAL, quantity: 2 }
+      inputs:
+        BONE: 1
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: CARPENTRY
+      required-skill-level: 0
+      stamina-cost: 6
+
+    BOWSTRING_WEAVE:
+      output: { item: BOWSTRING, quantity: 1 }
+      inputs:
+        SINEW: 2
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: LEATHERWORKING
+      required-skill-level: 0
+      stamina-cost: 6
+
+    DRIED_FUR_PROCESS:
+      output: { item: DRIED_FUR, quantity: 1 }
+      inputs:
+        FUR: 1
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: LEATHERWORKING
+      required-skill-level: 10
+      stamina-cost: 8
+
+    VENOM_EXTRACT_DISTILL:
+      output: { item: VENOM_EXTRACT, quantity: 1 }
+      inputs:
+        GLAND: 2
+      required-station: CRAFTING_STATION_POTION
+      required-skill: ALCHEMY
+      required-skill-level: 20
+      stamina-cost: 10
+
+    HARDENED_LEATHER_CURE:
+      output: { item: HARDENED_LEATHER, quantity: 1 }
+      inputs:
+        HIDE: 2
+        GLAND: 1
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: LEATHERWORKING
+      required-skill-level: 30
+      stamina-cost: 12

--- a/world/src/main/resources/world-definition/recipes-jewelry.yaml
+++ b/world/src/main/resources/world-definition/recipes-jewelry.yaml
@@ -83,3 +83,24 @@ recipes:
       required-skill: JEWELRYCRAFTING
       required-skill-level: 7
       stamina-cost: 20
+
+    # ───────────── Fauna-tier jewelry (bone / fang) ─────────────
+
+    BONE_AMULET_BASIC:
+      output: { item: BONE_AMULET, quantity: 1 }
+      inputs:
+        BONE: 2
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: JEWELRYCRAFTING
+      required-skill-level: 0
+      stamina-cost: 8
+
+    FANG_NECKLACE_BASIC:
+      output: { item: FANG_NECKLACE, quantity: 1 }
+      inputs:
+        FANG: 3
+        SINEW: 1
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: JEWELRYCRAFTING
+      required-skill-level: 20
+      stamina-cost: 10

--- a/world/src/main/resources/world-definition/recipes-weapons.yaml
+++ b/world/src/main/resources/world-definition/recipes-weapons.yaml
@@ -131,3 +131,46 @@ recipes:
       required-skill: SMITHING
       required-skill-level: 5
       stamina-cost: 18
+
+    # ───────────── Fauna-tier weapons (bone / fang / horn) ─────────────
+
+    BONE_DAGGER_BASIC:
+      output: { item: BONE_DAGGER, quantity: 1 }
+      inputs:
+        BONE: 3
+        WOOD: 1
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: CARPENTRY
+      required-skill-level: 0
+      stamina-cost: 10
+
+    HORN_CLUB_BASIC:
+      output: { item: HORN_CLUB, quantity: 1 }
+      inputs:
+        HORN: 1
+        WOOD: 2
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: CARPENTRY
+      required-skill-level: 5
+      stamina-cost: 11
+
+    BONE_ARROW_BATCH:
+      output: { item: BONE_ARROW, quantity: 5 }
+      inputs:
+        BONE: 1
+        FEATHER: 1
+        WOOD: 1
+      required-station: CRAFTING_STATION_WOOD
+      required-skill: CARPENTRY
+      required-skill-level: 0
+      stamina-cost: 8
+
+    FANG_DAGGER_BASIC:
+      output: { item: FANG_DAGGER, quantity: 1 }
+      inputs:
+        FANG: 2
+        LEATHER: 1
+      required-station: CRAFTING_STATION_METAL
+      required-skill: SMITHING
+      required-skill-level: 20
+      stamina-cost: 12

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/RecipesYamlLoadingTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/crafting/RecipesYamlLoadingTest.kt
@@ -4,6 +4,8 @@ import dev.gvart.genesara.player.Skill
 import dev.gvart.genesara.player.SkillCategory
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillLookup
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.internal.balance.ItemBalanceConfiguration
 import dev.gvart.genesara.world.internal.balance.ItemDefinitionProperties
 import dev.gvart.genesara.world.internal.balance.ItemLookupImpl
@@ -100,6 +102,131 @@ class RecipesYamlLoadingTest {
             assertEquals(SkillId("JEWELRYCRAFTING"), requireSkillOf("GEM_RING_BASIC"))
             assertEquals(SkillId("JEWELRYCRAFTING"), requireSkillOf("LEATHER_BRACELET_BASIC"))
             assertEquals(SkillId("JEWELRYCRAFTING"), requireSkillOf("IRON_BRACELET_BASIC"))
+        }
+    }
+
+    @Test
+    fun `fauna-expansion recipes (Slice 3) all load with the expected inputs, station, skill, level, stamina`() {
+        AnnotationConfigApplicationContext().use { ctx ->
+            ConfigurationPropertiesBindingPostProcessor.register(ctx)
+            ctx.register(RecipeBalanceConfiguration::class.java)
+            ctx.refresh()
+
+            val byId = RecipeLookupImpl(ctx.getBean(RecipeDefinitionProperties::class.java))
+                .all()
+                .associateBy { it.id.value }
+
+            data class Expected(
+                val outputItem: String,
+                val outputQty: Int,
+                val inputs: Map<String, Int>,
+                val station: BuildingCategoryHint,
+                val skill: String,
+                val level: Int,
+                val stamina: Int,
+            )
+
+            val expected = mapOf(
+                // cooking
+                "ROAST_MEAT" to Expected("ROAST_MEAT", 1, mapOf("MEAT" to 1), BuildingCategoryHint.COOKING, "COOKING", 0, 4),
+                "MEAT_STEW" to Expected("MEAT_STEW", 1, mapOf("MEAT" to 1, "POTATO" to 1, "HERB" to 1), BuildingCategoryHint.COOKING, "COOKING", 20, 9),
+                "GAME_PIE" to Expected("GAME_PIE", 1, mapOf("MEAT" to 2, "WHEAT" to 2), BuildingCategoryHint.COOKING, "COOKING", 40, 12),
+                "HEARTY_BROTH" to Expected("HEARTY_BROTH", 1, mapOf("BONE" to 1, "HERB" to 1), BuildingCategoryHint.COOKING, "COOKING", 10, 7),
+                "SMOKED_MEAT" to Expected("SMOKED_MEAT", 1, mapOf("MEAT" to 2), BuildingCategoryHint.CRAFTING_STATION_PRESERVE, "COOKING", 15, 8),
+                "SMOKED_FISH" to Expected("SMOKED_FISH", 1, mapOf("FISH" to 2), BuildingCategoryHint.CRAFTING_STATION_PRESERVE, "COOKING", 15, 8),
+                "JERKY" to Expected("JERKY", 1, mapOf("MEAT" to 1, "SALT" to 1), BuildingCategoryHint.CRAFTING_STATION_PRESERVE, "COOKING", 25, 10),
+                "VENISON_ROAST" to Expected("VENISON_ROAST", 1, mapOf("MEAT" to 3, "HERB" to 2, "SALT" to 1), BuildingCategoryHint.COOKING, "COOKING", 60, 14),
+                "BONE_MARROW_SOUP" to Expected("BONE_MARROW_SOUP", 1, mapOf("BONE" to 2, "HERB" to 1), BuildingCategoryHint.COOKING, "COOKING", 30, 10),
+                // brewing
+                "ALE" to Expected("ALE", 1, mapOf("WHEAT" to 3), BuildingCategoryHint.CRAFTING_STATION_BREW, "BREWING", 0, 8),
+                "BERRY_WINE" to Expected("BERRY_WINE", 1, mapOf("BERRY" to 5), BuildingCategoryHint.CRAFTING_STATION_BREW, "BREWING", 20, 10),
+                "HERBAL_TONIC" to Expected("HERBAL_TONIC", 1, mapOf("HERB" to 3), BuildingCategoryHint.CRAFTING_STATION_BREW, "BREWING", 10, 7),
+                "MEAD" to Expected("MEAD", 1, mapOf("HONEY" to 2), BuildingCategoryHint.CRAFTING_STATION_BREW, "BREWING", 30, 11),
+                "MUSHROOM_LIQUOR" to Expected("MUSHROOM_LIQUOR", 1, mapOf("MUSHROOM" to 4), BuildingCategoryHint.CRAFTING_STATION_BREW, "BREWING", 50, 13),
+                // weapons
+                "BONE_DAGGER_BASIC" to Expected("BONE_DAGGER", 1, mapOf("BONE" to 3, "WOOD" to 1), BuildingCategoryHint.CRAFTING_STATION_WOOD, "CARPENTRY", 0, 10),
+                "FANG_DAGGER_BASIC" to Expected("FANG_DAGGER", 1, mapOf("FANG" to 2, "LEATHER" to 1), BuildingCategoryHint.CRAFTING_STATION_METAL, "SMITHING", 20, 12),
+                "HORN_CLUB_BASIC" to Expected("HORN_CLUB", 1, mapOf("HORN" to 1, "WOOD" to 2), BuildingCategoryHint.CRAFTING_STATION_WOOD, "CARPENTRY", 5, 11),
+                "BONE_ARROW_BATCH" to Expected("BONE_ARROW", 5, mapOf("BONE" to 1, "FEATHER" to 1, "WOOD" to 1), BuildingCategoryHint.CRAFTING_STATION_WOOD, "CARPENTRY", 0, 8),
+                // armor
+                "FUR_CLOAK_BASIC" to Expected("FUR_CLOAK", 1, mapOf("FUR" to 4, "CLOTH" to 2), BuildingCategoryHint.CRAFTING_STATION_WOOD, "TAILORING", 20, 14),
+                "FUR_HOOD_BASIC" to Expected("FUR_HOOD", 1, mapOf("FUR" to 2), BuildingCategoryHint.CRAFTING_STATION_WOOD, "TAILORING", 0, 10),
+                "HORN_HELMET_BASIC" to Expected("HORN_HELMET", 1, mapOf("HORN" to 2, "LEATHER" to 1), BuildingCategoryHint.CRAFTING_STATION_WOOD, "LEATHERWORKING", 30, 12),
+                "SCALE_VEST_BASIC" to Expected("SCALE_VEST", 1, mapOf("SCALE" to 6, "LEATHER" to 2), BuildingCategoryHint.CRAFTING_STATION_METAL, "SMITHING", 40, 16),
+                "CHITIN_SHIELD_BASIC" to Expected("CHITIN_SHIELD", 1, mapOf("CHITIN" to 4, "WOOD" to 1), BuildingCategoryHint.CRAFTING_STATION_WOOD, "CARPENTRY", 30, 13),
+                "CHITIN_GAUNTLETS_BASIC" to Expected("CHITIN_GAUNTLETS", 1, mapOf("CHITIN" to 3, "LEATHER" to 1), BuildingCategoryHint.CRAFTING_STATION_WOOD, "LEATHERWORKING", 30, 11),
+                // jewelry
+                "BONE_AMULET_BASIC" to Expected("BONE_AMULET", 1, mapOf("BONE" to 2), BuildingCategoryHint.CRAFTING_STATION_WOOD, "JEWELRYCRAFTING", 0, 8),
+                "FANG_NECKLACE_BASIC" to Expected("FANG_NECKLACE", 1, mapOf("FANG" to 3, "SINEW" to 1), BuildingCategoryHint.CRAFTING_STATION_WOOD, "JEWELRYCRAFTING", 20, 10),
+                // intermediates
+                "HARDENED_LEATHER_CURE" to Expected("HARDENED_LEATHER", 1, mapOf("HIDE" to 2, "GLAND" to 1), BuildingCategoryHint.CRAFTING_STATION_WOOD, "LEATHERWORKING", 30, 12),
+                "BONE_MEAL_GRIND" to Expected("BONE_MEAL", 2, mapOf("BONE" to 1), BuildingCategoryHint.CRAFTING_STATION_WOOD, "CARPENTRY", 0, 6),
+                "DRIED_FUR_PROCESS" to Expected("DRIED_FUR", 1, mapOf("FUR" to 1), BuildingCategoryHint.CRAFTING_STATION_WOOD, "LEATHERWORKING", 10, 8),
+                "VENOM_EXTRACT_DISTILL" to Expected("VENOM_EXTRACT", 1, mapOf("GLAND" to 2), BuildingCategoryHint.CRAFTING_STATION_POTION, "ALCHEMY", 20, 10),
+                "BOWSTRING_WEAVE" to Expected("BOWSTRING", 1, mapOf("SINEW" to 2), BuildingCategoryHint.CRAFTING_STATION_WOOD, "LEATHERWORKING", 0, 6),
+                // consumables
+                "POISON_VIAL_BREW" to Expected("POISON_VIAL", 1, mapOf("VENOM_EXTRACT" to 2), BuildingCategoryHint.CRAFTING_STATION_POTION, "ALCHEMY", 30, 11),
+                "ANTIDOTE_BREW" to Expected("ANTIDOTE", 1, mapOf("GLAND" to 1, "HERB" to 2), BuildingCategoryHint.CRAFTING_STATION_POTION, "ALCHEMY", 20, 10),
+                "STAMINA_TONIC_BREW" to Expected("STAMINA_TONIC", 1, mapOf("HONEY" to 1, "HERB" to 2), BuildingCategoryHint.CRAFTING_STATION_POTION, "ALCHEMY", 10, 8),
+            )
+
+            assertEquals(34, expected.size, "expected exactly 34 new Slice-3 recipes")
+
+            for ((id, exp) in expected) {
+                val recipe = assertNotNull(byId[id], "missing recipe $id")
+                assertEquals(ItemId(exp.outputItem), recipe.output.item, "$id output item")
+                assertEquals(exp.outputQty, recipe.output.quantity, "$id output qty")
+                assertEquals(
+                    exp.inputs.mapKeys { ItemId(it.key) },
+                    recipe.inputs,
+                    "$id inputs",
+                )
+                assertEquals(exp.station, recipe.requiredStation, "$id station")
+                assertEquals(SkillId(exp.skill), recipe.requiredSkill, "$id skill")
+                assertEquals(exp.level, recipe.requiredSkillLevel, "$id level")
+                assertEquals(exp.stamina, recipe.staminaCost, "$id stamina")
+            }
+        }
+    }
+
+    @Test
+    fun `every Slice-3 recipe output resolves against the live items catalog`() {
+        AnnotationConfigApplicationContext().use { ctx ->
+            ConfigurationPropertiesBindingPostProcessor.register(ctx)
+            ctx.register(
+                RecipeBalanceConfiguration::class.java,
+                ItemBalanceConfiguration::class.java,
+            )
+            ctx.refresh()
+
+            val recipes = RecipeLookupImpl(ctx.getBean(RecipeDefinitionProperties::class.java)).all()
+            val items = ItemLookupImpl(ctx.getBean(ItemDefinitionProperties::class.java))
+
+            val slice3Ids = setOf(
+                "ROAST_MEAT", "MEAT_STEW", "GAME_PIE", "HEARTY_BROTH", "SMOKED_MEAT",
+                "SMOKED_FISH", "JERKY", "VENISON_ROAST", "BONE_MARROW_SOUP",
+                "ALE", "BERRY_WINE", "HERBAL_TONIC", "MEAD", "MUSHROOM_LIQUOR",
+                "BONE_DAGGER_BASIC", "FANG_DAGGER_BASIC", "HORN_CLUB_BASIC", "BONE_ARROW_BATCH",
+                "FUR_CLOAK_BASIC", "FUR_HOOD_BASIC", "HORN_HELMET_BASIC", "SCALE_VEST_BASIC",
+                "CHITIN_SHIELD_BASIC", "CHITIN_GAUNTLETS_BASIC",
+                "BONE_AMULET_BASIC", "FANG_NECKLACE_BASIC",
+                "HARDENED_LEATHER_CURE", "BONE_MEAL_GRIND", "DRIED_FUR_PROCESS",
+                "VENOM_EXTRACT_DISTILL", "BOWSTRING_WEAVE",
+                "POISON_VIAL_BREW", "ANTIDOTE_BREW", "STAMINA_TONIC_BREW",
+            )
+
+            for (recipe in recipes.filter { it.id.value in slice3Ids }) {
+                assertNotNull(
+                    items.byId(recipe.output.item),
+                    "recipe ${recipe.id.value} output ${recipe.output.item.value} missing from items catalog",
+                )
+                for (input in recipe.inputs.keys) {
+                    assertNotNull(
+                        items.byId(input),
+                        "recipe ${recipe.id.value} input ${input.value} missing from items catalog",
+                    )
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

**Slice 3 of 3** for the fauna expansion feature — the production crafting chains that consume Slice-2 raw materials (MEAT, FUR, BONE, FANG, CHITIN, GLAND, HONEY, etc.) and produce Slice-2 cooked / brewed / equipped outputs.

## Recipe deltas

| File | Before | New | After |
|---|---|---|---|
| recipes-cooking.yaml | 4 | +9 | 13 |
| recipes-brewing.yaml (new) | 0 | +5 | 5 |
| recipes-weapons.yaml | 12 | +4 | 16 |
| recipes-armor.yaml | 12 | +6 | 18 |
| recipes-jewelry.yaml | 8 | +2 | 10 |
| recipes-intermediates.yaml | 9 | +5 | 14 |
| recipes-consumables.yaml | 1 | +3 | 4 |
| **Total** | **46** | **+34** | **80** |

## Equipment items (+14)

- equipment-weapons.yaml +3: BONE_DAGGER, FANG_DAGGER, HORN_CLUB
- equipment-armor.yaml +6: FUR_CLOAK, FUR_HOOD, HORN_HELMET, SCALE_VEST, CHITIN_SHIELD, CHITIN_GAUNTLETS
- equipment-jewelry.yaml +2: BONE_AMULET, FANG_NECKLACE (+1 STRENGTH)
- items.yaml +2 RESOURCE: BOWSTRING, BONE_ARROW

**Design pin on BONE_ARROW**: lives in `items.yaml` as RESOURCE (max-stack: 50) rather than `equipment-weapons.yaml` as EQUIPMENT. The crafting reducer mints exactly one `ItemInstance` per EQUIPMENT recipe — `BONE_ARROW_BATCH` produces qty 5, so it had to be stackable. When a real ammo / quiver system lands, BONE_ARROW migrates to EQUIPMENT.

## Heads-up: Slice-2 retro-balance

Slice 2 (#184) shipped drinks at `weight-per-unit: 500`. Several brewing recipes have input weights below 500g (e.g. HERBAL_TONIC: HERB×3 = 90g) — the recipe weight invariant blocked them. **This PR reduces all five drink weights to 80g** (small flask / cup, more realistic). No other Slice-2 weights changed; consumable gauge effects unchanged.

## Engine wiring

- `RecipeBalanceConfiguration`: `@PropertySource` extended for `recipes-brewing.yaml`.
- `RecipeCatalogValidator`: new guard rejects `EQUIPMENT && output.quantity > 1` at startup — catches the BONE_ARROW failure mode before it could repeat.

## Subagent tuning calls

- BONE_MEAL_GRIND: output qty 3 → 2 (weight invariant: BONE 1 at 400g cannot produce 3 × BONE_MEAL at 600g).
- POISON_VIAL_BREW: input VENOM_EXTRACT 1 → 2 (1 × 100g cannot produce 1 × 200g).
- FANG_NECKLACE: +1 STRENGTH bonus (predator motif; mirrors IRON_RING).

## Test plan

- [x] New per-recipe tuple check for all 34 recipes in `RecipesYamlLoadingTest`.
- [x] New cross-catalog integrity check (every recipe's output resolves against the live items + equipment catalogs).
- [x] `:world:test` 856 / `:player:test` 216 / `:api:test` 392 — all green.
- [x] code-quality-reviewer pass: P0 (BONE_ARROW EQUIPMENT-vs-RESOURCE mismatch) addressed by moving to items.yaml + adding validator guard. M findings addressed (BOWSTRING orphan TODO, STAMINA_TONIC inert TODO).

## Known gaps (deferred to dedicated slices)

- BOWSTRING is orphan in this slice (no recipe consumes it — a bow recipe lands with the ranged-weapon slice).
- BONE_ARROW has no functional use until the ammo system ships.
- STAMINA_TONIC / POISON_VIAL / ANTIDOTE produced inert until the status-effect / stamina-refill engines land.