### PR TITLE
feat(api): admin live world feed — SSE + Redis replay (#202)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedConfiguration.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedConfiguration.kt
@@ -1,0 +1,8 @@
+package dev.gvart.genesara.api.internal.rest.admin.feed
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(AdminFeedProperties::class)
+internal class AdminFeedConfiguration

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedController.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedController.kt
@@ -1,0 +1,76 @@
+package dev.gvart.genesara.api.internal.rest.admin.feed
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.time.Duration
+import java.util.UUID
+
+@RestController
+@RequestMapping("/admin/feed")
+internal class AdminFeedController(
+    private val log: AdminFeedLog,
+    private val broker: AdminFeedBroker,
+) {
+
+    @GetMapping(produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
+    fun stream(
+        @RequestParam(name = "after", defaultValue = "0") after: Long,
+        @RequestParam(name = "type", required = false) type: String?,
+        @RequestParam(name = "agent", required = false) agent: String?,
+        @RequestParam(name = "node", required = false) node: Long?,
+        request: HttpServletRequest,
+    ): SseEmitter {
+        if (after < 0) throw ResponseStatusException(HttpStatus.BAD_REQUEST, "after must be >= 0")
+        val filter = buildFilter(type, agent, node)
+        val token = bearerToken(request)
+        return broker.register(token, after, filter, STREAM_TIMEOUT.toMillis())
+    }
+
+    @GetMapping("/range")
+    fun range(
+        @RequestParam(name = "from") from: Long,
+        @RequestParam(name = "to") to: Long,
+        @RequestParam(name = "type", required = false) type: String?,
+        @RequestParam(name = "agent", required = false) agent: String?,
+        @RequestParam(name = "node", required = false) node: Long?,
+    ): List<AdminFeedEvent> {
+        if (from < 0) throw ResponseStatusException(HttpStatus.BAD_REQUEST, "from must be >= 0")
+        if (to < from) throw ResponseStatusException(HttpStatus.BAD_REQUEST, "to must be >= from")
+        return log.range(from, to, buildFilter(type, agent, node))
+    }
+
+    private fun buildFilter(type: String?, agent: String?, node: Long?): AdminFeedFilter {
+        val types = type?.split(',')
+            ?.mapNotNull { it.trim().takeIf(String::isNotEmpty) }
+            ?.toSet()
+            ?.takeIf { it.isNotEmpty() }
+        val agentUuid = agent?.let {
+            runCatching { UUID.fromString(it) }
+                .getOrElse {
+                    throw ResponseStatusException(HttpStatus.BAD_REQUEST, "agent must be a UUID")
+                }
+        }
+        return AdminFeedFilter(types = types, agent = agentUuid, node = node)
+    }
+
+    private fun bearerToken(request: HttpServletRequest): String {
+        val header = request.getHeader("Authorization")
+            ?: throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "missing Authorization header")
+        if (!header.startsWith(BEARER_PREFIX)) {
+            throw ResponseStatusException(HttpStatus.UNAUTHORIZED, "expected Bearer token")
+        }
+        return header.substring(BEARER_PREFIX.length).trim()
+    }
+
+    private companion object {
+        val STREAM_TIMEOUT: Duration = Duration.ofMinutes(30)
+        const val BEARER_PREFIX = "Bearer "
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedDispatcher.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedDispatcher.kt
@@ -1,0 +1,87 @@
+package dev.gvart.genesara.api.internal.rest.admin.feed
+
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.events.WorldEvent
+import org.slf4j.LoggerFactory
+import org.springframework.context.event.EventListener
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ObjectMapper
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+internal class AdminFeedDispatcher(
+    private val log: AdminFeedLog,
+    private val redis: StringRedisTemplate,
+    private val mapper: ObjectMapper,
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val typeNameCache = ConcurrentHashMap<Class<*>, String>()
+
+    @EventListener
+    fun onWorld(event: WorldEvent) = publish(event, event.tick)
+
+    @EventListener
+    fun onAgent(event: AgentEvent) = publish(event, event.tick)
+
+    private fun publish(event: Any, tick: Long) {
+        val payload = mapper.valueToTree<JsonNode>(event)
+        val appended = log.append(
+            type = typeOf(event::class.java),
+            tick = tick,
+            agent = extractAgent(payload),
+            node = extractNode(payload),
+            payload = payload,
+        )
+        runCatching { redis.convertAndSend(RedisAdminFeedLog.NOTIFY_CHANNEL, appended.seq.toString()) }
+            .onFailure { logger.debug("publish to {} failed: {}", RedisAdminFeedLog.NOTIFY_CHANNEL, it.message) }
+    }
+
+    private fun typeOf(clazz: Class<*>): String =
+        typeNameCache.computeIfAbsent(clazz) { camelToSnakeFirstDot(it.simpleName) }
+
+    private fun extractAgent(payload: JsonNode): UUID? {
+        val agentNode = payload.path("agent")
+        val raw = when {
+            agentNode.isString -> agentNode.asString()
+            agentNode.isObject -> agentNode.path("id").asString(null)
+            else -> null
+        } ?: return null
+        return runCatching { UUID.fromString(raw) }.getOrNull()
+    }
+
+    private fun extractNode(payload: JsonNode): Long? {
+        for (field in NODE_FIELDS) {
+            val node = payload.path(field)
+            if (node.isMissingNode || node.isNull) continue
+            if (node.isIntegralNumber) return node.asLong()
+            val inner = node.path("value")
+            if (inner.isIntegralNumber) return inner.asLong()
+        }
+        return null
+    }
+
+    companion object {
+        private val NODE_FIELDS = listOf("at", "to", "node")
+
+        internal fun camelToSnakeFirstDot(simpleName: String): String {
+            val builder = StringBuilder(simpleName.length + 4)
+            var dotted = false
+            simpleName.forEachIndexed { i, ch ->
+                if (i > 0 && ch.isUpperCase()) {
+                    if (!dotted) {
+                        builder.append('.')
+                        dotted = true
+                    } else {
+                        builder.append('_')
+                    }
+                }
+                builder.append(ch.lowercaseChar())
+            }
+            return builder.toString()
+        }
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedEvent.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedEvent.kt
@@ -1,0 +1,19 @@
+package dev.gvart.genesara.api.internal.rest.admin.feed
+
+import tools.jackson.databind.JsonNode
+import java.util.UUID
+
+/**
+ * Envelope for one entry on the god-view `admin:feed`. [agent] and [node] are extracted
+ * from the underlying world/agent event at append time so server-side filtering does not
+ * re-parse the payload on every read.
+ */
+internal data class AdminFeedEvent(
+    val id: UUID,
+    val seq: Long,
+    val type: String,
+    val tick: Long,
+    val agent: UUID?,
+    val node: Long?,
+    val payload: JsonNode,
+)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedFilter.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedFilter.kt
@@ -1,0 +1,20 @@
+package dev.gvart.genesara.api.internal.rest.admin.feed
+
+import java.util.UUID
+
+internal data class AdminFeedFilter(
+    val types: Set<String>? = null,
+    val agent: UUID? = null,
+    val node: Long? = null,
+) {
+    fun matches(event: AdminFeedEvent): Boolean {
+        if (types != null && event.type !in types) return false
+        if (agent != null && event.agent != agent) return false
+        if (node != null && event.node != node) return false
+        return true
+    }
+
+    companion object {
+        val NONE = AdminFeedFilter()
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedLog.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedLog.kt
@@ -1,0 +1,70 @@
+package dev.gvart.genesara.api.internal.rest.admin.feed
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Component
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ObjectMapper
+import java.util.UUID
+
+/** God-view feed backing `GET /admin/feed` — bounded Redis list, monotonic seq, non-destructive reads. */
+internal interface AdminFeedLog {
+    /** Appends one entry, stamping it with a fresh monotonic [AdminFeedEvent.seq]. */
+    fun append(type: String, tick: Long, agent: UUID?, node: Long?, payload: JsonNode): AdminFeedEvent
+
+    /** Returns entries with `seq > after` matching [filter], in append order. */
+    fun since(after: Long, filter: AdminFeedFilter): List<AdminFeedEvent>
+
+    /** Returns entries with `from <= seq <= to` matching [filter], in append order. */
+    fun range(from: Long, to: Long, filter: AdminFeedFilter): List<AdminFeedEvent>
+}
+
+@Component
+internal class RedisAdminFeedLog(
+    private val redis: StringRedisTemplate,
+    private val mapper: ObjectMapper,
+    private val props: AdminFeedProperties,
+) : AdminFeedLog {
+
+    override fun append(
+        type: String,
+        tick: Long,
+        agent: UUID?,
+        node: Long?,
+        payload: JsonNode,
+    ): AdminFeedEvent {
+        val seq = redis.opsForValue().increment(SEQ_KEY)
+            ?: error("Redis INCR returned null for $SEQ_KEY")
+        val event = AdminFeedEvent(
+            id = UUID.randomUUID(),
+            seq = seq,
+            type = type,
+            tick = tick,
+            agent = agent,
+            node = node,
+            payload = payload,
+        )
+        val raw = mapper.writeValueAsString(event)
+        redis.opsForList().rightPush(LIST_KEY, raw)
+        redis.opsForList().trim(LIST_KEY, -props.backlogCap, -1)
+        redis.expire(LIST_KEY, props.ttl)
+        redis.expire(SEQ_KEY, props.ttl)
+        return event
+    }
+
+    override fun since(after: Long, filter: AdminFeedFilter): List<AdminFeedEvent> =
+        readAll().filter { it.seq > after && filter.matches(it) }
+
+    override fun range(from: Long, to: Long, filter: AdminFeedFilter): List<AdminFeedEvent> =
+        readAll().filter { it.seq in from..to && filter.matches(it) }
+
+    private fun readAll(): List<AdminFeedEvent> {
+        val raw = redis.opsForList().range(LIST_KEY, 0, -1).orEmpty()
+        return raw.map { mapper.readValue(it, AdminFeedEvent::class.java) }
+    }
+
+    companion object {
+        const val LIST_KEY = "admin:feed"
+        const val SEQ_KEY = "admin:feed:seq"
+        const val NOTIFY_CHANNEL = "admin:feed:notify"
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedProperties.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedProperties.kt
@@ -1,0 +1,15 @@
+package dev.gvart.genesara.api.internal.rest.admin.feed
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+/**
+ * [backlogCap] pinned at 5000 by ADR-0004 (`docs/adr/0004-admin-tool-open-questions.md`) — 5× the
+ * per-agent log's 1000 cap. Treat as tunable, not contractual.
+ */
+@ConfigurationProperties(prefix = "application.admin.feed")
+internal data class AdminFeedProperties(
+    val backlogCap: Long = 5000,
+    val ttl: Duration = Duration.ofHours(1),
+    val maxConnectionsPerToken: Int = 16,
+)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedSseBroker.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedSseBroker.kt
@@ -1,0 +1,123 @@
+package dev.gvart.genesara.api.internal.rest.admin.feed
+
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.data.redis.connection.Message
+import org.springframework.data.redis.connection.MessageListener
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.http.HttpStatus
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.web.server.ResponseStatusException
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArraySet
+import java.util.concurrent.atomic.AtomicLong
+
+internal interface AdminFeedBroker {
+    /**
+     * @throws ResponseStatusException 429 if this token already holds the per-token cap of concurrent
+     *   connections (pinned by [AdminFeedProperties.maxConnectionsPerToken]).
+     */
+    fun register(token: String, afterSeq: Long, filter: AdminFeedFilter, timeoutMs: Long): SseEmitter
+}
+
+@Component
+internal class AdminFeedSseBroker(
+    private val log: AdminFeedLog,
+    private val container: RedisMessageListenerContainer,
+    private val props: AdminFeedProperties,
+) : MessageListener, AdminFeedBroker {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+    private val emitters = ConcurrentHashMap<String, CopyOnWriteArraySet<Entry>>()
+
+    @PostConstruct
+    fun subscribe() {
+        container.addMessageListener(this, ChannelTopic(RedisAdminFeedLog.NOTIFY_CHANNEL))
+    }
+
+    override fun register(
+        token: String,
+        afterSeq: Long,
+        filter: AdminFeedFilter,
+        timeoutMs: Long,
+    ): SseEmitter = registerEmitter(token, SseEmitter(timeoutMs), afterSeq, filter)
+
+    internal fun registerEmitter(
+        token: String,
+        emitter: SseEmitter,
+        afterSeq: Long,
+        filter: AdminFeedFilter,
+    ): SseEmitter {
+        val bucket = emitters.computeIfAbsent(token) { CopyOnWriteArraySet() }
+        val entry = Entry(emitter, AtomicLong(afterSeq), filter)
+        synchronized(bucket) {
+            if (bucket.size >= props.maxConnectionsPerToken) {
+                throw ResponseStatusException(
+                    HttpStatus.TOO_MANY_REQUESTS,
+                    "Admin feed connection cap reached (${props.maxConnectionsPerToken} per token)",
+                )
+            }
+            bucket += entry
+        }
+        val cleanup = Runnable {
+            bucket.remove(entry)
+            if (bucket.isEmpty()) emitters.remove(token, bucket)
+        }
+        emitter.onCompletion(cleanup)
+        emitter.onTimeout {
+            emitter.complete()
+            cleanup.run()
+        }
+        emitter.onError {
+            cleanup.run()
+        }
+        dispatch(entry)
+        return emitter
+    }
+
+    override fun onMessage(message: Message, pattern: ByteArray?) {
+        emitters.values.forEach { bucket -> bucket.forEach { dispatch(it) } }
+    }
+
+    @Scheduled(fixedDelayString = "\${application.admin.feed.heartbeat:PT30S}")
+    fun heartbeat() {
+        emitters.values.forEach { bucket ->
+            bucket.forEach { entry ->
+                runCatching { entry.emitter.send(SseEmitter.event().comment("ping")) }
+                    .onFailure { runCatching { entry.emitter.complete() } }
+            }
+        }
+    }
+
+    internal fun connectionCount(token: String): Int = emitters[token]?.size ?: 0
+
+    private fun dispatch(entry: Entry) {
+        synchronized(entry) {
+            val events = log.since(entry.lastSeq.get(), entry.filter)
+            if (events.isEmpty()) return
+            for (event in events) {
+                val sent = runCatching {
+                    entry.emitter.send(
+                        SseEmitter.event().id(event.seq.toString()).name(event.type).data(event),
+                    )
+                }
+                if (sent.isFailure) {
+                    val cause = sent.exceptionOrNull()
+                    logger.debug("admin feed SSE send failed for seq={}: {}", event.seq, cause?.message)
+                    runCatching { entry.emitter.completeWithError(cause!!) }
+                    return
+                }
+                entry.lastSeq.set(event.seq)
+            }
+        }
+    }
+
+    private data class Entry(
+        val emitter: SseEmitter,
+        val lastSeq: AtomicLong,
+        val filter: AdminFeedFilter,
+    )
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedControllerTest.kt
@@ -1,0 +1,167 @@
+package dev.gvart.genesara.api.internal.rest.admin.feed
+
+import dev.gvart.genesara.api.internal.rest.GlobalExceptionAdvice
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.server.ResponseStatusException
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class AdminFeedControllerTest {
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+    private lateinit var log: StubFeedLog
+    private lateinit var broker: StubBroker
+    private lateinit var mvc: MockMvc
+
+    @BeforeEach
+    fun setup() {
+        log = StubFeedLog()
+        broker = StubBroker()
+        mvc = MockMvcBuilders.standaloneSetup(AdminFeedController(log, broker))
+            .setControllerAdvice(GlobalExceptionAdvice())
+            .build()
+    }
+
+    @Test
+    fun `range returns entries from log when bounds are valid`() {
+        log.rangeResult = listOf(adminFeedEvent(seq = 2L, type = "agent.moved"))
+
+        mvc.get("/admin/feed/range?from=1&to=5") {
+            header("Authorization", "Bearer t")
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.length()") { value(1) }
+            jsonPath("$[0].seq") { value(2) }
+            jsonPath("$[0].type") { value("agent.moved") }
+        }
+        assertEquals(1L to 5L, log.lastRangeBounds)
+    }
+
+    @Test
+    fun `range rejects negative from with 400`() {
+        mvc.get("/admin/feed/range?from=-1&to=5") {
+            header("Authorization", "Bearer t")
+        }.andExpect {
+            status { isBadRequest() }
+            jsonPath("$.detail") { value("from must be >= 0") }
+        }
+    }
+
+    @Test
+    fun `range rejects to less than from with 400`() {
+        mvc.get("/admin/feed/range?from=5&to=2") {
+            header("Authorization", "Bearer t")
+        }.andExpect {
+            status { isBadRequest() }
+            jsonPath("$.detail") { value("to must be >= from") }
+        }
+    }
+
+    @Test
+    fun `range parses csv type and uuid agent filters`() {
+        val agentUuid = UUID.randomUUID()
+        log.rangeResult = emptyList()
+
+        mvc.get("/admin/feed/range?from=0&to=10&type=agent.moved,agent.spawned&agent=$agentUuid&node=42") {
+            header("Authorization", "Bearer t")
+        }.andExpect { status { isOk() } }
+
+        val seenFilter = log.lastFilter!!
+        assertEquals(setOf("agent.moved", "agent.spawned"), seenFilter.types)
+        assertEquals(agentUuid, seenFilter.agent)
+        assertEquals(42L, seenFilter.node)
+    }
+
+    @Test
+    fun `range rejects malformed agent uuid with 400`() {
+        mvc.get("/admin/feed/range?from=0&to=10&agent=not-a-uuid") {
+            header("Authorization", "Bearer t")
+        }.andExpect {
+            status { isBadRequest() }
+            jsonPath("$.detail") { value("agent must be a UUID") }
+        }
+    }
+
+    @Test
+    fun `stream rejects negative after with 400`() {
+        mvc.get("/admin/feed?after=-1") {
+            header("Authorization", "Bearer t")
+        }.andExpect {
+            status { isBadRequest() }
+        }
+    }
+
+    @Test
+    fun `stream rejects missing Authorization header with 401`() {
+        mvc.get("/admin/feed").andExpect {
+            status { isUnauthorized() }
+        }
+    }
+
+    @Test
+    fun `stream propagates 429 from broker register`() {
+        broker.failWith = ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS, "cap reached")
+
+        mvc.get("/admin/feed") {
+            header("Authorization", "Bearer t")
+        }.andExpect {
+            status { isTooManyRequests() }
+            jsonPath("$.detail") { value("cap reached") }
+        }
+    }
+
+    private fun adminFeedEvent(seq: Long, type: String): AdminFeedEvent = AdminFeedEvent(
+        id = UUID.randomUUID(),
+        seq = seq,
+        type = type,
+        tick = 0L,
+        agent = null,
+        node = null,
+        payload = mapper.createObjectNode(),
+    )
+
+    private class StubFeedLog : AdminFeedLog {
+        var rangeResult: List<AdminFeedEvent> = emptyList()
+        var lastRangeBounds: Pair<Long, Long>? = null
+        var lastFilter: AdminFeedFilter? = null
+
+        override fun append(
+            type: String,
+            tick: Long,
+            agent: UUID?,
+            node: Long?,
+            payload: JsonNode,
+        ): AdminFeedEvent = error("append unused in controller tests")
+
+        override fun since(after: Long, filter: AdminFeedFilter): List<AdminFeedEvent> = emptyList()
+
+        override fun range(from: Long, to: Long, filter: AdminFeedFilter): List<AdminFeedEvent> {
+            lastRangeBounds = from to to
+            lastFilter = filter
+            return rangeResult
+        }
+    }
+
+    private class StubBroker : AdminFeedBroker {
+        var failWith: ResponseStatusException? = null
+
+        override fun register(
+            token: String,
+            afterSeq: Long,
+            filter: AdminFeedFilter,
+            timeoutMs: Long,
+        ): SseEmitter {
+            failWith?.let { throw it }
+            return SseEmitter(timeoutMs)
+        }
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedDispatcherTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedDispatcherTest.kt
@@ -1,0 +1,125 @@
+package dev.gvart.genesara.api.internal.rest.admin.feed
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.events.CombatEvent
+import dev.gvart.genesara.world.events.CoreEvent
+import org.mockito.Mockito.mock
+import org.springframework.data.redis.core.StringRedisTemplate
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AdminFeedDispatcherTest {
+
+    private val mapper: ObjectMapper = JsonMapper.builder().addModule(kotlinModule()).build()
+    private val redis: StringRedisTemplate = mock(StringRedisTemplate::class.java)
+    private val log = InMemoryAdminFeedLog()
+    private val dispatcher = AdminFeedDispatcher(log, redis, mapper)
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val cmd = UUID.randomUUID()
+
+    @Test
+    fun `AgentSpawned is appended with type agent_spawned and the node id at the time of spawn`() {
+        dispatcher.onWorld(CoreEvent.AgentSpawned(agent, NodeId(42L), tick = 1L, causedBy = cmd))
+
+        val event = log.appended.single()
+        assertEquals("agent.spawned", event.type)
+        assertEquals(1L, event.tick)
+        assertEquals(agent.id, event.agentArg)
+        assertEquals(42L, event.nodeArg)
+    }
+
+    @Test
+    fun `AgentMoved extracts the destination node from the to field`() {
+        dispatcher.onWorld(
+            CoreEvent.AgentMoved(
+                agent = agent,
+                from = NodeId(1L),
+                to = NodeId(2L),
+                staminaSpent = 1,
+                tick = 3L,
+                causedBy = cmd,
+            ),
+        )
+
+        val event = log.appended.single()
+        assertEquals("agent.moved", event.type)
+        assertEquals(2L, event.nodeArg)
+        assertEquals(agent.id, event.agentArg)
+    }
+
+    @Test
+    fun `events without an agent field append a null agent facet but still capture the node from at`() {
+        dispatcher.onWorld(
+            CombatEvent.AgentAttacked(
+                attacker = AgentId(UUID.randomUUID()),
+                target = AgentId(UUID.randomUUID()),
+                at = NodeId(99L),
+                damageType = dev.gvart.genesara.world.DamageType.SLASH,
+                baseDamage = 1,
+                hpLost = 1,
+                isCrit = false,
+                isDodged = false,
+                targetHpAfter = 9,
+                targetKilled = false,
+                tick = 7L,
+                causedBy = cmd,
+            ),
+        )
+
+        val event = log.appended.single()
+        assertEquals("agent.attacked", event.type)
+        assertNull(event.agentArg)
+        assertEquals(99L, event.nodeArg)
+    }
+
+    @Test
+    fun `camelToSnakeFirstDot converts multi-word class names with underscores after the first dot`() {
+        assertEquals("agent.spawned", AdminFeedDispatcher.camelToSnakeFirstDot("AgentSpawned"))
+        assertEquals("agent.moved", AdminFeedDispatcher.camelToSnakeFirstDot("AgentMoved"))
+        assertEquals("agent.attacked_npc", AdminFeedDispatcher.camelToSnakeFirstDot("AgentAttackedNpc"))
+        assertEquals("command.rejected", AdminFeedDispatcher.camelToSnakeFirstDot("CommandRejected"))
+    }
+
+    private data class AppendCall(
+        val type: String,
+        val tick: Long,
+        val agentArg: UUID?,
+        val nodeArg: Long?,
+        val payload: JsonNode,
+    )
+
+    private class InMemoryAdminFeedLog : AdminFeedLog {
+        val appended = mutableListOf<AppendCall>()
+
+        override fun append(
+            type: String,
+            tick: Long,
+            agent: UUID?,
+            node: Long?,
+            payload: JsonNode,
+        ): AdminFeedEvent {
+            appended += AppendCall(type, tick, agent, node, payload)
+            return AdminFeedEvent(
+                id = UUID.randomUUID(),
+                seq = appended.size.toLong(),
+                type = type,
+                tick = tick,
+                agent = agent,
+                node = node,
+                payload = payload,
+            )
+        }
+
+        override fun since(after: Long, filter: AdminFeedFilter): List<AdminFeedEvent> = emptyList()
+
+        override fun range(from: Long, to: Long, filter: AdminFeedFilter): List<AdminFeedEvent> = emptyList()
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedSseBrokerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedSseBrokerTest.kt
@@ -1,0 +1,64 @@
+package dev.gvart.genesara.api.internal.rest.admin.feed
+
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.web.server.ResponseStatusException
+import tools.jackson.databind.JsonNode
+import java.time.Duration
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AdminFeedSseBrokerTest {
+
+    private val props = AdminFeedProperties(
+        backlogCap = 5000,
+        ttl = Duration.ofMinutes(1),
+        maxConnectionsPerToken = 16,
+    )
+    private val log = EmptyAdminFeedLog()
+    private val broker = AdminFeedSseBroker(log, NoopContainer, props)
+
+    @Test
+    fun `17th concurrent connection for the same token is rejected with 429`() {
+        val token = "admin-token"
+
+        repeat(16) {
+            broker.register(token, afterSeq = 0L, filter = AdminFeedFilter.NONE, timeoutMs = 60_000L)
+        }
+        assertEquals(16, broker.connectionCount(token))
+
+        val ex = assertFailsWith<ResponseStatusException> {
+            broker.register(token, afterSeq = 0L, filter = AdminFeedFilter.NONE, timeoutMs = 60_000L)
+        }
+        assertEquals(429, ex.statusCode.value())
+        assertEquals(16, broker.connectionCount(token))
+    }
+
+    @Test
+    fun `different tokens have independent caps`() {
+        val tokenA = "token-a"
+        val tokenB = "token-b"
+
+        repeat(16) { broker.register(tokenA, 0L, AdminFeedFilter.NONE, 60_000L) }
+        repeat(16) { broker.register(tokenB, 0L, AdminFeedFilter.NONE, 60_000L) }
+
+        assertEquals(16, broker.connectionCount(tokenA))
+        assertEquals(16, broker.connectionCount(tokenB))
+    }
+
+    private class EmptyAdminFeedLog : AdminFeedLog {
+        override fun append(
+            type: String,
+            tick: Long,
+            agent: UUID?,
+            node: Long?,
+            payload: JsonNode,
+        ): AdminFeedEvent = error("append unused in broker tests")
+
+        override fun since(after: Long, filter: AdminFeedFilter): List<AdminFeedEvent> = emptyList()
+        override fun range(from: Long, to: Long, filter: AdminFeedFilter): List<AdminFeedEvent> = emptyList()
+    }
+
+    private object NoopContainer : RedisMessageListenerContainer()
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedSseIntegrationTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/AdminFeedSseIntegrationTest.kt
@@ -1,0 +1,195 @@
+package dev.gvart.genesara.api.internal.rest.admin.feed
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.events.CoreEvent
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Testcontainers
+class AdminFeedSseIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val redis: GenericContainer<*> =
+            GenericContainer(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379)
+    }
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+    private val props = AdminFeedProperties(
+        backlogCap = 5000,
+        ttl = Duration.ofMinutes(1),
+        maxConnectionsPerToken = 16,
+    )
+    private val resources = mutableListOf<AutoCloseable>()
+    private lateinit var template: StringRedisTemplate
+    private lateinit var container: RedisMessageListenerContainer
+    private lateinit var log: RedisAdminFeedLog
+    private lateinit var broker: AdminFeedSseBroker
+    private lateinit var dispatcher: AdminFeedDispatcher
+
+    @BeforeEach
+    fun setUp() {
+        template = newTemplate()
+        template.connectionFactory!!.connection.serverCommands().flushDb()
+        container = newContainer()
+        log = RedisAdminFeedLog(template, mapper, props)
+        broker = AdminFeedSseBroker(log, container, props)
+        broker.subscribe()
+        dispatcher = AdminFeedDispatcher(log, template, mapper)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        resources.reversed().forEach { runCatching { it.close() } }
+        resources.clear()
+    }
+
+    @Test
+    fun `spawn then two moves stream as agent_spawned plus two agent_moved with monotonic seq`() {
+        val agent = AgentId(UUID.randomUUID())
+        val emitter = subscribe(filter = AdminFeedFilter.NONE)
+
+        dispatcher.onWorld(CoreEvent.AgentSpawned(agent, NodeId(1L), tick = 1L, causedBy = UUID.randomUUID()))
+        dispatcher.onWorld(CoreEvent.AgentMoved(agent, NodeId(1L), NodeId(2L), staminaSpent = 1, tick = 2L, causedBy = UUID.randomUUID()))
+        dispatcher.onWorld(CoreEvent.AgentMoved(agent, NodeId(2L), NodeId(3L), staminaSpent = 1, tick = 3L, causedBy = UUID.randomUUID()))
+
+        emitter.awaitDataSize(3)
+
+        val captured = emitter.captured()
+        assertEquals(listOf(1L, 2L, 3L), captured.map { it.seq })
+        assertEquals(listOf("agent.spawned", "agent.moved", "agent.moved"), captured.map { it.type })
+        assertEquals(agent.id, captured.first().agent)
+    }
+
+    @Test
+    fun `server-side filter by type drops non-matching events`() {
+        val agent = AgentId(UUID.randomUUID())
+        val emitter = subscribe(filter = AdminFeedFilter(types = setOf("agent.moved")))
+
+        dispatcher.onWorld(CoreEvent.AgentSpawned(agent, NodeId(1L), tick = 1L, causedBy = UUID.randomUUID()))
+        dispatcher.onWorld(CoreEvent.AgentMoved(agent, NodeId(1L), NodeId(2L), staminaSpent = 1, tick = 2L, causedBy = UUID.randomUUID()))
+
+        emitter.awaitDataSize(1)
+        assertEquals(listOf("agent.moved"), emitter.captured().map { it.type })
+    }
+
+    @Test
+    fun `server-side filter by agent drops events from other agents`() {
+        val keep = AgentId(UUID.randomUUID())
+        val drop = AgentId(UUID.randomUUID())
+        val emitter = subscribe(filter = AdminFeedFilter(agent = keep.id))
+
+        dispatcher.onWorld(CoreEvent.AgentSpawned(drop, NodeId(1L), tick = 1L, causedBy = UUID.randomUUID()))
+        dispatcher.onWorld(CoreEvent.AgentSpawned(keep, NodeId(2L), tick = 2L, causedBy = UUID.randomUUID()))
+
+        emitter.awaitDataSize(1)
+        assertEquals(keep.id, emitter.captured().single().agent)
+    }
+
+    @Test
+    fun `range endpoint returns events whose seq falls in from to inclusive`() {
+        val agent = AgentId(UUID.randomUUID())
+        repeat(5) {
+            dispatcher.onWorld(CoreEvent.AgentMoved(agent, NodeId(it.toLong()), NodeId(it + 1L), staminaSpent = 1, tick = it.toLong(), causedBy = UUID.randomUUID()))
+        }
+
+        val slice = log.range(from = 2L, to = 4L, filter = AdminFeedFilter.NONE)
+        assertEquals(listOf(2L, 3L, 4L), slice.map { it.seq })
+    }
+
+    @Test
+    fun `pressure run of 500 events lands on one subscriber with no drops and monotonic seq`() {
+        val agent = AgentId(UUID.randomUUID())
+        val emitter = subscribe(filter = AdminFeedFilter.NONE)
+
+        val totalEvents = 500
+        for (i in 1..totalEvents) {
+            dispatcher.onWorld(CoreEvent.AgentMoved(agent, NodeId(0L), NodeId(i.toLong()), staminaSpent = 1, tick = i.toLong(), causedBy = UUID.randomUUID()))
+            if (i % 100 == 0) Thread.sleep(10)
+        }
+
+        emitter.awaitDataSize(totalEvents, timeoutMs = 30_000L)
+
+        val seqs = emitter.captured().map { it.seq }
+        assertEquals((1L..totalEvents.toLong()).toList(), seqs)
+    }
+
+    @Test
+    fun `backlog cap evicts the oldest entries beyond the configured size`() {
+        val tightProps = props.copy(backlogCap = 5)
+        val tightLog = RedisAdminFeedLog(template, mapper, tightProps)
+        val tightDispatcher = AdminFeedDispatcher(tightLog, template, mapper)
+        val agent = AgentId(UUID.randomUUID())
+
+        repeat(8) {
+            tightDispatcher.onWorld(CoreEvent.AgentMoved(agent, NodeId(0L), NodeId(it.toLong()), staminaSpent = 1, tick = it.toLong(), causedBy = UUID.randomUUID()))
+        }
+
+        val all = tightLog.since(after = 0L, filter = AdminFeedFilter.NONE)
+        assertEquals(5, all.size)
+        assertEquals(listOf(4L, 5L, 6L, 7L, 8L), all.map { it.seq })
+    }
+
+    private fun subscribe(filter: AdminFeedFilter): RecordingSseEmitter {
+        val emitter = RecordingSseEmitter()
+        broker.registerEmitter(token = "test-token", emitter = emitter, afterSeq = 0L, filter = filter)
+        return emitter
+    }
+
+    private fun newTemplate(): StringRedisTemplate {
+        val cf = LettuceConnectionFactory(redis.host, redis.firstMappedPort).apply { afterPropertiesSet() }
+        resources += AutoCloseable { cf.destroy() }
+        return StringRedisTemplate(cf)
+    }
+
+    private fun newContainer(): RedisMessageListenerContainer {
+        val cf = LettuceConnectionFactory(redis.host, redis.firstMappedPort).apply { afterPropertiesSet() }
+        resources += AutoCloseable { cf.destroy() }
+        val c = RedisMessageListenerContainer().apply {
+            setConnectionFactory(cf)
+            afterPropertiesSet()
+            start()
+        }
+        resources += AutoCloseable { c.stop() }
+        return c
+    }
+
+    private class RecordingSseEmitter : SseEmitter(60_000L) {
+        private val received = ConcurrentLinkedQueue<AdminFeedEvent>()
+
+        override fun send(builder: SseEventBuilder) {
+            builder.build().forEach { dwm ->
+                val value = dwm.data
+                if (value is AdminFeedEvent) received += value
+            }
+        }
+
+        fun captured(): List<AdminFeedEvent> = received.toList()
+
+        fun awaitDataSize(target: Int, timeoutMs: Long = 5_000L) {
+            val deadline = System.currentTimeMillis() + timeoutMs
+            while (System.currentTimeMillis() < deadline && received.size < target) {
+                Thread.sleep(10)
+            }
+            assertTrue(received.size >= target, "expected $target events, only saw ${received.size}")
+        }
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/RedisAdminFeedLogIntegrationTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/feed/RedisAdminFeedLogIntegrationTest.kt
@@ -1,0 +1,128 @@
+package dev.gvart.genesara.api.internal.rest.admin.feed
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+import java.time.Duration
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@Testcontainers
+class RedisAdminFeedLogIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val redis: GenericContainer<*> =
+            GenericContainer(DockerImageName.parse("redis:7-alpine")).withExposedPorts(6379)
+    }
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+    private val props = AdminFeedProperties(
+        backlogCap = 5,
+        ttl = Duration.ofMinutes(1),
+        maxConnectionsPerToken = 16,
+    )
+    private lateinit var template: StringRedisTemplate
+    private lateinit var cf: LettuceConnectionFactory
+    private lateinit var log: RedisAdminFeedLog
+
+    @BeforeEach
+    fun setUp() {
+        cf = LettuceConnectionFactory(redis.host, redis.firstMappedPort).apply { afterPropertiesSet() }
+        template = StringRedisTemplate(cf)
+        log = RedisAdminFeedLog(template, mapper, props)
+        template.connectionFactory!!.connection.serverCommands().flushDb()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        cf.destroy()
+    }
+
+    @Test
+    fun `append stamps monotonic seq across events`() {
+        val first = log.append("agent.moved", tick = 1L, agent = null, node = 1L, payload = mapper.createObjectNode())
+        val second = log.append("agent.moved", tick = 2L, agent = null, node = 2L, payload = mapper.createObjectNode())
+        val third = log.append("agent.moved", tick = 3L, agent = null, node = 3L, payload = mapper.createObjectNode())
+
+        assertEquals(listOf(1L, 2L, 3L), listOf(first.seq, second.seq, third.seq))
+    }
+
+    @Test
+    fun `since respects after cursor and filter`() {
+        val agentA = UUID.randomUUID()
+        val agentB = UUID.randomUUID()
+        log.append("agent.moved", tick = 1L, agent = agentA, node = 1L, payload = mapper.createObjectNode())
+        log.append("agent.spawned", tick = 2L, agent = agentB, node = 2L, payload = mapper.createObjectNode())
+        log.append("agent.moved", tick = 3L, agent = agentA, node = 3L, payload = mapper.createObjectNode())
+
+        val onlyMoves = log.since(after = 0L, filter = AdminFeedFilter(types = setOf("agent.moved")))
+        assertEquals(listOf(1L, 3L), onlyMoves.map { it.seq })
+
+        val afterCursor = log.since(after = 2L, filter = AdminFeedFilter.NONE)
+        assertEquals(listOf(3L), afterCursor.map { it.seq })
+
+        val onlyAgentB = log.since(after = 0L, filter = AdminFeedFilter(agent = agentB))
+        assertEquals(listOf(2L), onlyAgentB.map { it.seq })
+    }
+
+    @Test
+    fun `range returns the seq window inclusive on both ends`() {
+        repeat(6) { log.append("agent.moved", tick = it.toLong(), agent = null, node = null, payload = mapper.createObjectNode()) }
+
+        val slice = log.range(from = 2L, to = 4L, filter = AdminFeedFilter.NONE)
+        assertEquals(listOf(2L, 3L, 4L), slice.map { it.seq })
+    }
+
+    @Test
+    fun `backlog cap evicts oldest events past the configured size`() {
+        repeat(props.backlogCap.toInt() + 3) { i ->
+            log.append("agent.moved", tick = i.toLong(), agent = null, node = null, payload = mapper.createObjectNode())
+        }
+
+        val all = log.since(after = 0L, filter = AdminFeedFilter.NONE)
+        assertEquals(props.backlogCap.toInt(), all.size)
+        assertEquals(listOf(4L, 5L, 6L, 7L, 8L), all.map { it.seq })
+    }
+
+    @Test
+    fun `seq cursor at the latest entry returns empty since`() {
+        val last = log.append("agent.moved", tick = 0L, agent = null, node = null, payload = mapper.createObjectNode())
+
+        assertTrue(log.since(after = last.seq, filter = AdminFeedFilter.NONE).isEmpty())
+    }
+
+    @Test
+    fun `payload survives a roundtrip through redis`() {
+        val agent = UUID.randomUUID()
+        val payload = mapper.createObjectNode().apply { put("flag", true).put("counter", 7) }
+        log.append("agent.moved", tick = 1L, agent = agent, node = 42L, payload = payload)
+
+        val read = log.since(after = 0L, filter = AdminFeedFilter.NONE).single()
+        assertEquals("agent.moved", read.type)
+        assertEquals(agent, read.agent)
+        assertEquals(42L, read.node)
+        assertEquals(true, read.payload.get("flag").asBoolean())
+        assertEquals(7, read.payload.get("counter").asInt())
+    }
+
+    @Test
+    fun `event without an agent or node has null facets`() {
+        val event = log.append("ambient.tick", tick = 0L, agent = null, node = null, payload = mapper.createObjectNode())
+        val read = log.since(after = 0L, filter = AdminFeedFilter.NONE).single()
+        assertEquals(event.seq, read.seq)
+        assertNull(read.agent)
+        assertNull(read.node)
+    }
+}

--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -64,6 +64,11 @@ application:
   events:
     backlog-cap: 500
     ttl: PT1H
+  admin:
+    feed:
+      backlog-cap: 5000
+      ttl: PT1H
+      max-connections-per-token: 16
 
 # Admin bootstrap — set ADMIN_BOOTSTRAP_USERNAME / ADMIN_BOOTSTRAP_PASSWORD env vars to
 # seed the first admin on startup (idempotent: only runs when the admins table is empty).


### PR DESCRIPTION
Closes #202.

## Summary

God-view operator feed: every `WorldEvent` + `AgentEvent` lands in a bounded Redis list and fans out over SSE with server-side filters. Mirrors the per-agent `RedisAgentEventLog` + `AgentEventsSseBroker` pattern at world scope, plus a finite-range replay endpoint for the dashboard scrub-back view.

## Surfaces

- `AdminFeedDispatcher` — `@EventListener` on both `WorldEvent` and `player.events.AgentEvent` root interfaces. Serializes the event payload, extracts `agent`/`node` facets at append time so server-side filtering never re-parses, appends to `admin:feed`, publishes wakeup on `admin:feed:notify`.
- `AdminFeedSseBroker` — Redis pub/sub listener that fans out to per-token SSE emitters. Per-token concurrency cap (16) enforced under a `synchronized` bucket; 17th register raises a 429 via `ResponseStatusException`. 30s heartbeat keeps proxies warm.
- `AdminFeedController` — `GET /admin/feed?after=&type=csv&agent=uuid&node=long` (SSE) and `GET /admin/feed/range?from=&to=&...` (finite JSON array).
- `RedisAdminFeedLog` — list `admin:feed`, seq counter `admin:feed:seq`. **5000-entry backlog** (per ADR-0004), 1h TTL. Reads filter in-memory; tunable via `application.admin.feed.*`.

## Pinned configuration

```yaml
application.admin.feed:
  backlog-cap: 5000          # ADR-0004 §3
  ttl: PT1H
  max-connections-per-token: 16
```

## Tests

All under `api/src/test/.../rest/admin/feed/`:

- `AdminFeedDispatcherTest` — type-name derivation (`AgentSpawned` → `agent.spawned`, `AgentAttackedNpc` → `agent.attacked_npc`), agent/node facet extraction from value-class payloads.
- `AdminFeedSseBrokerTest` — 17th concurrent register returns 429; cap is per-token.
- `AdminFeedControllerTest` — MockMvc surface: filter parsing, 400 on bad bounds / bad UUID, 401 on missing bearer, 429 propagates.
- `RedisAdminFeedLogIntegrationTest` (Testcontainers Redis) — monotonic seq, cursor reads, range window, backlog cap, payload roundtrip.
- `AdminFeedSseIntegrationTest` (Testcontainers Redis) — full dispatcher → log → broker → SSE: spawn + 2 moves arrive as `agent.spawned` + 2× `agent.moved` with seq 1/2/3; type filter; agent filter; **500-event pressure run** verifies no drops with monotonic seq.

## Acceptance criteria coverage

- [x] Dispatcher subscribes to both event hierarchies and appends every emission
- [x] SSE endpoint streams events with `id` + `event` (type) + `data` (json) lines and 30s heartbeats
- [x] Server-side filtering by `type`, `agent`, `node` on both SSE and replay endpoints
- [x] Backlog cap + TTL per ADR-0004 (`5000` / `PT1H`)
- [x] 17th concurrent SSE connection per token returns 429
- [x] Integration test: spawn → move ×2 → SSE delivers `agent.spawned` + 2× `agent.moved` with monotonic seq
- [x] Pressure test: 500 events in 5s with one subscriber, no drops, monotonic seq
- [x] No new DB schema; Redis-only

## Deviations / notes

- **Pressure scale**: spec says "100 ev/s × 5s". The test fires 500 events in a tight burst over ~50ms with sleeps at every 100 to simulate the rate and asserts all 500 land in order. Tighter than the spec but cheaper to run in CI; if the dashboard playtest reveals back-pressure issues at the real rate we'll tune.
- **Read-path perf**: `since()` and `range()` deserialize the full 5000-entry list per call. Matches the per-agent log's pattern; ADR-0004 notes the cap is tunable from real-playtest data. If profiling shows this as a hot spot, a sorted-set-by-seq is a follow-up.
- **`SseEmitter.complete()` cleanup is not unit-tested** — invoking `complete()` on an emitter without a servlet-bound handler does not fire the registered `onCompletion` runnable. End-to-end cleanup is exercised via the Spring async lifecycle in production. The cap test still validates the 429 path with the bucket synchronization fix.
- **Per-token cap accounting**: the controller extracts the bearer token from the `Authorization` header to use as the bucket key. The defensive `401` in the controller is unreachable in production (the security chain rejects first) but keeps the bucket lookup correct under standalone MockMvc tests.