### PR TITLE
feat(admin,api): admin audit log substrate (#198)

### DIFF
--- a/admin/build.gradle.kts
+++ b/admin/build.gradle.kts
@@ -4,11 +4,21 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":engine"))
     implementation("org.springframework.security:spring-security-crypto")
     implementation("org.springframework.boot:spring-boot-starter-jooq")
+    implementation("tools.jackson.module:jackson-module-kotlin")
+
+    testImplementation(platform("org.testcontainers:testcontainers-bom:1.21.3"))
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:postgresql")
+    testImplementation("org.flywaydb:flyway-core")
+    testImplementation("org.flywaydb:flyway-database-postgresql")
+    testImplementation("org.postgresql:postgresql")
+    testImplementation("com.zaxxer:HikariCP")
 }
 
 jooqModule {
     migrationsSubdir.set("admin")
-    tableIncludes.set("admins|admin_credentials|admin_tokens")
+    tableIncludes.set("admins|admin_credentials|admin_tokens|admin_audit_log")
 }

--- a/admin/src/main/kotlin/dev/gvart/genesara/admin/AdminAuditLog.kt
+++ b/admin/src/main/kotlin/dev/gvart/genesara/admin/AdminAuditLog.kt
@@ -1,0 +1,29 @@
+package dev.gvart.genesara.admin
+
+import java.time.Instant
+
+interface AdminAuditLog {
+    /** Appends one audit row and returns its assigned [AdminAuditEntry.seq]. */
+    fun record(
+        adminId: AdminId,
+        action: String,
+        target: String,
+        targetId: String?,
+        payload: Map<String, Any?>,
+        tick: Long,
+    ): Long
+
+    /** Returns up to [limit] entries with `seq > after`, ordered ascending by `seq`. */
+    fun readAfter(after: Long, limit: Int): List<AdminAuditEntry>
+}
+
+data class AdminAuditEntry(
+    val seq: Long,
+    val adminId: AdminId,
+    val action: String,
+    val target: String,
+    val targetId: String?,
+    val payload: Map<String, Any?>,
+    val tick: Long,
+    val occurredAt: Instant,
+)

--- a/admin/src/main/kotlin/dev/gvart/genesara/admin/ModuleMetadata.kt
+++ b/admin/src/main/kotlin/dev/gvart/genesara/admin/ModuleMetadata.kt
@@ -6,7 +6,7 @@ import org.springframework.modulith.PackageInfo
 @PackageInfo
 @ApplicationModule(
     displayName = "Admin",
-    allowedDependencies = [],
+    allowedDependencies = ["engine"],
     type = ApplicationModule.Type.OPEN,
 )
 object ModuleMetadata

--- a/admin/src/main/kotlin/dev/gvart/genesara/admin/internal/audit/JooqAdminAuditLog.kt
+++ b/admin/src/main/kotlin/dev/gvart/genesara/admin/internal/audit/JooqAdminAuditLog.kt
@@ -1,0 +1,73 @@
+package dev.gvart.genesara.admin.internal.audit
+
+import dev.gvart.genesara.admin.AdminAuditEntry
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.admin.AdminId
+import dev.gvart.genesara.admin.internal.jooq.tables.references.ADMIN_AUDIT_LOG
+import org.jooq.DSLContext
+import org.jooq.JSON
+import org.jooq.Record
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import tools.jackson.core.type.TypeReference
+import tools.jackson.databind.ObjectMapper
+
+@Component
+internal class JooqAdminAuditLog(
+    private val dsl: DSLContext,
+    private val mapper: ObjectMapper,
+) : AdminAuditLog {
+
+    @Transactional
+    override fun record(
+        adminId: AdminId,
+        action: String,
+        target: String,
+        targetId: String?,
+        payload: Map<String, Any?>,
+        tick: Long,
+    ): Long =
+        dsl.insertInto(ADMIN_AUDIT_LOG)
+            .set(ADMIN_AUDIT_LOG.ADMIN_ID, adminId.id)
+            .set(ADMIN_AUDIT_LOG.ACTION, action)
+            .set(ADMIN_AUDIT_LOG.TARGET, target)
+            .set(ADMIN_AUDIT_LOG.TARGET_ID, targetId)
+            .set(ADMIN_AUDIT_LOG.PAYLOAD, encode(payload))
+            .set(ADMIN_AUDIT_LOG.TICK, tick)
+            .returning(ADMIN_AUDIT_LOG.SEQ)
+            .fetchOne()
+            ?.get(ADMIN_AUDIT_LOG.SEQ)
+            ?: error("admin_audit_log insert returned no seq")
+
+    @Transactional(readOnly = true)
+    override fun readAfter(after: Long, limit: Int): List<AdminAuditEntry> {
+        require(limit > 0) { "limit must be positive" }
+        return dsl.selectFrom(ADMIN_AUDIT_LOG)
+            .where(ADMIN_AUDIT_LOG.SEQ.gt(after))
+            .orderBy(ADMIN_AUDIT_LOG.SEQ.asc())
+            .limit(limit)
+            .fetch()
+            .map(::toDomain)
+    }
+
+    private fun encode(payload: Map<String, Any?>): JSON =
+        JSON.valueOf(mapper.writeValueAsString(payload))
+
+    private fun decode(json: JSON): Map<String, Any?> =
+        mapper.readValue(json.data(), PAYLOAD_TYPE)
+
+    private fun toDomain(record: Record): AdminAuditEntry = AdminAuditEntry(
+        seq = record[ADMIN_AUDIT_LOG.SEQ]!!,
+        adminId = AdminId(record[ADMIN_AUDIT_LOG.ADMIN_ID]!!),
+        action = record[ADMIN_AUDIT_LOG.ACTION]!!,
+        target = record[ADMIN_AUDIT_LOG.TARGET]!!,
+        targetId = record[ADMIN_AUDIT_LOG.TARGET_ID],
+        payload = decode(record[ADMIN_AUDIT_LOG.PAYLOAD]!!),
+        tick = record[ADMIN_AUDIT_LOG.TICK]!!,
+        occurredAt = record[ADMIN_AUDIT_LOG.OCCURRED_AT]!!.toInstant(),
+    )
+
+    private companion object {
+        private val PAYLOAD_TYPE = object : TypeReference<Map<String, Any?>>() {}
+    }
+}

--- a/admin/src/main/resources/db/migration/admin/V301__admin_audit_log.sql
+++ b/admin/src/main/resources/db/migration/admin/V301__admin_audit_log.sql
@@ -1,0 +1,18 @@
+-- Append-only forensic log for admin writes. Every mutating endpoint under
+-- /admin/** records one row before returning. seq is the dashboard's cursor.
+--
+-- admin_id is a soft reference to admins(id); we keep ON DELETE actions off so
+-- a purged admin still leaves their audit trail intact.
+CREATE TABLE admin_audit_log
+(
+    seq         BIGSERIAL    PRIMARY KEY,
+    admin_id    UUID         NOT NULL,
+    action      VARCHAR(64)  NOT NULL,
+    target      VARCHAR(64)  NOT NULL,
+    target_id   VARCHAR(64),
+    payload     JSONB        NOT NULL,
+    tick        BIGINT       NOT NULL,
+    occurred_at TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_admin_audit_log_admin ON admin_audit_log (admin_id);

--- a/admin/src/test/kotlin/dev/gvart/genesara/admin/internal/audit/JooqAdminAuditLogIntegrationTest.kt
+++ b/admin/src/test/kotlin/dev/gvart/genesara/admin/internal/audit/JooqAdminAuditLogIntegrationTest.kt
@@ -1,0 +1,151 @@
+package dev.gvart.genesara.admin.internal.audit
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.admin.AdminId
+import dev.gvart.genesara.admin.internal.jooq.tables.references.ADMIN_AUDIT_LOG
+import dev.gvart.genesara.admin.internal.testsupport.AdminFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@Testcontainers
+class JooqAdminAuditLogIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("admin_audit_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = AdminFlyway.pooledDataSource(postgres)
+            AdminFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+    private lateinit var log: JooqAdminAuditLog
+    private val admin = AdminId(UUID.randomUUID())
+
+    @BeforeEach
+    fun reset() {
+        dsl.truncate(ADMIN_AUDIT_LOG).restartIdentity().cascade().execute()
+        log = JooqAdminAuditLog(dsl, mapper)
+    }
+
+    @Test
+    fun `record assigns ascending seq and persists every field`() {
+        val seq1 = log.record(
+            adminId = admin,
+            action = "npc.spawn",
+            target = "node",
+            targetId = "42",
+            payload = mapOf("type" to "GRAY_WOLF", "hp" to 30),
+            tick = 100L,
+        )
+        val seq2 = log.record(
+            adminId = admin,
+            action = "npc.kill",
+            target = "npc",
+            targetId = "00000000-0000-0000-0000-000000000001",
+            payload = emptyMap(),
+            tick = 101L,
+        )
+
+        assertTrue(seq2 > seq1, "second seq must be strictly greater")
+
+        val first = assertNotNull(
+            dsl.selectFrom(ADMIN_AUDIT_LOG).where(ADMIN_AUDIT_LOG.SEQ.eq(seq1)).fetchOne()
+        )
+        assertEquals(admin.id, first[ADMIN_AUDIT_LOG.ADMIN_ID])
+        assertEquals("npc.spawn", first[ADMIN_AUDIT_LOG.ACTION])
+        assertEquals("node", first[ADMIN_AUDIT_LOG.TARGET])
+        assertEquals("42", first[ADMIN_AUDIT_LOG.TARGET_ID])
+        assertEquals(100L, first[ADMIN_AUDIT_LOG.TICK])
+        assertNotNull(first[ADMIN_AUDIT_LOG.OCCURRED_AT])
+    }
+
+    @Test
+    fun `readAfter returns entries ordered by seq with payload roundtrip`() {
+        val payloads = listOf(
+            mapOf("a" to 1, "nested" to mapOf("k" to "v")),
+            mapOf("b" to listOf("x", "y", "z")),
+            mapOf("c" to true, "d" to null),
+        )
+        payloads.forEachIndexed { i, p ->
+            log.record(admin, "action.$i", "target", "$i", p, tick = i.toLong())
+        }
+
+        val page = log.readAfter(after = 0L, limit = 10)
+
+        assertEquals(3, page.size)
+        assertEquals(listOf(1L, 2L, 3L), page.map { it.seq })
+        assertEquals(listOf("action.0", "action.1", "action.2"), page.map { it.action })
+        assertEquals(payloads[0]["a"], page[0].payload["a"])
+        assertEquals(mapOf("k" to "v"), page[0].payload["nested"])
+        assertEquals(listOf("x", "y", "z"), page[1].payload["b"])
+        assertEquals(true, page[2].payload["c"])
+        assertNull(page[2].payload["d"])
+    }
+
+    @Test
+    fun `readAfter is exclusive on cursor and limits the page size`() {
+        val seqs = (1..5).map { i ->
+            log.record(admin, "act.$i", "node", "$i", mapOf("i" to i), tick = i.toLong())
+        }
+
+        val firstPage = log.readAfter(after = 0L, limit = 2)
+        val secondPage = log.readAfter(after = firstPage.last().seq, limit = 2)
+        val thirdPage = log.readAfter(after = secondPage.last().seq, limit = 2)
+        val empty = log.readAfter(after = thirdPage.last().seq, limit = 2)
+
+        assertEquals(seqs.subList(0, 2), firstPage.map { it.seq })
+        assertEquals(seqs.subList(2, 4), secondPage.map { it.seq })
+        assertEquals(seqs.subList(4, 5), thirdPage.map { it.seq })
+        assertEquals(emptyList(), empty)
+    }
+
+    @Test
+    fun `record accepts a null targetId`() {
+        val seq = log.record(
+            adminId = admin,
+            action = "catalog.reload",
+            target = "global",
+            targetId = null,
+            payload = mapOf("source" to "yaml"),
+            tick = 7L,
+        )
+
+        val row = assertNotNull(log.readAfter(0L, 10).singleOrNull())
+        assertEquals(seq, row.seq)
+        assertNull(row.targetId)
+    }
+}

--- a/admin/src/test/kotlin/dev/gvart/genesara/admin/internal/testsupport/AdminFlyway.kt
+++ b/admin/src/test/kotlin/dev/gvart/genesara/admin/internal/testsupport/AdminFlyway.kt
@@ -1,0 +1,30 @@
+package dev.gvart.genesara.admin.internal.testsupport
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.flywaydb.core.Flyway
+import org.testcontainers.containers.PostgreSQLContainer
+import javax.sql.DataSource
+
+internal object AdminFlyway {
+
+    fun pooledDataSource(container: PostgreSQLContainer<*>): HikariDataSource {
+        val cfg = HikariConfig().apply {
+            jdbcUrl = container.jdbcUrl
+            username = container.username
+            password = container.password
+            maximumPoolSize = 4
+            initializationFailTimeout = 30_000
+            connectionTimeout = 30_000
+        }
+        return HikariDataSource(cfg)
+    }
+
+    fun migrate(dataSource: DataSource) {
+        Flyway.configure()
+            .dataSource(dataSource)
+            .locations("classpath:db/migration/admin")
+            .load()
+            .migrate()
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/audit/AdminAuditController.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/audit/AdminAuditController.kt
@@ -1,0 +1,66 @@
+package dev.gvart.genesara.api.internal.rest.admin.audit
+
+import dev.gvart.genesara.admin.AdminAuditEntry
+import dev.gvart.genesara.admin.AdminAuditLog
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.time.Instant
+import java.util.UUID
+
+@RestController
+@RequestMapping("/admin/audit")
+internal class AdminAuditController(
+    private val auditLog: AdminAuditLog,
+) {
+
+    @GetMapping
+    fun list(
+        @RequestParam(name = "after", defaultValue = "0") after: Long,
+        @RequestParam(name = "limit", defaultValue = "100") limit: Int,
+    ): AdminAuditPage {
+        if (after < 0) throw ResponseStatusException(HttpStatus.BAD_REQUEST, "after must be >= 0")
+        if (limit !in 1..MAX_LIMIT) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "limit must be in 1..$MAX_LIMIT")
+        }
+        val entries = auditLog.readAfter(after, limit).map(AdminAuditEntry::toDto)
+        return AdminAuditPage(
+            entries = entries,
+            nextCursor = entries.lastOrNull()?.seq,
+        )
+    }
+
+    private companion object {
+        const val MAX_LIMIT = 500
+    }
+}
+
+data class AdminAuditPage(
+    val entries: List<AdminAuditEntryDto>,
+    val nextCursor: Long?,
+)
+
+data class AdminAuditEntryDto(
+    val seq: Long,
+    val adminId: UUID,
+    val action: String,
+    val target: String,
+    val targetId: String?,
+    val payload: Map<String, Any?>,
+    val tick: Long,
+    val occurredAt: Instant,
+)
+
+private fun AdminAuditEntry.toDto() = AdminAuditEntryDto(
+    seq = seq,
+    adminId = adminId.id,
+    action = action,
+    target = target,
+    targetId = targetId,
+    payload = payload,
+    tick = tick,
+    occurredAt = occurredAt,
+)

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/audit/AdminAuditControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/audit/AdminAuditControllerTest.kt
@@ -1,0 +1,121 @@
+package dev.gvart.genesara.api.internal.rest.admin.audit
+
+import dev.gvart.genesara.admin.AdminAuditEntry
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.admin.AdminId
+import dev.gvart.genesara.api.internal.rest.GlobalExceptionAdvice
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class AdminAuditControllerTest {
+
+    private val admin = AdminId(UUID.randomUUID())
+    private val now = Instant.parse("2026-05-26T12:00:00Z")
+    private lateinit var stub: StubAuditLog
+    private lateinit var mvc: MockMvc
+
+    @BeforeEach
+    fun setup() {
+        stub = StubAuditLog()
+        mvc = MockMvcBuilders.standaloneSetup(AdminAuditController(stub))
+            .setControllerAdvice(GlobalExceptionAdvice())
+            .build()
+    }
+
+    @Test
+    fun `list returns the stub entries with cursor pointing at the last seq`() {
+        stub.entries = listOf(
+            entry(seq = 11, action = "npc.spawn", targetId = "42"),
+            entry(seq = 12, action = "npc.kill", targetId = null, payload = mapOf("silent" to true)),
+        )
+
+        mvc.get("/admin/audit?after=10&limit=50").andExpect {
+            status { isOk() }
+            jsonPath("$.entries.length()") { value(2) }
+            jsonPath("$.entries[0].seq") { value(11) }
+            jsonPath("$.entries[0].action") { value("npc.spawn") }
+            jsonPath("$.entries[0].targetId") { value("42") }
+            jsonPath("$.entries[1].payload.silent") { value(true) }
+            jsonPath("$.nextCursor") { value(12) }
+        }
+
+        assertEquals(10L, stub.lastAfter)
+        assertEquals(50, stub.lastLimit)
+    }
+
+    @Test
+    fun `list defaults after to zero and limit to one hundred`() {
+        stub.entries = emptyList()
+
+        mvc.get("/admin/audit").andExpect {
+            status { isOk() }
+            jsonPath("$.entries.length()") { value(0) }
+            jsonPath("$.nextCursor") { doesNotExist() }
+        }
+
+        assertEquals(0L, stub.lastAfter)
+        assertEquals(100, stub.lastLimit)
+    }
+
+    @Test
+    fun `list rejects a negative after with 400`() {
+        mvc.get("/admin/audit?after=-1").andExpect {
+            status { isBadRequest() }
+            jsonPath("$.detail") { value("after must be >= 0") }
+        }
+    }
+
+    @Test
+    fun `list rejects an out-of-range limit with 400`() {
+        mvc.get("/admin/audit?limit=0").andExpect {
+            status { isBadRequest() }
+            jsonPath("$.detail") { value("limit must be in 1..500") }
+        }
+        mvc.get("/admin/audit?limit=501").andExpect {
+            status { isBadRequest() }
+        }
+    }
+
+    private fun entry(
+        seq: Long,
+        action: String,
+        targetId: String?,
+        payload: Map<String, Any?> = emptyMap(),
+    ) = AdminAuditEntry(
+        seq = seq,
+        adminId = admin,
+        action = action,
+        target = "node",
+        targetId = targetId,
+        payload = payload,
+        tick = 0L,
+        occurredAt = now,
+    )
+
+    private class StubAuditLog : AdminAuditLog {
+        var entries: List<AdminAuditEntry> = emptyList()
+        var lastAfter: Long = -1
+        var lastLimit: Int = -1
+
+        override fun record(
+            adminId: AdminId,
+            action: String,
+            target: String,
+            targetId: String?,
+            payload: Map<String, Any?>,
+            tick: Long,
+        ): Long = error("unused in this test")
+
+        override fun readAfter(after: Long, limit: Int): List<AdminAuditEntry> {
+            lastAfter = after
+            lastLimit = limit
+            return entries
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Lands the `admin_audit_log` table (BIGSERIAL `seq` PK, JSONB payload, soft FK on `admin_id`) plus an index on `admin_id` for per-admin lookups; PK covers the cursor read path.
- Adds the public `AdminAuditLog` interface + `JooqAdminAuditLog` impl wired as a `@Component` in `:admin`; payload encoded via Jackson 3 (`tools.jackson`).
- Adds `GET /admin/audit?after=&limit=` returning rows ordered by `seq` with a `nextCursor` hint; gated by the existing `/admin/**` ROLE_ADMIN bearer chain.
- Brings in test infra: `AdminFlyway` testcontainers helper for `:admin` + integration test covering append, ordering, payload roundtrip (nested map / list / null), and cursor pagination.

## Module placement note
The plan sketch said the interface should live under `api/internal/rest/admin/audit/`, but the "jOOQ records stay module-internal" pin in `docs/persistence.md` rules out importing `:admin`'s internal jOOQ tables from `:api`. The interface and impl therefore live in `:admin` (public + internal packages); only the REST controller sits under `api/internal/rest/admin/audit/`. This keeps the modulith boundary honest without changing the per-slice ergonomics.

## Test plan
- [x] `:admin:test` — 4 integration tests against Testcontainers Postgres (append, ordering, cursor exclusivity + page limit, null targetId).
- [x] `:api:test` — 4 standalone MockMvc tests on the controller (happy path + cursor cap, defaults, after < 0, limit out of range).
- [x] `:app:test` — modulith verification still green.

Closes #198