### PR TITLE
feat(world,api,player): phase 2 PvP — outlaw state machine + green-zone enforcement (#17)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -231,6 +231,11 @@ internal class AgentEventDispatcher(
         event.listeners.forEach { listener -> publish(listener, "party.dissolved", event) }
     }
 
+    @EventListener
+    fun on(event: SocialEvent.OutlawStateChanged) {
+        event.listeners.forEach { listener -> publish(listener, "outlaw.state_changed", event) }
+    }
+
     private fun publish(agent: AgentId, type: String, payload: Any) {
         val tick = (payload as? WorldEvent)?.tick
             ?: (payload as? AgentEvent)?.tick

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
@@ -340,6 +340,7 @@ internal class InspectTool(
             activeEffects = activeEffects,
             authority = if (showReputation) target.authority else null,
             fame = if (showReputation) target.fame else null,
+            outlawState = if (showReputation) target.outlawState.name else null,
         )
     }
 

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
@@ -137,6 +137,8 @@ data class AgentInspectView(
     val authority: Int? = null,
     /** DETAILED+: global fame. Below `BalanceLookup.fameWitnessProtectionThreshold` the agent has no PvP protection — visible context for any nearby attacker. */
     val fame: Int? = null,
+    /** DETAILED+: outlaw bucket (mechanics-reference §11). One of CLEAN / WATCHED / OUTLAW. Phase 3 NPC behaviors will gate on this. */
+    val outlawState: String? = null,
 )
 
 /**

--- a/player/src/main/kotlin/dev/gvart/genesara/player/Agent.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/Agent.kt
@@ -32,6 +32,10 @@ data class Agent(
     val authority: Int = 0,
     /** Mechanics-reference §19 Fame. Below `BalanceLookup.fameWitnessProtectionThreshold` strips PvP protection. */
     val fame: Int = 0,
+    /** Mechanics-reference §11 outlaw status. Denormalized from [outlawMisconductScore] by the registry. */
+    val outlawState: OutlawState = OutlawState.CLEAN,
+    /** Raw misconduct score. Decayed by the world-tick sweep. Schema enforces `>= 0`. */
+    val outlawMisconductScore: Int = 0,
 )
 
 /**

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
@@ -146,6 +146,49 @@ interface AgentRegistry {
     /** Atomic clamp-add on `agents.fame` under a `forUpdate` row lock. Returns null for an unknown agent. */
     fun adjustFame(agentId: AgentId, delta: Int): Int? =
         throw NotImplementedError("adjustFame not implemented for this AgentRegistry")
+
+    /**
+     * Atomic misconduct write: clamps the resulting score at 0, recomputes
+     * the derived [OutlawState] via [OutlawState.deriveFrom], and writes
+     * both columns in one UPDATE under a `forUpdate` row lock. Production
+     * [dev.gvart.genesara.player.internal.store.JooqAgentRegistry] always
+     * returns a non-null outcome for a registered agent.
+     *
+     * `delta` may be positive (misconduct) or negative (operator-applied
+     * pardon — not used in v1 but free). The decay sweep takes the batched
+     * path via [decayMisconductScores] instead.
+     *
+     * The default returns `null` so the AttackReducer's accrual hook does
+     * not crash test stubs that don't model misconduct (witness-cascade
+     * tests, ability tests, etc.) — they share the same gate but assert
+     * on the cascade only. Stubs that DO care about misconduct (e.g.
+     * `OutlawAccrualTest.RecordingAgents`) override explicitly. A test
+     * that expects an `OutlawStateChanged` event but inherits this default
+     * fails on the missing event, not a silent pass.
+     */
+    fun adjustMisconduct(
+        agentId: AgentId,
+        delta: Int,
+        watchedAt: Int,
+        outlawAt: Int,
+    ): MisconductOutcome? = null
+
+    /**
+     * Batched decay pass over every agent with `outlaw_misconduct_score > 0`.
+     * Decrements each by [amount] (clamped at 0), recomputes [OutlawState],
+     * and persists both columns in a single transaction. Returns one
+     * [MisconductOutcome] per affected row — callers filter on
+     * [MisconductOutcome.didTransition] to decide what to emit.
+     *
+     * Default returns an empty list so the world-tick `OutlawDecaySweep`
+     * works against test fixtures that haven't migrated to the production
+     * registry — same convention as [adjustMisconduct].
+     */
+    fun decayMisconductScores(
+        amount: Int,
+        watchedAt: Int,
+        outlawAt: Int,
+    ): List<MisconductOutcome> = emptyList()
 }
 
 /**

--- a/player/src/main/kotlin/dev/gvart/genesara/player/OutlawState.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/OutlawState.kt
@@ -1,0 +1,55 @@
+package dev.gvart.genesara.player
+
+/**
+ * Mechanics-reference §11 outlaw state machine: a 3-bucket projection of the
+ * agent's `outlaw_misconduct_score`. Score is the source of truth (decayed
+ * by the world-tick sweep); state is the cheap-to-read cache the registry
+ * keeps in sync on every misconduct write or decay pass.
+ *
+ *  - [CLEAN]   — score below the watched threshold; no PvP-misconduct flag.
+ *  - [WATCHED] — score in `[watchedAt, outlawAt)`; a step short of full outlaw.
+ *  - [OUTLAW]  — score `>= outlawAt`; downstream NPC effects (Phase 3 #26)
+ *                read this to refuse trades / flag KOS.
+ */
+enum class OutlawState {
+    CLEAN,
+    WATCHED,
+    OUTLAW;
+
+    companion object {
+        /**
+         * Pure derivation. `outlawAt` MUST be `>= watchedAt`; the registry
+         * validates this at the call site so a caller-supplied inversion is
+         * caught with a clear contract violation rather than producing a
+         * silently-wrong state. Score is clamped at zero by the schema; a
+         * negative score still maps to [CLEAN] for defensive symmetry.
+         */
+        fun deriveFrom(score: Int, watchedAt: Int, outlawAt: Int): OutlawState {
+            require(outlawAt >= watchedAt) {
+                "outlawAt ($outlawAt) must be >= watchedAt ($watchedAt)"
+            }
+            return when {
+                score >= outlawAt -> OUTLAW
+                score >= watchedAt -> WATCHED
+                else -> CLEAN
+            }
+        }
+    }
+}
+
+/**
+ * Result of [AgentRegistry.adjustMisconduct] (single-row) and
+ * [AgentRegistry.decayMisconductScores] (batched). Carries the pre/post
+ * score+state so the world-side dispatcher emits `OutlawStateChanged` only
+ * when [didTransition] flips. A no-op write (delta = 0, same bucket) still
+ * returns a valid outcome with `oldState == newState`.
+ */
+data class MisconductOutcome(
+    val agentId: AgentId,
+    val oldScore: Int,
+    val newScore: Int,
+    val oldState: OutlawState,
+    val newState: OutlawState,
+) {
+    val didTransition: Boolean get() = oldState != newState
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
@@ -21,6 +21,8 @@ import dev.gvart.genesara.player.AttributePointLoss
 import dev.gvart.genesara.player.ClassLookup
 import dev.gvart.genesara.player.ClassOffer
 import dev.gvart.genesara.player.DeathPenaltyOutcome
+import dev.gvart.genesara.player.MisconductOutcome
+import dev.gvart.genesara.player.OutlawState
 import dev.gvart.genesara.player.RaceId
 import dev.gvart.genesara.player.RecordClassOfferOutcome
 import dev.gvart.genesara.player.RecordEvolutionOfferOutcome
@@ -525,6 +527,80 @@ internal class JooqAgentRegistry(
     @Transactional
     override fun adjustFame(agentId: AgentId, delta: Int): Int? = adjustReputation(agentId, delta, AGENTS.FAME)
 
+    @Transactional
+    override fun adjustMisconduct(
+        agentId: AgentId,
+        delta: Int,
+        watchedAt: Int,
+        outlawAt: Int,
+    ): MisconductOutcome? {
+        val record = lockAgentRow(agentId) ?: return null
+        val oldScore = record[AGENTS.OUTLAW_MISCONDUCT_SCORE]!!
+        val oldState = parseOutlawState(record[AGENTS.OUTLAW_STATE]!!)
+        // Long-saturate then clamp at zero — the schema's CHECK enforces non-negative,
+        // and we want a -1000 pardon delta to land at 0, not blow up the constraint.
+        val newScore = (oldScore.toLong() + delta.toLong())
+            .coerceIn(0L, Int.MAX_VALUE.toLong())
+            .toInt()
+        val newState = OutlawState.deriveFrom(newScore, watchedAt, outlawAt)
+        dsl.update(AGENTS)
+            .set(AGENTS.OUTLAW_MISCONDUCT_SCORE, newScore)
+            .set(AGENTS.OUTLAW_STATE, newState.name)
+            .where(AGENTS.ID.eq(agentId.id))
+            .execute()
+        return MisconductOutcome(agentId, oldScore, newScore, oldState, newState)
+    }
+
+    @Transactional
+    override fun decayMisconductScores(
+        amount: Int,
+        watchedAt: Int,
+        outlawAt: Int,
+    ): List<MisconductOutcome> {
+        require(amount >= 0) { "decay amount must be non-negative, got $amount" }
+        if (amount == 0) return emptyList()
+        // Single sweep query reads every misconduct-flagged agent, recomputes the
+        // pair locally, then issues per-row updates via jOOQ batch. Per-row writes
+        // (not bulk UPDATE) so the state column stays consistent with the score
+        // bucket — a bulk `SET state = CASE ... END` would duplicate the
+        // bucketing rule from [OutlawState.deriveFrom] in SQL.
+        // The partial index `agents_outlaw_misconduct_active_idx` (V210) keeps
+        // this scan proportional to the active-offender subset, not the full
+        // agent population.
+        // TODO(#17-followup): bucket outcomes by (newScore, newState) and emit
+        //  one bulk UPDATE per bucket once the flagged population grows past a
+        //  few thousand. Per-row batch is fine for the v1 agent count.
+        val records = dsl.selectFrom(AGENTS)
+            .where(AGENTS.OUTLAW_MISCONDUCT_SCORE.gt(0))
+            .fetch()
+        if (records.isEmpty()) return emptyList()
+
+        val outcomes = ArrayList<MisconductOutcome>(records.size)
+        val updates = records.mapNotNull { record ->
+            val agentId = AgentId(record[AGENTS.ID]!!)
+            val oldScore = record[AGENTS.OUTLAW_MISCONDUCT_SCORE]!!
+            val oldState = parseOutlawState(record[AGENTS.OUTLAW_STATE]!!)
+            val newScore = (oldScore - amount).coerceAtLeast(0)
+            if (newScore == oldScore) return@mapNotNull null
+            val newState = OutlawState.deriveFrom(newScore, watchedAt, outlawAt)
+            outcomes += MisconductOutcome(agentId, oldScore, newScore, oldState, newState)
+            dsl.update(AGENTS)
+                .set(AGENTS.OUTLAW_MISCONDUCT_SCORE, newScore)
+                .set(AGENTS.OUTLAW_STATE, newState.name)
+                .where(AGENTS.ID.eq(agentId.id))
+        }
+        if (updates.isNotEmpty()) dsl.batch(updates).execute()
+        return outcomes
+    }
+
+    /**
+     * Defensive parse: a corrupt enum value collapses to [OutlawState.CLEAN]
+     * rather than throwing. The decay sweep will reset it on the next pass
+     * if the score is non-zero, otherwise the agent silently lands clean.
+     */
+    private fun parseOutlawState(raw: String): OutlawState =
+        runCatching { OutlawState.valueOf(raw) }.getOrDefault(OutlawState.CLEAN)
+
     private fun adjustReputation(agentId: AgentId, delta: Int, column: TableField<AgentsRecord, Int?>): Int? {
         val record = lockAgentRow(agentId) ?: return null
         val current = record[column]!!
@@ -562,6 +638,8 @@ internal class JooqAgentRegistry(
         offeredEvolutions = toEvolutionOfferOrNull(),
         authority = this[AGENTS.AUTHORITY]!!,
         fame = this[AGENTS.FAME]!!,
+        outlawState = parseOutlawState(this[AGENTS.OUTLAW_STATE]!!),
+        outlawMisconductScore = this[AGENTS.OUTLAW_MISCONDUCT_SCORE]!!,
     )
 
     private companion object {

--- a/player/src/main/resources/db/migration/player/V210__outlaw_status.sql
+++ b/player/src/main/resources/db/migration/player/V210__outlaw_status.sql
@@ -1,0 +1,18 @@
+-- Phase 2 PvP infrastructure (#17): per-agent outlaw status state machine.
+-- Spec: mechanics-reference §11 (PvP). Score is the source of truth, decayed
+-- by the world-tick OutlawDecaySweep; state is the denormalized cache the
+-- registry keeps in sync (CLEAN/WATCHED/OUTLAW) so inspect reads cheap.
+ALTER TABLE agents
+    ADD COLUMN outlaw_state            TEXT NOT NULL DEFAULT 'CLEAN',
+    ADD COLUMN outlaw_misconduct_score INT  NOT NULL DEFAULT 0;
+
+ALTER TABLE agents
+    ADD CONSTRAINT agents_outlaw_misconduct_score_nonneg_check
+        CHECK (outlaw_misconduct_score >= 0);
+
+-- Partial index for the per-tick decay sweep: most agents are CLEAN with
+-- score 0, so a partial index over the flagged subset keeps the scan
+-- proportional to active offenders rather than the full population.
+CREATE INDEX agents_outlaw_misconduct_active_idx
+    ON agents (outlaw_misconduct_score)
+    WHERE outlaw_misconduct_score > 0;

--- a/player/src/test/kotlin/dev/gvart/genesara/player/OutlawStateTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/OutlawStateTest.kt
@@ -1,0 +1,53 @@
+package dev.gvart.genesara.player
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class OutlawStateTest {
+
+    @Test
+    fun `score below watched threshold is CLEAN`() {
+        assertEquals(OutlawState.CLEAN, OutlawState.deriveFrom(score = 0, watchedAt = 25, outlawAt = 100))
+        assertEquals(OutlawState.CLEAN, OutlawState.deriveFrom(score = 24, watchedAt = 25, outlawAt = 100))
+    }
+
+    @Test
+    fun `score equal to watched threshold is WATCHED — inclusive lower bound`() {
+        assertEquals(OutlawState.WATCHED, OutlawState.deriveFrom(score = 25, watchedAt = 25, outlawAt = 100))
+    }
+
+    @Test
+    fun `score in middle band is WATCHED`() {
+        assertEquals(OutlawState.WATCHED, OutlawState.deriveFrom(score = 50, watchedAt = 25, outlawAt = 100))
+        assertEquals(OutlawState.WATCHED, OutlawState.deriveFrom(score = 99, watchedAt = 25, outlawAt = 100))
+    }
+
+    @Test
+    fun `score equal to outlaw threshold is OUTLAW — inclusive lower bound`() {
+        assertEquals(OutlawState.OUTLAW, OutlawState.deriveFrom(score = 100, watchedAt = 25, outlawAt = 100))
+    }
+
+    @Test
+    fun `score above outlaw threshold is OUTLAW`() {
+        assertEquals(OutlawState.OUTLAW, OutlawState.deriveFrom(score = 9_999, watchedAt = 25, outlawAt = 100))
+    }
+
+    @Test
+    fun `negative score collapses to CLEAN — defensive symmetry`() {
+        assertEquals(OutlawState.CLEAN, OutlawState.deriveFrom(score = -5, watchedAt = 25, outlawAt = 100))
+    }
+
+    @Test
+    fun `inverted thresholds are rejected at the contract boundary`() {
+        assertFailsWith<IllegalArgumentException> {
+            OutlawState.deriveFrom(score = 50, watchedAt = 100, outlawAt = 25)
+        }
+    }
+
+    @Test
+    fun `equal thresholds collapse to a two-state machine — CLEAN below, OUTLAW at-or-above`() {
+        assertEquals(OutlawState.CLEAN, OutlawState.deriveFrom(score = 49, watchedAt = 50, outlawAt = 50))
+        assertEquals(OutlawState.OUTLAW, OutlawState.deriveFrom(score = 50, watchedAt = 50, outlawAt = 50))
+    }
+}

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryOutlawIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryOutlawIntegrationTest.kt
@@ -1,0 +1,228 @@
+package dev.gvart.genesara.player.internal.store
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentProfile
+import dev.gvart.genesara.player.AgentProfileRepository
+import dev.gvart.genesara.player.AttributeMods
+import dev.gvart.genesara.player.NoOpClassLookup
+import dev.gvart.genesara.player.OutlawState
+import dev.gvart.genesara.player.Race
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.player.RaceLookup
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENTS
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENT_PROFILES
+import dev.gvart.genesara.player.internal.race.RaceAssigner
+import dev.gvart.genesara.player.internal.race.RaceDefinitionProperties
+import dev.gvart.genesara.player.internal.race.RandomSource
+import dev.gvart.genesara.player.internal.testsupport.PlayerFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end coverage for [JooqAgentRegistry.adjustMisconduct] /
+ * [decayMisconductScores]. Pins the score+state column staying consistent
+ * across writes, the schema's CHECK(>=0) holding under negative deltas,
+ * and the batched decay path returning one outcome per affected row.
+ */
+@Testcontainers
+class JooqAgentRegistryOutlawIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("outlaw_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = PlayerFlyway.pooledDataSource(postgres)
+            PlayerFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private val owner = PlayerId(UUID.randomUUID())
+    private val watchedAt = 25
+    private val outlawAt = 100
+
+    @BeforeEach
+    fun resetTables() {
+        dsl.truncate(AGENT_PROFILES).cascade().execute()
+        dsl.truncate(AGENTS).cascade().execute()
+    }
+
+    @Test
+    fun `fresh agent starts CLEAN with score 0`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Newcomer")
+
+        val fresh = assertNotNull(registry.find(agent.id))
+        assertEquals(OutlawState.CLEAN, fresh.outlawState)
+        assertEquals(0, fresh.outlawMisconductScore)
+    }
+
+    @Test
+    fun `adjustMisconduct from clean to watched updates both score and state`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Sinner")
+
+        val outcome = assertNotNull(registry.adjustMisconduct(agent.id, delta = 30, watchedAt, outlawAt))
+        assertEquals(OutlawState.CLEAN, outcome.oldState)
+        assertEquals(OutlawState.WATCHED, outcome.newState)
+        assertEquals(30, outcome.newScore)
+        assertTrue(outcome.didTransition)
+
+        val reread = assertNotNull(registry.find(agent.id))
+        assertEquals(OutlawState.WATCHED, reread.outlawState)
+        assertEquals(30, reread.outlawMisconductScore)
+    }
+
+    @Test
+    fun `successive adjustMisconduct calls stack to OUTLAW`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Repeat")
+
+        registry.adjustMisconduct(agent.id, delta = 60, watchedAt, outlawAt)
+        val outcome = assertNotNull(registry.adjustMisconduct(agent.id, delta = 50, watchedAt, outlawAt))
+
+        assertEquals(OutlawState.WATCHED, outcome.oldState)
+        assertEquals(OutlawState.OUTLAW, outcome.newState)
+        assertEquals(110, outcome.newScore)
+    }
+
+    @Test
+    fun `negative adjustMisconduct clamps score at zero — schema CHECK holds`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Pardoned")
+
+        registry.adjustMisconduct(agent.id, delta = 50, watchedAt, outlawAt)
+        val outcome = assertNotNull(registry.adjustMisconduct(agent.id, delta = -1_000, watchedAt, outlawAt))
+
+        assertEquals(0, outcome.newScore, "negative delta saturates at zero")
+        assertEquals(OutlawState.CLEAN, outcome.newState)
+    }
+
+    @Test
+    fun `same-bucket adjust still records old=new state — no transition flag`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Stagnant")
+
+        registry.adjustMisconduct(agent.id, delta = 30, watchedAt, outlawAt)
+        val outcome = assertNotNull(registry.adjustMisconduct(agent.id, delta = 10, watchedAt, outlawAt))
+
+        assertEquals(OutlawState.WATCHED, outcome.oldState)
+        assertEquals(OutlawState.WATCHED, outcome.newState)
+        assertEquals(false, outcome.didTransition)
+    }
+
+    @Test
+    fun `adjustMisconduct returns null for an unregistered agent`() {
+        val registry = registry()
+        assertNull(registry.adjustMisconduct(AgentId(UUID.randomUUID()), delta = 5, watchedAt, outlawAt))
+    }
+
+    @Test
+    fun `decayMisconductScores ignores clean agents and downshifts the rest`() {
+        val registry = registry()
+        val clean = registry.register(owner, "Clean")
+        val watched = registry.register(owner, "Watched")
+        val outlaw = registry.register(owner, "Outlaw")
+        registry.adjustMisconduct(watched.id, delta = 25, watchedAt, outlawAt)
+        registry.adjustMisconduct(outlaw.id, delta = 100, watchedAt, outlawAt)
+
+        val outcomes = registry.decayMisconductScores(amount = 1, watchedAt, outlawAt)
+
+        // Clean agent has score 0 → query skips them.
+        assertEquals(2, outcomes.size)
+        val byAgent = outcomes.associateBy { it.agentId }
+        assertEquals(24, byAgent[watched.id]?.newScore)
+        assertEquals(OutlawState.CLEAN, byAgent[watched.id]?.newState, "score 24 < watchedAt → downshift")
+        assertEquals(99, byAgent[outlaw.id]?.newScore)
+        assertEquals(OutlawState.WATCHED, byAgent[outlaw.id]?.newState, "score 99 < outlawAt → downshift")
+        // Clean agent untouched.
+        assertEquals(0, assertNotNull(registry.find(clean.id)).outlawMisconductScore)
+    }
+
+    @Test
+    fun `decayMisconductScores noop when amount is zero`() {
+        val registry = registry()
+        val agent = registry.register(owner, "FrozenScore")
+        registry.adjustMisconduct(agent.id, delta = 50, watchedAt, outlawAt)
+
+        val outcomes = registry.decayMisconductScores(amount = 0, watchedAt, outlawAt)
+
+        assertTrue(outcomes.isEmpty())
+        assertEquals(50, assertNotNull(registry.find(agent.id)).outlawMisconductScore)
+    }
+
+    @Test
+    fun `decayMisconductScores returns empty list when no flagged agents exist`() {
+        val registry = registry()
+        registry.register(owner, "AlwaysClean")
+
+        val outcomes = registry.decayMisconductScores(amount = 1, watchedAt, outlawAt)
+
+        assertTrue(outcomes.isEmpty())
+    }
+
+    private fun registry(): JooqAgentRegistry {
+        val race = Race(
+            id = RaceId("test_race"),
+            displayName = "Test",
+            weight = 1,
+            attributeMods = AttributeMods.NONE,
+            description = "",
+        )
+        val lookup = SingleRaceLookup(race)
+        val props = RaceDefinitionProperties(defaultId = race.id.value)
+        val assigner = RaceAssigner(lookup, props, FixedRandom)
+        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner, NoOpClassLookup)
+    }
+
+    private class SingleRaceLookup(private val race: Race) : RaceLookup {
+        override fun byId(id: RaceId): Race? = if (id == race.id) race else null
+        override fun all(): List<Race> = listOf(race)
+    }
+
+    private object FixedRandom : RandomSource {
+        override fun nextInt(boundExclusive: Int): Int = 0
+    }
+
+    private class JooqProfileRepository(private val dsl: DSLContext) : AgentProfileRepository {
+        override fun save(profile: AgentProfile) {
+            dsl.insertInto(AGENT_PROFILES)
+                .set(AGENT_PROFILES.AGENT_ID, profile.id.id)
+                .set(AGENT_PROFILES.MAX_HP, profile.maxHp)
+                .set(AGENT_PROFILES.MAX_STAMINA, profile.maxStamina)
+                .set(AGENT_PROFILES.MAX_MANA, profile.maxMana)
+                .execute()
+        }
+    }
+}

--- a/world/combat/src/main/kotlin/dev/gvart/genesara/world/combat/internal/combat/AttackReducer.kt
+++ b/world/combat/src/main/kotlin/dev/gvart/genesara/world/combat/internal/combat/AttackReducer.kt
@@ -8,6 +8,7 @@ import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.ClassLookup
 import dev.gvart.genesara.player.LevelScalingAggregator
+import dev.gvart.genesara.player.MisconductOutcome
 import dev.gvart.genesara.player.PassiveAuraAggregator
 import dev.gvart.genesara.player.RelationshipsGateway
 import dev.gvart.genesara.player.ScalingEffect
@@ -26,6 +27,7 @@ import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.CombatCommand
 import dev.gvart.genesara.world.events.BodyEvent
 import dev.gvart.genesara.world.events.CombatEvent
+import dev.gvart.genesara.world.events.SocialEvent
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.abilities.PendingAttackScaleStore
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
@@ -99,6 +101,15 @@ fun reduceAttack(
     val targetNode = ensureNotNull(coreView.positions[command.target]) {
         WorldRejection.TargetNotInWorld(command.agent, command.target)
     }
+
+    // Mechanics-reference §11 green-zone enforcement. Reads the target node's
+    // pvpEnabled flag — the spec line is target-side ("attacks targeting agents
+    // in green zones are rejected"). Attacker-side enforcement (sniper from
+    // sanctuary) is a Phase 3 refinement.
+    val targetNodeDef = ensureNotNull(coreView.nodes[targetNode]) {
+        WorldRejection.UnknownNode(targetNode)
+    }
+    ensure(targetNodeDef.pvpEnabled) { WorldRejection.GreenZone(command.agent, targetNode) }
 
     val weaponInstance = equipment.equippedFor(command.agent)[EquipSlot.MAIN_HAND]
     val weaponDef = weaponInstance?.let { items.byId(it.itemId) }
@@ -319,6 +330,16 @@ fun reduceAttack(
         tick = tick,
     )
 
+    accrueOutlawMisconduct(
+        attacker = command.agent,
+        victimFame = defender.fame,
+        killed = nextTargetBody.hp == 0,
+        balance = balance,
+        agents = agents,
+        tick = tick,
+        commandId = command.commandId,
+    )?.let(emitted::add)
+
     ReducerOutput(sliceDelta = combat, effects = effects.toList(), events = emitted.toList())
 }
 
@@ -356,6 +377,49 @@ private fun applyWitnessCascade(
         .keys
     if (witnesses.isEmpty()) return
     relationships.adjustMany(attacker, witnesses, delta, tick)
+}
+
+/**
+ * Mechanics-reference §11 outlaw accrual. Gated on the same Fame predicate
+ * as [applyWitnessCascade] — killing or hitting a "nobody" (victim.fame
+ * below [BalanceLookup.fameWitnessProtectionThreshold]) costs the attacker
+ * nothing. For protected victims, kill weight beats non-lethal weight via
+ * separate tunables. Returns the transition event when the registry write
+ * crosses a bucket boundary; null otherwise (no event = no transition or
+ * suppressed by Fame gate).
+ */
+private fun accrueOutlawMisconduct(
+    attacker: AgentId,
+    victimFame: Int,
+    killed: Boolean,
+    balance: BalanceLookup,
+    agents: AgentRegistry,
+    tick: Long,
+    commandId: java.util.UUID,
+): SocialEvent.OutlawStateChanged? {
+    if (victimFame < balance.fameWitnessProtectionThreshold()) return null
+    val delta = if (killed) {
+        balance.outlawMisconductOnKillProtected()
+    } else {
+        balance.outlawMisconductOnAttackProtected()
+    }
+    if (delta == 0) return null
+    val outcome: MisconductOutcome = agents.adjustMisconduct(
+        agentId = attacker,
+        delta = delta,
+        watchedAt = balance.outlawWatchedScore(),
+        outlawAt = balance.outlawOutlawScore(),
+    ) ?: return null
+    if (!outcome.didTransition) return null
+    return SocialEvent.OutlawStateChanged(
+        agent = attacker,
+        previousState = outcome.oldState,
+        newState = outcome.newState,
+        score = outcome.newScore,
+        listeners = setOf(attacker),
+        tick = tick,
+        causedBy = commandId,
+    )
 }
 
 /**

--- a/world/combat/src/main/kotlin/dev/gvart/genesara/world/combat/internal/pvp/OutlawDecaySweep.kt
+++ b/world/combat/src/main/kotlin/dev/gvart/genesara/world/combat/internal/pvp/OutlawDecaySweep.kt
@@ -1,0 +1,52 @@
+package dev.gvart.genesara.world.combat.internal.pvp
+
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.world.events.SocialEvent
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import org.springframework.stereotype.Component
+
+/**
+ * Mechanics-reference §11 outlaw decay. Runs on a coarse beat — every
+ * [BalanceLookup.outlawDecayPeriodTicks] ticks the sweep subtracts
+ * [BalanceLookup.outlawDecayPerPeriod] from every misconduct-flagged agent's
+ * score, downshifting [dev.gvart.genesara.player.OutlawState] when the
+ * resulting score crosses a bucket boundary downward.
+ *
+ * The registry returns one [dev.gvart.genesara.player.MisconductOutcome]
+ * per affected row; the sweep filters to transitions and converts them
+ * into [SocialEvent.OutlawStateChanged] events for the dispatcher to fan
+ * out. `causedBy` is null — no single command caused the decay.
+ *
+ * Patterned after `MountMaintenanceSweep`: same period-gate shape, same
+ * tick-loop integration point in `WorldTickHandler`.
+ */
+@Component
+class OutlawDecaySweep(
+    private val agents: AgentRegistry,
+    private val balance: BalanceLookup,
+) {
+
+    fun sweep(tick: Long): List<WorldEvent> {
+        val period = balance.outlawDecayPeriodTicks().coerceAtLeast(1)
+        if (tick % period != 0L) return emptyList()
+        val amount = balance.outlawDecayPerPeriod().coerceAtLeast(0)
+        if (amount == 0) return emptyList()
+        val outcomes = agents.decayMisconductScores(
+            amount = amount,
+            watchedAt = balance.outlawWatchedScore(),
+            outlawAt = balance.outlawOutlawScore(),
+        )
+        return outcomes.filter { it.didTransition }.map { outcome ->
+            SocialEvent.OutlawStateChanged(
+                agent = outcome.agentId,
+                previousState = outcome.oldState,
+                newState = outcome.newState,
+                score = outcome.newScore,
+                listeners = setOf(outcome.agentId),
+                tick = tick,
+                causedBy = null,
+            )
+        }
+    }
+}

--- a/world/combat/src/test/kotlin/dev/gvart/genesara/world/combat/internal/pvp/OutlawAccrualTest.kt
+++ b/world/combat/src/test/kotlin/dev/gvart/genesara/world/combat/internal/pvp/OutlawAccrualTest.kt
@@ -1,0 +1,355 @@
+package dev.gvart.genesara.world.combat.internal.pvp
+
+import arrow.core.Either
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.DeathPenaltyOutcome
+import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
+import dev.gvart.genesara.player.MisconductOutcome
+import dev.gvart.genesara.player.OutlawState
+import dev.gvart.genesara.player.PassiveAuraAggregator.Companion.NoAura
+import dev.gvart.genesara.player.RelationshipsGateway
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillProgression
+import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.world.AgentItemInstancesStore
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.EquipSlot
+import dev.gvart.genesara.world.EquipmentBonusAggregator
+import dev.gvart.genesara.world.Gauge
+import dev.gvart.genesara.world.Item
+import dev.gvart.genesara.world.ItemCategory
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ItemInstance
+import dev.gvart.genesara.world.ItemLookup
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Rarity
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.ResourceSpawnRule
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldRejection
+import dev.gvart.genesara.world.combat.internal.combat.reduceAttack
+import dev.gvart.genesara.world.commands.CombatCommand
+import dev.gvart.genesara.world.events.SocialEvent
+import dev.gvart.genesara.world.events.WorldEvent
+import dev.gvart.genesara.world.internal.abilities.PendingAttackScaleStore
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.death.DeathProcessor
+import dev.gvart.genesara.world.internal.testsupport.InMemoryAgentItemInstancesStore
+import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
+import dev.gvart.genesara.world.internal.testsupport.InMemoryPendingAttackScaleStore
+import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import dev.gvart.genesara.world.internal.worldstate.applyEffects
+import java.util.UUID
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.springframework.context.ApplicationEventPublisher
+
+class OutlawAccrualTest {
+
+    private val attacker = AgentId(UUID.randomUUID())
+    private val victim = AgentId(UUID.randomUUID())
+
+    private val regionId = RegionId(1L)
+    private val openNodeId = NodeId(1L)
+    private val greenNodeId = NodeId(2L)
+    private val region = Region(
+        id = regionId, worldId = WorldId(1L), sphereIndex = 0,
+        biome = Biome.PLAINS, climate = Climate.OCEANIC,
+        centroid = Vec3(0.0, 0.0, 1.0), faceVertices = emptyList(), neighbors = emptySet(),
+    )
+    private val openNode = Node(openNodeId, regionId, q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())
+    private val greenNode = Node(
+        greenNodeId, regionId, q = 1, r = 0, terrain = Terrain.PLAINS,
+        adjacency = emptySet(), pvpEnabled = false,
+    )
+
+    private val rustySword = ItemId("RUSTY_SWORD")
+    private val swordSkill = SkillId("SWORD")
+
+    @Test
+    fun `green-zone targeted attack is rejected before any side-effect`() {
+        val agents = RecordingAgents(victimFame = 50)
+        val result = run(
+            state = state(victimHp = 100, attackerAt = openNodeId, victimAt = greenNodeId),
+            agents = agents,
+        )
+
+        val rejection = (result as Either.Left).value
+        assertTrue(rejection is WorldRejection.GreenZone, "expected GreenZone, got $rejection")
+        assertEquals(greenNodeId, rejection.node)
+        assertEquals(0, agents.misconductCalls, "rejected attack must not write misconduct")
+    }
+
+    @Test
+    fun `kill against Fame-protected victim raises misconduct and emits OutlawStateChanged on transition`() {
+        val agents = RecordingAgents(
+            victimFame = 50,
+            scriptedDeath = mapOf(victim to DeathPenaltyOutcome(0, false, null)),
+            scriptedAdjustment = MisconductOutcome(
+                attacker, oldScore = 0, newScore = 50,
+                oldState = OutlawState.CLEAN, newState = OutlawState.WATCHED,
+            ),
+        )
+        val result = run(
+            state = state(victimHp = 1, attackerAt = openNodeId, victimAt = openNodeId),
+            agents = agents,
+        )
+
+        val (_, events) = (result as Either.Right).value
+        val transition = events.filterIsInstance<SocialEvent.OutlawStateChanged>().single()
+        assertEquals(attacker, transition.agent)
+        assertEquals(OutlawState.CLEAN, transition.previousState)
+        assertEquals(OutlawState.WATCHED, transition.newState)
+        assertEquals(setOf(attacker), transition.listeners)
+        assertEquals(50, agents.lastDelta, "kill delta routed through balance.outlawMisconductOnKillProtected")
+    }
+
+    @Test
+    fun `non-lethal hit against Fame-protected victim uses the smaller delta`() {
+        val agents = RecordingAgents(
+            victimFame = 50,
+            scriptedAdjustment = MisconductOutcome(
+                attacker, oldScore = 0, newScore = 5,
+                oldState = OutlawState.CLEAN, newState = OutlawState.CLEAN,
+            ),
+        )
+        run(
+            state = state(victimHp = 1_000, attackerAt = openNodeId, victimAt = openNodeId),
+            agents = agents,
+        )
+
+        assertEquals(5, agents.lastDelta, "non-lethal delta routed through balance.outlawMisconductOnAttackProtected")
+    }
+
+    @Test
+    fun `attack against low-Fame victim is fully suppressed — no misconduct write`() {
+        val agents = RecordingAgents(victimFame = 0)
+        run(
+            state = state(victimHp = 1_000, attackerAt = openNodeId, victimAt = openNodeId),
+            agents = agents,
+        )
+
+        assertEquals(0, agents.misconductCalls, "Fame-protection threshold gates accrual as well as the cascade")
+    }
+
+    @Test
+    fun `kill against low-Fame victim is also suppressed — gate holds on the lethal branch`() {
+        val agents = RecordingAgents(
+            victimFame = 0,
+            scriptedDeath = mapOf(victim to DeathPenaltyOutcome(0, false, null)),
+        )
+        run(
+            state = state(victimHp = 1, attackerAt = openNodeId, victimAt = openNodeId),
+            agents = agents,
+        )
+
+        assertEquals(0, agents.misconductCalls, "kill-on-nobody must not accrue misconduct — symmetric with cascade suppression")
+    }
+
+    @Test
+    fun `same-bucket misconduct write does not emit a transition event`() {
+        val agents = RecordingAgents(
+            victimFame = 50,
+            scriptedAdjustment = MisconductOutcome(
+                attacker, oldScore = 5, newScore = 10,
+                oldState = OutlawState.CLEAN, newState = OutlawState.CLEAN,
+            ),
+        )
+        val result = run(
+            state = state(victimHp = 1_000, attackerAt = openNodeId, victimAt = openNodeId),
+            agents = agents,
+        )
+
+        val (_, events) = (result as Either.Right).value
+        assertNull(events.filterIsInstance<SocialEvent.OutlawStateChanged>().firstOrNull())
+    }
+
+    private fun run(
+        state: WorldState,
+        agents: RecordingAgents,
+    ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> {
+        val skills = StubSkillsRegistry()
+        val publisher = NoopPublisher()
+        return reduceAttack(
+            combat = state.combat,
+            bodyView = state.body,
+            coreView = state.core,
+            envView = state.environment,
+            command = CombatCommand.AttackTarget(attacker, victim),
+            balance = balance,
+            items = itemsWithSword,
+            agents = agents,
+            equipment = swordEquipped,
+            progression = SkillProgression(skills, publisher),
+            scaling = NoScaling,
+            passiveAura = NoAura,
+            equipmentBonuses = EquipmentBonusAggregator.NoBonuses,
+            deathProcessor = DeathProcessor(
+                balance = balance,
+                agents = agents,
+                equipment = swordEquipped,
+                groundItems = NoopGroundItemStore(),
+            ),
+            triggeredPassives = NoOpTriggeredPassiveDispatcher,
+            pendingScales = InMemoryPendingAttackScaleStore(),
+            behaviorTracker = InMemoryBehaviorTracker(),
+            relationships = RelationshipsGateway.NoOp,
+            rng = Random(seed = 42L),
+            tick = 5L,
+        ).map { out -> state.copy(combat = out.sliceDelta).applyEffects(out.effects) to out.events }
+    }
+
+    private fun state(
+        victimHp: Int,
+        attackerAt: NodeId,
+        victimAt: NodeId,
+    ): WorldState = WorldState(
+        regions = mapOf(regionId to region),
+        nodes = mapOf(openNodeId to openNode, greenNodeId to greenNode),
+        positions = mapOf(attacker to attackerAt, victim to victimAt),
+        bodies = mapOf(
+            attacker to AgentBody(hp = 100, maxHp = 100, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
+            victim to AgentBody(hp = victimHp, maxHp = victimHp.coerceAtLeast(100), stamina = 50, maxStamina = 50, mana = 0, maxMana = 0),
+        ),
+        inventories = emptyMap(),
+    )
+
+    private val balance: BalanceLookup = object : BalanceLookup {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain): Int = 1
+        override fun staminaRegenPerTick(climate: Climate): Int = 0
+        override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = 5
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: Gauge): Int = 25
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 25
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun xpLossOnDeath(): Int = 0
+        override fun dropChanceForKillCount(killCount: Int): Double = 0.0
+        override fun fameWitnessProtectionThreshold(): Int = 10
+        override fun outlawMisconductOnAttackProtected(): Int = 5
+        override fun outlawMisconductOnKillProtected(): Int = 50
+        override fun outlawWatchedScore(): Int = 25
+        override fun outlawOutlawScore(): Int = 100
+    }
+
+    private val itemsWithSword: ItemLookup = StubItemLookup(
+        mapOf(
+            rustySword to Item(
+                id = rustySword,
+                displayName = "Rusty Sword",
+                description = "",
+                category = ItemCategory.EQUIPMENT,
+                weightPerUnit = 1500,
+                maxStack = 1,
+                damageType = DamageType.SLASH,
+                weaponPower = 100,
+                combatSkill = swordSkill,
+                validSlots = setOf(EquipSlot.MAIN_HAND),
+            ),
+        ),
+    )
+
+    private val swordEquipped: AgentItemInstancesStore = StubEquipmentStore(
+        mapOf(
+            attacker to mapOf(
+                EquipSlot.MAIN_HAND to ItemInstance.Equipment(
+                    instanceId = UUID.randomUUID(),
+                    itemId = rustySword,
+                    agentId = attacker,
+                    rarity = Rarity.COMMON,
+                    durabilityCurrent = 10,
+                    durabilityMax = 10,
+                    creatorAgentId = null,
+                    createdAtTick = 0L,
+                ),
+            ),
+        ),
+    )
+
+    private class StubItemLookup(private val byId: Map<ItemId, Item>) : ItemLookup {
+        override fun byId(id: ItemId): Item? = byId[id]
+        override fun all(): List<Item> = byId.values.toList()
+    }
+
+    private class StubEquipmentStore(
+        private val equipped: Map<AgentId, Map<EquipSlot, ItemInstance.Equipment>>,
+    ) : InMemoryAgentItemInstancesStore() {
+        override fun equippedFor(agentId: AgentId): Map<EquipSlot, ItemInstance.Equipment> =
+            equipped[agentId] ?: emptyMap()
+    }
+
+    private inner class RecordingAgents(
+        private val victimFame: Int,
+        private val scriptedDeath: Map<AgentId, DeathPenaltyOutcome> = emptyMap(),
+        private val scriptedAdjustment: MisconductOutcome? = null,
+    ) : AgentRegistry {
+        var misconductCalls: Int = 0
+            private set
+        var lastDelta: Int? = null
+            private set
+
+        override fun find(id: AgentId): Agent? = Agent(
+            id = id, owner = PlayerId(UUID.randomUUID()), name = "test",
+            attributes = AgentAttributes(strength = 5, constitution = 1),
+            fame = if (id == victim) victimFame else 0,
+        )
+
+        override fun listForOwner(owner: PlayerId): List<Agent> = emptyList()
+
+        override fun applyDeathPenalty(agentId: AgentId, xpLossOnDeath: Int): DeathPenaltyOutcome? =
+            scriptedDeath[agentId]
+
+        override fun adjustMisconduct(
+            agentId: AgentId,
+            delta: Int,
+            watchedAt: Int,
+            outlawAt: Int,
+        ): MisconductOutcome? {
+            misconductCalls++
+            lastDelta = delta
+            return scriptedAdjustment?.also { assertEquals(attacker, agentId, "accrual must target the attacker") }
+        }
+    }
+
+    private class StubSkillsRegistry : AgentSkillsRegistry {
+        override fun snapshot(agent: AgentId): AgentSkillsSnapshot = AgentSkillsSnapshot(emptyMap(), 0, 0)
+        override fun slottedSkillLevel(agent: AgentId, skill: SkillId): Int = 0
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int): AddXpResult = AddXpResult.Unslotted
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? = null
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? = null
+    }
+
+    private class NoopPublisher : ApplicationEventPublisher {
+        override fun publishEvent(event: Any) = Unit
+    }
+
+    private class NoopGroundItemStore : dev.gvart.genesara.world.GroundItemStore {
+        override fun deposit(node: NodeId, drop: dev.gvart.genesara.world.DroppedItemView, droppedAtTick: Long) = Unit
+        override fun atNode(node: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
+        override fun take(node: NodeId, dropId: UUID): dev.gvart.genesara.world.GroundItemView? = null
+    }
+}

--- a/world/combat/src/test/kotlin/dev/gvart/genesara/world/combat/internal/pvp/OutlawDecaySweepTest.kt
+++ b/world/combat/src/test/kotlin/dev/gvart/genesara/world/combat/internal/pvp/OutlawDecaySweepTest.kt
@@ -1,0 +1,110 @@
+package dev.gvart.genesara.world.combat.internal.pvp
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.MisconductOutcome
+import dev.gvart.genesara.player.OutlawState
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.Gauge
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.ResourceSpawnRule
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.events.SocialEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OutlawDecaySweepTest {
+
+    private val balance = TunableBalance()
+
+    @Test
+    fun `does nothing on a non-period tick`() {
+        val registry = RecordingRegistry()
+        val sweep = OutlawDecaySweep(registry, balance)
+
+        val events = sweep.sweep(tick = 7L)
+
+        assertTrue(events.isEmpty())
+        assertEquals(0, registry.calls, "off-period tick must not touch the registry")
+    }
+
+    @Test
+    fun `period tick decays misconduct and emits only the transitions`() {
+        val transitioner = AgentId(UUID.randomUUID())
+        val downshifter = AgentId(UUID.randomUUID())
+        val sameBucket = AgentId(UUID.randomUUID())
+        val registry = RecordingRegistry(
+            scriptedOutcomes = listOf(
+                MisconductOutcome(transitioner, oldScore = 25, newScore = 24, oldState = OutlawState.WATCHED, newState = OutlawState.CLEAN),
+                MisconductOutcome(sameBucket, oldScore = 50, newScore = 49, oldState = OutlawState.WATCHED, newState = OutlawState.WATCHED),
+                MisconductOutcome(downshifter, oldScore = 100, newScore = 99, oldState = OutlawState.OUTLAW, newState = OutlawState.WATCHED),
+            ),
+        )
+        val sweep = OutlawDecaySweep(registry, balance)
+
+        val events = sweep.sweep(tick = 60L)
+
+        assertEquals(2, events.size, "only transitioning outcomes become events")
+        val byAgent = events.filterIsInstance<SocialEvent.OutlawStateChanged>().associateBy { it.agent }
+        assertEquals(OutlawState.CLEAN, byAgent[transitioner]?.newState)
+        assertEquals(OutlawState.WATCHED, byAgent[downshifter]?.newState)
+        assertTrue(events.all { (it as SocialEvent.OutlawStateChanged).causedBy == null }, "decay sweep is not caused by any command")
+        assertTrue(events.all { (it as SocialEvent.OutlawStateChanged).listeners.size == 1 }, "events are private to the affected agent")
+    }
+
+    @Test
+    fun `zero decay amount short-circuits — no registry call`() {
+        val registry = RecordingRegistry()
+        val zeroDecay = object : BalanceLookup by balance {
+            override fun outlawDecayPerPeriod(): Int = 0
+        }
+        val sweep = OutlawDecaySweep(registry, zeroDecay)
+
+        sweep.sweep(tick = 60L)
+
+        assertEquals(0, registry.calls)
+    }
+
+    private class RecordingRegistry(
+        private val scriptedOutcomes: List<MisconductOutcome> = emptyList(),
+    ) : AgentRegistry {
+        var calls: Int = 0
+            private set
+
+        override fun find(id: AgentId): Agent? = null
+        override fun listForOwner(owner: PlayerId): List<Agent> = emptyList()
+        override fun decayMisconductScores(
+            amount: Int,
+            watchedAt: Int,
+            outlawAt: Int,
+        ): List<MisconductOutcome> {
+            calls++
+            return scriptedOutcomes
+        }
+    }
+
+    private class TunableBalance : BalanceLookup {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain): Int = 1
+        override fun staminaRegenPerTick(climate: Climate): Int = 0
+        override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = 1
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: Gauge): Int = 0
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 1
+        override fun drinkThirstRefill(): Int = 1
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun outlawDecayPeriodTicks(): Int = 60
+        override fun outlawDecayPerPeriod(): Int = 1
+    }
+}

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/WorldRejection.kt
@@ -279,6 +279,18 @@ sealed interface WorldRejection {
     /** Attack target id is the same agent calling the attack — self-strike rejected. */
     data class CannotAttackSelf(val agent: AgentId) : WorldRejection
 
+    /**
+     * Mechanics-reference §11 green-zone enforcement: an attack targeting an
+     * agent in a `pvpEnabled = false` node is rejected at command time.
+     * Capital cities and sanctuary nodes carry the flag; clan-home nodes
+     * will join them in Phase 3 (#26).
+     *
+     * Per v1 design: target-side enforcement only. A future iteration may
+     * extend this to attacker-side (sniper-from-sanctuary) once the engine
+     * supports cross-node weapon reach.
+     */
+    data class GreenZone(val agent: AgentId, val node: NodeId) : WorldRejection
+
     /** Attack target is not currently positioned in the world (never spawned, despawned, or dead and unspawned). */
     data class TargetNotInWorld(val attacker: AgentId, val target: AgentId) : WorldRejection
 

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/events/SocialEvent.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/events/SocialEvent.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.world.events
 
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.OutlawState
 import dev.gvart.genesara.world.PartyId
 import dev.gvart.genesara.world.PartyInviteId
 import dev.gvart.genesara.world.PartyMember
@@ -118,5 +119,25 @@ sealed interface SocialEvent : WorldEvent {
         val listeners: Set<AgentId>,
         override val tick: Long,
         val causedBy: UUID,
+    ) : SocialEvent
+
+    /**
+     * Mechanics-reference §11 outlaw state transition. Emitted when the
+     * agent's misconduct write or the periodic decay sweep crosses a bucket
+     * boundary. Routed to the affected agent's own stream only — outlaw
+     * status is private until observed via inspect.
+     *
+     * `causedBy` is the attack `commandId` when accrual fires inside the
+     * AttackReducer, and `null` when the decay sweep is the trigger (no
+     * single command caused it).
+     */
+    data class OutlawStateChanged(
+        val agent: AgentId,
+        val previousState: OutlawState,
+        val newState: OutlawState,
+        val score: Int,
+        val listeners: Set<AgentId>,
+        override val tick: Long,
+        val causedBy: UUID?,
     ) : SocialEvent
 }

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -309,6 +309,36 @@ interface BalanceLookup {
     /** Per-pair relationship delta applied to every witness when an attack lands the killing blow. */
     fun relationshipDeltaOnKillWitnessed(): Int = -10
 
+    /**
+     * Mechanics-reference §11 outlaw thresholds. Score-bucket boundaries shared
+     * by both write paths (`adjustMisconduct`) and the decay sweep so the
+     * derived state stays consistent. Lifting either threshold without a
+     * migration just reshuffles the buckets on the next write/sweep.
+     */
+    fun outlawWatchedScore(): Int = 25
+    fun outlawOutlawScore(): Int = 100
+
+    /**
+     * Misconduct accrual on a non-lethal PvP hit against a Fame-protected
+     * victim (i.e. victim.fame meets [fameWitnessProtectionThreshold]).
+     * Pairs with the witness cascade, which is gated on the same predicate
+     * — kill a "nobody" and no consequence either way (§19).
+     */
+    fun outlawMisconductOnAttackProtected(): Int = 5
+
+    /** Misconduct accrual on a killing blow against a Fame-protected victim. */
+    fun outlawMisconductOnKillProtected(): Int = 50
+
+    /**
+     * Cadence (in ticks) of the decay sweep. At each cycle every agent with
+     * `outlaw_misconduct_score > 0` gets [outlawDecayPerPeriod] subtracted
+     * from their score; transitions downshift state. Mirrors the
+     * [mountMaintenancePeriodTicks] shape — a coarse beat is fine here, the
+     * score doesn't need per-tick resolution.
+     */
+    fun outlawDecayPeriodTicks(): Int = 60
+    fun outlawDecayPerPeriod(): Int = 1
+
     /** Stamina spent per `tame` attempt, regardless of success. */
     fun tameStaminaCost(): Int = 15
 

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -121,6 +121,7 @@ class WorldTickHandler(
     private val mounts: dev.gvart.genesara.world.MountInstanceStore = dev.gvart.genesara.world.MountInstanceStore.NoOp,
     private val mountDeathCleanup: dev.gvart.genesara.world.environment.internal.mount.MountDeathCleanup,
     private val mountMaintenanceSweep: dev.gvart.genesara.world.environment.internal.mount.MountMaintenanceSweep? = null,
+    private val outlawDecaySweep: dev.gvart.genesara.world.combat.internal.pvp.OutlawDecaySweep? = null,
     private val leaseFence: WorldLeaseFence,
     @Value("\${application.tick.interval}") private val tickInterval: Duration,
     private val classes: ClassLookup = NoOpClassLookup,
@@ -177,6 +178,7 @@ class WorldTickHandler(
         val (afterDeaths, deathEvents) = processDeaths(afterPassives, deathProcessor, number)
         val (afterNpcAi, npcAiEvents) = npcAiSweep.apply(afterDeaths, number)
         val mountSweepEvents = mountMaintenanceSweep?.sweep(number).orEmpty()
+        val outlawDecayEvents = outlawDecaySweep?.sweep(number).orEmpty()
 
         val (next, commandEvents) = commands.fold(afterNpcAi to emptyList<WorldEvent>()) { (state, acc), command ->
             reduce(
@@ -226,6 +228,7 @@ class WorldTickHandler(
         commandEvents.forEach(publisher::publishEvent)
         cropDeathEvents.forEach(publisher::publishEvent)
         mountSweepEvents.forEach(publisher::publishEvent)
+        outlawDecayEvents.forEach(publisher::publishEvent)
     }
 
     /**


### PR DESCRIPTION
## Summary
- **Green-zone enforcement** in `AttackReducer` — attacks targeting an agent on a `pvp_enabled = false` node reject with `WorldRejection.GreenZone(agent, node)` before any side-effect.
- **Outlaw state machine** (CLEAN / WATCHED / OUTLAW) — accrual on kills/hits against Fame-protected victims, periodic decay sweep walks the score back down. Pure derivation in `OutlawState.deriveFrom(score, watchedAt, outlawAt)`; `MisconductOutcome` carries pre/post state so the dispatcher emits `SocialEvent.OutlawStateChanged` only on bucket transitions.
- **Schema (V210)** — `agents.outlaw_state` + `agents.outlaw_misconduct_score` with a partial index over the active-offender subset so the per-tick decay sweep stays proportional to flagged rows, not the full agent population.
- **Inspect projection** — `AgentInspectView.outlawState` at DETAILED+ depth (same Perception gate fame/authority use).
- The Fame-protection predicate that gates the witness cascade now also gates outlaw accrual — killing a "nobody" remains consequence-free, matching mechanics-reference §11.

## Spec & design
- [`docs/lore/mechanics-reference.md` §11 PvP](../blob/main/docs/lore/mechanics-reference.md#11-pvp) — green zones, outlaw state machine, Fame-suppression rule.
- `BalanceLookup` tunables (defaults): `outlawWatchedScore = 25`, `outlawOutlawScore = 100`, `outlawMisconductOnKillProtected = 50`, `outlawMisconductOnAttackProtected = 5`, `outlawDecayPeriodTicks = 60`, `outlawDecayPerPeriod = 1`.

## Test plan
- [x] Unit: `OutlawStateTest` — pure derivation, threshold boundaries (inclusive lower, negative score, inverted-thresholds rejected, equal-thresholds collapse).
- [x] Unit: `OutlawAccrualTest` — green-zone reject; kill/non-lethal accrual deltas; Fame-gate suppression on both lethal and non-lethal branches; same-bucket no-event.
- [x] Unit: `OutlawDecaySweepTest` — period-gate off-tick, transition filter, zero-amount short-circuit.
- [x] Integration (testcontainers Postgres): `JooqAgentRegistryOutlawIntegrationTest` — adjustMisconduct write composes additively, score+state stay consistent, schema CHECK holds under negative deltas, `decayMisconductScores` batches and returns transitions only.
- [x] Existing `WitnessCascadeTest` + `AttackReducerTest` + `AttackKillIntegrationTest` still green.
- [x] **Live MCP playtest (4/4)** — green-zone reject; kill → WATCHED transition; low-Fame kill suppressed; inspect surfaces outlawState. (Session log in `docs/playtest/sessions/s09-pvp-outlaw-infrastructure.log`, gitignored.)

## Out of scope (per #17)
- Outlaw effects on NPCs (refused trades, faction KOS) — Phase 3 #26.
- Bounty / hunter mechanics — community-built post-Beta.
- Attacker-side green-zone enforcement (sniper from sanctuary) — flagged with TODO; v1 is target-node only per spec.