### PR TITLE
feat(world,api): trade v2 — instance trading (#190)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/trade/TradeOfferTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/trade/TradeOfferTool.kt
@@ -23,13 +23,16 @@ internal class TradeOfferTool(
 
     @Tool(
         name = "trade_offer",
-        description = "Send a barter offer to another agent on your current node. The 'offer' map " +
-            "lists items you'll give; the 'request' map lists items you want from them. Both maps " +
-            "use itemId -> quantity. At least one side must be non-empty. Queues a TradeOffer " +
-            "command; the recipient receives a trade_offer_received event with the tradeId. The " +
-            "QUEUED ack echoes the tradeId so you can correlate the eventual TradeAccepted / " +
-            "TradeRejected outcome. Rejections: CannotTradeWithSelf, TradeOfferEmpty, " +
-            "TradePartnerNotInSameNode, ItemNotInInventory, UnknownItem, InsufficientTrust.",
+        description = "Send a barter offer to another agent on your current node. The 'offer' / " +
+            "'request' maps swap stackable items by itemId -> quantity; 'offerInstances' / " +
+            "'requestInstances' swap per-instance items (specific equipment, keys, mount gear) " +
+            "by instance UUID. At least one bucket must be non-empty. Instance items must be " +
+            "unequipped + not stowed on a mount. Queues a TradeOffer command; the recipient " +
+            "receives a trade_offer_received event with the tradeId. The QUEUED ack echoes the " +
+            "tradeId so you can correlate the eventual TradeAccepted / TradeRejected outcome. " +
+            "Rejections: CannotTradeWithSelf, TradeOfferEmpty, TradePartnerNotInSameNode, " +
+            "ItemNotInInventory, UnknownItem, InsufficientTrust, TradeInstanceNotFound, " +
+            "TradeInstanceNotOwned, TradeInstanceUnavailable.",
     )
     fun invoke(
         @ToolParam(required = true, description = "Recipient agent UUID. Must be on your current node.")
@@ -38,6 +41,10 @@ internal class TradeOfferTool(
         offer: Map<String, Int>,
         @ToolParam(required = true, description = "Items you request in exchange, keyed by itemId -> positive quantity.")
         request: Map<String, Int>,
+        @ToolParam(required = false, description = "Per-instance item UUIDs you offer (equipment, keys, mount gear). Each must be unequipped and not stowed in a mount.")
+        offerInstances: List<String>?,
+        @ToolParam(required = false, description = "Per-instance item UUIDs you request. The recipient must own each one, unequipped and unstowed.")
+        requestInstances: List<String>?,
         toolContext: ToolContext,
     ): TradeOfferResponse {
         touchActivity(toolContext, activity, "trade_offer")
@@ -46,21 +53,51 @@ internal class TradeOfferTool(
                 reason = "bad_recipient_id",
                 detail = "recipientId must be a UUID",
             )
+        val offerInstanceList = offerInstances.orEmpty()
+        val requestInstanceList = requestInstances.orEmpty()
         if (offer.size > MAX_ITEMS_PER_SIDE || request.size > MAX_ITEMS_PER_SIDE) {
             return TradeOfferResponse.rejected(
                 reason = "offer_too_wide",
-                detail = "each side is capped at $MAX_ITEMS_PER_SIDE distinct items",
+                detail = "each stackable side is capped at $MAX_ITEMS_PER_SIDE distinct items",
             )
         }
+        if (offerInstanceList.size > MAX_INSTANCES_PER_SIDE || requestInstanceList.size > MAX_INSTANCES_PER_SIDE) {
+            return TradeOfferResponse.rejected(
+                reason = "offer_too_wide",
+                detail = "each instance side is capped at $MAX_INSTANCES_PER_SIDE UUIDs",
+            )
+        }
+        val offerInstanceIds = offerInstanceList.parseUuids()
+            ?: return TradeOfferResponse.rejected(
+                reason = "bad_instance_id",
+                detail = "offerInstances must contain valid UUIDs",
+            )
+        val requestInstanceIds = requestInstanceList.parseUuids()
+            ?: return TradeOfferResponse.rejected(
+                reason = "bad_instance_id",
+                detail = "requestInstances must contain valid UUIDs",
+            )
         val agent = AgentContextHolder.current()
         val command = EconomyCommand.TradeOffer(
             agent = agent,
             recipient = AgentId(recipientUuid),
             offered = offer.mapKeys { ItemId(it.key) },
             requested = request.mapKeys { ItemId(it.key) },
+            offeredInstances = offerInstanceIds,
+            requestedInstances = requestInstanceIds,
         )
         val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
         return TradeOfferResponse.queued(command.commandId, appliesAtTick, command.tradeId)
+    }
+
+    private fun List<String>.parseUuids(): Set<UUID>? {
+        if (isEmpty()) return emptySet()
+        val parsed = LinkedHashSet<UUID>(size)
+        for (raw in this) {
+            val uuid = runCatching { UUID.fromString(raw) }.getOrNull() ?: return null
+            parsed += uuid
+        }
+        return parsed
     }
 
     private companion object {
@@ -68,5 +105,9 @@ internal class TradeOfferTool(
         // (typical loadouts hold far fewer distinct stack types) while bounding the per-tick
         // validation walk + Redis-queue payload size against an over-wide map.
         const val MAX_ITEMS_PER_SIDE = 32
+
+        // Symmetric per-instance cap. An agent's full loadout (12 equip slots + small key
+        // ring + a handful of mount gear) sits well under this.
+        const val MAX_INSTANCES_PER_SIDE = 32
     }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/AgentInventoryControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/AgentInventoryControllerTest.kt
@@ -167,6 +167,7 @@ class AgentInventoryControllerTest {
         override fun unstowFromMount(instanceId: UUID): ItemInstance? = null
         override fun byStowedOnMount(mountId: MountId): List<ItemInstance> = emptyList()
         override fun gearOnMount(mountId: MountId, slot: MountSlot): ItemInstance.MountGear? = null
+        override fun reassignOwner(instanceId: UUID, fromAgent: AgentId, toAgent: AgentId): ItemInstance? = null
     }
 
     private class StubInstances(private val rows: List<ItemInstance>) : AgentItemInstancesStore {
@@ -192,5 +193,6 @@ class AgentInventoryControllerTest {
         override fun unstowFromMount(instanceId: UUID): ItemInstance? = null
         override fun byStowedOnMount(mountId: MountId): List<ItemInstance> = emptyList()
         override fun gearOnMount(mountId: MountId, slot: MountSlot): ItemInstance.MountGear? = null
+        override fun reassignOwner(instanceId: UUID, fromAgent: AgentId, toAgent: AgentId): ItemInstance? = null
     }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/testsupport/InMemoryAgentItemInstancesStore.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/testsupport/InMemoryAgentItemInstancesStore.kt
@@ -109,8 +109,6 @@ open class InMemoryAgentItemInstancesStore : AgentItemInstancesStore {
             .filterIsInstance<ItemInstance.MountGear>()
             .filter { it.equippedOnMount == mountId.value }
 
-    private val stowedOnMount: MutableMap<UUID, MountId> = mutableMapOf()
-
     override fun stowOnMount(instanceId: UUID, agentId: AgentId, mountId: MountId): ItemInstance? {
         val current = byId[instanceId] ?: return null
         if (current.agentId != agentId) return null
@@ -120,20 +118,50 @@ open class InMemoryAgentItemInstancesStore : AgentItemInstancesStore {
             is ItemInstance.Key -> false
         }
         if (equipped) return null
-        stowedOnMount[instanceId] = mountId
-        return current
+        val updated = current.withStowedInMountId(mountId.value)
+        byId[instanceId] = updated
+        return updated
     }
 
     override fun unstowFromMount(instanceId: UUID): ItemInstance? {
-        stowedOnMount.remove(instanceId)
-        return byId[instanceId]
+        val current = byId[instanceId] ?: return null
+        val updated = current.withStowedInMountId(null)
+        byId[instanceId] = updated
+        return updated
     }
 
     override fun byStowedOnMount(mountId: MountId): List<ItemInstance> =
-        stowedOnMount.filterValues { it == mountId }.keys.mapNotNull { byId[it] }
+        byId.values.filter { it.stowedInMountId == mountId.value }
 
     override fun gearOnMount(mountId: MountId, slot: MountSlot): ItemInstance.MountGear? =
         byId.values
             .filterIsInstance<ItemInstance.MountGear>()
             .firstOrNull { it.equippedOnMount == mountId.value && it.equippedMountSlot == slot }
+
+    override fun reassignOwner(instanceId: UUID, fromAgent: AgentId, toAgent: AgentId): ItemInstance? {
+        val current = byId[instanceId] ?: return null
+        if (current.agentId != fromAgent) return null
+        val equipped = when (current) {
+            is ItemInstance.Equipment -> current.equippedInSlot != null
+            is ItemInstance.MountGear -> current.equippedOnMount != null
+            is ItemInstance.Key -> false
+        }
+        if (equipped) return null
+        if (current.stowedInMountId != null) return null
+        val updated = current.withAgentId(toAgent)
+        byId[instanceId] = updated
+        return updated
+    }
+}
+
+private fun ItemInstance.withStowedInMountId(value: UUID?): ItemInstance = when (this) {
+    is ItemInstance.Equipment -> copy(stowedInMountId = value)
+    is ItemInstance.Key -> copy(stowedInMountId = value)
+    is ItemInstance.MountGear -> copy(stowedInMountId = value)
+}
+
+private fun ItemInstance.withAgentId(value: AgentId): ItemInstance = when (this) {
+    is ItemInstance.Equipment -> copy(agentId = value)
+    is ItemInstance.Key -> copy(agentId = value)
+    is ItemInstance.MountGear -> copy(agentId = value)
 }

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/AgentItemInstancesStore.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/AgentItemInstancesStore.kt
@@ -129,6 +129,18 @@ interface AgentItemInstancesStore {
     fun unstowFromMount(instanceId: UUID): ItemInstance?
 
     /**
+     * Reassign [instanceId] from [fromAgent] to [toAgent]. Atomic: succeeds only
+     * when the row exists, is owned by [fromAgent], and is unbound — not equipped
+     * in an agent slot, not equipped on a mount, not stowed in a mount. Returns
+     * the post-write row, or null when any precondition fails. The single WHERE
+     * clause is the authoritative TOCTOU fence — callers that need to distinguish
+     * "not found" from "not owned" from "bound" should re-`findById` after a null
+     * return and inspect the binding flags. Used by the trade respond reducer to
+     * move per-instance items between agents on accept.
+     */
+    fun reassignOwner(instanceId: UUID, fromAgent: AgentId, toAgent: AgentId): ItemInstance?
+
+    /**
      * Per-instance items currently stowed in [mountId]'s cargo. Used by the
      * cargo-weight totaller and by stage-D death cleanup to drop cargo on the
      * ground.

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/ItemInstance.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/ItemInstance.kt
@@ -17,6 +17,15 @@ sealed class ItemInstance {
     abstract val createdAtTick: Long
 
     /**
+     * Mount whose cargo currently holds this instance, or null when it isn't
+     * stowed. Mutually exclusive with `equippedInSlot` (Equipment),
+     * `equippedOnMount` (MountGear), and any future binding column. Surfaced so
+     * read paths (notably the trade reducer's transferability check) can probe
+     * all four binding flags from a single `findById` without a second query.
+     */
+    abstract val stowedInMountId: UUID?
+
+    /**
      * Catalog category for this per-instance item — mirrors the `agent_item_instances.category`
      * discriminator column. Defined on the sealed class so any future subtype (signed crafted
      * items, charged scrolls, named tools) must declare its category at the type level, rather
@@ -45,6 +54,7 @@ sealed class ItemInstance {
          * item catalog's `twoHanded` flag, not by a second row.
          */
         val equippedInSlot: EquipSlot? = null,
+        override val stowedInMountId: UUID? = null,
     ) : ItemInstance() {
         override val category: ItemCategory get() = ItemCategory.EQUIPMENT
 
@@ -74,6 +84,7 @@ sealed class ItemInstance {
         override val itemId: ItemId,
         val gateInstanceId: UUID,
         override val createdAtTick: Long,
+        override val stowedInMountId: UUID? = null,
     ) : ItemInstance() {
         override val category: ItemCategory get() = ItemCategory.KEY
     }
@@ -96,6 +107,7 @@ sealed class ItemInstance {
         override val createdAtTick: Long,
         val equippedOnMount: UUID? = null,
         val equippedMountSlot: MountSlot? = null,
+        override val stowedInMountId: UUID? = null,
     ) : ItemInstance() {
         override val category: ItemCategory get() = ItemCategory.MOUNT_GEAR
 

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/TradeStore.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/TradeStore.kt
@@ -45,4 +45,6 @@ data class TradeOffer(
     val status: TradeStatus,
     val openedAtTick: Long,
     val resolvedAtTick: Long?,
+    val offeredInstances: Set<UUID> = emptySet(),
+    val requestedInstances: Set<UUID> = emptySet(),
 )

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
@@ -390,6 +390,28 @@ sealed interface WorldRejection {
     data class NotTradeRecipient(val actor: AgentId, val tradeId: UUID) : WorldRejection
 
     /**
+     * Trade offer or respond referenced an instance UUID that either doesn't exist or
+     * isn't owned by the expected party. The two states are collapsed under one rejection
+     * so an offerer can't probe arbitrary UUIDs to learn other agents' loot — same anti-probe
+     * pattern as [GroundItemNoLongerAvailable]. Information asymmetry per design principle #7.
+     */
+    data class TradeInstanceUnavailable(val actor: AgentId, val instanceId: UUID) : WorldRejection
+
+    /**
+     * Trade offer or respond referenced an instance that exists and is owned correctly,
+     * but is currently bound somewhere that prevents transfer — equipped in the agent's
+     * slot grid, equipped on a mount, or stowed in a mount's cargo. The agent must
+     * unequip / unstow before the trade can complete.
+     */
+    data class TradeInstanceBound(
+        val actor: AgentId,
+        val instanceId: UUID,
+        val reason: Reason,
+    ) : WorldRejection {
+        enum class Reason { EQUIPPED_BY_AGENT, EQUIPPED_ON_MOUNT, STOWED_ON_MOUNT }
+    }
+
+    /**
      * High-value trade ([value] above [valueThreshold]) attempted between a pair
      * whose relationship score is below [relationshipThreshold]. The trust gate
      * blocks strangers from draining each other in one swap.

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/commands/EconomyCommand.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/commands/EconomyCommand.kt
@@ -75,12 +75,22 @@ sealed interface EconomyCommand : WorldCommand {
      * arbitrary read access to each other's inventories (information asymmetry per
      * design principle #7). The respond reducer re-validates both sides; a request
      * the recipient can't satisfy surfaces there as `ItemNotInInventory(recipient, ...)`.
+     *
+     * Per-instance items (equipment, keys, mount gear) travel in [offeredInstances] /
+     * [requestedInstances] as raw UUIDs. Each side must be unbound at offer time AND
+     * at respond time — not equipped in an agent slot, not equipped on a mount, not
+     * stowed in a mount. The reducer rejects with `TradeInstanceNotFound`,
+     * `TradeInstanceNotOwned`, or `TradeInstanceUnavailable` on violation. At
+     * respond time both sides go through `AgentItemInstancesStore.reassignOwner`
+     * inside the same transaction as the stackable swap.
      */
     data class TradeOffer(
         override val agent: AgentId,
         val recipient: AgentId,
-        val offered: Map<ItemId, Int>,
-        val requested: Map<ItemId, Int>,
+        val offered: Map<ItemId, Int> = emptyMap(),
+        val requested: Map<ItemId, Int> = emptyMap(),
+        val offeredInstances: Set<UUID> = emptySet(),
+        val requestedInstances: Set<UUID> = emptySet(),
         val tradeId: UUID = UUID.randomUUID(),
         override val commandId: UUID = UUID.randomUUID(),
     ) : EconomyCommand

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/events/EconomyEvent.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/events/EconomyEvent.kt
@@ -158,6 +158,8 @@ sealed interface EconomyEvent : WorldEvent {
         val listeners: Set<AgentId>,
         override val tick: Long,
         val causedBy: UUID,
+        val offeredInstances: Set<UUID> = emptySet(),
+        val requestedInstances: Set<UUID> = emptySet(),
     ) : EconomyEvent
 
     /**
@@ -175,6 +177,8 @@ sealed interface EconomyEvent : WorldEvent {
         val listeners: Set<AgentId>,
         override val tick: Long,
         val causedBy: UUID,
+        val offeredInstances: Set<UUID> = emptySet(),
+        val requestedInstances: Set<UUID> = emptySet(),
     ) : EconomyEvent
 
     /** Emitted by the trade-respond reducer when the recipient rejected the offer. */

--- a/world/core/src/main/resources/db/migration/world-core/V30__trade_instances.sql
+++ b/world/core/src/main/resources/db/migration/world-core/V30__trade_instances.sql
@@ -1,0 +1,12 @@
+-- Trade v2: extend trade offers with per-instance item UUIDs.
+--
+-- The stackable swap (offered/requested JSONB maps) covers materials by type+qty.
+-- Equipment, keys, and mount gear are per-instance items keyed by UUID — they
+-- now travel in their own JSONB array columns alongside the stackable maps.
+--
+-- DEFAULT '[]'::jsonb keeps the existing PENDING rows decodable post-migration
+-- without a backfill pass — they simply present empty instance sets to the
+-- respond reducer.
+ALTER TABLE trade_offers
+    ADD COLUMN offered_instances   JSONB NOT NULL DEFAULT '[]'::jsonb,
+    ADD COLUMN requested_instances JSONB NOT NULL DEFAULT '[]'::jsonb;

--- a/world/core/src/testFixtures/kotlin/dev/gvart/genesara/world/internal/testsupport/InMemoryAgentItemInstancesStore.kt
+++ b/world/core/src/testFixtures/kotlin/dev/gvart/genesara/world/internal/testsupport/InMemoryAgentItemInstancesStore.kt
@@ -118,8 +118,6 @@ open class InMemoryAgentItemInstancesStore : AgentItemInstancesStore {
             .filterIsInstance<ItemInstance.MountGear>()
             .filter { it.equippedOnMount == mountId.value }
 
-    private val stowedOnMount: MutableMap<UUID, MountId> = mutableMapOf()
-
     override fun stowOnMount(instanceId: UUID, agentId: AgentId, mountId: MountId): ItemInstance? {
         val current = byId[instanceId] ?: return null
         if (current.agentId != agentId) return null
@@ -129,20 +127,50 @@ open class InMemoryAgentItemInstancesStore : AgentItemInstancesStore {
             is ItemInstance.Key -> false
         }
         if (equipped) return null
-        stowedOnMount[instanceId] = mountId
-        return current
+        val updated = current.withStowedInMountId(mountId.value)
+        byId[instanceId] = updated
+        return updated
     }
 
     override fun unstowFromMount(instanceId: UUID): ItemInstance? {
-        stowedOnMount.remove(instanceId)
-        return byId[instanceId]
+        val current = byId[instanceId] ?: return null
+        val updated = current.withStowedInMountId(null)
+        byId[instanceId] = updated
+        return updated
     }
 
     override fun byStowedOnMount(mountId: MountId): List<ItemInstance> =
-        stowedOnMount.filterValues { it == mountId }.keys.mapNotNull { byId[it] }
+        byId.values.filter { it.stowedInMountId == mountId.value }
 
     override fun gearOnMount(mountId: MountId, slot: MountSlot): ItemInstance.MountGear? =
         byId.values
             .filterIsInstance<ItemInstance.MountGear>()
             .firstOrNull { it.equippedOnMount == mountId.value && it.equippedMountSlot == slot }
+
+    override fun reassignOwner(instanceId: UUID, fromAgent: AgentId, toAgent: AgentId): ItemInstance? {
+        val current = byId[instanceId] ?: return null
+        if (current.agentId != fromAgent) return null
+        val equipped = when (current) {
+            is ItemInstance.Equipment -> current.equippedInSlot != null
+            is ItemInstance.MountGear -> current.equippedOnMount != null
+            is ItemInstance.Key -> false
+        }
+        if (equipped) return null
+        if (current.stowedInMountId != null) return null
+        val updated = current.withAgentId(toAgent)
+        byId[instanceId] = updated
+        return updated
+    }
+}
+
+private fun ItemInstance.withStowedInMountId(value: UUID?): ItemInstance = when (this) {
+    is ItemInstance.Equipment -> copy(stowedInMountId = value)
+    is ItemInstance.Key -> copy(stowedInMountId = value)
+    is ItemInstance.MountGear -> copy(stowedInMountId = value)
+}
+
+private fun ItemInstance.withAgentId(value: AgentId): ItemInstance = when (this) {
+    is ItemInstance.Equipment -> copy(agentId = value)
+    is ItemInstance.Key -> copy(agentId = value)
+    is ItemInstance.MountGear -> copy(agentId = value)
 }

--- a/world/economy/src/main/kotlin/dev/gvart/genesara/world/economy/internal/trade/JooqTradeStore.kt
+++ b/world/economy/src/main/kotlin/dev/gvart/genesara/world/economy/internal/trade/JooqTradeStore.kt
@@ -29,6 +29,8 @@ internal class JooqTradeStore(
             .set(TRADE_OFFERS.RECIPIENT_ID, offer.recipient.id)
             .set(TRADE_OFFERS.OFFERED, encode(offer.offered))
             .set(TRADE_OFFERS.REQUESTED, encode(offer.requested))
+            .set(TRADE_OFFERS.OFFERED_INSTANCES, encodeInstances(offer.offeredInstances))
+            .set(TRADE_OFFERS.REQUESTED_INSTANCES, encodeInstances(offer.requestedInstances))
             .set(TRADE_OFFERS.STATUS, offer.status.name)
             .set(TRADE_OFFERS.OPENED_AT_TICK, offer.openedAtTick)
             .set(TRADE_OFFERS.RESOLVED_AT_TICK, offer.resolvedAtTick)
@@ -69,6 +71,12 @@ internal class JooqTradeStore(
     private fun decode(json: JSON): Map<ItemId, Int> =
         mapper.readValue(json.data(), STACK_MAP_TYPE).mapKeys { ItemId(it.key) }
 
+    private fun encodeInstances(ids: Set<UUID>): JSON =
+        JSON.valueOf(mapper.writeValueAsString(ids.map(UUID::toString)))
+
+    private fun decodeInstances(json: JSON): Set<UUID> =
+        mapper.readValue(json.data(), INSTANCE_LIST_TYPE).map(UUID::fromString).toSet()
+
     private fun toDomain(record: Record): TradeOffer = TradeOffer(
         tradeId = record[TRADE_OFFERS.TRADE_ID]!!,
         offerer = AgentId(record[TRADE_OFFERS.OFFERER_ID]!!),
@@ -78,9 +86,12 @@ internal class JooqTradeStore(
         status = TradeStatus.valueOf(record[TRADE_OFFERS.STATUS]!!),
         openedAtTick = record[TRADE_OFFERS.OPENED_AT_TICK]!!,
         resolvedAtTick = record[TRADE_OFFERS.RESOLVED_AT_TICK],
+        offeredInstances = decodeInstances(record[TRADE_OFFERS.OFFERED_INSTANCES]!!),
+        requestedInstances = decodeInstances(record[TRADE_OFFERS.REQUESTED_INSTANCES]!!),
     )
 
     private companion object {
         private val STACK_MAP_TYPE = object : TypeReference<Map<String, Int>>() {}
+        private val INSTANCE_LIST_TYPE = object : TypeReference<List<String>>() {}
     }
 }

--- a/world/economy/src/main/kotlin/dev/gvart/genesara/world/economy/internal/trade/TradeReducer.kt
+++ b/world/economy/src/main/kotlin/dev/gvart/genesara/world/economy/internal/trade/TradeReducer.kt
@@ -13,10 +13,12 @@ import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.player.TriggeredPassiveTrigger
+import dev.gvart.genesara.world.AgentItemInstancesStore
 import dev.gvart.genesara.world.BuildingStatus
 import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemInstance
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.RelationshipLookup
 import dev.gvart.genesara.world.TradeOffer
@@ -45,12 +47,14 @@ fun reduceTradeOffer(
     buildings: BuildingsLookup,
     passiveAura: PassiveAuraAggregator,
     scaling: LevelScalingAggregator,
+    equipment: AgentItemInstancesStore,
     tick: Long,
 ): Either<WorldRejection, ReducerOutput<BodySlice>> = either {
     ensure(command.agent != command.recipient) { WorldRejection.CannotTradeWithSelf(command.agent) }
-    ensure(command.offered.isNotEmpty() || command.requested.isNotEmpty()) {
-        WorldRejection.TradeOfferEmpty(command.agent)
-    }
+    ensure(
+        command.offered.isNotEmpty() || command.requested.isNotEmpty() ||
+            command.offeredInstances.isNotEmpty() || command.requestedInstances.isNotEmpty(),
+    ) { WorldRejection.TradeOfferEmpty(command.agent) }
     validatePositive(command.agent, command.offered)
     validatePositive(command.agent, command.requested)
 
@@ -63,8 +67,13 @@ fun reduceTradeOffer(
     validateKnown(items, command.offered)
     validateKnown(items, command.requested)
     validateStock(command.agent, body.inventoryOf(command.agent), command.offered)
+    validateInstancesTransferable(command.agent, command.agent, command.offeredInstances, equipment)
 
-    val value = command.offered.values.sum() + command.requested.values.sum()
+    // Per-instance items count flat (1 each) toward the trust gate. The engine has
+    // no rarity-tier pricing — barter-only design means agents establish their own
+    // valuations through repeated trades.
+    val value = command.offered.values.sum() + command.requested.values.sum() +
+        command.offeredInstances.size + command.requestedInstances.size
     val baseValueThreshold = balance.trustGateValueThreshold()
     val tradingPostActive = buildings.byNode(offererAt).any {
         it.type == BuildingType.TRADING_POST && it.status == BuildingStatus.ACTIVE
@@ -99,6 +108,8 @@ fun reduceTradeOffer(
             status = TradeStatus.PENDING,
             openedAtTick = tick,
             resolvedAtTick = null,
+            offeredInstances = command.offeredInstances,
+            requestedInstances = command.requestedInstances,
         )
     )
 
@@ -112,6 +123,8 @@ fun reduceTradeOffer(
         listeners = setOf(command.agent, command.recipient),
         tick = tick,
         causedBy = command.commandId,
+        offeredInstances = command.offeredInstances,
+        requestedInstances = command.requestedInstances,
     )
     ReducerOutput(sliceDelta = body, events = listOf(event))
 }
@@ -125,6 +138,7 @@ fun reduceTradeRespond(
     triggeredPassives: TriggeredPassiveDispatcher,
     progression: SkillProgression,
     agents: AgentRegistry,
+    equipment: AgentItemInstancesStore,
     tick: Long,
 ): Either<WorldRejection, ReducerOutput<BodySlice>> = either {
     val offer = ensureNotNull(tradeStore.findPendingForUpdate(command.tradeId)) {
@@ -163,6 +177,8 @@ fun reduceTradeRespond(
     val recipientInv = body.inventoryOf(offer.recipient)
     validateStock(offer.offerer, offererInv, offer.offered)
     validateStock(offer.recipient, recipientInv, offer.requested)
+    validateInstancesTransferable(offer.recipient, offer.offerer, offer.offeredInstances, equipment)
+    validateInstancesTransferable(offer.recipient, offer.recipient, offer.requestedInstances, equipment)
 
     val nextOfferer = offererInv.removeAll(offer.offered).addAll(offer.requested)
     val nextRecipient = recipientInv.removeAll(offer.requested).addAll(offer.offered)
@@ -171,6 +187,25 @@ fun reduceTradeRespond(
             (offer.offerer to nextOfferer) +
             (offer.recipient to nextRecipient),
     )
+
+    // Reassigns are DB-writes; once one succeeds in the @Transactional tick boundary
+    // any subsequent failure would leave a half-applied swap on commit. The
+    // upstream validateInstancesTransferable check ran against the same store and
+    // the only writer between then and now is this reducer itself, so a null here
+    // is an invariant violation, not a recoverable rejection — throwing forces a
+    // Spring rollback that unwinds the earlier successful reassigns.
+    offer.offeredInstances.forEach { instanceId ->
+        check(equipment.reassignOwner(instanceId, offer.offerer, offer.recipient) != null) {
+            "trade ${offer.tradeId}: reassignOwner($instanceId, ${offer.offerer}, ${offer.recipient}) " +
+                "failed after pre-validation passed — investigate concurrent writer"
+        }
+    }
+    offer.requestedInstances.forEach { instanceId ->
+        check(equipment.reassignOwner(instanceId, offer.recipient, offer.offerer) != null) {
+            "trade ${offer.tradeId}: reassignOwner($instanceId, ${offer.recipient}, ${offer.offerer}) " +
+                "failed after pre-validation passed — investigate concurrent writer"
+        }
+    }
 
     check(tradeStore.markResolved(offer.tradeId, TradeStatus.ACCEPTED, tick)) {
         "trade ${offer.tradeId} was PENDING under forUpdate but markResolved returned false"
@@ -185,6 +220,8 @@ fun reduceTradeRespond(
         listeners = setOf(offer.offerer, offer.recipient),
         tick = tick,
         causedBy = command.commandId,
+        offeredInstances = offer.offeredInstances,
+        requestedInstances = offer.requestedInstances,
     )
     val recipientTriggered = triggeredPassives.dispatch(
         firer = offer.recipient,
@@ -235,4 +272,37 @@ private fun Raise<WorldRejection>.validateStock(
 private fun resolveMissingTrade(tradeStore: TradeStore, tradeId: UUID): WorldRejection {
     val existing = tradeStore.find(tradeId) ?: return WorldRejection.TradeNotFound(tradeId)
     return WorldRejection.TradeNotPending(tradeId, existing.status)
+}
+
+private fun Raise<WorldRejection>.validateInstancesTransferable(
+    actor: AgentId,
+    expectedOwner: AgentId,
+    instanceIds: Set<UUID>,
+    equipment: AgentItemInstancesStore,
+) {
+    instanceIds.forEach { id ->
+        // Collapse "not found" and "owned by someone else" into one rejection so an
+        // offerer can't probe arbitrary UUIDs to learn other agents' loot. The actor
+        // gets enough to retry on their own state; the actual owner stays hidden.
+        val instance = equipment.findById(id)?.takeIf { it.agentId == expectedOwner }
+            ?: raise(WorldRejection.TradeInstanceUnavailable(actor, id))
+        val boundReason = instance.boundReason()
+        if (boundReason != null) {
+            raise(WorldRejection.TradeInstanceBound(actor, id, boundReason))
+        }
+    }
+}
+
+private fun ItemInstance.boundReason(): WorldRejection.TradeInstanceBound.Reason? = when (this) {
+    is ItemInstance.Equipment ->
+        if (equippedInSlot != null) WorldRejection.TradeInstanceBound.Reason.EQUIPPED_BY_AGENT
+        else if (stowedInMountId != null) WorldRejection.TradeInstanceBound.Reason.STOWED_ON_MOUNT
+        else null
+    is ItemInstance.MountGear ->
+        if (equippedOnMount != null) WorldRejection.TradeInstanceBound.Reason.EQUIPPED_ON_MOUNT
+        else if (stowedInMountId != null) WorldRejection.TradeInstanceBound.Reason.STOWED_ON_MOUNT
+        else null
+    is ItemInstance.Key ->
+        if (stowedInMountId != null) WorldRejection.TradeInstanceBound.Reason.STOWED_ON_MOUNT
+        else null
 }

--- a/world/economy/src/test/kotlin/dev/gvart/genesara/world/economy/internal/trade/JooqTradeStoreIntegrationTest.kt
+++ b/world/economy/src/test/kotlin/dev/gvart/genesara/world/economy/internal/trade/JooqTradeStoreIntegrationTest.kt
@@ -132,6 +132,41 @@ class JooqTradeStoreIntegrationTest {
         assertFalse(store.markResolved(UUID.randomUUID(), TradeStatus.ACCEPTED, resolvedAtTick = 1))
     }
 
+    @Test
+    fun `create then find round-trips offered and requested instance sets`() {
+        val swordId = UUID.randomUUID()
+        val keyId = UUID.randomUUID()
+        val helmetId = UUID.randomUUID()
+        val offer = TradeOffer(
+            tradeId = UUID.randomUUID(),
+            offerer = offerer,
+            recipient = recipient,
+            offered = mapOf(wood to 1),
+            requested = emptyMap(),
+            status = TradeStatus.PENDING,
+            openedAtTick = 1L,
+            resolvedAtTick = null,
+            offeredInstances = setOf(swordId, keyId),
+            requestedInstances = setOf(helmetId),
+        )
+
+        store.create(offer)
+
+        val loaded = assertNotNull(store.find(offer.tradeId))
+        assertEquals(setOf(swordId, keyId), loaded.offeredInstances)
+        assertEquals(setOf(helmetId), loaded.requestedInstances)
+    }
+
+    @Test
+    fun `find on a row with empty instance sets returns empty sets, not null`() {
+        val offer = pending(mapOf(wood to 1), mapOf(stone to 1))
+        store.create(offer)
+
+        val loaded = assertNotNull(store.find(offer.tradeId))
+        assertEquals(emptySet(), loaded.offeredInstances)
+        assertEquals(emptySet(), loaded.requestedInstances)
+    }
+
     private fun pending(offered: Map<ItemId, Int>, requested: Map<ItemId, Int>) = TradeOffer(
         tradeId = UUID.randomUUID(),
         offerer = offerer,

--- a/world/economy/src/test/kotlin/dev/gvart/genesara/world/economy/internal/trade/TradeFlowIntegrationTest.kt
+++ b/world/economy/src/test/kotlin/dev/gvart/genesara/world/economy/internal/trade/TradeFlowIntegrationTest.kt
@@ -18,9 +18,11 @@ import dev.gvart.genesara.world.Climate
 import dev.gvart.genesara.world.Item
 import dev.gvart.genesara.world.ItemCategory
 import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemInstance
 import dev.gvart.genesara.world.ItemLookup
 import dev.gvart.genesara.world.Node
 import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Rarity
 import dev.gvart.genesara.world.Region
 import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.RelationshipLookup
@@ -34,6 +36,7 @@ import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.inventory.AgentInventory
 import dev.gvart.genesara.world.internal.jooq.tables.references.TRADE_OFFERS
+import dev.gvart.genesara.world.internal.testsupport.InMemoryAgentItemInstancesStore
 import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
 import dev.gvart.genesara.world.internal.worldstate.WorldState
@@ -94,6 +97,7 @@ class TradeFlowIntegrationTest {
     private val wood = ItemId("WOOD")
     private val stone = ItemId("STONE")
     private val items = StubItemLookup(mapOf(wood to itemFor(wood), stone to itemFor(stone)))
+    private val equipment = InMemoryAgentItemInstancesStore()
 
     @BeforeEach
     fun reset() {
@@ -114,7 +118,7 @@ class TradeFlowIntegrationTest {
         )
 
         val offerEvents = assertNotNull(
-            reduceTradeOffer(initial.body, initial.core, offerCommand, FixedBalance, items, TrustingRelationships, store, NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, tick = 1).getOrNull(),
+            reduceTradeOffer(initial.body, initial.core, offerCommand, FixedBalance, items, TrustingRelationships, store, NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, tick =1).getOrNull(),
         ).events
         val received = assertIs<EconomyEvent.TradeOfferReceived>(offerEvents.single())
         assertEquals(offerCommand.tradeId, received.tradeId)
@@ -128,7 +132,7 @@ class TradeFlowIntegrationTest {
             reduceTradeRespond(
                 initial.body, initial.core,
                 EconomyCommand.TradeRespond(agent = recipient, tradeId = offerCommand.tradeId, accept = true),
-                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, tick = 2,
+                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =2,
             ).getOrNull(),
         )
         val afterRespond = respondOut.sliceDelta
@@ -157,13 +161,13 @@ class TradeFlowIntegrationTest {
             offered = mapOf(wood to 2),
             requested = mapOf(stone to 2),
         )
-        reduceTradeOffer(initial.body, initial.core, offerCommand, FixedBalance, items, TrustingRelationships, store, NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, tick = 1)
+        reduceTradeOffer(initial.body, initial.core, offerCommand, FixedBalance, items, TrustingRelationships, store, NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, tick =1)
 
         val afterRespond = assertNotNull(
             reduceTradeRespond(
                 initial.body, initial.core,
                 EconomyCommand.TradeRespond(agent = recipient, tradeId = offerCommand.tradeId, accept = false),
-                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, tick = 2,
+                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =2,
             ).getOrNull(),
         ).sliceDelta
 
@@ -186,17 +190,59 @@ class TradeFlowIntegrationTest {
             offered = mapOf(wood to 1),
             requested = mapOf(stone to 1),
         )
-        reduceTradeOffer(initial.body, initial.core, offerCommand, FixedBalance, items, TrustingRelationships, store, NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, tick = 1)
+        reduceTradeOffer(initial.body, initial.core, offerCommand, FixedBalance, items, TrustingRelationships, store, NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, tick =1)
 
         // First respond resolves successfully.
         reduceTradeRespond(
             initial.body, initial.core, EconomyCommand.TradeRespond(recipient, offerCommand.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, tick = 2,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =2,
         )
 
         // Second respond sees the terminal row — forUpdate returns null, reducer falls
         // back to a TradeNotPending diagnosis from `find`.
         assertNull(store.findPendingForUpdate(offerCommand.tradeId))
+    }
+
+    @Test
+    fun `instance trade flow round-trips ownership through real trade_offers + equipment store`() {
+        val initial = bothAtSameNode(
+            offererInventory = mapOf(wood to 1),
+            recipientInventory = mapOf(stone to 1),
+        )
+        val sword = ItemInstance.Equipment(
+            instanceId = UUID.randomUUID(), agentId = offerer, itemId = wood,
+            rarity = Rarity.COMMON, durabilityCurrent = 10, durabilityMax = 10,
+            creatorAgentId = null, createdAtTick = 0L,
+        )
+        val helmet = ItemInstance.Equipment(
+            instanceId = UUID.randomUUID(), agentId = recipient, itemId = stone,
+            rarity = Rarity.COMMON, durabilityCurrent = 10, durabilityMax = 10,
+            creatorAgentId = null, createdAtTick = 0L,
+        )
+        equipment.seed(sword)
+        equipment.seed(helmet)
+
+        val offerCommand = EconomyCommand.TradeOffer(
+            agent = offerer, recipient = recipient,
+            offeredInstances = setOf(sword.instanceId),
+            requestedInstances = setOf(helmet.instanceId),
+        )
+        reduceTradeOffer(initial.body, initial.core, offerCommand, FixedBalance, items, TrustingRelationships, store, NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, tick = 1)
+
+        val persistedOffer = assertNotNull(store.find(offerCommand.tradeId))
+        assertEquals(setOf(sword.instanceId), persistedOffer.offeredInstances)
+        assertEquals(setOf(helmet.instanceId), persistedOffer.requestedInstances)
+
+        reduceTradeRespond(
+            initial.body, initial.core,
+            EconomyCommand.TradeRespond(recipient, offerCommand.tradeId, accept = true),
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2,
+        )
+
+        assertEquals(recipient, equipment.findById(sword.instanceId)?.agentId)
+        assertEquals(offerer, equipment.findById(helmet.instanceId)?.agentId)
+        val terminal = assertNotNull(store.find(offerCommand.tradeId))
+        assertEquals(TradeStatus.ACCEPTED, terminal.status)
     }
 
     private fun bothAtSameNode(

--- a/world/economy/src/test/kotlin/dev/gvart/genesara/world/economy/internal/trade/TradeReducerTest.kt
+++ b/world/economy/src/test/kotlin/dev/gvart/genesara/world/economy/internal/trade/TradeReducerTest.kt
@@ -22,12 +22,16 @@ import dev.gvart.genesara.world.BuildingStatus
 import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.EquipSlot
 import dev.gvart.genesara.world.Item
 import dev.gvart.genesara.world.ItemCategory
 import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemInstance
 import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.MountSlot
 import dev.gvart.genesara.world.Node
 import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Rarity
 import dev.gvart.genesara.world.Region
 import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.RelationshipLookup
@@ -43,10 +47,12 @@ import dev.gvart.genesara.world.events.EconomyEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.inventory.AgentInventory
+import dev.gvart.genesara.world.internal.testsupport.InMemoryAgentItemInstancesStore
 import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -77,6 +83,8 @@ class TradeReducerTest {
             stone to itemFor(stone),
         ),
     )
+
+    private val equipment = InMemoryAgentItemInstancesStore()
 
     // Override the production-tuned thresholds with small numbers so the trust-gate
     // tests can exercise both sides of the boundary with single-digit quantities.
@@ -141,7 +149,7 @@ class TradeReducerTest {
         )
 
         val out = assertNotNull(
-            reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,rel, store, NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, tick = 5).getOrNull(),
+            reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,rel, store, NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, tick =5).getOrNull(),
         )
         val next = out.sliceDelta
         val events = out.events
@@ -159,7 +167,7 @@ class TradeReducerTest {
     fun `offer rejects when recipient is the offerer`() {
         val command = EconomyCommand.TradeOffer(offerer, offerer, mapOf(wood to 1), mapOf(stone to 1))
 
-        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, 1)
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
 
         assertEquals(WorldRejection.CannotTradeWithSelf(offerer), result.leftOrNull())
     }
@@ -168,7 +176,7 @@ class TradeReducerTest {
     fun `offer rejects when both sides are empty`() {
         val command = EconomyCommand.TradeOffer(offerer, recipient, emptyMap(), emptyMap())
 
-        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, 1)
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
 
         assertEquals(WorldRejection.TradeOfferEmpty(offerer), result.leftOrNull())
     }
@@ -177,7 +185,7 @@ class TradeReducerTest {
     fun `offer rejects on non-positive quantity`() {
         val command = EconomyCommand.TradeOffer(offerer, recipient, mapOf(wood to 0), mapOf(stone to 1))
 
-        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, 1)
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
 
         assertEquals(WorldRejection.NonPositiveQuantity(offerer, 0), result.leftOrNull())
     }
@@ -189,7 +197,7 @@ class TradeReducerTest {
         val state = stateWith(recipientAt = otherNodeId)
         val result = reduceTradeOffer(
             state.body, state.core,
-            command, balance, items, FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, 1,
+            command, balance, items, FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1,
         )
 
         val rejection = assertIs<WorldRejection.TradePartnerNotInSameNode>(result.leftOrNull())
@@ -206,7 +214,7 @@ class TradeReducerTest {
         val state = stateWith(offererAt = null)
         val result = reduceTradeOffer(
             state.body, state.core,
-            command, balance, items, FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, 1,
+            command, balance, items, FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1,
         )
 
         assertEquals(WorldRejection.NotInWorld(offerer), result.leftOrNull())
@@ -216,7 +224,7 @@ class TradeReducerTest {
     fun `offer rejects when offered item is unknown to the catalog`() {
         val command = EconomyCommand.TradeOffer(offerer, recipient, mapOf(unknown to 1), mapOf(stone to 1))
 
-        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, 1)
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
 
         assertEquals(WorldRejection.UnknownItem(unknown), result.leftOrNull())
     }
@@ -225,7 +233,7 @@ class TradeReducerTest {
     fun `offer rejects when offerer lacks the offered stock`() {
         val command = EconomyCommand.TradeOffer(offerer, recipient, mapOf(wood to 99), mapOf(stone to 1))
 
-        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, 1)
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
 
         assertEquals(WorldRejection.ItemNotInInventory(offerer, wood), result.leftOrNull())
     }
@@ -236,7 +244,7 @@ class TradeReducerTest {
         // 4 + 4 = 8 > 5 triggers the gate; score 0 < 25 rejects.
         val command = EconomyCommand.TradeOffer(offerer, recipient, mapOf(wood to 4), mapOf(stone to 4))
 
-        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(0), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, 1)
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(0), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
 
         val rejection = assertIs<WorldRejection.InsufficientTrust>(result.leftOrNull())
         assertEquals(8, rejection.value)
@@ -249,7 +257,7 @@ class TradeReducerTest {
     fun `trust gate passes when relationship clears the threshold`() {
         val command = EconomyCommand.TradeOffer(offerer, recipient, mapOf(wood to 4), mapOf(stone to 4))
 
-        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(50), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, 1)
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(50), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
 
         assertNotNull(result.getOrNull())
     }
@@ -259,7 +267,7 @@ class TradeReducerTest {
         // value = 5 == threshold; not strictly greater so gate doesn't engage.
         val command = EconomyCommand.TradeOffer(offerer, recipient, mapOf(wood to 3), mapOf(stone to 2))
 
-        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(0), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, 1)
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(0), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
 
         assertNotNull(result.getOrNull())
     }
@@ -282,7 +290,7 @@ class TradeReducerTest {
         val out = assertNotNull(
             reduceTradeRespond(
                 stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, tick = 9,
+                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =9,
             ).getOrNull(),
         )
         val next = out.sliceDelta
@@ -307,7 +315,7 @@ class TradeReducerTest {
         val out = assertNotNull(
             reduceTradeRespond(
                 stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = false),
-                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, tick = 4,
+                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =4,
             ).getOrNull(),
         )
         val next = out.sliceDelta
@@ -325,7 +333,7 @@ class TradeReducerTest {
 
         val result = reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, phantom, accept = true),
-            items, FakeTradeStore(), NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, tick = 1,
+            items, FakeTradeStore(), NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =1,
         )
 
         assertEquals(WorldRejection.TradeNotFound(phantom), result.leftOrNull())
@@ -341,7 +349,7 @@ class TradeReducerTest {
 
         val result = reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, tick = 2,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =2,
         )
 
         assertEquals(
@@ -359,7 +367,7 @@ class TradeReducerTest {
 
         val result = reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(interloper, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, tick = 1,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =1,
         )
 
         assertEquals(WorldRejection.NotTradeRecipient(interloper, trade.tradeId), result.leftOrNull())
@@ -376,7 +384,7 @@ class TradeReducerTest {
         val result = reduceTradeRespond(
             state.body, state.core,
             EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, tick = 1,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =1,
         )
 
         val rejection = assertIs<WorldRejection.TradePartnerNotInSameNode>(result.leftOrNull())
@@ -393,7 +401,7 @@ class TradeReducerTest {
 
         val result = reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, tick = 1,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =1,
         )
 
         assertEquals(WorldRejection.ItemNotInInventory(offerer, wood), result.leftOrNull())
@@ -407,7 +415,7 @@ class TradeReducerTest {
 
         val result = reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, tick = 1,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =1,
         )
 
         assertEquals(WorldRejection.ItemNotInInventory(recipient, stone), result.leftOrNull())
@@ -423,11 +431,288 @@ class TradeReducerTest {
         val result = reduceTradeRespond(
             state.body, state.core,
             EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = false),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, tick = 1,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =1,
         )
 
         assertTrue(result.isRight(), "rejecting should succeed even when the offerer wandered off")
         assertEquals(TradeStatus.REJECTED, store.byId(trade.tradeId)?.status)
+    }
+
+    // ─────────────────────── instance trading ───────────────────────
+
+    @Test
+    fun `offer with instance succeeds — instance UUIDs persisted and event carries them`() {
+        val store = FakeTradeStore()
+        val sword = equipment(owner = offerer)
+        val helmet = equipment(owner = recipient)
+
+        val command = EconomyCommand.TradeOffer(
+            agent = offerer, recipient = recipient,
+            offeredInstances = setOf(sword.instanceId),
+            requestedInstances = setOf(helmet.instanceId),
+        )
+
+        val out = assertNotNull(
+            reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items, FakeRelationships(), store, NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, tick = 1).getOrNull(),
+        )
+        val persisted = assertNotNull(store.byId(command.tradeId))
+        assertEquals(setOf(sword.instanceId), persisted.offeredInstances)
+        assertEquals(setOf(helmet.instanceId), persisted.requestedInstances)
+        val received = assertIs<EconomyEvent.TradeOfferReceived>(out.events.single())
+        assertEquals(setOf(sword.instanceId), received.offeredInstances)
+        assertEquals(setOf(helmet.instanceId), received.requestedInstances)
+    }
+
+    @Test
+    fun `offer rejects when an offered instance UUID does not resolve`() {
+        val phantom = UUID.randomUUID()
+        val command = EconomyCommand.TradeOffer(
+            agent = offerer, recipient = recipient,
+            offeredInstances = setOf(phantom),
+        )
+
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items, FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
+
+        assertEquals(WorldRejection.TradeInstanceUnavailable(offerer, phantom), result.leftOrNull())
+    }
+
+    @Test
+    fun `offer rejects when an offered instance is owned by someone else — without leaking the owner`() {
+        val notMine = equipment(owner = recipient)
+        val command = EconomyCommand.TradeOffer(
+            agent = offerer, recipient = recipient,
+            offeredInstances = setOf(notMine.instanceId),
+        )
+
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items, FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
+
+        assertEquals(
+            WorldRejection.TradeInstanceUnavailable(offerer, notMine.instanceId),
+            result.leftOrNull(),
+        )
+    }
+
+    @Test
+    fun `offer rejects when offered equipment is currently equipped in an agent slot`() {
+        val sword = equipment(owner = offerer, equippedInSlot = EquipSlot.MAIN_HAND)
+        val command = EconomyCommand.TradeOffer(
+            agent = offerer, recipient = recipient,
+            offeredInstances = setOf(sword.instanceId),
+        )
+
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items, FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
+
+        assertEquals(
+            WorldRejection.TradeInstanceBound(
+                offerer, sword.instanceId, WorldRejection.TradeInstanceBound.Reason.EQUIPPED_BY_AGENT,
+            ),
+            result.leftOrNull(),
+        )
+    }
+
+    @Test
+    fun `offer rejects when offered mount gear is equipped on a mount`() {
+        val mountId = UUID.randomUUID()
+        val saddle = mountGear(owner = offerer, equippedOnMount = mountId, mountSlot = MountSlot.SADDLE)
+        val command = EconomyCommand.TradeOffer(
+            agent = offerer, recipient = recipient,
+            offeredInstances = setOf(saddle.instanceId),
+        )
+
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items, FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
+
+        assertEquals(
+            WorldRejection.TradeInstanceBound(
+                offerer, saddle.instanceId, WorldRejection.TradeInstanceBound.Reason.EQUIPPED_ON_MOUNT,
+            ),
+            result.leftOrNull(),
+        )
+    }
+
+    @Test
+    fun `offer rejects when offered instance is stowed in a mount`() {
+        val mountId = UUID.randomUUID()
+        val item = equipment(owner = offerer, stowedInMountId = mountId)
+        val command = EconomyCommand.TradeOffer(
+            agent = offerer, recipient = recipient,
+            offeredInstances = setOf(item.instanceId),
+        )
+
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items, FakeRelationships(), FakeTradeStore(), NoBuildingsLookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
+
+        assertEquals(
+            WorldRejection.TradeInstanceBound(
+                offerer, item.instanceId, WorldRejection.TradeInstanceBound.Reason.STOWED_ON_MOUNT,
+            ),
+            result.leftOrNull(),
+        )
+    }
+
+    @Test
+    fun `respond accept reassigns instance owners atomically and emits instance sets`() {
+        val sword = equipment(owner = offerer)
+        val helmet = equipment(owner = recipient)
+        val store = FakeTradeStore()
+        store.create(
+            TradeOffer(
+                tradeId = UUID.randomUUID(),
+                offerer = offerer, recipient = recipient,
+                offered = emptyMap(), requested = emptyMap(),
+                status = TradeStatus.PENDING, openedAtTick = 1, resolvedAtTick = null,
+                offeredInstances = setOf(sword.instanceId),
+                requestedInstances = setOf(helmet.instanceId),
+            ),
+        )
+        val trade = store.allByStatus(TradeStatus.PENDING).single()
+
+        val out = assertNotNull(
+            reduceTradeRespond(
+                stateWith().body, stateWith().core,
+                EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
+                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2,
+            ).getOrNull(),
+        )
+
+        assertEquals(recipient, equipment.findById(sword.instanceId)?.agentId, "sword moves to recipient")
+        assertEquals(offerer, equipment.findById(helmet.instanceId)?.agentId, "helmet moves to offerer")
+        assertEquals(TradeStatus.ACCEPTED, store.byId(trade.tradeId)?.status)
+        val accepted = assertIs<EconomyEvent.TradeAccepted>(out.events.single())
+        assertEquals(setOf(sword.instanceId), accepted.offeredInstances)
+        assertEquals(setOf(helmet.instanceId), accepted.requestedInstances)
+    }
+
+    @Test
+    fun `respond rejects when offered instance was equipped between offer and respond`() {
+        val sword = equipment(owner = offerer)
+        val store = FakeTradeStore()
+        store.create(
+            TradeOffer(
+                tradeId = UUID.randomUUID(),
+                offerer = offerer, recipient = recipient,
+                offered = emptyMap(), requested = emptyMap(),
+                status = TradeStatus.PENDING, openedAtTick = 1, resolvedAtTick = null,
+                offeredInstances = setOf(sword.instanceId),
+            ),
+        )
+        val trade = store.allByStatus(TradeStatus.PENDING).single()
+        equipment.seed(sword.copy(equippedInSlot = EquipSlot.MAIN_HAND))
+
+        val result = reduceTradeRespond(
+            stateWith().body, stateWith().core,
+            EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2,
+        )
+
+        assertEquals(
+            WorldRejection.TradeInstanceBound(
+                recipient, sword.instanceId, WorldRejection.TradeInstanceBound.Reason.EQUIPPED_BY_AGENT,
+            ),
+            result.leftOrNull(),
+        )
+        assertEquals(TradeStatus.PENDING, store.byId(trade.tradeId)?.status, "trade stays open for retry")
+    }
+
+    @Test
+    fun `respond rejects when recipient no longer owns a requested instance`() {
+        val helmet = equipment(owner = recipient)
+        val store = FakeTradeStore()
+        store.create(
+            TradeOffer(
+                tradeId = UUID.randomUUID(),
+                offerer = offerer, recipient = recipient,
+                offered = emptyMap(), requested = emptyMap(),
+                status = TradeStatus.PENDING, openedAtTick = 1, resolvedAtTick = null,
+                requestedInstances = setOf(helmet.instanceId),
+            ),
+        )
+        val trade = store.allByStatus(TradeStatus.PENDING).single()
+        equipment.seed(helmet.copy(agentId = offerer))
+
+        val result = reduceTradeRespond(
+            stateWith().body, stateWith().core,
+            EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2,
+        )
+
+        assertEquals(
+            WorldRejection.TradeInstanceUnavailable(recipient, helmet.instanceId),
+            result.leftOrNull(),
+        )
+    }
+
+    @Test
+    fun `respond throws (forcing tick rollback) when reassignOwner returns null after pre-validation`() {
+        // Simulates a concurrent writer flipping an instance row between
+        // validateInstancesTransferable and reassignOwner: pre-validation passes
+        // (sword is owned, unbound) but the UPDATE returns null. The half-applied
+        // hazard means we MUST throw rather than raise, so Spring rolls the tick
+        // back instead of committing the prior already-flipped instance.
+        val sword = equipment(owner = offerer)
+        val racingEquipment = object : InMemoryAgentItemInstancesStore() {
+            override fun reassignOwner(instanceId: UUID, fromAgent: AgentId, toAgent: AgentId): ItemInstance? = null
+        }
+        racingEquipment.seed(sword)
+        val store = FakeTradeStore()
+        store.create(
+            TradeOffer(
+                tradeId = UUID.randomUUID(),
+                offerer = offerer, recipient = recipient,
+                offered = emptyMap(), requested = emptyMap(),
+                status = TradeStatus.PENDING, openedAtTick = 1, resolvedAtTick = null,
+                offeredInstances = setOf(sword.instanceId),
+            ),
+        )
+        val trade = store.allByStatus(TradeStatus.PENDING).single()
+
+        assertFailsWith<IllegalStateException> {
+            reduceTradeRespond(
+                stateWith().body, stateWith().core,
+                EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
+                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, racingEquipment, tick = 2,
+            )
+        }
+    }
+
+    private fun equipment(
+        owner: AgentId,
+        equippedInSlot: EquipSlot? = null,
+        stowedInMountId: UUID? = null,
+    ): ItemInstance.Equipment {
+        val instance = ItemInstance.Equipment(
+            instanceId = UUID.randomUUID(),
+            agentId = owner,
+            itemId = wood,
+            rarity = Rarity.COMMON,
+            durabilityCurrent = 10,
+            durabilityMax = 10,
+            creatorAgentId = null,
+            createdAtTick = 0L,
+            equippedInSlot = equippedInSlot,
+            stowedInMountId = stowedInMountId,
+        )
+        equipment.seed(instance)
+        return instance
+    }
+
+    private fun mountGear(
+        owner: AgentId,
+        equippedOnMount: UUID? = null,
+        mountSlot: MountSlot? = null,
+    ): ItemInstance.MountGear {
+        val instance = ItemInstance.MountGear(
+            instanceId = UUID.randomUUID(),
+            agentId = owner,
+            itemId = wood,
+            rarity = Rarity.COMMON,
+            durabilityCurrent = 10,
+            durabilityMax = 10,
+            creatorAgentId = null,
+            createdAtTick = 0L,
+            equippedOnMount = equippedOnMount,
+            equippedMountSlot = mountSlot,
+        )
+        equipment.seed(instance)
+        return instance
     }
 
     private fun pending(offered: Map<ItemId, Int>, requested: Map<ItemId, Int>) = TradeOffer(
@@ -520,7 +805,7 @@ class TradeReducerTest {
         val command = EconomyCommand.TradeOffer(offerer, recipient, mapOf(wood to 4), mapOf(stone to 4))
         val lookup = WithBuildingsLookup(listOf(tradingPost(nodeId, BuildingStatus.ACTIVE)))
 
-        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(0), FakeTradeStore(), lookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, 1)
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(0), FakeTradeStore(), lookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
 
         assertNotNull(result.getOrNull())
     }
@@ -531,7 +816,7 @@ class TradeReducerTest {
         val command = EconomyCommand.TradeOffer(offerer, recipient, mapOf(wood to 6), mapOf(stone to 6))
         val lookup = WithBuildingsLookup(listOf(tradingPost(nodeId, BuildingStatus.ACTIVE)))
 
-        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(0), FakeTradeStore(), lookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, 1)
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(0), FakeTradeStore(), lookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
 
         val rejection = assertIs<WorldRejection.InsufficientTrust>(result.leftOrNull())
         assertEquals(12, rejection.value)
@@ -544,7 +829,7 @@ class TradeReducerTest {
         val command = EconomyCommand.TradeOffer(offerer, recipient, mapOf(wood to 4), mapOf(stone to 4))
         val lookup = WithBuildingsLookup(listOf(tradingPost(nodeId, BuildingStatus.UNDER_CONSTRUCTION)))
 
-        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(0), FakeTradeStore(), lookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, 1)
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(0), FakeTradeStore(), lookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
 
         assertIs<WorldRejection.InsufficientTrust>(result.leftOrNull())
     }
@@ -555,7 +840,7 @@ class TradeReducerTest {
         val command = EconomyCommand.TradeOffer(offerer, recipient, mapOf(wood to 4), mapOf(stone to 4))
         val lookup = WithBuildingsLookup(listOf(tradingPost(otherNodeId, BuildingStatus.ACTIVE)))
 
-        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(0), FakeTradeStore(), lookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, 1)
+        val result = reduceTradeOffer(stateWith().body, stateWith().core, command, balance, items,FakeRelationships(0), FakeTradeStore(), lookup, PassiveAuraAggregator.NoAura, LevelScalingAggregator.NoScaling, equipment, 1)
 
         assertIs<WorldRejection.InsufficientTrust>(result.leftOrNull())
     }
@@ -575,7 +860,7 @@ class TradeReducerTest {
 
         reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, SkillProgression(skills, publisher), NoAgents, tick = 7,
+            items, store, NoOpTriggeredPassiveDispatcher, SkillProgression(skills, publisher), NoAgents, equipment, tick =7,
         )
 
         val recommended = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>()
@@ -595,7 +880,7 @@ class TradeReducerTest {
 
         reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, SkillProgression(skills, RecordingPublisher()), NoAgents, tick = 7,
+            items, store, NoOpTriggeredPassiveDispatcher, SkillProgression(skills, RecordingPublisher()), NoAgents, equipment, tick =7,
         )
 
         assertEquals(listOf(offerer to 1, recipient to 1), skills.xpAddCalls.map { (a, _, d) -> a to d })
@@ -614,7 +899,7 @@ class TradeReducerTest {
 
         reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = false),
-            items, store, NoOpTriggeredPassiveDispatcher, SkillProgression(skills, RecordingPublisher()), NoAgents, tick = 7,
+            items, store, NoOpTriggeredPassiveDispatcher, SkillProgression(skills, RecordingPublisher()), NoAgents, equipment, tick =7,
         )
 
         assertTrue(skills.xpAddCalls.isEmpty(), "reject should not grant any XP")

--- a/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/instances/JooqAgentItemInstancesStore.kt
+++ b/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/instances/JooqAgentItemInstancesStore.kt
@@ -231,6 +231,20 @@ internal class JooqAgentItemInstancesStore(
             ?.into(AGENT_ITEM_INSTANCES)
             ?.let(::toDomain)
 
+    @Transactional
+    override fun reassignOwner(instanceId: UUID, fromAgent: AgentId, toAgent: AgentId): ItemInstance? =
+        dsl.update(AGENT_ITEM_INSTANCES)
+            .set(AGENT_ITEM_INSTANCES.AGENT_ID, toAgent.id)
+            .where(AGENT_ITEM_INSTANCES.INSTANCE_ID.eq(instanceId))
+            .and(AGENT_ITEM_INSTANCES.AGENT_ID.eq(fromAgent.id))
+            .and(AGENT_ITEM_INSTANCES.EQUIPPED_IN_SLOT.isNull)
+            .and(AGENT_ITEM_INSTANCES.EQUIPPED_ON_MOUNT_ID.isNull)
+            .and(AGENT_ITEM_INSTANCES.STOWED_IN_MOUNT_ID.isNull)
+            .returningResult(AGENT_ITEM_INSTANCES.asterisk())
+            .fetchOne()
+            ?.into(AGENT_ITEM_INSTANCES)
+            ?.let(::toDomain)
+
     @Transactional(readOnly = true)
     override fun byStowedOnMount(mountId: MountId): List<ItemInstance> =
         dsl.selectFrom(AGENT_ITEM_INSTANCES)
@@ -282,6 +296,7 @@ internal class JooqAgentItemInstancesStore(
         creatorAgentId = record.creatorAgentId?.let(::AgentId),
         createdAtTick = record.createdAtTick,
         equippedInSlot = record.equippedInSlot?.let(EquipSlot::valueOf),
+        stowedInMountId = record.stowedInMountId,
     )
 
     private fun toKey(
@@ -292,6 +307,7 @@ internal class JooqAgentItemInstancesStore(
         itemId = ItemId(record.itemId),
         gateInstanceId = requireNotNull(record.boundBuildingId) { "KEY row ${record.instanceId} missing bound_building_id" },
         createdAtTick = record.createdAtTick,
+        stowedInMountId = record.stowedInMountId,
     )
 
     private fun toMountGear(
@@ -307,5 +323,6 @@ internal class JooqAgentItemInstancesStore(
         createdAtTick = record.createdAtTick,
         equippedOnMount = record.equippedOnMountId,
         equippedMountSlot = record.equippedMountSlot?.let(MountSlot::valueOf),
+        stowedInMountId = record.stowedInMountId,
     )
 }

--- a/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/instances/JooqAgentItemInstancesStoreReassignOwnerIntegrationTest.kt
+++ b/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/instances/JooqAgentItemInstancesStoreReassignOwnerIntegrationTest.kt
@@ -1,0 +1,180 @@
+package dev.gvart.genesara.world.environment.internal.instances
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemInstance
+import dev.gvart.genesara.world.Mount
+import dev.gvart.genesara.world.MountId
+import dev.gvart.genesara.world.MountSlot
+import dev.gvart.genesara.world.MountType
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Rarity
+import dev.gvart.genesara.world.environment.internal.mount.JooqMountInstanceStore
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_ITEM_INSTANCES
+import dev.gvart.genesara.world.internal.jooq.tables.references.MOUNTS
+import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@Testcontainers
+class JooqAgentItemInstancesStoreReassignOwnerIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("item_instances_reassign_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = WorldFlyway.pooledDataSource(postgres)
+            WorldFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private lateinit var store: JooqAgentItemInstancesStore
+    private lateinit var mounts: JooqMountInstanceStore
+    private val from = AgentId(UUID.randomUUID())
+    private val to = AgentId(UUID.randomUUID())
+    private val mountId = MountId(UUID.randomUUID())
+
+    @BeforeEach
+    fun reset() {
+        dsl.truncate(AGENT_ITEM_INSTANCES).cascade().execute()
+        dsl.truncate(MOUNTS).cascade().execute()
+        store = JooqAgentItemInstancesStore(dsl)
+        mounts = JooqMountInstanceStore(dsl)
+        mounts.insert(sampleMount(mountId))
+    }
+
+    @Test
+    fun `reassignOwner flips agent_id on an unbound instance`() {
+        val instance = equipment(from)
+        store.insert(instance)
+
+        val updated = assertNotNull(store.reassignOwner(instance.instanceId, from, to))
+
+        assertEquals(to, updated.agentId)
+        assertEquals(to.id, currentAgentId(instance.instanceId))
+    }
+
+    @Test
+    fun `reassignOwner rejects when the instance does not exist`() {
+        val phantom = UUID.randomUUID()
+        assertNull(store.reassignOwner(phantom, from, to))
+    }
+
+    @Test
+    fun `reassignOwner rejects when the from-agent does not match the row owner`() {
+        val instance = equipment(from)
+        store.insert(instance)
+
+        assertNull(store.reassignOwner(instance.instanceId, to, from))
+        assertEquals(from.id, currentAgentId(instance.instanceId))
+    }
+
+    @Test
+    fun `reassignOwner rejects when the instance is currently equipped in a slot`() {
+        val instance = equipment(from, slot = EquipSlot.MAIN_HAND)
+        store.insert(instance)
+
+        assertNull(store.reassignOwner(instance.instanceId, from, to))
+        assertEquals(from.id, currentAgentId(instance.instanceId))
+    }
+
+    @Test
+    fun `reassignOwner rejects when the instance is equipped on a mount`() {
+        val gear = mountGear(from, equippedOnMount = mountId, slot = MountSlot.SADDLE)
+        store.insert(gear)
+
+        assertNull(store.reassignOwner(gear.instanceId, from, to))
+        assertEquals(from.id, currentAgentId(gear.instanceId))
+    }
+
+    @Test
+    fun `reassignOwner rejects when the instance is stowed on a mount`() {
+        val instance = equipment(from)
+        store.insert(instance)
+        store.stowOnMount(instance.instanceId, from, mountId)
+
+        assertNull(store.reassignOwner(instance.instanceId, from, to))
+        assertEquals(from.id, currentAgentId(instance.instanceId))
+    }
+
+    private fun currentAgentId(instanceId: UUID): UUID? =
+        dsl.select(AGENT_ITEM_INSTANCES.AGENT_ID)
+            .from(AGENT_ITEM_INSTANCES)
+            .where(AGENT_ITEM_INSTANCES.INSTANCE_ID.eq(instanceId))
+            .fetchOne(AGENT_ITEM_INSTANCES.AGENT_ID)
+
+    private fun equipment(agent: AgentId, slot: EquipSlot? = null): ItemInstance.Equipment =
+        ItemInstance.Equipment(
+            instanceId = UUID.randomUUID(),
+            agentId = agent,
+            itemId = ItemId("IRON_SWORD"),
+            rarity = Rarity.COMMON,
+            durabilityCurrent = 50,
+            durabilityMax = 100,
+            creatorAgentId = null,
+            createdAtTick = 1L,
+            equippedInSlot = slot,
+        )
+
+    private fun mountGear(
+        agent: AgentId,
+        equippedOnMount: MountId? = null,
+        slot: MountSlot? = null,
+    ): ItemInstance.MountGear = ItemInstance.MountGear(
+        instanceId = UUID.randomUUID(),
+        agentId = agent,
+        itemId = ItemId("LEATHER_SADDLE"),
+        rarity = Rarity.COMMON,
+        durabilityCurrent = 50,
+        durabilityMax = 100,
+        creatorAgentId = null,
+        createdAtTick = 1L,
+        equippedOnMount = equippedOnMount?.value,
+        equippedMountSlot = slot,
+    )
+
+    private fun sampleMount(id: MountId): Mount = Mount(
+        id = id,
+        type = MountType("RIDING_HORSE"),
+        nodeId = NodeId(1L),
+        hpCurrent = 80,
+        hpMax = 80,
+        hunger = 100,
+        hungerMax = 100,
+        fatigue = 100,
+        fatigueMax = 100,
+        mountedByAgentId = null,
+        tamedAtTick = 100L,
+    )
+}

--- a/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/mount/MountCargoServiceImplTest.kt
+++ b/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/mount/MountCargoServiceImplTest.kt
@@ -434,6 +434,7 @@ private class FakeInstancesStore(
     override fun byStowedOnMount(mountId: MountId): List<ItemInstance> =
         stowedOn.filterValues { it == mountId }.keys.mapNotNull { rows[it] }
     override fun gearOnMount(mountId: MountId, slot: MountSlot): ItemInstance.MountGear? = harness[slot]
+    override fun reassignOwner(instanceId: UUID, fromAgent: AgentId, toAgent: AgentId): ItemInstance? = null
 }
 
 private open class StubWorldQueryGateway : WorldQueryGateway {

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -203,11 +203,12 @@ fun reduce(
     is EconomyCommand.TradeOffer ->
         reduceTradeOffer(
             state.body, state.core, command, balance, items, relationships, tradeStore,
-            buildingsLookup, passiveAura, scaling, tick,
+            buildingsLookup, passiveAura, scaling, itemInstances, tick,
         ).map { out -> state.copy(body = out.sliceDelta).applyEffects(out.effects) to out.events }
     is EconomyCommand.TradeRespond ->
         reduceTradeRespond(
-            state.body, state.core, command, items, tradeStore, triggeredPassives, progression, agents, tick,
+            state.body, state.core, command, items, tradeStore, triggeredPassives, progression, agents,
+            itemInstances, tick,
         ).map { out -> state.copy(body = out.sliceDelta).applyEffects(out.effects) to out.events }
     is EconomyCommand.PlantCrop ->
         reducePlantCrop(state.body, state.core, command, crops, plots, agents, skills, progression, behaviorTracker, tick)


### PR DESCRIPTION
Closes #190.

## Summary
- Extends `EconomyCommand.TradeOffer` and the persisted `TradeOffer` with `offered/requestedInstances: Set<UUID>` (defaulted empty → additive wire-compat).
- Adds atomic `AgentItemInstancesStore.reassignOwner(instanceId, fromAgent, toAgent)` — single `UPDATE` fenced by `agent_id = ? AND equipped_in_slot IS NULL AND equipped_on_mount_id IS NULL AND stowed_in_mount_id IS NULL`. Domain `ItemInstance` now surfaces `stowedInMountId` (the V27 column was previously unread).
- Respond reducer pre-validates both sides under the existing `forUpdate` trade lock, then loops `reassignOwner`. A post-validation null return throws (forces `@Transactional` rollback) so a half-applied swap can't commit.
- Rejections: `TradeInstanceUnavailable(actor, instanceId)` collapses "not found" + "not owned" (anti-probe per design principle #7). `TradeInstanceBound(reason)` discriminates `EQUIPPED_BY_AGENT` / `EQUIPPED_ON_MOUNT` / `STOWED_ON_MOUNT`.
- V30 migration adds `offered_instances` + `requested_instances` JSONB columns with `'[]'::jsonb` defaults — existing PENDING rows decode cleanly post-migration.
- MCP `trade_offer` tool gains optional `offerInstances` / `requestInstances` UUID-list params, capped at 32 per side.

## Out of scope
Per #190 body: auction houses, multi-party trades. Mount-itself trading also out of scope — mounts are world-owned (`Mount.kt:12-15`), no per-agent ownership exists to transfer. `MountGear` instances (saddle, barding, harness) trade as any other `ItemInstance`.

## Test plan
- [x] `:world:economy:test` — unit (`TradeReducerTest` +9 cases inc. half-applied rollback canary)
- [x] `:world:economy:test` — integration (`TradeFlowIntegrationTest` end-to-end instance swap, `JooqTradeStoreIntegrationTest` V30 JSONB round-trip)
- [x] `:world:environment:test` — `JooqAgentItemInstancesStoreReassignOwnerIntegrationTest` covers all five reject paths against real Postgres
- [x] `:api:test`, `:world:test`, `:world:body:test`, `:world:combat:test`, `:world:core:test` — full suite green
- [x] Live MCP playtest with two real agents driving `trade_offer` (bob) + `trade_respond` (alice) — confirmed `agent_id` flipped end-to-end in DB