### PR TITLE
fix(api): route AgentAttackedNpc and NpcDied to the agent event stream

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -120,6 +120,15 @@ internal class AgentEventDispatcher(
     }
 
     @EventListener
+    fun on(event: CombatEvent.AgentAttackedNpc) = publish(event.attacker, "agent.attacked_npc", event)
+
+    @EventListener
+    fun on(event: EnvironmentEvent.NpcDied) {
+        val killer = event.killedBy ?: return
+        publish(killer, "npc.died", event)
+    }
+
+    @EventListener
     fun on(event: BodyEvent.AgentDied) = publish(event.agent, "agent.died", event)
 
     @EventListener

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
@@ -264,6 +264,75 @@ class AgentEventDispatcherTest {
     }
 
     @Test
+    fun `AgentAttackedNpc lands on the attacker's stream`() {
+        val cmdId = UUID.randomUUID()
+        val event = CombatEvent.AgentAttackedNpc(
+            attacker = agent,
+            npc = dev.gvart.genesara.world.NpcId(UUID.randomUUID()),
+            npcType = dev.gvart.genesara.world.NpcType("WILD_HORSE"),
+            at = NodeId(1L),
+            damageType = DamageType.BLUNT,
+            baseDamage = 12,
+            hpLost = 12,
+            isCrit = false,
+            isDodged = false,
+            npcHpAfter = 28,
+            npcKilled = false,
+            tick = 7,
+            causedBy = cmdId,
+        )
+
+        dispatcher.on(event)
+
+        val entry = log.since(agent, 0).single()
+        assertEquals("agent.attacked_npc", entry.type)
+        assertEquals(7L, entry.tick)
+        assertEquals(12, entry.payload.get("baseDamage").asInt())
+        assertEquals(cmdId.toString(), entry.payload.get("causedBy").asString())
+    }
+
+    @Test
+    fun `NpcDied lands on the killer's stream when killedBy is set`() {
+        val killer = AgentId(UUID.randomUUID())
+        val cmdId = UUID.randomUUID()
+        val event = EnvironmentEvent.NpcDied(
+            npc = dev.gvart.genesara.world.NpcId(UUID.randomUUID()),
+            npcType = dev.gvart.genesara.world.NpcType("WILD_HORSE"),
+            at = NodeId(1L),
+            killedBy = killer,
+            drops = emptyList(),
+            tick = 8,
+            causedBy = cmdId,
+        )
+
+        dispatcher.on(event)
+
+        val entry = log.since(killer, 0).single()
+        assertEquals("npc.died", entry.type)
+        assertEquals(8L, entry.tick)
+    }
+
+    @Test
+    fun `NpcDied with null killedBy is silently skipped`() {
+        // Today every NPC death is agent-caused, so killedBy is always set in production.
+        // The dispatcher still guards against a future non-agent death cause (e.g. NPC vs NPC,
+        // environmental hazard) by skipping the publish rather than routing nowhere.
+        val event = EnvironmentEvent.NpcDied(
+            npc = dev.gvart.genesara.world.NpcId(UUID.randomUUID()),
+            npcType = dev.gvart.genesara.world.NpcType("WILD_HORSE"),
+            at = NodeId(1L),
+            killedBy = null,
+            drops = emptyList(),
+            tick = 9,
+            causedBy = null,
+        )
+
+        dispatcher.on(event)
+
+        assertEquals(0, log.since(agent, 0).size)
+    }
+
+    @Test
     fun `AgentDied lands on the dying agent's stream`() {
         val cmdId = UUID.randomUUID()
         val event = BodyEvent.AgentDied(


### PR DESCRIPTION
## Summary
- `AgentEventDispatcher` had no `@EventListener` for `CombatEvent.AgentAttackedNpc` or `EnvironmentEvent.NpcDied`, so NPC-combat events died on the Spring bus and never reached the per-agent SSE log.
- Discovered during a live playtest of party-v1 (#194): queued NPC attacks returned QUEUED but produced no `agent.attacked_npc` event. `AttackTool`'s own docstring promises that event arrives on the stream, so this was a contract gap.
- Mirrors precedent set by #137 (`fix(api): wire missing WorldEvent dispatchers`).

## Behavior changes
- **`CombatEvent.AgentAttackedNpc`** → attacker's stream as `agent.attacked_npc` (carries `baseDamage`, `hpLost`, `isCrit`, `isDodged`, `npcHpAfter`, `npcKilled`, `causedBy`).
- **`EnvironmentEvent.NpcDied`** → killer's stream as `npc.died` when `killedBy != null`. `killedBy == null` paths (no agent attribution, e.g. future non-agent death causes) are silently skipped — no routing target.

## Deliberately not routed
- `EnvironmentEvent.NpcMoved` (PASSIVE flee) — payload has no agent. Spectator routing would need a vision lookup the dispatcher doesn't own; lands with the spectator-vision slice instead.

## Test plan
- [x] `:api:test --tests *AgentEventDispatcherTest*` — added 3 new tests (`AgentAttackedNpc` happy path, `NpcDied` happy path, `NpcDied` null-killer skip), all green.
- [x] Existing dispatcher tests still pass.
- [ ] Manual playtest: queue `attack(npc:<id>)`, confirm `agent.attacked_npc` envelope appears on the SSE stream with the right `causedBy`.