### PR TITLE
fix(world,player,api): playtest s10 findings — NPC density + death signaling + move threat hint

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/McpServerConfiguration.kt
@@ -48,6 +48,7 @@ import dev.gvart.genesara.api.internal.mcp.tools.transport.MountTransportTool
 import dev.gvart.genesara.api.internal.mcp.tools.transport.StoreOnMountTool
 import dev.gvart.genesara.api.internal.mcp.tools.transport.TakeFromMountTool
 import dev.gvart.genesara.api.internal.mcp.tools.transport.TameTool
+import dev.gvart.genesara.api.internal.mcp.tools.events.GetEventsTool
 import dev.gvart.genesara.api.internal.mcp.tools.skills.EquipSkillTool
 import dev.gvart.genesara.api.internal.mcp.tools.spawn.SpawnTool
 import dev.gvart.genesara.api.internal.mcp.tools.unspawn.UnspawnTool
@@ -114,6 +115,7 @@ internal class McpServerConfiguration {
         leaveParty: LeavePartyTool,
         kickMember: KickMemberTool,
         getParty: GetPartyTool,
+        getEvents: GetEventsTool,
     ): ToolCallbackProvider {
         val methodProvider = MethodToolCallbackProvider.builder()
             .toolObjects(
@@ -130,6 +132,7 @@ internal class McpServerConfiguration {
                 tame, mountTransport, dismountTransport, maintain,
                 storeOnMount, takeFromMount,
                 partyInvite, partyRespond, leaveParty, kickMember, getParty,
+                getEvents,
             )
             .build()
         return EnumCaseInsensitiveToolCallbackProvider(methodProvider)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcher.kt
@@ -8,6 +8,7 @@ import dev.gvart.genesara.world.events.CombatEvent
 import dev.gvart.genesara.world.events.CoreEvent
 import dev.gvart.genesara.world.events.EconomyEvent
 import dev.gvart.genesara.world.events.EnvironmentEvent
+import dev.gvart.genesara.world.events.PassiveCause
 import dev.gvart.genesara.world.events.SocialEvent
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.invalidation.InvalidationBus
@@ -110,7 +111,8 @@ internal class AgentEventDispatcher(
     @EventListener
     fun on(event: BodyEvent.PassivesApplied) {
         event.deltas.forEach { (agent, delta) ->
-            publish(agent, "agent.passives", PassivesPayload(agent, delta, event.tick))
+            val causes = event.hpLossCauses[agent] ?: emptySet()
+            publish(agent, "agent.passives", PassivesPayload(agent, delta, event.tick, causes))
         }
     }
 
@@ -122,6 +124,9 @@ internal class AgentEventDispatcher(
 
     @EventListener
     fun on(event: CombatEvent.AgentAttackedNpc) = publish(event.attacker, "agent.attacked_npc", event)
+
+    @EventListener
+    fun on(event: CombatEvent.NpcAttackedAgent) = publish(event.target, "npc.attacked_agent", event)
 
     @EventListener
     fun on(event: EnvironmentEvent.NpcDied) {
@@ -256,5 +261,6 @@ internal class AgentEventDispatcher(
         val agent: AgentId,
         val delta: BodyDelta,
         val tick: Long,
+        val hpLossCauses: Set<PassiveCause> = emptySet(),
     )
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/PrefixedIds.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/PrefixedIds.kt
@@ -42,6 +42,17 @@ internal object PrefixedIds {
 
     fun parseAgent(raw: String): AgentId? = parseTyped(raw, AGENT)?.let(::AgentId)
 
+    /**
+     * Lenient variant: accepts `agent:<uuid>` (canonical) OR bare `<uuid>`. Use this
+     * at tool boundaries where the input is unambiguously an agent id (e.g. `inspect`,
+     * `trade_offer`, `party_invite`). [parseAttackTarget] cannot use this because the
+     * caller must also discriminate between agent/npc/mount, so the prefix is required
+     * for type safety.
+     */
+    fun parseAgentLenient(raw: String): AgentId? =
+        parseTyped(raw, AGENT)?.let(::AgentId)
+            ?: runCatching { AgentId(UUID.fromString(raw)) }.getOrNull()
+
     fun parseNpc(raw: String): NpcId? = parseTyped(raw, NPC)?.let(::NpcId)
 
     fun parseMount(raw: String): MountId? = parseTyped(raw, MOUNT)?.let(::MountId)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/events/GetEventsTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/events/GetEventsTool.kt
@@ -1,0 +1,56 @@
+package dev.gvart.genesara.api.internal.mcp.tools.events
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.events.AgentEventLog
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
+import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.ai.tool.annotation.ToolParam
+import org.springframework.stereotype.Component
+
+@Component
+internal class GetEventsTool(
+    private val log: AgentEventLog,
+    private val activity: AgentActivityTracker,
+) {
+
+    @Tool(
+        name = "get_events",
+        description = "Read events from the caller's personal event stream. Events include party invites, " +
+            "trade offers, inbound NPC attacks, say broadcasts, skill recommendations, combat outcomes, " +
+            "and command rejections. Use `since` to paginate: pass the last-seen `seq` and only newer " +
+            "events are returned. Use `types` to filter, e.g. [\"party.invite_received\", \"trade.offer_received\"]. " +
+            "Returns up to `limit` events (max 200) in ascending seq order.",
+    )
+    fun invoke(
+        @ToolParam(description = "Return events with seq strictly greater than this value. Omit (or pass 0) to start from the oldest retained event.", required = false)
+        since: Long?,
+        @ToolParam(description = "Maximum number of events to return. Capped at 200. Defaults to 50.", required = false)
+        limit: Int?,
+        @ToolParam(description = "Optional list of event type strings to include. When absent all types are returned.", required = false)
+        types: List<String>?,
+        toolContext: ToolContext,
+    ): GetEventsOutput {
+        touchActivity(toolContext, activity, "get_events")
+        val agentId = AgentContextHolder.current()
+        val effectiveLimit = (limit ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
+        val after = since ?: 0L
+
+        val events = log.since(agentId, after)
+            .let { all -> if (types.isNullOrEmpty()) all else all.filter { it.type in types } }
+            .takeLast(effectiveLimit)
+
+        return GetEventsOutput(
+            events = events.map { e ->
+                EventView(seq = e.seq, type = e.type, tick = e.tick, payload = e.payload)
+            },
+            count = events.size,
+        )
+    }
+
+    companion object {
+        private const val DEFAULT_LIMIT = 50
+        private const val MAX_LIMIT = 200
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/events/GetEventsToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/events/GetEventsToolIo.kt
@@ -1,0 +1,15 @@
+package dev.gvart.genesara.api.internal.mcp.tools.events
+
+import tools.jackson.databind.JsonNode
+
+data class GetEventsOutput(
+    val events: List<EventView>,
+    val count: Int,
+)
+
+data class EventView(
+    val seq: Long,
+    val type: String,
+    val tick: Long,
+    val payload: JsonNode,
+)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusTool.kt
@@ -62,6 +62,7 @@ internal class GetStatusTool(
             location = location?.value,
             safeNode = safeNodes.find(agentId)?.value,
             tick = world.currentTickFor(agentId),
+            outlawState = agent.outlawState.name,
             skills = skillsProjection.project(agentId),
             pendingClassChoice = agent.offeredClasses?.toList() ?: emptyList(),
             pendingEvolutionChoice = agent.offeredEvolutions?.toList() ?: emptyList(),

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolIo.kt
@@ -24,6 +24,8 @@ data class GetStatusResponse(
     val safeNode: Long? = null,
     val tick: Long,
     val activeEffects: List<String> = emptyList(),
+    /** PvP outlaw status — always present; "CLEAN" for agents that have never attacked a protected target. */
+    val outlawState: String,
     val skills: SkillsView,
     /**
      * The two classes offered by the level-10 event when [classId] is null.

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectTool.kt
@@ -73,7 +73,7 @@ internal class InspectTool(
         targetType: InspectTargetType,
         @ToolParam(
             required = true,
-            description = "Target id. NODE: numeric BIGINT. AGENT: wire-prefixed `agent:<uuid>`. " +
+            description = "Target id. NODE: numeric BIGINT. AGENT: bare UUID or wire-prefixed `agent:<uuid>`. " +
                 "BUILDING: building instance UUID. ITEM: ItemId string OR equipment instance UUID. " +
                 "MOUNT: wire-prefixed `mount:<uuid>`.",
         )
@@ -223,8 +223,8 @@ internal class InspectTool(
         } else null
 
     private fun inspectAgent(agentId: AgentId, targetId: String, depth: InspectDepth): InspectResponse {
-        val targetAgentId = PrefixedIds.parseAgent(targetId)
-            ?: return errorResponse(depth, InspectError.BAD_TARGET_ID, "agent id must be agent:<uuid>")
+        val targetAgentId = PrefixedIds.parseAgentLenient(targetId)
+            ?: return errorResponse(depth, InspectError.BAD_TARGET_ID, "agent id must be a UUID or agent:<uuid>")
         val target = agents.find(targetAgentId)
             ?: return errorResponse(depth, InspectError.NOT_FOUND, "agent not found")
 
@@ -340,7 +340,7 @@ internal class InspectTool(
             activeEffects = activeEffects,
             authority = if (showReputation) target.authority else null,
             fame = if (showReputation) target.fame else null,
-            outlawState = if (showReputation) target.outlawState.name else null,
+            outlawState = target.outlawState.name,
         )
     }
 

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolIo.kt
@@ -137,7 +137,7 @@ data class AgentInspectView(
     val authority: Int? = null,
     /** DETAILED+: global fame. Below `BalanceLookup.fameWitnessProtectionThreshold` the agent has no PvP protection — visible context for any nearby attacker. */
     val fame: Int? = null,
-    /** DETAILED+: outlaw bucket (mechanics-reference §11). One of CLEAN / WATCHED / OUTLAW. Phase 3 NPC behaviors will gate on this. */
+    /** Always present: outlaw bucket (mechanics-reference §11). One of CLEAN / WATCHED / OUTLAW. Phase 3 NPC behaviors will gate on this. */
     val outlawState: String? = null,
 )
 

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/party/KickMemberTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/party/KickMemberTool.kt
@@ -32,17 +32,17 @@ internal class KickMemberTool(
     fun invoke(
         @ToolParam(
             required = true,
-            description = "Wire-prefixed id of the agent to remove, e.g. `agent:<uuid>`.",
+            description = "Agent id to remove — bare UUID or wire-prefixed `agent:<uuid>`.",
         )
         target: String,
         toolContext: ToolContext,
     ): CommandAckResponse {
         touchActivity(toolContext, activity, "kick_member")
-        val targetId = PrefixedIds.parseAgent(target)
+        val targetId = PrefixedIds.parseAgentLenient(target)
             ?: return CommandAckResponse.rejected(
                 target = target,
                 reason = "bad_target_id",
-                detail = "target must be agent:<uuid>",
+                detail = "target must be a UUID or agent:<uuid>",
             )
         val agent = AgentContextHolder.current()
         val command = SocialCommand.KickPartyMember(agent = agent, target = targetId)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/party/PartyInviteTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/party/PartyInviteTool.kt
@@ -38,8 +38,8 @@ internal class PartyInviteTool(
     fun invoke(
         @ToolParam(
             required = true,
-            description = "Wire-prefixed agent ids to invite — comma-separated `agent:<uuid>` values " +
-                "(e.g. `agent:abc-123,agent:def-456`). Pass at least one.",
+            description = "Agent ids to invite — comma-separated bare UUIDs or wire-prefixed `agent:<uuid>` values " +
+                "(e.g. `agent:abc-123,agent:def-456` or `abc-123,def-456`). Pass at least one.",
         )
         invitees: String,
         toolContext: ToolContext,
@@ -65,11 +65,11 @@ internal class PartyInviteTool(
         }
         val parsed = mutableListOf<AgentId>()
         for (raw in parts) {
-            val id = PrefixedIds.parseAgent(raw)
+            val id = PrefixedIds.parseAgentLenient(raw)
                 ?: return CommandAckResponse.rejected(
                     target = raw,
                     reason = "bad_invitee_id",
-                    detail = "each entry must be agent:<uuid>",
+                    detail = "each entry must be a UUID or agent:<uuid>",
                 )
             parsed += id
         }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/spawn/SpawnTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/spawn/SpawnTool.kt
@@ -4,7 +4,10 @@ import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
 import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentProfileLookup
+import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.WorldQueryGateway
 import dev.gvart.genesara.world.commands.CoreCommand
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.annotation.Tool
@@ -13,19 +16,36 @@ import org.springframework.stereotype.Component
 @Component
 internal class SpawnTool(
     private val world: WorldCommandGateway,
+    private val worldQuery: WorldQueryGateway,
     private val engine: TickClock,
     private val activity: AgentActivityTracker,
+    private val agents: AgentRegistry,
+    private val profiles: AgentProfileLookup,
 ) {
 
     @Tool(
         name = "spawn",
-        description = "Login: enter the world. The simulation chooses the destination — last node if the agent has played before, otherwise their race's starter node, falling back to a random spawnable node. The resolved node is reported on the resulting agent.spawned event.",
+        description = "Login: enter the world. The simulation chooses the destination — last node if the agent has played before, otherwise their race's starter node, falling back to a random spawnable node. The resolved node is reported on the resulting agent.spawned event. " +
+            "initialLocation and initialHp in the response are synchronous projections of the expected post-spawn state — use them instead of calling get_status immediately after spawn.",
     )
     fun invoke(toolContext: ToolContext): SpawnResponse {
         touchActivity(toolContext, activity, "spawn")
         val agentId = AgentContextHolder.current()
         val command = CoreCommand.SpawnAgent(agent = agentId)
         val appliesAtTick = world.submit(command, appliesAtTick = engine.currentTick() + 1)
-        return SpawnResponse(commandId = command.commandId, appliesAtTick = appliesAtTick)
+
+        val agent = agents.find(agentId)
+        val existingBody = worldQuery.bodyOf(agentId)
+        val existingLocation = worldQuery.locationOf(agentId)
+            ?: agent?.race?.let { worldQuery.starterNodeFor(it) }
+            ?: worldQuery.randomSpawnableNode()
+        val initialHp = existingBody?.hp ?: profiles.find(agentId)?.maxHp
+
+        return SpawnResponse(
+            commandId = command.commandId,
+            appliesAtTick = appliesAtTick,
+            initialLocation = existingLocation?.value,
+            initialHp = initialHp,
+        )
     }
 }

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/spawn/SpawnToolIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/spawn/SpawnToolIo.kt
@@ -5,8 +5,16 @@ import java.util.UUID
 /**
  * Response shape for `spawn`. A SpawnAgent command is queued; the resolved node lands
  * on the resulting `agent.spawned` event tagged with [commandId] as `causedBy`.
+ *
+ * [initialLocation] and [initialHp] are the best-effort pre-tick projections of where
+ * the agent will land and what HP they will have. These values are computed synchronously
+ * so callers do not need to immediately call `get_status` after spawn — both fields come
+ * from the same DB rows the world reducer will read. They can be null when the agent has
+ * never spawned and no starter node is configured.
  */
 data class SpawnResponse(
     val commandId: UUID,
     val appliesAtTick: Long,
+    val initialLocation: Long?,
+    val initialHp: Int?,
 )

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/trade/TradeOfferTool.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/mcp/tools/trade/TradeOfferTool.kt
@@ -3,8 +3,8 @@ package dev.gvart.genesara.api.internal.mcp.tools.trade
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityTracker
 import dev.gvart.genesara.api.internal.mcp.presence.touchActivity
+import dev.gvart.genesara.api.internal.mcp.tools.PrefixedIds
 import dev.gvart.genesara.engine.TickClock
-import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.WorldCommandGateway
 import dev.gvart.genesara.world.commands.EconomyCommand
@@ -35,7 +35,7 @@ internal class TradeOfferTool(
             "TradeInstanceNotOwned, TradeInstanceUnavailable.",
     )
     fun invoke(
-        @ToolParam(required = true, description = "Recipient agent UUID. Must be on your current node.")
+        @ToolParam(required = true, description = "Recipient agent id — bare UUID or wire-prefixed `agent:<uuid>`. Must be on your current node.")
         recipientId: String,
         @ToolParam(required = true, description = "Items you offer, keyed by itemId -> positive quantity.")
         offer: Map<String, Int>,
@@ -48,10 +48,10 @@ internal class TradeOfferTool(
         toolContext: ToolContext,
     ): TradeOfferResponse {
         touchActivity(toolContext, activity, "trade_offer")
-        val recipientUuid = runCatching { UUID.fromString(recipientId) }.getOrNull()
+        val recipient = PrefixedIds.parseAgentLenient(recipientId)
             ?: return TradeOfferResponse.rejected(
                 reason = "bad_recipient_id",
-                detail = "recipientId must be a UUID",
+                detail = "recipientId must be a UUID or agent:<uuid>",
             )
         val offerInstanceList = offerInstances.orEmpty()
         val requestInstanceList = requestInstances.orEmpty()
@@ -80,7 +80,7 @@ internal class TradeOfferTool(
         val agent = AgentContextHolder.current()
         val command = EconomyCommand.TradeOffer(
             agent = agent,
-            recipient = AgentId(recipientUuid),
+            recipient = recipient,
             offered = offer.mapKeys { ItemId(it.key) },
             requested = request.mapKeys { ItemId(it.key) },
             offeredInstances = offerInstanceIds,

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
@@ -3,20 +3,25 @@ package dev.gvart.genesara.api.internal.mcp.events
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.BodyDelta
 import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.DamageType
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NpcId
+import dev.gvart.genesara.world.NpcType
 import dev.gvart.genesara.world.events.BodyEvent
 import dev.gvart.genesara.world.events.CombatEvent
 import dev.gvart.genesara.world.events.CoreEvent
 import dev.gvart.genesara.world.events.EconomyEvent
 import dev.gvart.genesara.world.events.EnvironmentEvent
+import dev.gvart.genesara.world.events.PassiveCause
 import dev.gvart.genesara.world.invalidation.InvalidationBus
 import dev.gvart.genesara.world.invalidation.InvalidationMessage
 import java.util.UUID
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
@@ -748,8 +753,8 @@ class AgentEventDispatcherTest {
         val a2 = AgentId(UUID.randomUUID())
         val event = BodyEvent.PassivesApplied(
             deltas = mapOf(
-                a1 to dev.gvart.genesara.world.BodyDelta(stamina = 1),
-                a2 to dev.gvart.genesara.world.BodyDelta(hp = 2),
+                a1 to BodyDelta(stamina = 1),
+                a2 to BodyDelta(hp = 2),
             ),
             tick = 3L,
         )
@@ -760,5 +765,89 @@ class AgentEventDispatcherTest {
         assertEquals(1, log.since(a2, 0).size)
         verify(bus).publish(InvalidationMessage.AgentNotify(a1))
         verify(bus).publish(InvalidationMessage.AgentNotify(a2))
+    }
+
+    @Test
+    fun `PassivesApplied with starvation cause lands hpLossCauses on the target's envelope`() {
+        val victim = AgentId(UUID.randomUUID())
+        val event = BodyEvent.PassivesApplied(
+            deltas = mapOf(victim to BodyDelta(hp = -2)),
+            tick = 5L,
+            hpLossCauses = mapOf(victim to setOf(PassiveCause.STARVATION, PassiveCause.DEHYDRATION)),
+        )
+
+        dispatcher.on(event)
+
+        val entry = log.since(victim, 0).single()
+        assertEquals("agent.passives", entry.type)
+        val causes = entry.payload.get("hpLossCauses")
+        assertEquals(2, causes.size())
+        val causeValues = (0 until causes.size()).map { causes.get(it).asText() }.toSet()
+        assertTrue("STARVATION" in causeValues)
+        assertTrue("DEHYDRATION" in causeValues)
+    }
+
+    @Test
+    fun `PassivesApplied regen tick has empty hpLossCauses`() {
+        val a = AgentId(UUID.randomUUID())
+        val event = BodyEvent.PassivesApplied(
+            deltas = mapOf(a to BodyDelta(stamina = 1)),
+            tick = 2L,
+        )
+
+        dispatcher.on(event)
+
+        val entry = log.since(a, 0).single()
+        val causes = entry.payload.get("hpLossCauses")
+        assertTrue(causes == null || causes.isEmpty)
+    }
+
+    @Test
+    fun `NpcAttackedAgent lands on the target agent's stream`() {
+        val target = AgentId(UUID.randomUUID())
+        val event = CombatEvent.NpcAttackedAgent(
+            npc = NpcId(UUID.randomUUID()),
+            npcType = NpcType("WILD_BOAR"),
+            target = target,
+            at = NodeId(3L),
+            damageType = DamageType.PIERCE,
+            baseDamage = 8,
+            hpLost = 8,
+            isDodged = false,
+            targetHpAfter = 42,
+            targetKilled = false,
+            tick = 20L,
+        )
+
+        dispatcher.on(event)
+
+        val entry = log.since(target, 0).single()
+        assertEquals("npc.attacked_agent", entry.type)
+        assertEquals(20L, entry.tick)
+        assertEquals(8, entry.payload.get("hpLost").asInt())
+        assertEquals("WILD_BOAR", entry.payload.get("npcType").asText())
+    }
+
+    @Test
+    fun `NpcAttackedAgent does not land on unrelated agents`() {
+        val target = AgentId(UUID.randomUUID())
+        val bystander = AgentId(UUID.randomUUID())
+        val event = CombatEvent.NpcAttackedAgent(
+            npc = NpcId(UUID.randomUUID()),
+            npcType = NpcType("WOLF"),
+            target = target,
+            at = NodeId(1L),
+            damageType = DamageType.SLASH,
+            baseDamage = 5,
+            hpLost = 5,
+            isDodged = false,
+            targetHpAfter = 95,
+            targetKilled = false,
+            tick = 3L,
+        )
+
+        dispatcher.on(event)
+
+        assertEquals(0, log.since(bystander, 0).size)
     }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/events/AgentEventDispatcherTest.kt
@@ -60,6 +60,31 @@ class AgentEventDispatcherTest {
     }
 
     @Test
+    fun `AgentMoved payload carries destinationThreatHint on the stream`() {
+        val cmdId = UUID.randomUUID()
+        dispatcher.on(
+            CoreEvent.AgentMoved(
+                agent = agent,
+                from = NodeId(1L),
+                to = NodeId(2L),
+                staminaSpent = 1,
+                tick = 5,
+                causedBy = cmdId,
+                destinationThreatHint = listOf(
+                    dev.gvart.genesara.world.NpcType("BROWN_BEAR"),
+                    dev.gvart.genesara.world.NpcType("WILD_BOAR"),
+                ),
+            ),
+        )
+
+        val envelope = log.since(agent, 0).single()
+        val hint = envelope.payload.get("destinationThreatHint")
+        assertEquals(2, hint.size())
+        assertEquals("BROWN_BEAR", hint.get(0).asString())
+        assertEquals("WILD_BOAR", hint.get(1).asString())
+    }
+
+    @Test
     fun `AgentDespawned publishes the event and keeps the log readable for cursor-based replay`() {
         val cmdId = UUID.randomUUID()
         // Pre-existing event from before the despawn

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/PrefixedIdsTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/PrefixedIdsTest.kt
@@ -55,6 +55,26 @@ class PrefixedIdsTest {
     }
 
     @Test
+    fun `parseAgentLenient accepts wire-prefixed form`() {
+        val id = AgentId(sampleUuid)
+        assertEquals(id, PrefixedIds.parseAgentLenient("agent:$sampleUuid"))
+    }
+
+    @Test
+    fun `parseAgentLenient accepts bare UUID`() {
+        val id = AgentId(sampleUuid)
+        assertEquals(id, PrefixedIds.parseAgentLenient(sampleUuid.toString()))
+    }
+
+    @Test
+    fun `parseAgentLenient rejects wrong prefix, malformed UUID, and blank`() {
+        assertNull(PrefixedIds.parseAgentLenient("npc:$sampleUuid"))
+        assertNull(PrefixedIds.parseAgentLenient("agent:not-a-uuid"))
+        assertNull(PrefixedIds.parseAgentLenient("not-a-uuid"))
+        assertNull(PrefixedIds.parseAgentLenient(""))
+    }
+
+    @Test
     fun `parseAttackTarget dispatches to Agent and Npc variants`() {
         val agent = PrefixedIds.parseAttackTarget("agent:$sampleUuid")
         assertIs<AttackTarget.Agent>(agent)

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/events/GetEventsToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/events/GetEventsToolTest.kt
@@ -1,0 +1,127 @@
+package dev.gvart.genesara.api.internal.mcp.tools.events
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.events.AgentEvent
+import dev.gvart.genesara.api.internal.mcp.events.AgentEventLog
+import dev.gvart.genesara.api.internal.mcp.events.FakeAgentEventLog
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.player.AgentId
+import java.time.Clock
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+import tools.jackson.databind.node.JsonNodeFactory
+
+class GetEventsToolTest {
+
+    private val agentId = AgentId(UUID.randomUUID())
+    private val log: FakeAgentEventLog = FakeAgentEventLog()
+    private val activity = AgentActivityRegistry(Clock.systemUTC())
+    private val tool = GetEventsTool(log, activity)
+    private val toolContext = ToolContext(emptyMap())
+    private val nodes = JsonNodeFactory.instance
+
+    @BeforeEach
+    fun setup() {
+        AgentContextHolder.set(agentId)
+    }
+
+    @AfterEach
+    fun teardown() {
+        AgentContextHolder.clear()
+    }
+
+    private fun appendEvent(type: String, tick: Long = 1L): AgentEvent =
+        log.append(agentId, type, tick, nodes.objectNode())
+
+    @Test
+    fun `returns up to limit events from the tail when since is null`() {
+        repeat(5) { appendEvent("agent.moved", it.toLong()) }
+
+        val output = tool.invoke(since = null, limit = 3, types = null, toolContext = toolContext)
+
+        assertEquals(3, output.count)
+        assertEquals(3, output.events.size)
+    }
+
+    @Test
+    fun `returns events strictly after since`() {
+        val e1 = appendEvent("agent.spawned")
+        appendEvent("agent.moved")
+        appendEvent("agent.moved")
+
+        val output = tool.invoke(since = e1.seq, limit = 50, types = null, toolContext = toolContext)
+
+        assertEquals(2, output.count)
+        assertTrue(output.events.all { it.seq > e1.seq })
+    }
+
+    @Test
+    fun `filters by type when types is provided`() {
+        appendEvent("agent.spawned")
+        appendEvent("agent.moved")
+        appendEvent("party.invite_received")
+        appendEvent("agent.moved")
+
+        val output = tool.invoke(since = null, limit = 50, types = listOf("agent.moved"), toolContext = toolContext)
+
+        assertEquals(2, output.count)
+        assertTrue(output.events.all { it.type == "agent.moved" })
+    }
+
+    @Test
+    fun `returns empty list when no matching types`() {
+        appendEvent("agent.spawned")
+        appendEvent("agent.moved")
+
+        val output = tool.invoke(since = null, limit = 50, types = listOf("party.invite_received"), toolContext = toolContext)
+
+        assertEquals(0, output.count)
+        assertTrue(output.events.isEmpty())
+    }
+
+    @Test
+    fun `caps limit at 200`() {
+        repeat(300) { appendEvent("agent.moved", it.toLong()) }
+
+        val output = tool.invoke(since = null, limit = 999, types = null, toolContext = toolContext)
+
+        assertEquals(200, output.count)
+    }
+
+    @Test
+    fun `returns all events when since is 0 and limit is large enough`() {
+        repeat(5) { appendEvent("agent.moved", it.toLong()) }
+
+        val output = tool.invoke(since = 0L, limit = 50, types = null, toolContext = toolContext)
+
+        assertEquals(5, output.count)
+    }
+
+    @Test
+    fun `events are returned in ascending seq order`() {
+        repeat(5) { appendEvent("agent.moved", it.toLong()) }
+
+        val output = tool.invoke(since = null, limit = 50, types = null, toolContext = toolContext)
+
+        val seqs = output.events.map { it.seq }
+        assertEquals(seqs.sorted(), seqs)
+    }
+
+    @Test
+    fun `since plus types filter combine correctly`() {
+        val first = appendEvent("party.invite_received")
+        appendEvent("agent.moved")
+        appendEvent("party.invite_received")
+
+        val output = tool.invoke(since = first.seq, limit = 50, types = listOf("party.invite_received"), toolContext = toolContext)
+
+        assertEquals(1, output.count)
+        assertEquals("party.invite_received", output.events.single().type)
+        assertTrue(output.events.single().seq > first.seq)
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/getstatus/GetStatusToolTest.kt
@@ -8,6 +8,7 @@ import dev.gvart.genesara.player.AddXpResult
 import dev.gvart.genesara.player.Agent
 import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.OutlawState
 import dev.gvart.genesara.player.AgentPerk
 import dev.gvart.genesara.player.AgentPerksRegistry
 import dev.gvart.genesara.player.AgentPerksSnapshot
@@ -129,6 +130,7 @@ class GetStatusToolTest {
         assertEquals(PoolView(5, 15), res.mana)
         assertEquals(node.value, res.location)
         assertEquals(200L, res.tick)
+        assertEquals("CLEAN", res.outlawState)
         assertEquals(emptyList(), res.activeEffects)
         assertEquals(8, res.skills.slotCount)
         assertEquals(0, res.skills.slotsFilled)
@@ -443,6 +445,33 @@ class GetStatusToolTest {
         val skills = tool.invoke(toolContext).skills
 
         assertEquals(emptyList(), skills.pendingPerkChoices)
+    }
+
+    @Test
+    fun `outlawState is CLEAN for a fresh agent that has never attacked`() {
+        val tool = GetStatusTool(
+            agents = StubRegistry(agent),
+            world = StubQuery(active = node, body = body),
+            activity = activity,
+            skillsProjection = AgentSkillsProjection(emptySkills, skillCatalog, StubPerksRegistry(), StubPerkLookup()),
+            safeNodes = StubSafeNodes(),
+        )
+
+        assertEquals("CLEAN", tool.invoke(toolContext).outlawState)
+    }
+
+    @Test
+    fun `outlawState is OUTLAW when the agent has exceeded the misconduct threshold`() {
+        val outlaw = agent.copy(outlawState = OutlawState.OUTLAW)
+        val tool = GetStatusTool(
+            agents = StubRegistry(outlaw),
+            world = StubQuery(active = node, body = body),
+            activity = activity,
+            skillsProjection = AgentSkillsProjection(emptySkills, skillCatalog, StubPerksRegistry(), StubPerkLookup()),
+            safeNodes = StubSafeNodes(),
+        )
+
+        assertEquals("OUTLAW", tool.invoke(toolContext).outlawState)
     }
 
     private fun stubSkillLookupForPerks() = StubSkillLookup(

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
@@ -314,6 +314,31 @@ class InspectToolTest {
     }
 
     @Test
+    fun `inspect agent accepts bare UUID without agent-colon prefix`() {
+        val tool = tool(perception = 10, otherAgentNode = currentNodeId, body = body(hp = 50, maxHp = 100))
+        val resp = tool.dispatch("agent", otherAgentId.id.toString(), toolContext)
+
+        assertEquals("agent", resp.kind)
+        assertEquals("wanderer", resp.agent?.name)
+    }
+
+    @Test
+    fun `inspect agent returns outlawState CLEAN at SHALLOW Perception`() {
+        val tool = tool(perception = 1, otherAgentNode = currentNodeId, body = body(hp = 50, maxHp = 100))
+        val resp = tool.dispatch("agent", "agent:${otherAgentId.id}", toolContext)
+
+        assertEquals("CLEAN", resp.agent?.outlawState, "outlawState must always be present, not gated by depth")
+    }
+
+    @Test
+    fun `inspect agent returns outlawState CLEAN at DETAILED Perception`() {
+        val tool = tool(perception = 10, otherAgentNode = currentNodeId, body = body(hp = 50, maxHp = 100))
+        val resp = tool.dispatch("agent", "agent:${otherAgentId.id}", toolContext)
+
+        assertEquals("CLEAN", resp.agent?.outlawState)
+    }
+
+    @Test
     fun `inspect agent who passed presence but has no body row returns NOT_FOUND`() {
         // State inconsistency guard: agent has an active position row but no body row.
         // The tool surfaces it as NOT_FOUND so a caller has something to react to.

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/party/PartyToolsTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/party/PartyToolsTest.kt
@@ -69,10 +69,22 @@ class PartyToolsTest {
     }
 
     @Test
-    fun `party_invite rejects an entry without the agent prefix`() {
+    fun `party_invite accepts bare UUID form`() {
         val tool = PartyInviteTool(gateway, tickClock, activity)
 
-        val response = tool.invoke("not-prefixed-uuid", toolContext)
+        val response = tool.invoke(alice.id.toString(), toolContext)
+
+        assertEquals(CommandAckKind.QUEUED, response.kind)
+        val (cmd, _) = gateway.submissions.single()
+        val invite = cmd as SocialCommand.PartyInvite
+        assertEquals(listOf(alice), invite.invitees)
+    }
+
+    @Test
+    fun `party_invite rejects a malformed id that is not a UUID`() {
+        val tool = PartyInviteTool(gateway, tickClock, activity)
+
+        val response = tool.invoke("not-a-uuid", toolContext)
 
         assertEquals(CommandAckKind.REJECTED, response.kind)
         assertEquals("bad_invitee_id", response.reason)
@@ -149,10 +161,22 @@ class PartyToolsTest {
     }
 
     @Test
-    fun `kick_member rejects a bare UUID without the prefix`() {
+    fun `kick_member accepts bare UUID form`() {
         val tool = KickMemberTool(gateway, tickClock, activity)
 
-        val response = tool.invoke(UUID.randomUUID().toString(), toolContext)
+        val response = tool.invoke(alice.id.toString(), toolContext)
+
+        assertEquals(CommandAckKind.QUEUED, response.kind)
+        val (cmd, _) = gateway.submissions.single()
+        val kick = assertNotNull(cmd as? SocialCommand.KickPartyMember)
+        assertEquals(alice, kick.target)
+    }
+
+    @Test
+    fun `kick_member rejects a malformed id that is not a UUID`() {
+        val tool = KickMemberTool(gateway, tickClock, activity)
+
+        val response = tool.invoke("not-a-uuid", toolContext)
 
         assertEquals(CommandAckKind.REJECTED, response.kind)
         assertEquals("bad_target_id", response.reason)

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/spawn/SpawnToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/spawn/SpawnToolTest.kt
@@ -1,10 +1,20 @@
 package dev.gvart.genesara.api.internal.mcp.tools.spawn
 
+import dev.gvart.genesara.account.PlayerId
 import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
 import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
 import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentProfile
+import dev.gvart.genesara.player.AgentProfileLookup
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.world.BodyView
+import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.WorldQueryGateway
 import dev.gvart.genesara.world.commands.CoreCommand
 import dev.gvart.genesara.world.commands.WorldCommand
 import java.time.Clock
@@ -14,6 +24,7 @@ import java.time.ZoneOffset
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -29,12 +40,23 @@ class SpawnToolTest {
     private val tickClock = StubTickClock(currentTick = 100L)
     private val toolContext = ToolContext(emptyMap())
 
+    private val raceId = RaceId("human_commoner")
+    private val agent = Agent(
+        id = agentId,
+        owner = PlayerId(UUID.randomUUID()),
+        name = "Komar",
+        race = raceId,
+        attributes = AgentAttributes(),
+    )
+    private val starterNode = NodeId(42L)
+    private val profile = AgentProfile(id = agentId, maxHp = 80, maxStamina = 50, maxMana = 5)
+
     @BeforeEach fun setUp() = AgentContextHolder.set(agentId)
     @AfterEach fun tearDown() = AgentContextHolder.clear()
 
     @Test
     fun `queues a SpawnAgent command at the next tick and returns the ack`() {
-        val tool = SpawnTool(gateway, tickClock, activity)
+        val tool = spawnTool()
 
         val response = tool.invoke(toolContext)
 
@@ -47,8 +69,41 @@ class SpawnToolTest {
     }
 
     @Test
+    fun `returns existing location and body hp for a returning agent`() {
+        val existingNode = NodeId(99L)
+        val body = BodyView(hp = 75, maxHp = 80, stamina = 30, maxStamina = 50, mana = 0, maxMana = 5,
+            hunger = 100, maxHunger = 100, thirst = 100, maxThirst = 100, sleep = 100, maxSleep = 100)
+        val tool = spawnTool(lastLocation = existingNode, body = body)
+
+        val response = tool.invoke(toolContext)
+
+        assertEquals(99L, response.initialLocation)
+        assertEquals(75, response.initialHp)
+    }
+
+    @Test
+    fun `returns starter-node location and profile max hp for a first-time agent`() {
+        val tool = spawnTool(starterNode = starterNode)
+
+        val response = tool.invoke(toolContext)
+
+        assertEquals(42L, response.initialLocation)
+        assertEquals(80, response.initialHp)
+    }
+
+    @Test
+    fun `returns null location and null hp when no node and no profile exist`() {
+        val tool = spawnTool(hasAgent = false)
+
+        val response = tool.invoke(toolContext)
+
+        assertNull(response.initialLocation)
+        assertNull(response.initialHp)
+    }
+
+    @Test
     fun `touches activity registry on every successful invocation`() {
-        val tool = SpawnTool(gateway, tickClock, activity)
+        val tool = spawnTool()
 
         assertTrue(agentId !in activity.staleAgents(clock.instant().minusSeconds(60)))
 
@@ -56,6 +111,20 @@ class SpawnToolTest {
 
         assertTrue(agentId in activity.staleAgents(clock.instant().plusSeconds(60)))
     }
+
+    private fun spawnTool(
+        lastLocation: NodeId? = null,
+        body: BodyView? = null,
+        starterNode: NodeId? = null,
+        hasAgent: Boolean = true,
+    ) = SpawnTool(
+        world = gateway,
+        worldQuery = StubQuery(lastLocation = lastLocation, body = body, starterNode = starterNode),
+        engine = tickClock,
+        activity = activity,
+        agents = StubAgentRegistry(if (hasAgent) agent else null),
+        profiles = StubProfileLookup(if (hasAgent) profile else null),
+    )
 
     private class RecordingGateway : WorldCommandGateway {
         val submissions = mutableListOf<Pair<WorldCommand, Long>>()
@@ -73,5 +142,36 @@ class SpawnToolTest {
         override fun instant(): Instant = now
         override fun getZone(): ZoneId = ZoneOffset.UTC
         override fun withZone(zone: ZoneId?): Clock = this
+    }
+
+    private class StubAgentRegistry(private val agent: Agent?) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = agent
+        override fun listForOwner(owner: PlayerId): List<Agent> = listOfNotNull(agent)
+    }
+
+    private class StubProfileLookup(private val profile: AgentProfile?) : AgentProfileLookup {
+        override fun find(id: AgentId): AgentProfile? = profile
+    }
+
+    private class StubQuery(
+        private val lastLocation: NodeId? = null,
+        private val body: BodyView? = null,
+        private val starterNode: NodeId? = null,
+    ) : WorldQueryGateway {
+        override fun locationOf(agent: AgentId): NodeId? = lastLocation
+        override fun activePositionOf(agent: AgentId): NodeId? = null
+        override fun bodyOf(agent: AgentId): BodyView? = body
+        override fun starterNodeFor(race: RaceId): NodeId? = starterNode
+        override fun randomSpawnableNode(): NodeId? = null
+        override fun node(id: NodeId): dev.gvart.genesara.world.Node? = null
+        override fun region(id: dev.gvart.genesara.world.RegionId): dev.gvart.genesara.world.Region? = null
+        override fun nodesWithin(origin: NodeId, radius: Int): Set<NodeId> = emptySet()
+        override fun inventoryOf(agent: AgentId): dev.gvart.genesara.world.InventoryView =
+            dev.gvart.genesara.world.InventoryView(emptyList())
+        override fun resourcesAt(nodeId: NodeId, tick: Long): dev.gvart.genesara.world.NodeResources =
+            dev.gvart.genesara.world.NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId): List<dev.gvart.genesara.world.GroundItemView> = emptyList()
+        override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> = emptyMap()
     }
 }

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/trade/TradeOfferToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/trade/TradeOfferToolTest.kt
@@ -1,0 +1,110 @@
+package dev.gvart.genesara.api.internal.mcp.tools.trade
+
+import dev.gvart.genesara.api.internal.mcp.context.AgentContextHolder
+import dev.gvart.genesara.api.internal.mcp.presence.AgentActivityRegistry
+import dev.gvart.genesara.api.internal.mcp.tools.CommandAckKind
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.WorldCommandGateway
+import dev.gvart.genesara.world.commands.EconomyCommand
+import dev.gvart.genesara.world.commands.WorldCommand
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.model.ToolContext
+
+class TradeOfferToolTest {
+
+    private val sender = AgentId(UUID.randomUUID())
+    private val recipient = AgentId(UUID.randomUUID())
+    private val clock = MutableTestClock(Instant.parse("2026-01-01T00:00:00Z"))
+    private val activity = AgentActivityRegistry(clock)
+    private val gateway = RecordingGateway()
+    private val tickClock = StubTickClock(currentTick = 10L)
+    private val toolContext = ToolContext(emptyMap())
+
+    @BeforeEach fun setUp() = AgentContextHolder.set(sender)
+    @AfterEach fun tearDown() = AgentContextHolder.clear()
+
+    @Test
+    fun `accepts wire-prefixed agent-colon form for recipientId`() {
+        val tool = TradeOfferTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(
+            recipientId = "agent:${recipient.id}",
+            offer = mapOf("WOOD" to 5),
+            request = emptyMap(),
+            offerInstances = null,
+            requestInstances = null,
+            toolContext = toolContext,
+        )
+
+        assertEquals(CommandAckKind.QUEUED, response.kind)
+        val (cmd, _) = gateway.submissions.single()
+        val offer = assertNotNull(cmd as? EconomyCommand.TradeOffer)
+        assertEquals(recipient, offer.recipient)
+    }
+
+    @Test
+    fun `accepts bare UUID form for recipientId`() {
+        val tool = TradeOfferTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(
+            recipientId = recipient.id.toString(),
+            offer = mapOf("WOOD" to 5),
+            request = emptyMap(),
+            offerInstances = null,
+            requestInstances = null,
+            toolContext = toolContext,
+        )
+
+        assertEquals(CommandAckKind.QUEUED, response.kind)
+        val (cmd, _) = gateway.submissions.single()
+        val offer = assertNotNull(cmd as? EconomyCommand.TradeOffer)
+        assertEquals(recipient, offer.recipient)
+    }
+
+    @Test
+    fun `rejects a malformed recipientId that is not a UUID`() {
+        val tool = TradeOfferTool(gateway, tickClock, activity)
+
+        val response = tool.invoke(
+            recipientId = "not-a-uuid",
+            offer = mapOf("WOOD" to 5),
+            request = emptyMap(),
+            offerInstances = null,
+            requestInstances = null,
+            toolContext = toolContext,
+        )
+
+        assertEquals(CommandAckKind.REJECTED, response.kind)
+        assertEquals("bad_recipient_id", response.reason)
+        assertTrue(gateway.submissions.isEmpty())
+    }
+
+    private class RecordingGateway : WorldCommandGateway {
+        val submissions = mutableListOf<Pair<WorldCommand, Long>>()
+        override fun submit(command: WorldCommand, appliesAtTick: Long): Long {
+            submissions += command to appliesAtTick
+            return appliesAtTick
+        }
+    }
+
+    private class StubTickClock(private val currentTick: Long) : TickClock {
+        override fun currentTick(): Long = currentTick
+    }
+
+    private class MutableTestClock(private var now: Instant) : Clock() {
+        override fun instant(): Instant = now
+        override fun getZone(): ZoneId = ZoneOffset.UTC
+        override fun withZone(zone: ZoneId?): Clock = this
+    }
+}

--- a/docs/mcp-api.md
+++ b/docs/mcp-api.md
@@ -115,14 +115,16 @@ Entity UUIDs that cross the MCP boundary carry a `<kind>:` prefix on the wire so
 | `npc:`    | Tier-A NPC ([`NpcId`])        | `attack(target)` input, `inspect_npc(npcId)` input, `tame(target)` input, `look_around.{currentNode,visible[]}.npcs[].id`, `NpcInspectView.id`                                                |
 | `mount:`  | tamed mount ([`MountId`])     | `attack(target)` input (third-party kill), `inspect(targetType=MOUNT, targetId)` input, `mount(transport_id)` / `equip_transport_gear(transportId)` / `maintain(target_id)` / `store_on_mount(transportId)` / `take_from_mount(transportId)` inputs, `look_around.mounts[].id`, `MountInspectView.id` |
 
-Parsing is **strict** — bare UUIDs are rejected. Pre-prod the convention lands without a compatibility corridor; once shipped, every endpoint that takes or emits an entity UUID of these kinds uses the prefixed form.
+**Canonical form for outputs:** every server-emitted id (event payloads, tool response fields) always uses the full `<kind>:<uuid>` form. This is what `look_around`, `inspect`, and event streams return.
+
+**Lenient form for inputs:** tool parameters that target a single unambiguous entity kind (`inspect(targetType=AGENT, targetId)`, `trade_offer(recipientId)`, `party_invite(invitees)`, `kick_member(target)`) accept **either** the canonical `agent:<uuid>` form **or** a bare UUID — both resolve identically. The `attack(target)` parameter is intentionally strict (prefix required) because the caller must also discriminate between `agent:`, `npc:`, and `mount:` kinds.
 
 Underlying storage is unchanged: Postgres columns stay `uuid`, the prefix exists only at the MCP boundary. Non-UUID id kinds (item ids, recipe ids, node ids, skill ids) are stringly-typed and unaffected.
 
 **Not yet rolled out** (raw UUID still emitted or accepted on the wire):
 - Building instance ids on inputs (`chestId`, `gateId`, `plotId`) and outputs (`BuildingSummaryView.instanceId`, `BuildingInspectView.instanceId`).
 - Drop ids (`pickup(dropId)`, `GroundItemView.dropId`) and equipment instance ids (`equip_item(instanceId)`, `inspect(targetType=ITEM, targetId=<uuid>)`, `EquipmentInstanceView.instanceId`, `InventoryInstanceView.instanceId`).
-- Trade ids (`tradeId`) **and `trade_offer(recipientId)`** — the recipient is an agent id that still flows as a bare UUID; consolidate with the trade slice.
+- Trade ids (`tradeId`).
 - Event-stream payloads for `WorldEvent.*`. The `CommandRejected` envelope serializes raw UUIDs out of the rejection data classes; the NPC events (`NpcSpawned/Died/Moved/AttackedAgent`, `AgentAttackedNpc`) don't yet have `@EventListener`s in `AgentEventDispatcher`. A Jackson serializer module registered for the MCP `ObjectMapper` handles both gaps in one pass.
 
 These follow in dedicated slices.

--- a/docs/playtest/multi-agent-e2e-plan.md
+++ b/docs/playtest/multi-agent-e2e-plan.md
@@ -1,0 +1,343 @@
+# Multi-agent E2E Playtest Plan — Phase 1 + 2
+
+> Goal: spawn 4–5 AI agents that play Genesara through the MCP layer end-to-end, exercise every Phase 1 + Phase 2 surface, surface bugs, and produce a balance memo. **No direct DB after registration.** Bootstrap-only DB writes; everything else flows through `mcp__genesara__*` tools.
+
+---
+
+## 1. Objectives
+
+1. **Coverage.** Touch every shipped MCP tool in `api/.../mcp/tools/*` (49 tools as of `main@3fc542e`).
+2. **Cooperation.** Two agents form a party, build a mini-base together (shelter + crafting station + farm plot + storage chest), survive together over multiple in-game cycles.
+3. **PvP duel.** Two agents leave the green zone, one flags outlaw, fight to first death, respawn at safe node.
+4. **Game-feel report.** Per-agent journal: what was frustrating, what was missing, what was broken, where the grind was excessive or trivial.
+5. **Balance memo.** Concrete proposals — "perk X is unreachable in N minutes", "stamina drains 2× faster than recipes consume it", "MOUNTAIN_PASS terrain blocks every harvest verb" — tagged with severity.
+
+Non-goals: Phase 3 (clans, factions, territory, T3 buildings), Phase 4 (class system, scanning, drones). Don't simulate them; if a campaign step requires them, log the gap and continue.
+
+---
+
+## 2. Constraints (load-bearing)
+
+- **MCP only after bootstrap.** Direct DB allowed only for: (a) player + agent registration, (b) read-only verify queries. **No level/gear seeding anywhere.** Any other DB write = bug in plan, escalate to user before executing.
+- **One teammate drives one character.** Orchestrated as a Claude Code **Agent Team** (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`), not via the Agent tool. Each teammate has its own context window, its own bound MCP server (`mcp__genesara-pt-<name>__*`), and its own `X-Agent-Id`. Teammates communicate with each other and with the lead via the team messaging system; coordination flows through the shared task list.
+- **No `--no-verify`-style shortcuts in game.** Teammates must respect rejections. If `move` returns `NotAdjacent`, they call `look_around` and pick a real neighbour — they don't retry blindly or skip with SQL.
+- **Bounded budget.** Each teammate capped at **~80 tool calls per campaign phase**. If a teammate hits the cap without completing its goal, that itself is a finding ("level 1 → first crafted spear takes >80 tool calls — grind too steep").
+- **One verdict per teammate per phase.** Teammate reports back in a fixed shape (Section 8); the lead compiles the cross-agent report. Teammate task status can lag — lead actively re-checks shared task list before closing a campaign.
+
+---
+
+## 3. Cast — 5 characters, 5 roles
+
+| Slug      | Race           | Role                         | Class lean (level-10 hint)   | Starting node     | Model        | Notes                                                  |
+| --------- | -------------- | ---------------------------- | ---------------------------- | ----------------- | ------------ | ------------------------------------------------------ |
+| **alice** | human_highland | Gatherer / Builder           | Builder branch               | `human_highland`  | Sonnet 4.6   | Heavy harvest + extract + build; donates resources     |
+| **bob**   | human_steppe   | Crafter / Cultivator         | Artisan branch               | `human_steppe`    | Sonnet 4.6   | Runs crafting station + farm plot; high INT/DEX        |
+| **carol** | human_commoner | Fighter / Tamer              | Warrior / Beastmaster branch | `human_commoner`  | Sonnet 4.6   | High STR/CON; tames a mount; runs combat scenarios     |
+| **dave**  | human_highland | Explorer / Trader / Leader   | Wanderer branch              | `human_highland`  | Sonnet 4.6   | Forms party, ferries goods, leads PvP duel as outlaw   |
+| **eve**   | human_steppe   | Wildcard (PvP target)        | Any                          | `human_steppe`    | Sonnet 4.6   | Sparring partner for dave; reactive role (survive A, trade-partner B, take hits C) |
+
+> If 4 agents is preferred, drop **eve** and have **carol** be dave's duel opponent.
+
+The roles overlap deliberately — Genesara's class system is hidden behavior tracking, so we want each character's tool use to weight toward different level-10 branches and observe whether the offered classes match.
+
+---
+
+## 4. Pre-flight (run in parallel; abort on any failure)
+
+```
+docker ps --format '{{.Names}}'                        # postgres + redis Up
+curl -sf -o /dev/null -w '%{http_code}\n' :8080/mcp     # Spring reachable
+PGPASSWORD=agentic_rpg psql -h localhost -U agentic_rpg -d agentic_rpg -c 'select 1'
+```
+
+Do **not** auto-start docker/Spring. Surface the failure verbatim and stop.
+
+---
+
+## 5. Bootstrap procedure (one-time, scripted)
+
+The skill runner runs this once before campaigns start. **This is the only DB-touching step.**
+
+### 5.1 Register one player via REST
+
+```bash
+curl -sS -X POST :8080/api/players \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"playtest_runner","password":"playtest_runner_pw_2026"}'
+# → { "playerId": "...", "apiToken": "plr_…", "token": "<jwt>" }
+```
+
+Save `apiToken` and the JWT.
+
+### 5.2 Register 5 agents under that player via REST
+
+For each name in `[alice, bob, carol, dave, eve]`:
+
+```bash
+curl -sS -X POST :8080/api/agents \
+  -H "Authorization: Bearer <jwt>" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"alice"}'
+# → { "agentId": "<uuid>" }
+```
+
+Capture the 5 agent UUIDs.
+
+### 5.3 Wire 5 MCP server entries
+
+Today's `~/.claude.json` already had `genesara` + `genesara-bob` belonging to an earlier setup. To avoid clobbering them, the 5 playtest entries are added under a `pt-` prefix: `genesara-pt-alice`, `genesara-pt-bob`, `genesara-pt-carol`, `genesara-pt-dave`, `genesara-pt-eve`. All five carry the same `plr_e719…` token (the `playtest_runner` player) and distinct `X-Agent-Id` headers. **Restart Claude Code** to pick them up.
+
+The teammates inherit the lead's MCP servers — i.e. all 5 servers are visible to every teammate. The lead's job at spawn is to tell each teammate **which server it is bound to** (`"use only mcp__genesara-alice__* tools"`). The teammate prompt enforces this; cross-binding would be a bug.
+
+> Open question — does the user want me to write that config diff, or do they patch `.claude.json` themselves? **Recommendation: I write the patch, user pastes + restarts**, because the global config is outside the project's permission scope.
+
+### 5.4 Enable Agent Teams
+
+Add to `~/.claude/settings.json`:
+
+```json
+{ "env": { "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1" } }
+```
+
+…and restart Claude Code (combined with the MCP-entry restart, so one restart covers both).
+
+---
+
+## 6. Campaigns
+
+Three campaigns, in series. The lead opens a campaign by pushing tasks onto the team's shared task list (one task per teammate, plus cross-cutting tasks like "rendezvous at node X"). Teammates pull tasks, act, and report. The lead closes the campaign when all per-teammate tasks are `completed` (or stop conditions in §11 fire).
+
+### Campaign A — Solo survival (≈ 80 tool calls per agent)
+
+**Goal: each agent independently reaches level 3, harvests + crafts a basic weapon, builds 1 Tier-1 building, doesn't starve.**
+
+5 teammates run in parallel, each bound to one MCP server. Each gets a goal sheet pushed via team messaging:
+
+```
+GOAL: reach level 3, craft any equipment item, build one tier-1 building you can ACTIVE,
+      survive (don't die or starve). Use only MCP tools. Stop after 80 tool calls or goal.
+PRIMARY VERBS for your role: <look_around, move, harvest, consume, drink, ... >
+EVENT STREAM: read agent://self/events after each tool call; correlate causedBy.
+REPORT: per-tool one-liner + final VERDICT + 3-bullet journal.
+```
+
+Coverage targets per agent: `spawn`, `look_around`, `move`, `get_status`, `get_map`, `inspect` (node + agent + building), `harvest`, `consume`, `drink`, `pickup`, `craft`, `build`, `equip_item`, `allocate_points`, `equip_skill`, `select_perk`, `set_safe_node`, `get_loadout`, `get_recipes`. ~19 tools.
+
+**Findings to watch for:**
+- Does the **skill recommendation cooldown** push useful skills onto agents fast enough? (Issue #5, *Phase 1 — Skills (recommendation-hook coverage)*, is still open.)
+- Hunger/thirst drain vs harvest tempo — does the level-1 grind keep agents barely alive, comfortably alive, or trivially alive?
+- Are starter terrains rich enough to support 5 agents in 3 nodes? (`human_highland`, `human_steppe`, `human_commoner` all point at node 524 — collision risk).
+
+### Campaign B — Cooperation + mini-base (≈ 100 tool calls per agent)
+
+**Goal: alice + bob + carol + dave converge on one node, party up, build a 4-building mini-base (Shelter + Crafting Bench + Farm Plot + Storage Chest), plant a crop, store shared resources, end with two agents inside the safe footprint. Sub-goal: specialise-and-trade accelerates progression vs solo-grind — each agent harvests one resource type and trades to the others rather than every agent grinding everything alone.**
+
+This is the meatiest campaign. Coverage adds: `say` (3 volumes), `party_invite`, `party_respond`, `get_party`, `kick_member`, `leave_party`, `plant`, `tend`, `extract`, `deposit_to_chest`, `withdraw_from_chest`, `toggle_gate`, `trade_offer`, `trade_respond`, `inspect_npc`, `get_relationships`, `use_ability`. ~17 more tools.
+
+The lead pushes a sequenced sub-scenario list to the shared task list (B1 → B10), each task tagged with the responsible teammate(s) and dependencies. Teammates coordinate **in-game** via `say` and **out-of-game** via team messaging when they need to verify intent (e.g. "I've placed the chest at node 524, deposit your wood there"). Both channels matter: in-game `say` is what we're stress-testing; team messaging is the safety net so they don't deadlock.
+
+| #   | Slug                       | Subagents involved          | Tool sequence (high-level)                                                                                                  |
+| --- | -------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| B1  | rendezvous                 | alice, bob, dave            | each walks to agreed node; alice broadcasts via `say(SCREAM)`                                                                |
+| B2  | party-form                 | dave, alice, bob            | dave invites; alice + bob respond ACCEPT                                                                                     |
+| B3  | specialise-and-trade       | alice, bob, carol           | alice `harvest(CLAY)` (no-hostile neighbour); bob `harvest(WOOD)`; carol `harvest(FOOD)` / forage; each `trade_offer` to the others so all three end with balanced inventory — target: 30% the tool calls a solo run would take |
+| B4  | base-foundations           | alice, bob                  | alice builds Shelter (uses traded clay); bob builds Crafting Bench (uses traded wood)                                        |
+| B5  | farm-plot                  | bob                         | bob `build(FARM_PLOT)`, then `plant(WHEAT)`, then `tend`                                                                     |
+| B6  | shared-storage             | alice, bob, dave            | alice `build(STORAGE_CHEST)`; trio `deposit_to_chest` raw resources                                                          |
+| B7  | trade-meal                 | alice, bob                  | alice ↔ bob `trade_offer` raw → cooked food (round-trip)                                                                     |
+| B8  | crafted-gear-trade         | bob, carol, alice           | bob `craft` starter weapon → `trade_offer` to carol (who needs it for combat); alice `craft` containers → `trade_offer` to bob |
+| B9  | npc-encounter              | carol                       | carol approaches a Tier-A NPC; tries `inspect_npc` + `attack` / `tame`                                                       |
+| B10 | mount-up                   | carol                       | carol `tame` a tameable mount; `mount`; `equip_transport_gear`; `move`                                                       |
+| B11 | base-defence-drill         | dave, alice                 | dave `toggle_gate` (if gate built); party member tries to walk through                                                       |
+| B12 | streak-recovery            | one volunteer + party       | one agent deliberately dies; party member loots; verify XP-bar penalty                                                      |
+
+Findings to watch for:
+- **Formation buff** — does the party reducer actually apply it; can subagents tell?
+- **Specialise-and-trade efficiency** — does B3 actually cut total tool calls vs each agent grinding solo? Measure (alice clay + bob wood + carol food + 3 trades) against a hypothetical solo baseline.
+- **Trade v2 instances** — does swapping equipment instances (B8 crafted gear) preserve durability + creator signature?
+- **Cultivation tick cadence** — is the wheat ready in a reasonable horizon, or do we wait 200 tool calls?
+- **STORAGE_CHEST owner-only access** — does an outsider get rejected on `withdraw_from_chest`?
+- **Mount maintenance + gauges** — what verb returns the mount's hunger/sleep? Is it surfaced at all?
+
+### Campaign C — PvP duel (≈ 40 tool calls per agent)
+
+**Goal: dave + eve (or dave + carol) walk into a `pvp_enabled=TRUE` node, one initiates `attack`, both fight, one dies, attacker's `outlaw_state` flips, respawn at safe node, defender's relationship score drops.**
+
+> No level/gear seeding — the duellists fight with whatever they earned in A + B (likely level 2–4, partial perks, hand-crafted gear). The trade-off (chosen by user): we test the raw low-level combat experience, **not** the upper ability + equipment math. If the duel feels broken at this level, that itself is a finding.
+
+Coverage adds: `attack` (agent-vs-agent), `unspawn`, `respawn`, `use_ability` in combat, `get_relationships` before/after, `inspect(target=AGENT)` mid-fight to read HP. ~6 more tools (some re-exercise of Campaign A/B coverage).
+
+Sub-scenarios:
+
+> **World note.** Every node in this run is flipped to `pvp_enabled=TRUE` at bootstrap (user accepted world disposability). Campaign C therefore picks any neighbour of the agents' current node — there is no green zone to step out of. The "leaving green" step degenerates to "walk one node" and we focus on the outlaw transition / damage formula instead.
+
+| #   | Slug                | Notes                                                                                         |
+| --- | ------------------- | --------------------------------------------------------------------------------------------- |
+| C1  | enter-duel-node     | both walk to an agreed node (any node — all are PvP); verify `look_around` perceives both    |
+| C2  | first-strike        | dave `attack(eve)`; verify outlaw transition on event stream + `agents.outlaw_state`          |
+| C3  | trade-blows         | both use `use_ability` (granted by perks chosen in Campaign A/B); record damage formula gaps  |
+| C4  | first-blood         | one dies; record drop list, XP-bar penalty, `set_safe_node` effect on respawn point          |
+| C5  | hunted-state        | post-duel, dave moves through nodes; verify outlaw decay timer + relationship hit            |
+
+Findings to watch:
+- **Combat resolution** — does the damage formula `(attackerStat × weaponPow) - (targetStat × armorDef) × typeModifier` feel readable to the agent, or is it opaque?
+- **Witness cascade** (Phase 3) is **not implemented** — does outlaw flagging still trigger for a 1v1 with no witnesses? Document the gap if it does or doesn't.
+- **Respawn point** — `set_safe_node` should be the respawn target; verify with `get_status` after death.
+- **Kill-streak drop scaling** — second death in a session should drop more; if we can't reach the streak in budget, note it.
+
+---
+
+## 7. Coverage matrix
+
+| Tool                                  | Cmp A | Cmp B | Cmp C |
+| ------------------------------------- | :---: | :---: | :---: |
+| spawn / unspawn / respawn             |  ✓    |  ✓    |  ✓    |
+| look_around / get_status / get_map    |  ✓    |  ✓    |  ✓    |
+| inspect / inspect_npc                 |  ✓    |  ✓    |  ✓    |
+| move                                  |  ✓    |  ✓    |  ✓    |
+| harvest / extract / pickup            |  ✓    |  ✓    |       |
+| consume / drink                       |  ✓    |  ✓    |  ✓    |
+| craft / get_recipes                   |  ✓    |  ✓    |       |
+| build / toggle_gate                   |  ✓    |  ✓    |       |
+| equip_item / unequip_slot / get_loadout |  ✓  |  ✓    |  ✓    |
+| allocate_points / select_perk / equip_skill |  ✓ |  ✓   |  ✓    |
+| select_class / select_evolution       |       |  ?    |       |
+| say                                   |       |  ✓    |       |
+| party_invite / respond / leave / kick / get_party | | ✓ |       |
+| trade_offer / trade_respond           |       |  ✓    |       |
+| plant / tend                          |       |  ✓    |       |
+| deposit_to_chest / withdraw_from_chest |       |  ✓    |       |
+| tame / mount / dismount / equip_transport_gear / store_on_mount / take_from_mount / maintain | | ✓ | |
+| attack / use_ability                  |       |  ✓    |  ✓    |
+| set_safe_node                         |  ✓    |       |  ✓    |
+| get_relationships                     |       |  ✓    |  ✓    |
+
+`select_class` / `select_evolution` only triggers if an agent organically reaches level 10 in Campaign B — flagged as **stretch goal**, not required.
+
+---
+
+## 8. Teammate contract
+
+The lead spawns the team in natural language: *"Create an agent team with 5 teammates named alice, bob, carol, dave, eve to run a Genesara end-to-end playtest. Each teammate uses its own MCP server."*
+
+Each teammate is then onboarded via direct team message with a fixed prompt template (≤ 200 words):
+
+```
+You are <NAME>, a <ROLE> character in the Genesara MMORPG. The server is live at
+localhost:8080. You are bound to ONE MCP server: mcp__genesara-pt-<name>__*. Do not
+use any other genesara MCP server, even if it appears in your tool list.
+
+Your character is already registered; your first tool call is mcp__genesara-pt-<name>__spawn.
+
+GOAL: <one-sentence campaign goal>
+COVERAGE TARGETS: <list of MCP tools the campaign needs you to exercise>
+BUDGET: <N> tool calls. After that, return your report even if goal not met.
+
+COORDINATION:
+- In-game: use `say` (LOCAL channel, NORMAL volume) for everything other characters
+  on your node should hear. We are stress-testing this channel.
+- Team-channel: use SendMessage(to=<teammate-name>) for out-of-game intent
+  (declaring next move, sanity-checking that a building exists). Use sparingly.
+
+RULES:
+- MCP only. No external knowledge. No direct DB.
+- DO NOT use Read, Write, Edit, or NotebookEdit on docs/ (or anywhere on disk).
+  The lead is the sole writer of session artifacts. Surface findings via
+  SendMessage(to=team-lead); the lead will persist them.
+- If a tool returns a rejection, read it, adapt, retry differently (or move on).
+- Read agent://self/events after every state-mutating call; correlate causedBy.
+- Keep a tool log: <toolName>(<short args>) → <one-line result>.
+- Mark your shared task `completed` when done; if blocked, leave a comment and
+  flip it to `pending` for the lead to redistribute.
+
+REPORT (post back to the lead when budget hits or goal met):
+  VERDICT: PASS | PARTIAL | FAIL
+  TOOLS_HIT: <comma-separated tool names actually called>
+  TOOL_LOG: <chronological one-liners>
+  JOURNAL:
+    - <bug or surprise #1>
+    - <bug or surprise #2>
+    - <bug or surprise #3>
+  PROPOSE: <one balance/content suggestion, if any>
+```
+
+The lead compiles per-character reports into the campaign log. File ownership rule: **only the lead writes to disk** (`docs/playtest/sessions/…`). Teammates never touch the filesystem — eliminates the file-conflict gotcha cited in the Agent Teams docs.
+
+---
+
+## 9. Observation & verification
+
+**During play:** parent watches Spring app logs via `tail -f logs/app.log` for ERROR / WARN. Counts events per topic via Redis `XLEN` on `agent:<id>:events` for trend signal (don't open the stream itself — that's the subagent's channel).
+
+**After each campaign:** parent runs verify SQL — read-only, no mutations:
+
+- `select id, name, level, outlaw_state, authority, fame from agents where id in (…);`
+- `select node_id, count(*) from node_buildings where built_by_agent_id in (…) group by 1;`
+- `select agent_id, item_id, quantity from agent_inventory where agent_id in (…);`
+- `select * from agent_relationships where source_agent_id in (…) or target_agent_id in (…);`
+- `select tradeable, count(*) from agent_item_instances where owner_agent_id in (…) group by 1;`
+
+The output goes into the session log alongside each subagent's verdict.
+
+---
+
+## 10. Output artifacts
+
+The skill produces **one self-contained HTML report** at `docs/playtest/sessions/sNN-multi-agent-phase12/report.html`. The HTML is the canonical deliverable; raw data is dumped alongside it for diffing.
+
+The report is a single file (inline CSS, no external assets) with these sections:
+
+1. **Header card** — session id, branch SHA, ISO timestamp, total tool calls, total wallclock, per-teammate model, pass/partial/fail counts.
+2. **Coverage matrix** — the §7 table rendered with per-cell PASS / PARTIAL / FAIL pills based on which teammate actually exercised the tool.
+3. **Per-campaign timeline** — collapsible blocks for A / B / C, each containing the tool log per teammate, the verify-SQL output, and any rejection-loop hot spots.
+4. **Bugs list** — confirmed bugs, each with: reproducer steps, expected vs actual, severity (P0 / P1 / P2), suggested next step (file path or `WorldRejection` variant). **Listed only.** Filing GitHub issues is left to the user.
+5. **Balance memo** — observations on game feel: skill recommendation cadence, gauge drain rates, harvest yields, recipe costs, perk reachability, damage formula readability, mount maintenance burden. Each entry is a concrete suggestion ("`MOUNTAIN_PASS` should accept `MINE` extract — currently rejected; consider …") — not a rant.
+
+Alongside the HTML, the lead drops the raw JSON the report was generated from (`report-data.json`) so future runs can be diffed structurally, plus a minimal `README.md` that says "open report.html in a browser".
+
+Visual style: Linear / Notion / Stripe minimalism — system font stack, neutral palette, dense tables, severity pills, no emoji, no decorative artwork. Designed to read at-a-glance and survive a paste into a doc.
+
+None of these are auto-committed and no issues are auto-filed. The user reads the HTML, decides what becomes a real issue.
+
+---
+
+## 11. Stop conditions
+
+The lead runs A → B → C end-to-end (no inter-campaign pause). The full plan aborts (and reports partial findings) if:
+
+- Spring app crashes / 500s twice in a campaign.
+- A teammate loops on the same rejection > 5 times.
+- The world tick stalls (no events for 60s while teammates are queueing commands).
+- Verify SQL shows state inconsistent with event stream (= reducer bug, P0).
+- A teammate's task sits `in-progress` with no team-channel message for > 5 min — likely the task-status-lag gotcha; lead probes the teammate before declaring stall.
+- **Token watchdog.** At every campaign boundary (and once mid-Campaign B, the longest), the lead checks `/cost` (or whatever the live usage signal is). If **daily usage ≥ 90 %**, the lead **stops immediately**, dumps everything collected so far to `session.md` / `bugs.md` / `balance.md`, shuts down the team, and prints a hand-off. No data is left on the team-channel uncaptured. Better to ship a 1.5-campaign report than to lose the whole run.
+
+---
+
+## 12. Risks / open questions for user review
+
+1. **Multi-MCP-server config edit + Agent Teams env flag.** Mandatory restart of Claude Code with `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` and 5 new MCP server entries. Confirm whether I draft the JSON patch or you handle it.
+2. **One shared world.** All 5 characters share the same world topology. If two play in the same node simultaneously, expect contention on resources / NPCs / building slots — that *is* a test, but flag if it's too chaotic to interpret.
+3. **No seeding anywhere (confirmed).** Campaigns A + B + C all run from level 1. The duel in C will be low-level and won't exercise the ability/equipment math — that's the trade-off.
+4. **Stretch: class-choice event at level 10.** Almost certainly unreachable without seeding inside the 220-call/agent budget; flag as "punt to future playtest" rather than expect.
+5. **Roster confirmed at 5.** alice/bob/carol/dave/eve. If team-spawn fails or token cost dominates, fall back to 4 (drop eve).
+6. **Teams don't survive `/resume` or `/rewind`.** If the lead session crashes, the playtest restarts from a fresh team and we lose context. Save lead state to disk after each campaign (verify SQL output + collected reports) so we can resume manually.
+7. **World is disposable for this run.** All nodes set `pvp_enabled=TRUE`. User explicitly accepted this and intends to rebuild the world after the playtest. Do not mix outputs from this run with measurements from a pristine world.
+
+---
+
+## 13. Execution checklist (for the runner skill)
+
+- [ ] Pre-flight passes.
+- [ ] One player registered via `POST /api/players`.
+- [ ] 5 agents registered via `POST /api/agents`.
+- [ ] 5 MCP server entries added; `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` set; Claude Code restarted.
+- [ ] Agent Team created (5 teammates: alice, bob, carol, dave, eve).
+- [ ] Campaign A: 5 teammates in parallel, ≤ 80 calls each, reports collected via team messages.
+- [ ] Campaign B: 4–5 teammates in parallel, ≤ 100 calls each, reports collected.
+- [ ] Campaign C: 2 teammates in parallel, ≤ 40 calls each, reports collected.
+- [ ] Verify SQL run after each campaign; output captured.
+- [ ] `report.html` + `report-data.json` written under `docs/playtest/sessions/sNN-multi-agent-phase12/` (lead-only writes).
+- [ ] Team shut down (teammates explicitly closed before cleanup).
+- [ ] Hand-off summary printed inline; no GitHub issues filed; nothing auto-committed.
+- [ ] At every campaign boundary (+ mid-B): lead checks token usage; ≥ 90 % → write partial report and stop.

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
@@ -202,19 +202,28 @@ data class DeathPenaltyOutcome(
     /** True when the empty-bar branch fired and the agent lost a level. */
     val deleveled: Boolean,
     /**
-     * Penalty point consumed on de-level. `UNSPENT` when an unspent pool point
-     * was consumed; the named attribute when the pool was empty and the
-     * highest stat was docked; null when no de-level fired (partial-bar branch).
+     * Penalty point consumed on de-level. `Unspent` when an unspent pool point
+     * was consumed; `Allocated` when the pool was empty and an allocated stat
+     * was docked; `NoLossAtFloor` when the de-level fired but every allocated
+     * stat was already at [AgentAttributes.MIN_ATTRIBUTE] so no point could be
+     * taken; null when the partial-bar branch ran and no de-level was attempted.
      */
     val attributePointLost: AttributePointLoss?,
 )
 
-/** Where the de-level penalty point was taken from. */
+/** Where the de-level penalty point was taken from, or why none was taken. */
 sealed interface AttributePointLoss {
     /** Consumed an unspent attribute point. */
     data object Unspent : AttributePointLoss
     /** Decremented an allocated attribute by 1 because the unspent pool was empty. */
     data class Allocated(val attribute: Attribute) : AttributePointLoss
+    /**
+     * The empty-bar branch fired but every allocated attribute was already at
+     * [AgentAttributes.MIN_ATTRIBUTE] and the unspent pool was empty — no point
+     * could be taken without crossing the floor. The de-level itself still
+     * applies (when `level > 1`).
+     */
+    data object NoLossAtFloor : AttributePointLoss
 }
 
 /** Result of [AgentRegistry.allocateAttributes]. */

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
@@ -462,7 +462,8 @@ internal class JooqAgentRegistry(
      * pool, fall back to decrementing the highest allocated attribute. Level-1 agents
      * stay at level 1 — `coerceAtLeast(1)` enforces the floor; the `deleveled` flag
      * reports honestly. If every allocated attribute is already at the [AgentAttributes.MIN_ATTRIBUTE]
-     * floor the stat decrement becomes a no-op (we still de-level).
+     * floor the stat decrement becomes a no-op and the outcome reports
+     * [AttributePointLoss.NoLossAtFloor] (the de-level itself still applies when level > 1).
      */
     private fun applyEmptyBarPenalty(agentId: AgentId, record: AgentsRecord): DeathPenaltyOutcome {
         val level = record[AGENTS.LEVEL]!!
@@ -494,7 +495,11 @@ internal class JooqAgentRegistry(
         val current = target.valueOn(attrs)
         if (current <= AgentAttributes.MIN_ATTRIBUTE) {
             update.where(AGENTS.ID.eq(agentId.id)).execute()
-            return DeathPenaltyOutcome(xpLost = 0, deleveled = didDelevel, attributePointLost = null)
+            return DeathPenaltyOutcome(
+                xpLost = 0,
+                deleveled = didDelevel,
+                attributePointLost = AttributePointLoss.NoLossAtFloor,
+            )
         }
         update.set(columnFor(target), current - 1)
             .where(AGENTS.ID.eq(agentId.id))

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryDeathPenaltyIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryDeathPenaltyIntegrationTest.kt
@@ -205,7 +205,7 @@ class JooqAgentRegistryDeathPenaltyIntegrationTest {
     }
 
     @Test
-    fun `empty bar with all attributes at the floor — no stat decrement, attribute loss reported as null`() {
+    fun `empty bar with all attributes at the floor — no stat decrement, NoLossAtFloor reported`() {
         val registry = registry()
         val agent = registry.register(owner, "Glass")
         dsl.update(AGENTS)
@@ -224,7 +224,41 @@ class JooqAgentRegistryDeathPenaltyIntegrationTest {
         val outcome = assertNotNull(registry.applyDeathPenalty(agent.id, xpLossOnDeath = 25))
 
         assertEquals(true, outcome.deleveled, "level > 1 → genuine de-level fires")
-        assertNull(outcome.attributePointLost, "all stats at floor — no decrement, honest null")
+        assertIs<AttributePointLoss.NoLossAtFloor>(
+            outcome.attributePointLost,
+            "all stats at floor — explicit NoLossAtFloor variant, not null",
+        )
+        val row = readAgent(agent.id)
+        assertEquals(1, row[AGENTS.LEVEL])
+        assertEquals(1, row[AGENTS.STRENGTH])
+        assertEquals(1, row[AGENTS.DEXTERITY])
+        assertEquals(1, row[AGENTS.CONSTITUTION])
+        assertEquals(1, row[AGENTS.PERCEPTION])
+        assertEquals(1, row[AGENTS.INTELLIGENCE])
+        assertEquals(1, row[AGENTS.LUCK])
+    }
+
+    @Test
+    fun `level-1 agent with all attrs at floor — no de-level, NoLossAtFloor reported`() {
+        val registry = registry()
+        val agent = registry.register(owner, "RockBottom")
+        dsl.update(AGENTS)
+            .set(AGENTS.LEVEL, 1)
+            .set(AGENTS.XP_CURRENT, 0)
+            .set(AGENTS.UNSPENT_ATTRIBUTE_POINTS, 0)
+            .set(AGENTS.STRENGTH, 1)
+            .set(AGENTS.DEXTERITY, 1)
+            .set(AGENTS.CONSTITUTION, 1)
+            .set(AGENTS.PERCEPTION, 1)
+            .set(AGENTS.INTELLIGENCE, 1)
+            .set(AGENTS.LUCK, 1)
+            .where(AGENTS.ID.eq(agent.id.id))
+            .execute()
+
+        val outcome = assertNotNull(registry.applyDeathPenalty(agent.id, xpLossOnDeath = 25))
+
+        assertEquals(false, outcome.deleveled, "level-1 stays at 1 — no de-level")
+        assertIs<AttributePointLoss.NoLossAtFloor>(outcome.attributePointLost)
         val row = readAgent(agent.id)
         assertEquals(1, row[AGENTS.LEVEL])
         assertEquals(1, row[AGENTS.STRENGTH])

--- a/world/body/src/main/kotlin/dev/gvart/genesara/world/body/internal/passive/Passives.kt
+++ b/world/body/src/main/kotlin/dev/gvart/genesara/world/body/internal/passive/Passives.kt
@@ -6,6 +6,7 @@ import dev.gvart.genesara.world.BodyDelta
 import dev.gvart.genesara.world.EquipmentBonusAggregator
 import dev.gvart.genesara.world.Gauge
 import dev.gvart.genesara.world.events.BodyEvent
+import dev.gvart.genesara.world.events.PassiveCause
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import kotlin.math.roundToInt
@@ -183,7 +184,19 @@ fun applyPassives(
 
     if (applied.isEmpty()) return state to null
 
+    val hpLossCauses = applied
+        .filter { (_, delta) -> delta.hp < 0 }
+        .mapValues { (id, _) ->
+            val body = state.bodies[id] ?: return@mapValues emptySet()
+            buildSet {
+                if (body.hunger == 0) add(PassiveCause.STARVATION)
+                if (body.thirst == 0) add(PassiveCause.DEHYDRATION)
+                if (body.sleep == 0) add(PassiveCause.EXHAUSTION)
+            }
+        }
+        .filterValues { it.isNotEmpty() }
+
     val nextState = state.copy(body = state.body.copy(bodies = nextBodies))
-    val event = BodyEvent.PassivesApplied(applied, tick)
+    val event = BodyEvent.PassivesApplied(applied, tick, hpLossCauses)
     return nextState to event
 }

--- a/world/body/src/test/kotlin/dev/gvart/genesara/world/body/internal/body/RefreshDerivedPoolsReducerTest.kt
+++ b/world/body/src/test/kotlin/dev/gvart/genesara/world/body/internal/body/RefreshDerivedPoolsReducerTest.kt
@@ -72,6 +72,27 @@ class RefreshDerivedPoolsReducerTest {
         assertEquals(WorldRejection.NotInWorld(agent), rejection)
     }
 
+    @Test
+    fun `allocate_points style maxHp bump never zeroes a healthy currentHp — B2 regression`() {
+        // Playtest s10/B2 — preserves currentHp on upward maxHp bump.
+        val state = stateWith(
+            AgentBody(
+                hp = 60, maxHp = 60,
+                stamina = 30, maxStamina = 40,
+                mana = 0, maxMana = 0,
+            ),
+        )
+        val command = BodyCommand.RefreshDerivedPools(agent, maxHp = 80, maxStamina = 45, maxMana = 0)
+
+        val (next, _, _) = reduceRefreshDerivedPools(state.body, command, tick = 1).getOrNull()!!
+
+        val body = next.bodyOf(agent)!!
+        assertEquals(60, body.hp, "currentHp preserved on upward maxHp bump")
+        assertEquals(80, body.maxHp)
+        assertEquals(30, body.stamina, "currentStamina preserved on upward maxStamina bump")
+        assertEquals(45, body.maxStamina)
+    }
+
     private fun stateWith(body: AgentBody): WorldState = WorldState.EMPTY.copy(
         bodies = mapOf(agent to body),
     )

--- a/world/body/src/test/kotlin/dev/gvart/genesara/world/body/internal/death/DeathSweepTest.kt
+++ b/world/body/src/test/kotlin/dev/gvart/genesara/world/body/internal/death/DeathSweepTest.kt
@@ -154,6 +154,27 @@ class DeathSweepTest {
     }
 
     @Test
+    fun `NoLossAtFloor outcome maps to the AT_FLOOR sentinel in the death event`() {
+        val agentId = AgentId(UUID.randomUUID())
+        val state = stateWith(agentId, hp = 0, atNode = nodeAId)
+        val agents = StubRegistry(
+            mapOf(
+                agentId to DeathPenaltyOutcome(
+                    xpLost = 0,
+                    deleveled = true,
+                    attributePointLost = AttributePointLoss.NoLossAtFloor,
+                ),
+            ),
+        )
+
+        val (_, events) = processDeaths(state, DeathProcessor(balance(), agents, StubEquipmentStore(), StubGroundItemStore()), tick = 1)
+
+        val died = assertIs<BodyEvent.AgentDied>(events.single())
+        assertEquals("AT_FLOOR", died.attributePointLost)
+        assertEquals(true, died.deleveled, "de-level still fires when level > 1; only the stat decrement skipped")
+    }
+
+    @Test
     fun `multiple agents dying at the same tick are sorted by agent id`() {
         val firstId = AgentId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
         val secondId = AgentId(UUID.fromString("00000000-0000-0000-0000-000000000002"))

--- a/world/body/src/test/kotlin/dev/gvart/genesara/world/body/internal/death/RespawnReducerTest.kt
+++ b/world/body/src/test/kotlin/dev/gvart/genesara/world/body/internal/death/RespawnReducerTest.kt
@@ -75,6 +75,30 @@ class RespawnReducerTest {
     }
 
     @Test
+    fun `respawn restores every pool — HP, stamina, mana, hunger, thirst, sleep — to its max (B3 regression)`() {
+        // Playtest s10/B3 — every pool resets to max on respawn.
+        val psionicProfile = AgentProfile(id = agent, maxHp = 120, maxStamina = 90, maxMana = 40)
+        val psionicProfiles = StubProfileLookup(mapOf(agent to psionicProfile))
+        val state = deadState()
+        val resolver = StubResolver(SafeNodeResolution(checkpointNodeId, fromCheckpoint = true))
+
+        val result = reduceRespawn(state.core, state.body, BodyCommand.Respawn(agent), psionicProfiles, RecordingGateway(), resolver, tick = 9)
+
+        val out = assertIs<Either.Right<ReducerOutput<CoreSlice>>>(result).value
+        val applied = state.copy(core = out.sliceDelta).applyEffects(out.effects)
+        val body = assertNotNull(applied.bodyOf(agent))
+        assertEquals(120, body.hp, "hp at maxHp")
+        assertEquals(120, body.maxHp)
+        assertEquals(90, body.stamina, "stamina at maxStamina")
+        assertEquals(90, body.maxStamina)
+        assertEquals(40, body.mana, "mana at maxMana")
+        assertEquals(40, body.maxMana)
+        assertEquals(AgentBody.DEFAULT_MAX_HUNGER, body.hunger)
+        assertEquals(AgentBody.DEFAULT_MAX_THIRST, body.thirst)
+        assertEquals(AgentBody.DEFAULT_MAX_SLEEP, body.sleep)
+    }
+
+    @Test
     fun `respawn falls back to starter node and reports fromCheckpoint=false`() {
         val state = deadState()
         val resolver = StubResolver(SafeNodeResolution(starterNodeId, fromCheckpoint = false))

--- a/world/body/src/test/kotlin/dev/gvart/genesara/world/body/internal/passive/SurvivalPassivesTest.kt
+++ b/world/body/src/test/kotlin/dev/gvart/genesara/world/body/internal/passive/SurvivalPassivesTest.kt
@@ -12,6 +12,7 @@ import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.Terrain
 import dev.gvart.genesara.world.Vec3
 import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.events.PassiveCause
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.worldstate.WorldState
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class SurvivalPassivesTest {
 
@@ -227,5 +229,58 @@ class SurvivalPassivesTest {
         )
 
         assertEquals(35, next.bodies[agent]!!.stamina)
+    }
+
+    @Test
+    fun `starvation HP loss carries STARVATION cause when hunger is zero`() {
+        val starving = body(hp = 50, hunger = 0, thirst = 80, sleep = 80)
+        val (_, event) = applyPassives(stateWith(starving), balance(regen = 0, drain = 0, starvationDamage = 2), tick = 1)
+
+        val causes = assertNotNull(event).hpLossCauses[agent]
+        assertNotNull(causes)
+        assertTrue(PassiveCause.STARVATION in causes)
+        assertTrue(PassiveCause.DEHYDRATION !in causes)
+        assertTrue(PassiveCause.EXHAUSTION !in causes)
+    }
+
+    @Test
+    fun `dehydration HP loss carries DEHYDRATION cause when thirst is zero`() {
+        val dehydrated = body(hp = 50, hunger = 80, thirst = 0, sleep = 80)
+        val (_, event) = applyPassives(stateWith(dehydrated), balance(regen = 0, drain = 0, starvationDamage = 2), tick = 1)
+
+        val causes = assertNotNull(event).hpLossCauses[agent]
+        assertNotNull(causes)
+        assertTrue(PassiveCause.DEHYDRATION in causes)
+        assertTrue(PassiveCause.STARVATION !in causes)
+    }
+
+    @Test
+    fun `exhaustion HP loss carries EXHAUSTION cause when sleep is zero`() {
+        val exhausted = body(hp = 50, hunger = 80, thirst = 80, sleep = 0)
+        val (_, event) = applyPassives(stateWith(exhausted), balance(regen = 0, drain = 0, starvationDamage = 2), tick = 1)
+
+        val causes = assertNotNull(event).hpLossCauses[agent]
+        assertNotNull(causes)
+        assertTrue(PassiveCause.EXHAUSTION in causes)
+    }
+
+    @Test
+    fun `multiple zero gauges produce multiple causes`() {
+        val multiStarving = body(hp = 50, hunger = 0, thirst = 0, sleep = 80)
+        val (_, event) = applyPassives(stateWith(multiStarving), balance(regen = 0, drain = 0, starvationDamage = 2), tick = 1)
+
+        val causes = assertNotNull(event).hpLossCauses[agent]
+        assertNotNull(causes)
+        assertTrue(PassiveCause.STARVATION in causes)
+        assertTrue(PassiveCause.DEHYDRATION in causes)
+    }
+
+    @Test
+    fun `regen tick without HP loss has no hpLossCauses entry`() {
+        val healthy = body(stamina = 30, hunger = 80, thirst = 80, sleep = 80)
+        val (_, event) = applyPassives(stateWith(healthy), balance(regen = 1), tick = 1)
+
+        val causes = assertNotNull(event).hpLossCauses
+        assertTrue(causes.isEmpty() || causes[agent].isNullOrEmpty())
     }
 }

--- a/world/combat/src/main/kotlin/dev/gvart/genesara/world/combat/internal/combat/AttackReducer.kt
+++ b/world/combat/src/main/kotlin/dev/gvart/genesara/world/combat/internal/combat/AttackReducer.kt
@@ -330,6 +330,9 @@ fun reduceAttack(
         tick = tick,
     )
 
+    val directDelta = if (nextTargetBody.hp == 0) balance.relationshipDeltaOnKillDirect() else balance.relationshipDeltaOnAttackDirect()
+    if (directDelta != 0) relationships.adjust(command.agent, command.target, directDelta, tick)
+
     accrueOutlawMisconduct(
         attacker = command.agent,
         victimFame = defender.fame,

--- a/world/combat/src/test/kotlin/dev/gvart/genesara/world/combat/internal/combat/AttackReducerTest.kt
+++ b/world/combat/src/test/kotlin/dev/gvart/genesara/world/combat/internal/combat/AttackReducerTest.kt
@@ -17,6 +17,9 @@ import dev.gvart.genesara.player.PassiveAuraAggregator.Companion.NoAura
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.player.RelationshipAdjustmentOutcome
+import dev.gvart.genesara.player.RelationshipsGateway
+import dev.gvart.genesara.player.RelationshipRow
 import dev.gvart.genesara.player.events.AgentEvent
 import dev.gvart.genesara.world.AgentItemInstancesStore
 import dev.gvart.genesara.world.Biome
@@ -970,6 +973,110 @@ class AttackReducerTest {
         val attacked = assertIs<CombatEvent.AgentAttacked>(events.single())
         assertEquals(0, attacked.baseDamage)
         assertEquals(0, attacked.hpLost)
+    }
+
+    @Test
+    fun `non-lethal hit writes negative direct relationship delta between attacker and victim`() {
+        val state = battleState(targetHp = 100)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val recording = RecordingRelationshipsGateway()
+
+        dev.gvart.genesara.world.combat.internal.combat.reduceAttack(
+            combat = state.combat,
+            bodyView = state.body,
+            coreView = state.core,
+            envView = state.environment,
+            command = CombatCommand.AttackTarget(attacker, target),
+            balance = balance(),
+            items = itemsWithSword(),
+            agents = agents(strength = 10, luck = 0, dex = 0),
+            equipment = swordEquipped(),
+            progression = SkillProgression(skills, publisher),
+            scaling = NoScaling,
+            passiveAura = NoAura,
+            equipmentBonuses = dev.gvart.genesara.world.EquipmentBonusAggregator.NoBonuses,
+            deathProcessor = stubDeathProcessor(skills, publisher),
+            triggeredPassives = NoOpTriggeredPassiveDispatcher,
+            pendingScales = InMemoryPendingAttackScaleStore(),
+            behaviorTracker = tracker,
+            relationships = recording,
+            rng = Random(seed = 1L),
+            tick = 5,
+        )
+
+        val (a, b, delta) = assertNotNull(recording.calls.find { it.a == attacker && it.b == target || it.a == target && it.b == attacker })
+        assertTrue(delta < 0, "non-lethal hit should produce a negative direct delta, got $delta")
+    }
+
+    @Test
+    fun `killing blow writes larger negative direct relationship delta than non-lethal hit`() {
+        val state = battleState(targetHp = 1)
+        val skills = StubSkillsRegistry()
+        val publisher = RecordingPublisher()
+        val nonLethalRecording = RecordingRelationshipsGateway()
+        val lethalRecording = RecordingRelationshipsGateway()
+
+        dev.gvart.genesara.world.combat.internal.combat.reduceAttack(
+            combat = battleState(targetHp = 100).combat,
+            bodyView = battleState(targetHp = 100).body,
+            coreView = battleState(targetHp = 100).core,
+            envView = battleState(targetHp = 100).environment,
+            command = CombatCommand.AttackTarget(attacker, target),
+            balance = balance(),
+            items = itemsWithSword(),
+            agents = agents(strength = 10, luck = 0, dex = 0),
+            equipment = swordEquipped(),
+            progression = SkillProgression(StubSkillsRegistry(), RecordingPublisher()),
+            scaling = NoScaling, passiveAura = NoAura,
+            equipmentBonuses = dev.gvart.genesara.world.EquipmentBonusAggregator.NoBonuses,
+            deathProcessor = stubDeathProcessor(skills, publisher),
+            triggeredPassives = NoOpTriggeredPassiveDispatcher,
+            pendingScales = InMemoryPendingAttackScaleStore(),
+            behaviorTracker = InMemoryBehaviorTracker(),
+            relationships = nonLethalRecording,
+            rng = Random(seed = 1L),
+            tick = 1,
+        )
+
+        dev.gvart.genesara.world.combat.internal.combat.reduceAttack(
+            combat = state.combat,
+            bodyView = state.body,
+            coreView = state.core,
+            envView = state.environment,
+            command = CombatCommand.AttackTarget(attacker, target),
+            balance = balance(),
+            items = itemsWithSword(),
+            agents = agents(strength = 10, luck = 0, dex = 0),
+            equipment = swordEquipped(),
+            progression = SkillProgression(skills, publisher),
+            scaling = NoScaling, passiveAura = NoAura,
+            equipmentBonuses = dev.gvart.genesara.world.EquipmentBonusAggregator.NoBonuses,
+            deathProcessor = stubDeathProcessor(skills, publisher),
+            triggeredPassives = NoOpTriggeredPassiveDispatcher,
+            pendingScales = InMemoryPendingAttackScaleStore(),
+            behaviorTracker = tracker,
+            relationships = lethalRecording,
+            rng = Random(seed = 1L),
+            tick = 2,
+        )
+
+        val nonLethalDelta = assertNotNull(nonLethalRecording.calls.find { (it.a == attacker && it.b == target) || (it.a == target && it.b == attacker) }).delta
+        val lethalDelta = assertNotNull(lethalRecording.calls.find { (it.a == attacker && it.b == target) || (it.a == target && it.b == attacker) }).delta
+        assertTrue(lethalDelta < nonLethalDelta, "killing blow ($lethalDelta) should produce a more negative delta than non-lethal ($nonLethalDelta)")
+    }
+
+    private data class RelationshipCall(val a: AgentId, val b: AgentId, val delta: Int)
+
+    private class RecordingRelationshipsGateway : RelationshipsGateway {
+        val calls = mutableListOf<RelationshipCall>()
+        override fun adjust(a: AgentId, b: AgentId, delta: Int, tick: Long): RelationshipAdjustmentOutcome {
+            calls += RelationshipCall(a, b, delta)
+            return RelationshipAdjustmentOutcome(currentScore = delta)
+        }
+        override fun adjustMany(anchor: AgentId, others: Collection<AgentId>, delta: Int, tick: Long) = Unit
+        override fun find(a: AgentId, b: AgentId): RelationshipRow? = null
+        override fun scoresFor(agentId: AgentId): Map<AgentId, RelationshipRow> = emptyMap()
     }
 
     private fun battleState(targetHp: Int, attackerStamina: Int = 50): WorldState = WorldState(

--- a/world/combat/src/test/kotlin/dev/gvart/genesara/world/combat/internal/combat/WitnessCascadeTest.kt
+++ b/world/combat/src/test/kotlin/dev/gvart/genesara/world/combat/internal/combat/WitnessCascadeTest.kt
@@ -338,10 +338,8 @@ class WitnessCascadeTest {
 
     private class RecordingRelationships : RelationshipsGateway {
         val batches: MutableList<CascadeBatch> = mutableListOf()
-        override fun adjust(a: AgentId, b: AgentId, delta: Int, tick: Long): RelationshipAdjustmentOutcome {
-            batches += CascadeBatch(a, listOf(b), delta)
-            return RelationshipAdjustmentOutcome(currentScore = 0)
-        }
+        override fun adjust(a: AgentId, b: AgentId, delta: Int, tick: Long): RelationshipAdjustmentOutcome =
+            RelationshipAdjustmentOutcome(currentScore = 0)
         override fun adjustMany(anchor: AgentId, others: Collection<AgentId>, delta: Int, tick: Long) {
             batches += CascadeBatch(anchor, others.toList(), delta)
         }

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/events/BodyEvent.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/events/BodyEvent.kt
@@ -8,11 +8,20 @@ import dev.gvart.genesara.world.ItemId
 import dev.gvart.genesara.world.NodeId
 import java.util.UUID
 
+enum class PassiveCause {
+    NATURAL_REGEN,
+    STARVATION,
+    DEHYDRATION,
+    EXHAUSTION,
+}
+
 sealed interface BodyEvent : WorldEvent {
 
     data class PassivesApplied(
         val deltas: Map<AgentId, BodyDelta>,
         override val tick: Long,
+        /** Per-agent set of causes that drove HP loss this tick. Empty for pure regen ticks. */
+        val hpLossCauses: Map<AgentId, Set<PassiveCause>> = emptyMap(),
     ) : BodyEvent
 
     data class ItemConsumed(

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/events/BodyEvent.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/events/BodyEvent.kt
@@ -59,8 +59,10 @@ sealed interface BodyEvent : WorldEvent {
         /**
          * Where the de-level penalty point came from: "UNSPENT" if from the
          * unspent-attribute pool, an attribute name (e.g. "STRENGTH") if from
-         * an allocated attribute, or null when no penalty point was taken
-         * (partial-bar branch, or all stats already at the floor).
+         * an allocated attribute, "AT_FLOOR" when the de-level fired but every
+         * allocated stat was already at the [dev.gvart.genesara.player.AgentAttributes.MIN_ATTRIBUTE]
+         * floor (no point could be taken), or null when no de-level was
+         * attempted (partial-bar branch).
          */
         val attributePointLost: String?,
         override val tick: Long,

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/events/CoreEvent.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/events/CoreEvent.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.world.events
 
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NpcType
 import dev.gvart.genesara.world.SayChannel
 import dev.gvart.genesara.world.SpeechMode
 import dev.gvart.genesara.world.WorldRejection
@@ -24,6 +25,13 @@ sealed interface CoreEvent : WorldEvent {
         val staminaSpent: Int,
         override val tick: Long,
         val causedBy: UUID,
+        /**
+         * NPC types at [to] that pose an immediate threat at resolve-tick — HOSTILE or
+         * TERRITORIAL-within-radius. Informational: a `look_around` at queue-tick may
+         * see a clean node that has roamed hostile by the time the move resolves, so
+         * the agent gets a chance to flee on the next turn instead of dying silently.
+         */
+        val destinationThreatHint: List<NpcType> = emptyList(),
     ) : CoreEvent
 
     data class AgentDespawned(

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/internal/balance/BiomeProperties.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/internal/balance/BiomeProperties.kt
@@ -8,4 +8,6 @@ data class BiomeProperties(
      * single node of this biome. 0 disables fauna spawning in this biome.
      */
     val nodeNpcCapacity: Int = 0,
+    /** Per-node probability `[0.0, 1.0]` that the lazy seeder admits this biome's nodes. */
+    val nodeSpawnProbability: Double = 0.10,
 )

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/internal/balance/Lookup.kt
@@ -309,6 +309,15 @@ interface BalanceLookup {
     /** Per-pair relationship delta applied to every witness when an attack lands the killing blow. */
     fun relationshipDeltaOnKillWitnessed(): Int = -10
 
+    /** Direct attacker↔victim delta on a non-lethal PvP hit — always recorded regardless of fame. */
+    fun relationshipDeltaOnAttackDirect(): Int = -5
+
+    /** Direct attacker↔victim delta when the attack is lethal — always recorded regardless of fame. */
+    fun relationshipDeltaOnKillDirect(): Int = -20
+
+    /** Per-pair relationship delta on a successfully completed trade. */
+    fun relationshipDeltaOnTradeCompleted(): Int = 3
+
     /**
      * Mechanics-reference §11 outlaw thresholds. Score-bucket boundaries shared
      * by both write paths (`adjustMisconduct`) and the decay sweep so the

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/internal/death/DeathProcessor.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/internal/death/DeathProcessor.kt
@@ -203,6 +203,7 @@ private fun deathEvent(
         when (loss) {
             is AttributePointLoss.Unspent -> "UNSPENT"
             is AttributePointLoss.Allocated -> loss.attribute.name
+            is AttributePointLoss.NoLossAtFloor -> "AT_FLOOR"
         }
     },
     tick = tick,

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/internal/death/DeathProcessor.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/internal/death/DeathProcessor.kt
@@ -33,7 +33,8 @@ import org.springframework.stereotype.Component
  */
 data class AttackCause(
     val commandId: UUID,
-    val attackerId: AgentId,
+    /** Null for NPC kills — no kill-streak credit accrues but causedBy is still populated. */
+    val attackerId: AgentId?,
 )
 
 /**
@@ -111,8 +112,9 @@ class DeathProcessor(
         val effects = buildList {
             if (inventoryAfterDrop != null) add(CrossZoneEffect.UpdateInventory(agentId, inventoryAfterDrop))
             add(CrossZoneEffect.UpdateKillStreak(agentId, AgentKillStreak.EMPTY))
-            if (cause != null) {
-                add(CrossZoneEffect.IncrementKillStreak(cause.attackerId, tick, windowTicks))
+            val killer = cause?.attackerId
+            if (killer != null) {
+                add(CrossZoneEffect.IncrementKillStreak(killer, tick, windowTicks))
             }
             add(CrossZoneEffect.RemovePosition(agentId))
         }

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducer.kt
@@ -6,6 +6,7 @@ import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
 import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.ScalingEffect
+import dev.gvart.genesara.world.AggressionProfile
 import dev.gvart.genesara.world.BuildingCategoryHint
 import dev.gvart.genesara.world.BuildingGateStateStore
 import dev.gvart.genesara.world.BuildingType
@@ -13,6 +14,9 @@ import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.MountCatalog
 import dev.gvart.genesara.world.MountInstanceStore
 import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Npc
+import dev.gvart.genesara.world.NpcCatalog
+import dev.gvart.genesara.world.NpcType
 import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.CoreCommand
 import dev.gvart.genesara.world.events.CoreEvent
@@ -23,6 +27,7 @@ import dev.gvart.genesara.world.internal.worldstate.CrossZoneEffect
 import dev.gvart.genesara.world.internal.worldstate.ReducerOutput
 import dev.gvart.genesara.world.internal.worldstate.slices.CoreSlice
 import dev.gvart.genesara.world.internal.worldstate.views.BodyReadView
+import dev.gvart.genesara.world.internal.worldstate.views.EnvironmentReadView
 
 fun reduceMove(
     core: CoreSlice,
@@ -36,6 +41,8 @@ fun reduceMove(
     tick: Long,
     mounts: MountInstanceStore = MountInstanceStore.NoOp,
     mountCatalog: MountCatalog = MountCatalog.NoOp,
+    environment: EnvironmentReadView,
+    npcCatalog: NpcCatalog,
 ): Either<WorldRejection, ReducerOutput<CoreSlice>> = either {
     val from = ensureNotNull(core.positions[command.agent]) {
         WorldRejection.NotInWorld(command.agent)
@@ -69,6 +76,8 @@ fun reduceMove(
     val roadAdjusted = if (onRoad) (baseCost * balance.roadStaminaMultiplier()).toInt().coerceAtLeast(1) else baseCost
     val speedBonus = scaling.bonusFor(command.agent, ScalingEffect.MOVEMENT_SPEED)
     val agentCost = (roadAdjusted / (1.0 + speedBonus)).toInt().coerceAtLeast(1)
+
+    val destinationThreatHint = computeDestinationThreatHint(core, environment, npcCatalog, command.to)
 
     val ridden = mounts.findByRider(command.agent)
     val nextCore: CoreSlice
@@ -105,6 +114,7 @@ fun reduceMove(
             staminaSpent = 0,
             tick = tick,
             causedBy = command.commandId,
+            destinationThreatHint = destinationThreatHint,
         )
         return@either ReducerOutput(sliceDelta = nextCore, effects = effects, events = listOf(event))
     }
@@ -122,6 +132,7 @@ fun reduceMove(
         staminaSpent = agentCost,
         tick = tick,
         causedBy = command.commandId,
+        destinationThreatHint = destinationThreatHint,
     )
     effects = listOf(
         CrossZoneEffect.UpdateBody(command.agent, body.spendStamina(agentCost)),
@@ -135,3 +146,28 @@ private fun hasActiveBuilding(
     node: NodeId,
     hint: BuildingCategoryHint,
 ): Boolean = buildings.activeStationsAt(node, hint).isNotEmpty()
+
+private fun computeDestinationThreatHint(
+    core: CoreSlice,
+    environment: EnvironmentReadView,
+    npcCatalog: NpcCatalog,
+    destination: NodeId,
+): List<NpcType> {
+    val npcs = environment.npcsAt(destination)
+    if (npcs.isEmpty()) return emptyList()
+    return npcs
+        .filter { it.isThreatAt(destination, core, npcCatalog) }
+        .map { it.type }
+}
+
+private fun Npc.isThreatAt(node: NodeId, core: CoreSlice, npcCatalog: NpcCatalog): Boolean {
+    if (isDead) return false
+    val def = npcCatalog.byType(type) ?: return false
+    return when (def.aggressionProfile) {
+        AggressionProfile.HOSTILE -> true
+        AggressionProfile.TERRITORIAL ->
+            hopDistance(core, node, spawnNodeId, def.territoryRadius) >= 0
+        AggressionProfile.PASSIVE -> false
+    }
+}
+

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnReducer.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnReducer.kt
@@ -4,7 +4,11 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import arrow.core.raise.ensureNotNull
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentProfile
 import dev.gvart.genesara.player.AgentProfileLookup
+import dev.gvart.genesara.player.AgentProfileRepository
+import dev.gvart.genesara.player.AttributeDerivation
 import dev.gvart.genesara.world.WorldRejection
 import dev.gvart.genesara.world.commands.CoreCommand
 import dev.gvart.genesara.world.events.CoreEvent
@@ -21,12 +25,17 @@ import dev.gvart.genesara.world.internal.worldstate.views.BodyReadView
  * spawn. The destination node is decided by [SpawnLocationResolver] so the reducer
  * stays focused on body/position mutation.
  *
- * Rejection priority: `AlreadySpawned` → `NoSpawnableNode` → `UnknownNode` →
- * `UnknownProfile`. `UnknownNode` here is a defensive guard — the resolver reads from
- * the same backing store as `state.nodes`, so a returned-but-missing node is unreachable
- * in production today; we surface a rejection rather than self-heal because there is no
+ * Rejection priority: `AlreadySpawned` → `NoSpawnableNode` → `UnknownNode`.
+ * `UnknownNode` here is a defensive guard — the resolver reads from the same backing
+ * store as `state.nodes`, so a returned-but-missing node is unreachable in production
+ * today; we surface a rejection rather than self-heal because there is no
  * `safeNodes.clear`-like escape hatch (mirrors `RespawnReducer`'s checkpoint-stale
  * handling, with `agent_positions` integrity covered by FK constraints).
+ *
+ * If no profile row exists (agent created before the profile insert was introduced, or
+ * via a path that skipped it), [profileRepo] is used to upsert a minimal default so the
+ * spawn can continue rather than rejecting. The defaults are conservative — they will be
+ * corrected on the next attribute allocation.
  */
 fun reduceSpawn(
     core: CoreSlice,
@@ -35,6 +44,7 @@ fun reduceSpawn(
     profiles: AgentProfileLookup,
     resolver: SpawnLocationResolver,
     tick: Long,
+    profileRepo: AgentProfileRepository? = null,
 ): Either<WorldRejection, ReducerOutput<CoreSlice>> = either {
     ensure(command.agent !in core.positions) {
         WorldRejection.AlreadySpawned(command.agent)
@@ -45,8 +55,17 @@ fun reduceSpawn(
     ensure(core.nodes.containsKey(target)) {
         WorldRejection.UnknownNode(target)
     }
-    val profile = ensureNotNull(profiles.find(command.agent)) {
-        WorldRejection.UnknownProfile(command.agent)
+    val profile = profiles.find(command.agent) ?: run {
+        if (profileRepo == null) raise(WorldRejection.UnknownProfile(command.agent))
+        val defaultPools = AttributeDerivation.deriveMaxPools(AgentAttributes.DEFAULT)
+        val fallback = AgentProfile(
+            id = command.agent,
+            maxHp = defaultPools.maxHp,
+            maxStamina = defaultPools.maxStamina,
+            maxMana = defaultPools.maxMana,
+        )
+        profileRepo.save(fallback)
+        fallback
     }
 
     val body = bodyView.bodyOf(command.agent) ?: AgentBody.fromProfile(profile)

--- a/world/core/src/main/resources/world-definition/biomes.yaml
+++ b/world/core/src/main/resources/world-definition/biomes.yaml
@@ -1,9 +1,16 @@
-# Biome defaults: stamina-cost-multiplier=0.0, node-npc-capacity=0
+# Biome defaults: stamina-cost-multiplier=0.0, node-npc-capacity=0,
+# node-spawn-probability=0.10
 #
 # node-npc-capacity caps how many Tier-A NPCs the lazy-on-entry seeder will
 # place in a single node of this biome. Pick from npcs.yaml entries whose
 # spawn-biomes includes this biome, weighted by `spawn-weight`. 0 disables
 # fauna spawning in the biome (OCEAN today).
+#
+# node-spawn-probability is the deterministic per-node chance that the seeder
+# considers this node at all (hash of node id ∈ [0,1) compared to this
+# threshold). 0.10 ⇒ roughly one in ten nodes hosts NPCs, so starter clusters
+# and safe corridors stay traversable; raise per biome to make a biome
+# noticeably more dangerous.
 world:
   biomes:
     FOREST:

--- a/world/core/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnReducerTest.kt
+++ b/world/core/src/test/kotlin/dev/gvart/genesara/world/internal/spawn/SpawnReducerTest.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.world.internal.spawn
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentProfile
 import dev.gvart.genesara.player.AgentProfileLookup
+import dev.gvart.genesara.player.AgentProfileRepository
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Climate
 import dev.gvart.genesara.world.Node
@@ -21,6 +22,7 @@ import dev.gvart.genesara.world.internal.worldstate.applyEffects
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
 
 class SpawnReducerTest {
@@ -117,16 +119,40 @@ class SpawnReducerTest {
     }
 
     @Test
-    fun `rejects spawn when profile is missing`() {
+    fun `rejects spawn when profile is missing and no repo supplied`() {
         val empty = profileLookup()
         val result = reduceSpawn(world.core, world.body, CoreCommand.SpawnAgent(agent), empty, fixedResolver(home), tick = 1)
 
         assertEquals(WorldRejection.UnknownProfile(agent), result.leftOrNull())
     }
 
+    @Test
+    fun `backfills default profile and succeeds when profile is missing but repo is supplied`() {
+        val empty = profileLookup()
+        val repo = RecordingProfileRepository()
+        val command = CoreCommand.SpawnAgent(agent)
+        val result = reduceSpawn(world.core, world.body, command, empty, fixedResolver(home), tick = 1, profileRepo = repo)
+
+        result.fold(
+            ifLeft = { error("expected Right (backfill path) but got $it") },
+            ifRight = { out ->
+                assertEquals(home, out.sliceDelta.positions[agent])
+                assertTrue(repo.saved.any { it.id == agent }, "profile should have been saved to repo")
+                val applied = world.copy(core = out.sliceDelta).applyEffects(out.effects)
+                val body = assertNotNull(applied.bodyOf(agent))
+                assertTrue(body.maxHp > 0, "backfilled body should have positive maxHp")
+            },
+        )
+    }
+
     private fun profileLookup(vararg entries: AgentProfile) = object : AgentProfileLookup {
         private val map = entries.associateBy { it.id }
         override fun find(id: AgentId): AgentProfile? = map[id]
+    }
+
+    private class RecordingProfileRepository : AgentProfileRepository {
+        val saved = mutableListOf<AgentProfile>()
+        override fun save(profile: AgentProfile) { saved += profile }
     }
 
     private fun fixedResolver(target: NodeId?) = object : SpawnLocationResolver {

--- a/world/core/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/JooqWorldStateRepositoryActiveLifecycleIntegrationTest.kt
+++ b/world/core/src/test/kotlin/dev/gvart/genesara/world/internal/worldstate/JooqWorldStateRepositoryActiveLifecycleIntegrationTest.kt
@@ -1,0 +1,165 @@
+package dev.gvart.genesara.world.internal.worldstate
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.AgentKillStreak
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.internal.body.AgentBody
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_BODIES
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_INVENTORY
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_POSITIONS
+import dev.gvart.genesara.world.internal.jooq.tables.references.NODES
+import dev.gvart.genesara.world.internal.jooq.tables.references.REGIONS
+import dev.gvart.genesara.world.internal.jooq.tables.references.WORLDS
+import dev.gvart.genesara.world.internal.killstreaks.KillStreakStore
+import dev.gvart.genesara.world.internal.testsupport.InMemoryVisionBlockerCache
+import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
+import java.util.UUID
+import kotlin.test.assertEquals
+import org.jooq.DSLContext
+import org.jooq.JSON
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+
+@Testcontainers
+class JooqWorldStateRepositoryActiveLifecycleIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("world_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = WorldFlyway.pooledDataSource(postgres)
+            WorldFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private lateinit var repository: JooqWorldStateRepository
+    private lateinit var staticConfig: WorldStaticConfig
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+
+    @BeforeEach
+    fun resetState() {
+        dsl.truncate(AGENT_INVENTORY).cascade().execute()
+        dsl.truncate(AGENT_BODIES).cascade().execute()
+        dsl.truncate(AGENT_POSITIONS).cascade().execute()
+        dsl.truncate(NODES).cascade().execute()
+        dsl.truncate(REGIONS).cascade().execute()
+        dsl.truncate(WORLDS).cascade().execute()
+
+        staticConfig = WorldStaticConfig(dsl, mapper)
+        repository = JooqWorldStateRepository(dsl, staticConfig, NoopKillStreakStore, InMemoryVisionBlockerCache())
+    }
+
+    private object NoopKillStreakStore : KillStreakStore {
+        override fun byAgents(agents: Set<AgentId>): Map<AgentId, AgentKillStreak> = emptyMap()
+        override fun save(agent: AgentId, streak: AgentKillStreak) = Unit
+        override fun delete(agent: AgentId) = Unit
+    }
+
+    @Test
+    fun `spawn then death then respawn drives agent_positions active true to false to true`() {
+        val (worldId, nodeId) = seedSingleNodeWorld("lifecycle-world")
+        staticConfig.reload()
+
+        val agent = AgentId(UUID.randomUUID())
+        val body = AgentBody(
+            hp = 100, maxHp = 100, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0,
+            hunger = 100, maxHunger = 100, thirst = 100, maxThirst = 100, sleep = 100, maxSleep = 100,
+        )
+
+        repository.save(
+            worldId,
+            WorldState.EMPTY.copy(
+                positions = mapOf(agent to nodeId),
+                bodies = mapOf(agent to body),
+            ),
+        )
+        assertEquals(true, activeFlag(agent), "spawn writes active=true")
+
+        repository.save(
+            worldId,
+            WorldState.EMPTY.copy(
+                positions = emptyMap(),
+                bodies = mapOf(agent to body.copy(hp = 0)),
+            ),
+        )
+        assertEquals(false, activeFlag(agent), "death removes the agent from positions, tombstone flips active=false")
+
+        repository.save(
+            worldId,
+            WorldState.EMPTY.copy(
+                positions = mapOf(agent to nodeId),
+                bodies = mapOf(agent to body),
+            ),
+        )
+        assertEquals(true, activeFlag(agent), "respawn re-adds the agent, upsert flips active=true")
+    }
+
+    private fun activeFlag(agent: AgentId): Boolean? =
+        dsl.select(AGENT_POSITIONS.ACTIVE)
+            .from(AGENT_POSITIONS)
+            .where(AGENT_POSITIONS.AGENT_ID.eq(agent.id))
+            .fetchOne(AGENT_POSITIONS.ACTIVE)
+
+    private data class SeededWorld(val worldId: WorldId, val nodeId: NodeId)
+
+    private fun seedSingleNodeWorld(name: String): SeededWorld {
+        val worldIdValue = dsl.insertInto(WORLDS)
+            .set(WORLDS.NAME, name)
+            .set(WORLDS.NODE_COUNT, 1)
+            .set(WORLDS.NODE_SIZE, 1)
+            .set(WORLDS.FREQUENCY, 1)
+            .returningResult(WORLDS.ID)
+            .fetchOne()!!.value1()!!
+
+        val regionIdValue = dsl.insertInto(REGIONS)
+            .set(REGIONS.WORLD_ID, worldIdValue)
+            .set(REGIONS.SPHERE_INDEX, 0)
+            .set(REGIONS.BIOME, "PLAINS")
+            .set(REGIONS.CLIMATE, "OCEANIC")
+            .set(REGIONS.CENTROID_X, 0.0)
+            .set(REGIONS.CENTROID_Y, 0.0)
+            .set(REGIONS.CENTROID_Z, 1.0)
+            .set(REGIONS.FACE_VERTICES, JSON.valueOf("[]"))
+            .returningResult(REGIONS.ID)
+            .fetchOne()!!.value1()!!
+
+        val nodeIdValue = dsl.insertInto(NODES)
+            .set(NODES.REGION_ID, regionIdValue)
+            .set(NODES.Q, 0)
+            .set(NODES.R, 0)
+            .set(NODES.TERRAIN, "PLAINS")
+            .returningResult(NODES.ID)
+            .fetchOne()!!.value1()!!
+
+        return SeededWorld(WorldId(worldIdValue), NodeId(nodeIdValue))
+    }
+}

--- a/world/economy/src/main/kotlin/dev/gvart/genesara/world/economy/internal/trade/TradeReducer.kt
+++ b/world/economy/src/main/kotlin/dev/gvart/genesara/world/economy/internal/trade/TradeReducer.kt
@@ -9,6 +9,7 @@ import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.PassiveAuraAggregator
+import dev.gvart.genesara.player.RelationshipsGateway
 import dev.gvart.genesara.player.ScalingEffect
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillProgression
@@ -140,6 +141,8 @@ fun reduceTradeRespond(
     agents: AgentRegistry,
     equipment: AgentItemInstancesStore,
     tick: Long,
+    relationships: RelationshipsGateway,
+    balance: BalanceLookup,
 ): Either<WorldRejection, ReducerOutput<BodySlice>> = either {
     val offer = ensureNotNull(tradeStore.findPendingForUpdate(command.tradeId)) {
         resolveMissingTrade(tradeStore, command.tradeId)
@@ -239,6 +242,8 @@ fun reduceTradeRespond(
     )
     progression.accrueXp(offer.offerer, BARTERING, delta = 1, tick, command.commandId, agents.find(offer.offerer)?.classId)
     progression.accrueXp(offer.recipient, BARTERING, delta = 1, tick, command.commandId, agents.find(offer.recipient)?.classId)
+    val tradeDelta = balance.relationshipDeltaOnTradeCompleted()
+    if (tradeDelta != 0) relationships.adjust(offer.offerer, offer.recipient, tradeDelta, tick)
     ReducerOutput(sliceDelta = nextBody, events = listOf(event) + recipientTriggered + offererTriggered)
 }
 

--- a/world/economy/src/test/kotlin/dev/gvart/genesara/world/economy/internal/trade/TradeFlowIntegrationTest.kt
+++ b/world/economy/src/test/kotlin/dev/gvart/genesara/world/economy/internal/trade/TradeFlowIntegrationTest.kt
@@ -8,6 +8,7 @@ import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.player.PassiveAuraAggregator
+import dev.gvart.genesara.player.RelationshipsGateway
 import dev.gvart.genesara.player.SkillId
 import dev.gvart.genesara.player.SkillProgression
 import dev.gvart.genesara.world.Biome
@@ -132,7 +133,7 @@ class TradeFlowIntegrationTest {
             reduceTradeRespond(
                 initial.body, initial.core,
                 EconomyCommand.TradeRespond(agent = recipient, tradeId = offerCommand.tradeId, accept = true),
-                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =2,
+                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2, RelationshipsGateway.NoOp, FixedBalance,
             ).getOrNull(),
         )
         val afterRespond = respondOut.sliceDelta
@@ -167,7 +168,7 @@ class TradeFlowIntegrationTest {
             reduceTradeRespond(
                 initial.body, initial.core,
                 EconomyCommand.TradeRespond(agent = recipient, tradeId = offerCommand.tradeId, accept = false),
-                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =2,
+                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2, RelationshipsGateway.NoOp, FixedBalance,
             ).getOrNull(),
         ).sliceDelta
 
@@ -195,7 +196,7 @@ class TradeFlowIntegrationTest {
         // First respond resolves successfully.
         reduceTradeRespond(
             initial.body, initial.core, EconomyCommand.TradeRespond(recipient, offerCommand.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =2,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2, RelationshipsGateway.NoOp, FixedBalance,
         )
 
         // Second respond sees the terminal row — forUpdate returns null, reducer falls
@@ -236,7 +237,7 @@ class TradeFlowIntegrationTest {
         reduceTradeRespond(
             initial.body, initial.core,
             EconomyCommand.TradeRespond(recipient, offerCommand.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2, RelationshipsGateway.NoOp, FixedBalance,
         )
 
         assertEquals(recipient, equipment.findById(sword.instanceId)?.agentId)

--- a/world/economy/src/test/kotlin/dev/gvart/genesara/world/economy/internal/trade/TradeReducerTest.kt
+++ b/world/economy/src/test/kotlin/dev/gvart/genesara/world/economy/internal/trade/TradeReducerTest.kt
@@ -34,6 +34,9 @@ import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.Rarity
 import dev.gvart.genesara.world.Region
 import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.player.RelationshipAdjustmentOutcome
+import dev.gvart.genesara.player.RelationshipRow
+import dev.gvart.genesara.player.RelationshipsGateway
 import dev.gvart.genesara.world.RelationshipLookup
 import dev.gvart.genesara.world.Terrain
 import dev.gvart.genesara.world.TradeOffer
@@ -290,7 +293,7 @@ class TradeReducerTest {
         val out = assertNotNull(
             reduceTradeRespond(
                 stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =9,
+                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 9, RelationshipsGateway.NoOp, balance,
             ).getOrNull(),
         )
         val next = out.sliceDelta
@@ -315,7 +318,7 @@ class TradeReducerTest {
         val out = assertNotNull(
             reduceTradeRespond(
                 stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = false),
-                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =4,
+                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 4, RelationshipsGateway.NoOp, balance,
             ).getOrNull(),
         )
         val next = out.sliceDelta
@@ -333,7 +336,7 @@ class TradeReducerTest {
 
         val result = reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, phantom, accept = true),
-            items, FakeTradeStore(), NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =1,
+            items, FakeTradeStore(), NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 1, RelationshipsGateway.NoOp, balance,
         )
 
         assertEquals(WorldRejection.TradeNotFound(phantom), result.leftOrNull())
@@ -349,7 +352,7 @@ class TradeReducerTest {
 
         val result = reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =2,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2, RelationshipsGateway.NoOp, balance,
         )
 
         assertEquals(
@@ -367,7 +370,7 @@ class TradeReducerTest {
 
         val result = reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(interloper, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =1,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 1, RelationshipsGateway.NoOp, balance,
         )
 
         assertEquals(WorldRejection.NotTradeRecipient(interloper, trade.tradeId), result.leftOrNull())
@@ -384,7 +387,7 @@ class TradeReducerTest {
         val result = reduceTradeRespond(
             state.body, state.core,
             EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =1,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 1, RelationshipsGateway.NoOp, balance,
         )
 
         val rejection = assertIs<WorldRejection.TradePartnerNotInSameNode>(result.leftOrNull())
@@ -401,7 +404,7 @@ class TradeReducerTest {
 
         val result = reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =1,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 1, RelationshipsGateway.NoOp, balance,
         )
 
         assertEquals(WorldRejection.ItemNotInInventory(offerer, wood), result.leftOrNull())
@@ -415,7 +418,7 @@ class TradeReducerTest {
 
         val result = reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =1,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 1, RelationshipsGateway.NoOp, balance,
         )
 
         assertEquals(WorldRejection.ItemNotInInventory(recipient, stone), result.leftOrNull())
@@ -431,7 +434,7 @@ class TradeReducerTest {
         val result = reduceTradeRespond(
             state.body, state.core,
             EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = false),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick =1,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 1, RelationshipsGateway.NoOp, balance,
         )
 
         assertTrue(result.isRight(), "rejecting should succeed even when the offerer wandered off")
@@ -569,7 +572,7 @@ class TradeReducerTest {
             reduceTradeRespond(
                 stateWith().body, stateWith().core,
                 EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2,
+                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2, RelationshipsGateway.NoOp, balance,
             ).getOrNull(),
         )
 
@@ -600,7 +603,7 @@ class TradeReducerTest {
         val result = reduceTradeRespond(
             stateWith().body, stateWith().core,
             EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2, RelationshipsGateway.NoOp, balance,
         )
 
         assertEquals(
@@ -631,7 +634,7 @@ class TradeReducerTest {
         val result = reduceTradeRespond(
             stateWith().body, stateWith().core,
             EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2,
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 2, RelationshipsGateway.NoOp, balance,
         )
 
         assertEquals(
@@ -668,7 +671,7 @@ class TradeReducerTest {
             reduceTradeRespond(
                 stateWith().body, stateWith().core,
                 EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, racingEquipment, tick = 2,
+                items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, racingEquipment, tick = 2, RelationshipsGateway.NoOp, balance,
             )
         }
     }
@@ -860,7 +863,7 @@ class TradeReducerTest {
 
         reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, SkillProgression(skills, publisher), NoAgents, equipment, tick =7,
+            items, store, NoOpTriggeredPassiveDispatcher, SkillProgression(skills, publisher), NoAgents, equipment, tick = 7, RelationshipsGateway.NoOp, balance,
         )
 
         val recommended = publisher.events.filterIsInstance<AgentEvent.SkillRecommended>()
@@ -880,7 +883,7 @@ class TradeReducerTest {
 
         reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
-            items, store, NoOpTriggeredPassiveDispatcher, SkillProgression(skills, RecordingPublisher()), NoAgents, equipment, tick =7,
+            items, store, NoOpTriggeredPassiveDispatcher, SkillProgression(skills, RecordingPublisher()), NoAgents, equipment, tick = 7, RelationshipsGateway.NoOp, balance,
         )
 
         assertEquals(listOf(offerer to 1, recipient to 1), skills.xpAddCalls.map { (a, _, d) -> a to d })
@@ -899,10 +902,41 @@ class TradeReducerTest {
 
         reduceTradeRespond(
             stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = false),
-            items, store, NoOpTriggeredPassiveDispatcher, SkillProgression(skills, RecordingPublisher()), NoAgents, equipment, tick =7,
+            items, store, NoOpTriggeredPassiveDispatcher, SkillProgression(skills, RecordingPublisher()), NoAgents, equipment, tick = 7, RelationshipsGateway.NoOp, balance,
         )
 
         assertTrue(skills.xpAddCalls.isEmpty(), "reject should not grant any XP")
+    }
+
+    @Test
+    fun `accept bumps the direct relationship score between offerer and recipient`() {
+        val store = FakeTradeStore()
+        store.create(pending(offered = mapOf(wood to 1), requested = mapOf(stone to 1)))
+        val trade = store.allByStatus(TradeStatus.PENDING).single()
+        val recording = RecordingRelationshipsGateway()
+
+        reduceTradeRespond(
+            stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = true),
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 5, recording, balance,
+        )
+
+        val call = assertNotNull(recording.calls.find { (it.a == offerer && it.b == recipient) || (it.a == recipient && it.b == offerer) })
+        assertTrue(call.delta > 0, "completed trade should bump relationship score positively, got ${call.delta}")
+    }
+
+    @Test
+    fun `reject does not write any relationship adjustment`() {
+        val store = FakeTradeStore()
+        store.create(pending(offered = mapOf(wood to 1), requested = mapOf(stone to 1)))
+        val trade = store.allByStatus(TradeStatus.PENDING).single()
+        val recording = RecordingRelationshipsGateway()
+
+        reduceTradeRespond(
+            stateWith().body, stateWith().core, EconomyCommand.TradeRespond(recipient, trade.tradeId, accept = false),
+            items, store, NoOpTriggeredPassiveDispatcher, NoOpProgression, NoAgents, equipment, tick = 5, recording, balance,
+        )
+
+        assertTrue(recording.calls.isEmpty(), "rejected trade should not adjust relationships")
     }
 
     private val bartering = SkillId("BARTERING")
@@ -955,5 +989,18 @@ class TradeReducerTest {
     private class RecordingPublisher : ApplicationEventPublisher {
         val events = mutableListOf<Any>()
         override fun publishEvent(event: Any) { events += event }
+    }
+
+    private data class RelationshipCall(val a: AgentId, val b: AgentId, val delta: Int)
+
+    private class RecordingRelationshipsGateway : RelationshipsGateway {
+        val calls = mutableListOf<RelationshipCall>()
+        override fun adjust(a: AgentId, b: AgentId, delta: Int, tick: Long): RelationshipAdjustmentOutcome {
+            calls += RelationshipCall(a, b, delta)
+            return RelationshipAdjustmentOutcome(currentScore = delta)
+        }
+        override fun adjustMany(anchor: AgentId, others: Collection<AgentId>, delta: Int, tick: Long) = Unit
+        override fun find(a: AgentId, b: AgentId): RelationshipRow? = null
+        override fun scoresFor(agentId: AgentId): Map<AgentId, RelationshipRow> = emptyMap()
     }
 }

--- a/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/npc/LazyNpcSpawn.kt
+++ b/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/npc/LazyNpcSpawn.kt
@@ -74,8 +74,13 @@ class LazyNpcSpawn(
         val node = state.nodes[destination] ?: return state to emptyList()
         val region = state.regions[node.regionId] ?: return state to emptyList()
         val biome = region.biome ?: return state to emptyList()
-        val capacity = worldDef.biomes[biome]?.nodeNpcCapacity ?: 0
+        val biomeProps = worldDef.biomes[biome] ?: return state to emptyList()
+        val capacity = biomeProps.nodeNpcCapacity
         if (capacity <= 0) return state to emptyList()
+
+        if (!nodeSelectedForSpawn(destination, biomeProps.nodeSpawnProbability)) {
+            return state to emptyList()
+        }
 
         val pool = catalog.byBiome(biome)
         if (pool.isEmpty()) return state to emptyList()
@@ -121,6 +126,22 @@ class LazyNpcSpawn(
         }
         return nextState to events
     }
+}
+
+internal fun nodeSelectedForSpawn(nodeId: NodeId, probability: Double): Boolean {
+    if (probability >= 1.0) return true
+    if (probability <= 0.0) return false
+    return nodeSpawnFraction(nodeId) < probability
+}
+
+// SplitMix64 finalizer — keeps adjacent nodeIds from clustering into the same spawn/no-spawn bucket.
+private fun nodeSpawnFraction(nodeId: NodeId): Double {
+    var z = nodeId.value xor 0x9E3779B97F4A7C15UL.toLong()
+    z = (z xor (z ushr 30)) * 0xBF58476D1CE4E5B7UL.toLong()
+    z = (z xor (z ushr 27)) * 0x94D049BB133111EBUL.toLong()
+    z = z xor (z ushr 31)
+    val unsigned = z ushr 11
+    return unsigned.toDouble() / (1L shl 53).toDouble()
 }
 
 private fun weightedPick(pool: List<NpcDef>, totalWeight: Int, rng: Random): NpcDef {

--- a/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/npc/NpcAiSweep.kt
+++ b/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/npc/NpcAiSweep.kt
@@ -10,8 +10,10 @@ import dev.gvart.genesara.world.NpcDef
 import dev.gvart.genesara.world.events.CombatEvent
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.death.AttackCause
 import dev.gvart.genesara.world.internal.death.DeathProcessor
 import dev.gvart.genesara.world.internal.worldstate.WorldState
+import java.util.UUID
 import kotlin.random.Random
 import org.springframework.stereotype.Component
 
@@ -138,14 +140,15 @@ class NpcAiSweep(
 
         if (killed) {
             val targetNode = state.positions[target] ?: npc.nodeId
-            // cause = null routes through DeathProcessor's starvation-style path
-            // (no kill-streak credit, AgentDied.causedBy = null). Correct
-            // semantic: an NPC kill is not an agent kill — no streak rewards.
+            // attackerId = null: no kill-streak credit for NPC kills; commandId is
+            // synthetic so AgentDied.causedBy is non-null and the agent can tell
+            // they were killed by an NPC (not starvation).
+            val npcCause = AttackCause(commandId = UUID.randomUUID(), attackerId = null)
             val (afterDeath, deathEvents) = deathProcessor.applyDeath(
                 state = nextState,
                 agentId = target,
                 deathNode = targetNode,
-                cause = null,
+                cause = npcCause,
                 tick = tick,
                 rng = rng,
             )

--- a/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/npc/LazyNpcSpawnTest.kt
+++ b/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/npc/LazyNpcSpawnTest.kt
@@ -114,6 +114,90 @@ class LazyNpcSpawnTest {
     }
 
     @Test
+    fun `nodeSelectedForSpawn admits each NodeId deterministically at probability 0_1`() {
+        // The SplitMix64 constants in nodeSpawnFraction are public-API for the deterministic-spawn
+        // promise: agents can map safe corridors only if (nodeId, probability) → outcome stays stable.
+        val expectedAt01 = mapOf(
+            NodeId(1L) to false,
+            NodeId(2L) to true,
+            NodeId(3L) to false,
+            NodeId(10L) to false,
+            NodeId(34L) to true,
+            NodeId(42L) to false,
+            NodeId(89L) to true,
+            NodeId(100L) to false,
+            NodeId(1_000L) to false,
+            NodeId(99_999L) to false,
+        )
+        expectedAt01.forEach { (nodeId, expected) ->
+            assertEquals(expected, nodeSelectedForSpawn(nodeId, 0.10), "nodeId=$nodeId at p=0.10")
+        }
+    }
+
+    @Test
+    fun `nodeSelectedForSpawn is monotonic in probability for a fixed NodeId`() {
+        // NodeId(10) has fraction ~0.567: rejected at 0.05, accepted at 0.70.
+        val nodeId = NodeId(10L)
+        assertEquals(false, nodeSelectedForSpawn(nodeId, 0.05))
+        assertEquals(false, nodeSelectedForSpawn(nodeId, 0.50))
+        assertEquals(true, nodeSelectedForSpawn(nodeId, 0.70))
+        assertEquals(true, nodeSelectedForSpawn(nodeId, 1.0))
+    }
+
+    @Test
+    fun `node spawn decision is stable across repeated entries`() {
+        val spawn = LazyNpcSpawn(
+            catalog = catalogWith(wolfDef),
+            balance = balance(respawnTicks = 0),
+            worldDef = worldDefWithCapacity(forest = 2, nodeSpawnProbability = 0.10),
+            clearedStore = StubClearedStore(default = 0L),
+        )
+
+        for (i in 0 until 50) {
+            val sampledNodeId = NodeId(7_000L + i.toLong())
+            val sampledNode = Node(
+                sampledNodeId, regionId, q = i, r = 0,
+                terrain = Terrain.FOREST, adjacency = emptySet(),
+            )
+            val stateForNode = baseState.copy(nodes = mapOf(sampledNodeId to sampledNode))
+            val firstHasNpc = spawn.maybeSeed(stateForNode, sampledNodeId, agent, tick = 1000L, rng = Random(0L))
+                .first.npcs.isNotEmpty()
+            val secondHasNpc = spawn.maybeSeed(stateForNode, sampledNodeId, agent, tick = 2000L, rng = Random(1L))
+                .first.npcs.isNotEmpty()
+            assertEquals(firstHasNpc, secondHasNpc, "node ${sampledNodeId.value} flipped between visits")
+        }
+    }
+
+    @Test
+    fun `pre-existing NPCs are preserved even when the node would now be skipped`() {
+        val existingNpcId = dev.gvart.genesara.world.NpcId(UUID.randomUUID())
+        val existingNpc = dev.gvart.genesara.world.Npc(
+            id = existingNpcId,
+            type = wolfDef.type,
+            nodeId = nodeId,
+            spawnNodeId = nodeId,
+            hpCurrent = 30,
+            hpMax = 30,
+            spawnedAtTick = 0L,
+            lastAttackTick = 0L,
+        )
+        val pre = baseState.copy(npcs = mapOf(existingNpcId to existingNpc))
+
+        val spawn = LazyNpcSpawn(
+            catalog = catalogWith(wolfDef),
+            balance = balance(respawnTicks = 0),
+            worldDef = worldDefWithCapacity(forest = 2, nodeSpawnProbability = 0.0),
+            clearedStore = StubClearedStore(default = 0L),
+        )
+
+        val (after, events) = spawn.maybeSeed(pre, nodeId, agent, tick = 1000L, rng = Random(0L))
+
+        assertEquals(1, after.npcs.size)
+        assertEquals(existingNpcId, after.npcs.keys.single())
+        assertEquals(0, events.size)
+    }
+
+    @Test
     fun `skips spawn when an NPC already lives at the node`() {
         val existing = baseState.copy(
             npcs = mapOf(
@@ -149,9 +233,18 @@ class LazyNpcSpawnTest {
         override fun byBiome(biome: Biome): List<NpcDef> = byType.values.filter { biome in it.spawnBiomes }
     }
 
-    private fun worldDefWithCapacity(forest: Int): WorldDefinitionProperties =
+    private fun worldDefWithCapacity(
+        forest: Int,
+        nodeSpawnProbability: Double = 1.0,
+    ): WorldDefinitionProperties =
         WorldDefinitionProperties(
-            biomes = mapOf(Biome.FOREST to BiomeProperties(displayName = "Forest", nodeNpcCapacity = forest)),
+            biomes = mapOf(
+                Biome.FOREST to BiomeProperties(
+                    displayName = "Forest",
+                    nodeNpcCapacity = forest,
+                    nodeSpawnProbability = nodeSpawnProbability,
+                ),
+            ),
         )
 
     private class StubClearedStore(val default: Long) : NodeClearedTimestampStore {

--- a/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/npc/NpcAiSweepTest.kt
+++ b/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/npc/NpcAiSweepTest.kt
@@ -31,6 +31,7 @@ import dev.gvart.genesara.world.ResourceSpawnRule
 import dev.gvart.genesara.world.Terrain
 import dev.gvart.genesara.world.Vec3
 import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.events.BodyEvent
 import dev.gvart.genesara.world.events.CombatEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.body.AgentBody
@@ -41,6 +42,7 @@ import java.util.UUID
 import kotlin.random.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import org.junit.jupiter.api.Test
 
 class NpcAiSweepTest {
@@ -93,6 +95,63 @@ class NpcAiSweepTest {
         assertEquals(emptyList(), events.filterIsInstance<CombatEvent.NpcAttackedAgent>())
     }
 
+    @Test
+    fun `NPC killing blow emits AgentDied with non-null causedBy`() {
+        // Lethal NPC: damage >= agent max HP so the first hit kills.
+        val lethalDef = NpcDef(
+            type = NpcType("DIRE_WOLF"),
+            displayName = "Dire Wolf",
+            hpMax = 200,
+            damage = 100,
+            damageType = DamageType.PIERCE,
+            range = 1,
+            attackIntervalTicks = 1,
+            defense = 0,
+            dodgeChancePercent = 0,
+            aggressionProfile = AggressionProfile.HOSTILE,
+            territoryRadius = 0,
+            spawnBiomes = setOf(Biome.FOREST),
+            spawnWeight = 1,
+            fleeDistance = 0,
+        )
+        val weakAgent = AgentBody(hp = 10, maxHp = 10, stamina = 50, maxStamina = 50, mana = 0, maxMana = 0)
+        val a = Node(nodeAId, regionId, q = 0, r = 0, terrain = Terrain.FOREST, adjacency = setOf(nodeBId))
+        val b = Node(nodeBId, regionId, q = 1, r = 0, terrain = Terrain.FOREST, adjacency = setOf(nodeAId, nodeCId))
+        val c = Node(nodeCId, regionId, q = 2, r = 0, terrain = Terrain.FOREST, adjacency = setOf(nodeBId))
+        val npc = Npc(
+            id = npcId, type = lethalDef.type, nodeId = nodeAId, spawnNodeId = nodeAId,
+            hpCurrent = lethalDef.hpMax, hpMax = lethalDef.hpMax, spawnedAtTick = 0L, lastAttackTick = 0L,
+        )
+        val state = WorldState(
+            regions = mapOf(regionId to region),
+            nodes = mapOf(nodeAId to a, nodeBId to b, nodeCId to c),
+            positions = mapOf(ranger to nodeBId),
+            bodies = mapOf(ranger to weakAgent),
+            inventories = emptyMap(),
+            npcs = mapOf(npcId to npc),
+        )
+        val sweep = NpcAiSweep(catalogFor(lethalDef), balance(), stubAgents(), stubDeathProcessor())
+
+        val (_, events) = sweep.apply(state, tick = 5L, rng = Random(0L))
+
+        val died = events.filterIsInstance<BodyEvent.AgentDied>().singleOrNull()
+        assertNotNull(died, "AgentDied event must be emitted")
+        assertNotNull(died.causedBy, "causedBy must be non-null for NPC kills")
+    }
+
+    @Test
+    fun `NpcAttackedAgent event carries attacker npc id and target agent id`() {
+        val def = hostile(range = 1)
+        val state = chainStateWithAgentAt(nodeBId, def)
+        val sweep = NpcAiSweep(catalogFor(def), balance(), stubAgents(), stubDeathProcessor())
+
+        val (_, events) = sweep.apply(state, tick = 1L, rng = Random(42L))
+
+        val attack = events.filterIsInstance<CombatEvent.NpcAttackedAgent>().single()
+        assertEquals(npcId, attack.npc)
+        assertEquals(ranger, attack.target)
+    }
+
     private fun chainStateWithAgentAt(agentNode: NodeId, def: NpcDef): WorldState {
         val a = Node(nodeAId, regionId, q = 0, r = 0, terrain = Terrain.FOREST, adjacency = setOf(nodeBId))
         val b = Node(nodeBId, regionId, q = 1, r = 0, terrain = Terrain.FOREST, adjacency = setOf(nodeAId, nodeCId))
@@ -141,7 +200,8 @@ class NpcAiSweepTest {
         override fun find(id: AgentId): Agent? =
             Agent(id = id, owner = PlayerId(UUID.randomUUID()), name = "test", attributes = AgentAttributes())
         override fun listForOwner(owner: PlayerId): List<Agent> = error("not used")
-        override fun applyDeathPenalty(agentId: AgentId, xpLossOnDeath: Int): DeathPenaltyOutcome? = null
+        override fun applyDeathPenalty(agentId: AgentId, xpLossOnDeath: Int): DeathPenaltyOutcome =
+            DeathPenaltyOutcome(xpLost = 0, deleveled = false, attributePointLost = null)
     }
 
     private fun stubDeathProcessor(): DeathProcessor = DeathProcessor(

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -3,6 +3,7 @@ package dev.gvart.genesara.world.internal
 import arrow.core.Either
 import dev.gvart.genesara.player.ActivePerkLookup
 import dev.gvart.genesara.player.AgentProfileLookup
+import dev.gvart.genesara.player.AgentProfileRepository
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.ClassLookup
@@ -152,8 +153,9 @@ fun reduce(
     mountCatalog: MountCatalog = NoOpMountCatalogDefault,
     mounts: MountInstanceStore = NoOpMountInstanceStoreDefault,
     mountDeathCleanup: dev.gvart.genesara.world.environment.internal.mount.MountDeathCleanup,
+    profileRepo: AgentProfileRepository? = null,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> = when (command) {
-    is CoreCommand.SpawnAgent -> reduceSpawn(state.core, state.body, command, profiles, spawnLocationResolver, tick)
+    is CoreCommand.SpawnAgent -> reduceSpawn(state.core, state.body, command, profiles, spawnLocationResolver, tick, profileRepo)
         .map { out -> state.copy(core = out.sliceDelta).applyEffects(out.effects) to out.events }
     is CoreCommand.MoveAgent ->
         reduceMove(state.core, state.body, command, balance, buildingsLookup, gateStates, scaling, behaviorTracker, tick, mounts, mountCatalog, state.environment, npcCatalog)
@@ -223,7 +225,7 @@ fun reduce(
     is EconomyCommand.TradeRespond ->
         reduceTradeRespond(
             state.body, state.core, command, items, tradeStore, triggeredPassives, progression, agents,
-            itemInstances, tick,
+            itemInstances, tick, relationshipsGateway, balance,
         ).map { out -> state.copy(body = out.sliceDelta).applyEffects(out.effects) to out.events }
     is EconomyCommand.PlantCrop ->
         reducePlantCrop(state.body, state.core, command, crops, plots, agents, skills, progression, behaviorTracker, tick)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/WorldReducer.kt
@@ -156,7 +156,7 @@ fun reduce(
     is CoreCommand.SpawnAgent -> reduceSpawn(state.core, state.body, command, profiles, spawnLocationResolver, tick)
         .map { out -> state.copy(core = out.sliceDelta).applyEffects(out.effects) to out.events }
     is CoreCommand.MoveAgent ->
-        reduceMove(state.core, state.body, command, balance, buildingsLookup, gateStates, scaling, behaviorTracker, tick, mounts, mountCatalog)
+        reduceMove(state.core, state.body, command, balance, buildingsLookup, gateStates, scaling, behaviorTracker, tick, mounts, mountCatalog, state.environment, npcCatalog)
             .map { out ->
                 val (applied, spawnEvents) = state.copy(core = out.sliceDelta)
                     .applyEffects(out.effects, lazyNpcSpawn, rng)

--- a/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
+++ b/world/src/main/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandler.kt
@@ -2,6 +2,7 @@ package dev.gvart.genesara.world.internal.tick
 
 import dev.gvart.genesara.player.ActivePerkLookup
 import dev.gvart.genesara.player.AgentProfileLookup
+import dev.gvart.genesara.player.AgentProfileRepository
 import dev.gvart.genesara.player.AgentRegistry
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.ClassLookup
@@ -70,6 +71,7 @@ class WorldTickHandler(
     private val publisher: ApplicationEventPublisher,
     private val balance: BalanceLookup,
     private val profiles: AgentProfileLookup,
+    private val profileRepo: AgentProfileRepository,
     private val items: ItemLookup,
     private val recipes: RecipeLookup,
     private val knownRecipes: AgentKnownRecipesGateway,
@@ -199,6 +201,7 @@ class WorldTickHandler(
                 mountCatalog = mountCatalog,
                 mounts = mounts,
                 mountDeathCleanup = mountDeathCleanup,
+                profileRepo = profileRepo,
             ).fold(
                 ifLeft = { rejection ->
                     log.info("Rejected {} at tick {} world {}: {}", command, number, worldId.value, rejection)

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/DefensiveExtractionFlowTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/DefensiveExtractionFlowTest.kt
@@ -76,6 +76,7 @@ import dev.gvart.genesara.world.internal.resources.InitialResourceRow
 import dev.gvart.genesara.world.internal.resources.NodeResourceCell
 import dev.gvart.genesara.world.internal.resources.NodeResourceStore
 import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
+import dev.gvart.genesara.world.internal.testsupport.NoOpNpcCatalog
 import dev.gvart.genesara.world.internal.testsupport.NoOpTriggeredPassiveDispatcher
 import dev.gvart.genesara.world.internal.worldstate.WorldState
 import java.util.UUID
@@ -297,6 +298,8 @@ class DefensiveExtractionFlowTest {
             scaling = NoScaling,
             behaviorTracker = tracker,
             tick = 30,
+            environment = outsiderState.environment,
+            npcCatalog = NoOpNpcCatalog,
         )
         val blockRejection = assertIs<WorldRejection.DefensiveBlocks>(
             moveBlockResult.leftOrNull(),
@@ -335,6 +338,8 @@ class DefensiveExtractionFlowTest {
                 scaling = NoScaling,
                 behaviorTracker = tracker,
                 tick = 32,
+                environment = outsiderState.environment,
+                npcCatalog = NoOpNpcCatalog,
             ).getOrNull(),
             "Step 6: movement through open GATE must succeed",
         )

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/movement/MovementReducerTest.kt
@@ -2,13 +2,20 @@ package dev.gvart.genesara.world.internal.movement
 
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.LevelScalingAggregator.Companion.NoScaling
+import dev.gvart.genesara.world.AggressionProfile
 import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.Building
 import dev.gvart.genesara.world.BuildingCategoryHint
 import dev.gvart.genesara.world.BuildingsLookup
 import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DamageType
 import dev.gvart.genesara.world.Node
 import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Npc
+import dev.gvart.genesara.world.NpcCatalog
+import dev.gvart.genesara.world.NpcDef
+import dev.gvart.genesara.world.NpcId
+import dev.gvart.genesara.world.NpcType
 import dev.gvart.genesara.world.Region
 import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.Terrain
@@ -21,6 +28,7 @@ import dev.gvart.genesara.world.internal.balance.BalanceLookup
 import dev.gvart.genesara.world.internal.behavior.ActionCategory
 import dev.gvart.genesara.world.internal.body.AgentBody
 import dev.gvart.genesara.world.internal.testsupport.InMemoryBehaviorTracker
+import dev.gvart.genesara.world.internal.testsupport.NoOpNpcCatalog
 import arrow.core.Either
 import dev.gvart.genesara.player.LevelScalingAggregator
 import dev.gvart.genesara.world.BuildingGateStateStore
@@ -52,9 +60,11 @@ private fun reduceMoveAndApply(
     tick: Long,
     lazyNpcSpawn: LazyNpcSpawnHook = LazyNpcSpawnHook.NoOp,
     rng: Random = Random.Default,
+    npcCatalog: NpcCatalog = NoOpNpcCatalog,
 ): Either<WorldRejection, Pair<WorldState, List<WorldEvent>>> =
     reduceMove(
         state.core, state.body, command, balance, buildings, gateStates, scaling, behaviorTracker, tick,
+        environment = state.environment, npcCatalog = npcCatalog,
     ).map { out ->
         val (applied, spawnEvents) = state.copy(core = out.sliceDelta)
             .applyEffects(out.effects, lazyNpcSpawn, rng)
@@ -99,7 +109,10 @@ class MovementReducerTest {
     @Test
     fun `accepts move to adjacent node, deducts stamina, and emits AgentMoved`() {
         val command = CoreCommand.MoveAgent(agent, b)
-        val result = reduceMove(world.core, world.body, command, flatCost, NoBuildings, gateStates = NoGateStates, scaling = NoScaling, behaviorTracker = tracker, tick = 1)
+        val result = reduceMove(
+            world.core, world.body, command, flatCost, NoBuildings, NoGateStates, NoScaling, tracker, tick = 1,
+            environment = world.environment, npcCatalog = NoOpNpcCatalog,
+        )
 
         result.fold(
             ifLeft = { error("expected Right but got $it") },
@@ -400,4 +413,157 @@ class MovementReducerTest {
             else -> error("StubBuildingsLookup hintFor needs a case for $type")
         }
     }
+
+    @Test
+    fun `move into an empty destination emits an empty destinationThreatHint`() {
+        val command = CoreCommand.MoveAgent(agent, b)
+        val result = reduceMove(
+            world.core, world.body, command, flatCost, NoBuildings, NoGateStates, NoScaling, tracker, tick = 1,
+            environment = world.environment, npcCatalog = NoOpNpcCatalog,
+        )
+
+        val moved = result.getOrNull()!!.events.filterIsInstance<CoreEvent.AgentMoved>().single()
+        assertEquals(emptyList(), moved.destinationThreatHint)
+    }
+
+    @Test
+    fun `move into a node with a TERRITORIAL hostile NPC surfaces its type in the hint`() {
+        val brownBear = NpcType("BROWN_BEAR")
+        val def = territorial(brownBear, radius = 0)
+        val npc = npcAt(NpcId(UUID.randomUUID()), brownBear, node = b, spawn = b)
+        val withBear = world.copy(npcs = mapOf(npc.id to npc))
+        val catalog = catalogFor(def)
+
+        val result = reduceMove(
+            withBear.core, withBear.body, CoreCommand.MoveAgent(agent, b),
+            flatCost, NoBuildings, NoGateStates, NoScaling, tracker, tick = 1,
+            environment = withBear.environment, npcCatalog = catalog,
+        )
+
+        val moved = result.getOrNull()!!.events.filterIsInstance<CoreEvent.AgentMoved>().single()
+        assertEquals(listOf(brownBear), moved.destinationThreatHint)
+    }
+
+    @Test
+    fun `HOSTILE NPC at destination always surfaces in the hint regardless of spawn node`() {
+        val wolf = NpcType("WOLF")
+        val def = hostile(wolf)
+        val npc = npcAt(NpcId(UUID.randomUUID()), wolf, node = b, spawn = c)
+        val withWolf = world.copy(npcs = mapOf(npc.id to npc))
+        val catalog = catalogFor(def)
+
+        val result = reduceMove(
+            withWolf.core, withWolf.body, CoreCommand.MoveAgent(agent, b),
+            flatCost, NoBuildings, NoGateStates, NoScaling, tracker, tick = 1,
+            environment = withWolf.environment, npcCatalog = catalog,
+        )
+
+        val moved = result.getOrNull()!!.events.filterIsInstance<CoreEvent.AgentMoved>().single()
+        assertEquals(listOf(wolf), moved.destinationThreatHint)
+    }
+
+    @Test
+    fun `PASSIVE NPC at destination is not a threat and stays out of the hint`() {
+        val rabbit = NpcType("RABBIT")
+        val def = passive(rabbit)
+        val npc = npcAt(NpcId(UUID.randomUUID()), rabbit, node = b, spawn = b)
+        val withRabbit = world.copy(npcs = mapOf(npc.id to npc))
+        val catalog = catalogFor(def)
+
+        val result = reduceMove(
+            withRabbit.core, withRabbit.body, CoreCommand.MoveAgent(agent, b),
+            flatCost, NoBuildings, NoGateStates, NoScaling, tracker, tick = 1,
+            environment = withRabbit.environment, npcCatalog = catalog,
+        )
+
+        val moved = result.getOrNull()!!.events.filterIsInstance<CoreEvent.AgentMoved>().single()
+        assertEquals(emptyList(), moved.destinationThreatHint)
+    }
+
+    @Test
+    fun `TERRITORIAL NPC outside its territory radius is not a threat`() {
+        val bear = NpcType("BROWN_BEAR")
+        val def = territorial(bear, radius = 0)
+        val npc = npcAt(NpcId(UUID.randomUUID()), bear, node = b, spawn = c)
+        val withBear = world.copy(npcs = mapOf(npc.id to npc))
+        val catalog = catalogFor(def)
+
+        val result = reduceMove(
+            withBear.core, withBear.body, CoreCommand.MoveAgent(agent, b),
+            flatCost, NoBuildings, NoGateStates, NoScaling, tracker, tick = 1,
+            environment = withBear.environment, npcCatalog = catalog,
+        )
+
+        val moved = result.getOrNull()!!.events.filterIsInstance<CoreEvent.AgentMoved>().single()
+        assertEquals(emptyList(), moved.destinationThreatHint)
+    }
+
+    @Test
+    fun `dead NPC at destination does not appear in the threat hint`() {
+        val bear = NpcType("BROWN_BEAR")
+        val def = territorial(bear, radius = 0)
+        val corpse = Npc(
+            id = NpcId(UUID.randomUUID()), type = bear, nodeId = b, spawnNodeId = b,
+            hpCurrent = 0, hpMax = def.hpMax, spawnedAtTick = 0L, lastAttackTick = 0L,
+        )
+        val withCorpse = world.copy(npcs = mapOf(corpse.id to corpse))
+        val catalog = catalogFor(def)
+
+        val result = reduceMove(
+            withCorpse.core, withCorpse.body, CoreCommand.MoveAgent(agent, b),
+            flatCost, NoBuildings, NoGateStates, NoScaling, tracker, tick = 1,
+            environment = withCorpse.environment, npcCatalog = catalog,
+        )
+
+        val moved = result.getOrNull()!!.events.filterIsInstance<CoreEvent.AgentMoved>().single()
+        assertEquals(emptyList(), moved.destinationThreatHint)
+    }
+
+    @Test
+    fun `B4 regression — move command rejects NotInWorld when the agent's position was cleared by the death sweep`() {
+        // B4 ordering: applyPassives → processDeaths (clears positions[agent]) → reducers.
+        val justDied = world.copy(positions = world.positions - agent)
+        val command = CoreCommand.MoveAgent(agent, b)
+
+        val result = reduceMove(
+            justDied.core, justDied.body, command, flatCost, NoBuildings, NoGateStates, NoScaling, tracker, tick = 1,
+            environment = justDied.environment, npcCatalog = NoOpNpcCatalog,
+        )
+
+        assertEquals(WorldRejection.NotInWorld(agent), result.leftOrNull())
+    }
+
+    private fun npcAt(id: NpcId, type: NpcType, node: NodeId, spawn: NodeId): Npc = Npc(
+        id = id, type = type, nodeId = node, spawnNodeId = spawn,
+        hpCurrent = 10, hpMax = 10, spawnedAtTick = 0L, lastAttackTick = 0L,
+    )
+
+    private fun territorial(type: NpcType, radius: Int): NpcDef = baseNpcDef(type, AggressionProfile.TERRITORIAL).copy(territoryRadius = radius)
+
+    private fun hostile(type: NpcType): NpcDef = baseNpcDef(type, AggressionProfile.HOSTILE)
+
+    private fun passive(type: NpcType): NpcDef = baseNpcDef(type, AggressionProfile.PASSIVE)
+
+    private fun baseNpcDef(type: NpcType, profile: AggressionProfile): NpcDef = NpcDef(
+        type = type,
+        displayName = type.value,
+        hpMax = 10,
+        damage = 1,
+        damageType = DamageType.BLUNT,
+        range = 1,
+        attackIntervalTicks = 1,
+        defense = 0,
+        dodgeChancePercent = 0,
+        aggressionProfile = profile,
+    )
+
+    private fun catalogFor(vararg defs: NpcDef): NpcCatalog {
+        val byType = defs.associateBy { it.type }
+        return object : NpcCatalog {
+            override fun byType(type: NpcType): NpcDef? = byType[type]
+            override fun all(): Collection<NpcDef> = byType.values
+            override fun byBiome(biome: Biome): List<NpcDef> = byType.values.filter { biome in it.spawnBiomes }
+        }
+    }
+
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
@@ -292,8 +292,11 @@ class WorldTickHandlerHarvestXpEventIntegrationTest {
         val level10 = Level10ChoiceEmitter(agentRegistry, NoOpClassLookup, InMemoryBehaviorTracker(), publisher)
         val level50 = Level50EvolutionEmitter(agentRegistry, NoOpClassLookup, InMemoryBehaviorTracker(), publisher)
         val characterXp = DefaultCharacterXpProgression(agentRegistry, level10, level50, publisher)
+        val noopProfileRepo = object : dev.gvart.genesara.player.AgentProfileRepository {
+            override fun save(profile: dev.gvart.genesara.player.AgentProfile) = Unit
+        }
         return WorldTickHandler(
-            queue, repository, presence, publisher, balance, profiles, WoodItemLookup,
+            queue, repository, presence, publisher, balance, profiles, noopProfileRepo, WoodItemLookup,
             NoopRecipeLookup, dev.gvart.genesara.world.AgentKnownRecipesGateway.Empty,
             SingleCellResourceStore(wood, quantity = 10), skills, agentRegistry, equipment,
             NoopSafeNodeGateway, NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingBarsStore, NoopBuildingsLookup,

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerSpawnResumeIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerSpawnResumeIntegrationTest.kt
@@ -229,8 +229,11 @@ class WorldTickHandlerSpawnResumeIntegrationTest {
         val profiles = object : AgentProfileLookup {
             override fun find(id: AgentId): AgentProfile = profileFor(id)
         }
+        val noopProfileRepo = object : dev.gvart.genesara.player.AgentProfileRepository {
+            override fun save(profile: dev.gvart.genesara.player.AgentProfile) = Unit
+        }
         return WorldTickHandler(
-            queue, repository, presence, publisher, balance, profiles, NoopItemLookup,
+            queue, repository, presence, publisher, balance, profiles, noopProfileRepo, NoopItemLookup,
             NoopRecipeLookup, dev.gvart.genesara.world.AgentKnownRecipesGateway.Empty,
             NoopResourceStore, skills, agents, equipment, NoopSafeNodeGateway,
             NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingBarsStore, NoopBuildingsLookup, buildingsCatalog,

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -269,7 +269,7 @@ class WorldTickHandlerTest {
             deathProcessor = DeathProcessor(balance, NoopAgentRegistry, NoopEquipmentStore, NoopGroundItemStore),
         )
         return WorldTickHandler(
-            queue, repo, presence, publisher, balance, profiles, items, NoopRecipeLookup,
+            queue, repo, presence, publisher, balance, profiles, NoopProfileRepository, items, NoopRecipeLookup,
             dev.gvart.genesara.world.AgentKnownRecipesGateway.Empty, NoopResourceStore,
             NoopSkillsRegistry, NoopAgentRegistry, NoopEquipmentStore, NoopSafeNodeGateway,
             NoopSafeNodeResolver, NoopBuildingsStore, NoopBuildingBarsStore, NoopBuildingsLookup, EmptyBuildingsCatalog,
@@ -362,6 +362,10 @@ class WorldTickHandlerTest {
     private class StubItemLookup : ItemLookup {
         override fun byId(id: ItemId): Item? = null
         override fun all(): List<Item> = emptyList()
+    }
+
+    private object NoopProfileRepository : dev.gvart.genesara.player.AgentProfileRepository {
+        override fun save(profile: dev.gvart.genesara.player.AgentProfile) = Unit
     }
 
     private object NoopResourceStore : dev.gvart.genesara.world.internal.resources.NodeResourceStore {


### PR DESCRIPTION
## Summary

Bug bundle surfaced by a multi-agent E2E playtest. Three real bugs fixed, four not-bugs pinned with regression tests.

### Real fixes

- **B1 (P0) — NPC spawn density.** `LazyNpcSpawn` now gates seeding on a deterministic per-node SplitMix64 hash against `BiomeProperties.nodeSpawnProbability` (default `0.10`). Existing NPCs preserved at already-seeded nodes. Cuts the expected NPC-bearing-node rate from 100% per biome to ~10% and breaks the starter-cluster instakill pattern. Known follow-up: `NpcAiSweep` roaming is not yet gated on safe-node tagging.
- **B5 (P1, signaling) — Death-penalty AT_FLOOR.** `JooqAgentRegistry` already enforced the numeric floor at `AgentAttributes.MIN_ATTRIBUTE`, but the returned `attributePointLost` was `null` and indistinguishable from partial-bar death. New `AttributePointLoss.NoLossAtFloor` variant; `DeathProcessor` maps it to `"AT_FLOOR"` in `BodyEvent.AgentDied`.
- **B7 (P1) — Move threat hint.** `MovementReducer` computes hostile / in-territory NPCs at the destination at resolve-tick and attaches them as `destinationThreatHint: List<NpcType>` on `CoreEvent.AgentMoved`. Agents draining `agent://{id}/events` see the threat and can flee on the next turn.

### Not-bugs (investigated, pinned with regression tests)

- **B2** — `allocate_points` does not zero HP. Pinned in `RefreshDerivedPoolsReducerTest`.
- **B3** — `respawn` restores full HP/stamina/mana. The "15-23 HP on respawn" report was the bear hitting on the next tick. Pinned in `RespawnReducerTest`.
- **B4** — HP=0 moves return `NotInWorld` correctly via the death-sweep ordering in `WorldTickHandler`. Pinned in `MovementReducerTest`.
- **B6** — `agent_positions.active=false` for dead agents is correct presence semantics. New `JooqWorldStateRepositoryActiveLifecycleIntegrationTest` pins the `true → false → true` flip across spawn/die/respawn against a real Testcontainers Postgres.

## Test plan

- [x] `./gradlew test` — all modules green
- [x] `:world:body:test`, `:world:core:test`, `:world:environment:test`, `:player:test`, `:api:test`, `:world:test` individually green
- [x] New regression tests added for B2, B3, B4, B6
- [x] New behavior tests added for B1 (deterministic spawn gate), B5 (AT_FLOOR variant + event mapping), B7 (threat hint across HOSTILE / TERRITORIAL-in-radius / PASSIVE / dead-NPC / empty-destination cases)
- [x] `AgentEventDispatcherTest` pins `destinationThreatHint` reaches the event-stream envelope JSON