### PR TITLE
feat(api,world,player): admin sentinel + building CRUD (#200)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/BuildingAdminController.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/BuildingAdminController.kt
@@ -1,0 +1,311 @@
+package dev.gvart.genesara.api.internal.rest.admin.worlds
+
+import dev.gvart.genesara.admin.Admin
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AdminSentinel
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingDefLookup
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.MaybeSet
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldQueryGateway
+import dev.gvart.genesara.world.events.EnvironmentEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
+
+@RestController
+@RequestMapping("/admin/worlds/{worldId}")
+internal class BuildingAdminController(
+    private val store: BuildingsStore,
+    private val world: WorldQueryGateway,
+    private val catalog: BuildingDefLookup,
+    private val tick: TickClock,
+    private val auditLog: AdminAuditLog,
+    private val publisher: ApplicationEventPublisher,
+) {
+
+    @GetMapping("/nodes/{nodeId}/buildings")
+    fun list(
+        @PathVariable worldId: Long,
+        @PathVariable nodeId: Long,
+    ): List<BuildingDto> {
+        requireNodeInWorld(WorldId(worldId), NodeId(nodeId))
+        return store.listAtNode(NodeId(nodeId)).map { it.toDto() }
+    }
+
+    @PostMapping("/nodes/{nodeId}/buildings")
+    fun create(
+        @PathVariable worldId: Long,
+        @PathVariable nodeId: Long,
+        @RequestBody req: CreateBuildingRequest,
+        @AuthenticationPrincipal admin: Admin,
+    ): ResponseEntity<BuildingDto> {
+        requireNodeInWorld(WorldId(worldId), NodeId(nodeId))
+        val def = catalog.byType(req.type)
+            ?: throw badRequest("building type ${req.type} is not in the catalog")
+        val now = tick.currentTick()
+        val totalSteps = req.totalSteps ?: def.totalSteps
+        val hpMax = req.hpMax ?: def.hp
+        val progressSteps = req.progressSteps ?: totalSteps
+        val status = req.status ?: BuildingStatus.ACTIVE
+        val hpCurrent = req.hpCurrent ?: hpMax
+        val builtBy = req.builtByAgentId?.let(::AgentId) ?: AdminSentinel.agentId
+
+        validateInvariants(
+            status = status,
+            progressSteps = progressSteps,
+            totalSteps = totalSteps,
+            hpCurrent = hpCurrent,
+            hpMax = hpMax,
+        )
+
+        val building = Building(
+            instanceId = UUID.randomUUID(),
+            nodeId = NodeId(nodeId),
+            type = req.type,
+            status = status,
+            builtByAgentId = builtBy,
+            builtAtTick = now,
+            lastProgressTick = now,
+            progressSteps = progressSteps,
+            totalSteps = totalSteps,
+            hpCurrent = hpCurrent,
+            hpMax = hpMax,
+        )
+        store.insert(building)
+
+        val changedFields = mutableSetOf<String>().apply {
+            if (req.status != null) add("status")
+            if (req.hpCurrent != null) add("hpCurrent")
+            if (req.hpMax != null) add("hpMax")
+            if (req.progressSteps != null) add("progressSteps")
+            if (req.totalSteps != null) add("totalSteps")
+            if (req.builtByAgentId != null) add("builtByAgentId")
+        }
+        emitAdminEdited(building, removed = false, changedFields = changedFields, adminId = admin.id.id)
+        auditCreate(admin, building)
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(building.toDto())
+    }
+
+    @PatchMapping("/buildings/{instanceId}")
+    fun patch(
+        @PathVariable worldId: Long,
+        @PathVariable instanceId: UUID,
+        @RequestBody req: PatchBuildingRequest,
+        @AuthenticationPrincipal admin: Admin,
+    ): BuildingDto {
+        val existing = store.findById(instanceId) ?: throw notFound("building $instanceId not found")
+        requireNodeInWorld(WorldId(worldId), existing.nodeId)
+
+        val newStatus = req.status.resolveOrCurrent(existing.status) {
+            it ?: throw badRequest("status cannot be cleared")
+        }
+        val newHpCurrent = req.hpCurrent.resolveOrCurrent(existing.hpCurrent) {
+            it ?: throw badRequest("hpCurrent cannot be cleared")
+        }
+        val newHpMax = req.hpMax.resolveOrCurrent(existing.hpMax) {
+            it ?: throw badRequest("hpMax cannot be cleared")
+        }
+        val newProgressSteps = req.progressSteps.resolveOrCurrent(existing.progressSteps) {
+            it ?: throw badRequest("progressSteps cannot be cleared")
+        }
+        val newTotalSteps = req.totalSteps.resolveOrCurrent(existing.totalSteps) {
+            it ?: throw badRequest("totalSteps cannot be cleared")
+        }
+        val newBuiltBy = req.builtByAgentId.resolveOrCurrent(existing.builtByAgentId) {
+            (it ?: throw badRequest("builtByAgentId cannot be cleared")).let(::AgentId)
+        }
+
+        validateInvariants(
+            status = newStatus,
+            progressSteps = newProgressSteps,
+            totalSteps = newTotalSteps,
+            hpCurrent = newHpCurrent,
+            hpMax = newHpMax,
+        )
+
+        val now = tick.currentTick()
+        val updated = existing.copy(
+            status = newStatus,
+            builtByAgentId = newBuiltBy,
+            lastProgressTick = now,
+            progressSteps = newProgressSteps,
+            totalSteps = newTotalSteps,
+            hpCurrent = newHpCurrent,
+            hpMax = newHpMax,
+        )
+        val persisted = store.update(updated)
+            ?: throw notFound("building $instanceId not found")
+
+        val changedFields = mutableSetOf<String>().apply {
+            if (req.status is MaybeSet.Set) add("status")
+            if (req.hpCurrent is MaybeSet.Set) add("hpCurrent")
+            if (req.hpMax is MaybeSet.Set) add("hpMax")
+            if (req.progressSteps is MaybeSet.Set) add("progressSteps")
+            if (req.totalSteps is MaybeSet.Set) add("totalSteps")
+            if (req.builtByAgentId is MaybeSet.Set) add("builtByAgentId")
+        }
+        emitAdminEdited(persisted, removed = false, changedFields = changedFields, adminId = admin.id.id)
+        auditPatch(admin, persisted, changedFields)
+
+        return persisted.toDto()
+    }
+
+    @DeleteMapping("/buildings/{instanceId}")
+    fun delete(
+        @PathVariable worldId: Long,
+        @PathVariable instanceId: UUID,
+        @AuthenticationPrincipal admin: Admin,
+    ): ResponseEntity<Void> {
+        val existing = store.findById(instanceId) ?: throw notFound("building $instanceId not found")
+        requireNodeInWorld(WorldId(worldId), existing.nodeId)
+        val removed = store.delete(instanceId)
+        if (!removed) throw notFound("building $instanceId not found")
+
+        emitAdminEdited(existing, removed = true, changedFields = emptySet(), adminId = admin.id.id)
+        auditDelete(admin, existing)
+        return ResponseEntity.noContent().build()
+    }
+
+    private fun validateInvariants(
+        status: BuildingStatus,
+        progressSteps: Int,
+        totalSteps: Int,
+        hpCurrent: Int,
+        hpMax: Int,
+    ) {
+        if (totalSteps <= 0) throw badRequest("totalSteps ($totalSteps) must be positive")
+        if (progressSteps < 0 || progressSteps > totalSteps) {
+            throw badRequest("progressSteps ($progressSteps) must be in 0..totalSteps ($totalSteps)")
+        }
+        if (hpMax <= 0) throw badRequest("hpMax ($hpMax) must be positive")
+        if (hpCurrent < 0 || hpCurrent > hpMax) {
+            throw badRequest("hpCurrent ($hpCurrent) must be in 0..hpMax ($hpMax)")
+        }
+        val isActive = status == BuildingStatus.ACTIVE
+        val isComplete = progressSteps == totalSteps
+        if (isActive != isComplete) {
+            throw badRequest(
+                "status ($status) must match completion " +
+                    "(progressSteps=$progressSteps, totalSteps=$totalSteps)"
+            )
+        }
+    }
+
+    private fun requireNodeInWorld(worldId: WorldId, nodeId: NodeId) {
+        val node = world.node(nodeId) ?: throw notFound("node ${nodeId.value} not found in world ${worldId.value}")
+        val region = world.region(node.regionId)
+            ?: throw notFound("node ${nodeId.value} not found in world ${worldId.value}")
+        if (region.worldId != worldId) {
+            throw notFound("node ${nodeId.value} not found in world ${worldId.value}")
+        }
+    }
+
+    private fun emitAdminEdited(
+        building: Building,
+        removed: Boolean,
+        changedFields: Set<String>,
+        adminId: UUID,
+    ) {
+        publisher.publishEvent(
+            EnvironmentEvent.BuildingAdminEdited(
+                instanceId = building.instanceId,
+                type = building.type,
+                at = building.nodeId,
+                status = building.status,
+                hpCurrent = building.hpCurrent,
+                hpMax = building.hpMax,
+                progressSteps = building.progressSteps,
+                totalSteps = building.totalSteps,
+                removed = removed,
+                changedFields = changedFields,
+                byAdminId = adminId,
+                tick = tick.currentTick(),
+            )
+        )
+    }
+
+    private fun auditCreate(admin: Admin, building: Building) {
+        auditLog.record(
+            adminId = admin.id,
+            action = "building.create",
+            target = "building",
+            targetId = building.instanceId.toString(),
+            payload = building.toAuditPayload(),
+            tick = building.lastProgressTick,
+        )
+    }
+
+    private fun auditPatch(admin: Admin, building: Building, changedFields: Set<String>) {
+        auditLog.record(
+            adminId = admin.id,
+            action = "building.patch",
+            target = "building",
+            targetId = building.instanceId.toString(),
+            payload = building.toAuditPayload() + ("changedFields" to changedFields.toList()),
+            tick = building.lastProgressTick,
+        )
+    }
+
+    private fun auditDelete(admin: Admin, building: Building) {
+        auditLog.record(
+            adminId = admin.id,
+            action = "building.delete",
+            target = "building",
+            targetId = building.instanceId.toString(),
+            payload = building.toAuditPayload(),
+            tick = tick.currentTick(),
+        )
+    }
+
+    private fun Building.toAuditPayload(): Map<String, Any?> = mapOf(
+        "instanceId" to instanceId.toString(),
+        "nodeId" to nodeId.value,
+        "type" to type.name,
+        "status" to status.name,
+        "hpCurrent" to hpCurrent,
+        "hpMax" to hpMax,
+        "progressSteps" to progressSteps,
+        "totalSteps" to totalSteps,
+        "builtByAgentId" to builtByAgentId.id.toString(),
+    )
+
+    private fun notFound(detail: String) = ResponseStatusException(HttpStatus.NOT_FOUND, detail)
+    private fun badRequest(detail: String) = ResponseStatusException(HttpStatus.BAD_REQUEST, detail)
+}
+
+private inline fun <T, R> MaybeSet<T?>.resolveOrCurrent(current: R, transform: (T?) -> R): R = when (this) {
+    is MaybeSet.Skip -> current
+    is MaybeSet.Set -> transform(value)
+}
+
+private fun Building.toDto() = BuildingDto(
+    instanceId = instanceId,
+    nodeId = nodeId.value,
+    type = type,
+    status = status,
+    builtByAgentId = builtByAgentId.id,
+    builtAtTick = builtAtTick,
+    lastProgressTick = lastProgressTick,
+    progressSteps = progressSteps,
+    totalSteps = totalSteps,
+    hpCurrent = hpCurrent,
+    hpMax = hpMax,
+)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/BuildingAdminIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/BuildingAdminIo.kt
@@ -1,0 +1,47 @@
+package dev.gvart.genesara.api.internal.rest.admin.worlds
+
+import dev.gvart.genesara.api.internal.rest.worlds.MaybeSetDeserializer
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.MaybeSet
+import tools.jackson.databind.annotation.JsonDeserialize
+import java.util.UUID
+
+data class CreateBuildingRequest(
+    val type: BuildingType,
+    val status: BuildingStatus? = null,
+    val hpCurrent: Int? = null,
+    val hpMax: Int? = null,
+    val progressSteps: Int? = null,
+    val totalSteps: Int? = null,
+    val builtByAgentId: UUID? = null,
+)
+
+data class PatchBuildingRequest(
+    @JsonDeserialize(using = MaybeSetDeserializer::class)
+    val status: MaybeSet<BuildingStatus?> = MaybeSet.Skip,
+    @JsonDeserialize(using = MaybeSetDeserializer::class)
+    val hpCurrent: MaybeSet<Int?> = MaybeSet.Skip,
+    @JsonDeserialize(using = MaybeSetDeserializer::class)
+    val hpMax: MaybeSet<Int?> = MaybeSet.Skip,
+    @JsonDeserialize(using = MaybeSetDeserializer::class)
+    val progressSteps: MaybeSet<Int?> = MaybeSet.Skip,
+    @JsonDeserialize(using = MaybeSetDeserializer::class)
+    val totalSteps: MaybeSet<Int?> = MaybeSet.Skip,
+    @JsonDeserialize(using = MaybeSetDeserializer::class)
+    val builtByAgentId: MaybeSet<UUID?> = MaybeSet.Skip,
+)
+
+data class BuildingDto(
+    val instanceId: UUID,
+    val nodeId: Long,
+    val type: BuildingType,
+    val status: BuildingStatus,
+    val builtByAgentId: UUID,
+    val builtAtTick: Long,
+    val lastProgressTick: Long,
+    val progressSteps: Int,
+    val totalSteps: Int,
+    val hpCurrent: Int,
+    val hpMax: Int,
+)

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/BuildingAdminControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/BuildingAdminControllerTest.kt
@@ -1,0 +1,590 @@
+package dev.gvart.genesara.api.internal.rest.admin.worlds
+
+import dev.gvart.genesara.admin.Admin
+import dev.gvart.genesara.admin.AdminAuditEntry
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.admin.AdminId
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AdminSentinel
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingBarView
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingDefLookup
+import dev.gvart.genesara.world.BuildingDefView
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.MaybeSet
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldQueryGateway
+import dev.gvart.genesara.world.events.EnvironmentEvent
+import dev.gvart.genesara.world.events.WorldEvent
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.web.server.ResponseStatusException
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BuildingAdminControllerTest {
+
+    private val worldId = WorldId(1L)
+    private val regionId = RegionId(7L)
+    private val nodeId = NodeId(42L)
+    private val foreignNodeId = NodeId(43L)
+    private val unknownNodeId = NodeId(99L)
+
+    private val region = Region(
+        id = regionId,
+        worldId = worldId,
+        sphereIndex = 0,
+        biome = Biome.FOREST,
+        climate = Climate.CONTINENTAL,
+        centroid = Vec3(0.0, 0.0, 0.0),
+        faceVertices = emptyList(),
+        neighbors = emptySet(),
+    )
+    private val foreignRegion = Region(
+        id = RegionId(8L),
+        worldId = WorldId(2L),
+        sphereIndex = 0,
+        biome = Biome.FOREST,
+        climate = Climate.CONTINENTAL,
+        centroid = Vec3(0.0, 0.0, 0.0),
+        faceVertices = emptyList(),
+        neighbors = emptySet(),
+    )
+    private val node = Node(nodeId, regionId, q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())
+    private val foreignNode = Node(foreignNodeId, foreignRegion.id, q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())
+
+    private val admin = Admin(id = AdminId(UUID.randomUUID()), username = "ops")
+
+    private lateinit var store: InMemoryBuildingsStore
+    private lateinit var world: StubWorld
+    private lateinit var catalog: StubCatalog
+    private lateinit var audit: RecordingAuditLog
+    private lateinit var publisher: RecordingPublisher
+    private lateinit var controller: BuildingAdminController
+
+    @BeforeEach
+    fun setup() {
+        store = InMemoryBuildingsStore()
+        world = StubWorld(
+            nodes = mapOf(nodeId to node, foreignNodeId to foreignNode),
+            regions = mapOf(regionId to region, foreignRegion.id to foreignRegion),
+        )
+        catalog = StubCatalog(
+            mapOf(
+                BuildingType.WOODEN_WALL to defView(BuildingType.WOODEN_WALL, hp = 100, steps = 3),
+                BuildingType.CAMPFIRE to defView(BuildingType.CAMPFIRE, hp = 30, steps = 1),
+            )
+        )
+        audit = RecordingAuditLog()
+        publisher = RecordingPublisher()
+        controller = BuildingAdminController(
+            store = store,
+            world = world,
+            catalog = catalog,
+            tick = FixedTickClock(500L),
+            auditLog = audit,
+            publisher = publisher,
+        )
+    }
+
+    @Test
+    fun `create defaults status and HP and progress from the catalog`() {
+        val response = controller.create(
+            worldId = worldId.value,
+            nodeId = nodeId.value,
+            req = CreateBuildingRequest(type = BuildingType.WOODEN_WALL),
+            admin = admin,
+        )
+
+        val dto = assertNotNull(response.body)
+        assertEquals(BuildingStatus.ACTIVE, dto.status)
+        assertEquals(100, dto.hpCurrent)
+        assertEquals(100, dto.hpMax)
+        assertEquals(3, dto.progressSteps)
+        assertEquals(3, dto.totalSteps)
+        assertEquals(AdminSentinel.agentId.id, dto.builtByAgentId)
+        assertEquals(500L, dto.builtAtTick)
+
+        assertEquals(1, store.rows.size)
+        assertEquals(BuildingType.WOODEN_WALL, store.rows.single().type)
+    }
+
+    @Test
+    fun `create accepts a half-HP ACTIVE WOODEN_WALL and lists it via GET`() {
+        controller.create(
+            worldId = worldId.value,
+            nodeId = nodeId.value,
+            req = CreateBuildingRequest(
+                type = BuildingType.WOODEN_WALL,
+                status = BuildingStatus.ACTIVE,
+                hpCurrent = 50,
+                hpMax = 100,
+            ),
+            admin = admin,
+        )
+
+        val listed = controller.list(worldId.value, nodeId.value)
+
+        assertEquals(1, listed.size)
+        assertEquals(BuildingStatus.ACTIVE, listed.single().status)
+        assertEquals(50, listed.single().hpCurrent)
+        assertEquals(100, listed.single().hpMax)
+    }
+
+    @Test
+    fun `create accepts an UNDER_CONSTRUCTION building at any progress step`() {
+        val response = controller.create(
+            worldId = worldId.value,
+            nodeId = nodeId.value,
+            req = CreateBuildingRequest(
+                type = BuildingType.WOODEN_WALL,
+                status = BuildingStatus.UNDER_CONSTRUCTION,
+                progressSteps = 1,
+                totalSteps = 3,
+            ),
+            admin = admin,
+        )
+
+        val dto = assertNotNull(response.body)
+        assertEquals(BuildingStatus.UNDER_CONSTRUCTION, dto.status)
+        assertEquals(1, dto.progressSteps)
+        assertEquals(3, dto.totalSteps)
+    }
+
+    @Test
+    fun `create rejects ACTIVE with partial progress`() {
+        val error = assertThrows<ResponseStatusException> {
+            controller.create(
+                worldId = worldId.value,
+                nodeId = nodeId.value,
+                req = CreateBuildingRequest(
+                    type = BuildingType.WOODEN_WALL,
+                    status = BuildingStatus.ACTIVE,
+                    progressSteps = 1,
+                    totalSteps = 3,
+                ),
+                admin = admin,
+            )
+        }
+        assertEquals(400, error.statusCode.value())
+        assertTrue(error.reason!!.contains("status (ACTIVE) must match completion"))
+    }
+
+    @Test
+    fun `create rejects UNDER_CONSTRUCTION at full progress`() {
+        val error = assertThrows<ResponseStatusException> {
+            controller.create(
+                worldId = worldId.value,
+                nodeId = nodeId.value,
+                req = CreateBuildingRequest(
+                    type = BuildingType.WOODEN_WALL,
+                    status = BuildingStatus.UNDER_CONSTRUCTION,
+                    progressSteps = 3,
+                    totalSteps = 3,
+                ),
+                admin = admin,
+            )
+        }
+        assertEquals(400, error.statusCode.value())
+    }
+
+    @Test
+    fun `create rejects hpCurrent above hpMax`() {
+        val error = assertThrows<ResponseStatusException> {
+            controller.create(
+                worldId = worldId.value,
+                nodeId = nodeId.value,
+                req = CreateBuildingRequest(
+                    type = BuildingType.WOODEN_WALL,
+                    hpCurrent = 200,
+                    hpMax = 100,
+                ),
+                admin = admin,
+            )
+        }
+        assertEquals(400, error.statusCode.value())
+        assertTrue(error.reason!!.contains("hpCurrent (200)"))
+    }
+
+    @Test
+    fun `create rejects non-positive hpMax`() {
+        val error = assertThrows<ResponseStatusException> {
+            controller.create(
+                worldId = worldId.value,
+                nodeId = nodeId.value,
+                req = CreateBuildingRequest(
+                    type = BuildingType.WOODEN_WALL,
+                    hpMax = 0,
+                ),
+                admin = admin,
+            )
+        }
+        assertEquals(400, error.statusCode.value())
+    }
+
+    @Test
+    fun `create rejects progressSteps above totalSteps`() {
+        val error = assertThrows<ResponseStatusException> {
+            controller.create(
+                worldId = worldId.value,
+                nodeId = nodeId.value,
+                req = CreateBuildingRequest(
+                    type = BuildingType.WOODEN_WALL,
+                    progressSteps = 5,
+                    totalSteps = 3,
+                ),
+                admin = admin,
+            )
+        }
+        assertEquals(400, error.statusCode.value())
+    }
+
+    @Test
+    fun `create rejects nodes that don't belong to the world`() {
+        val error = assertThrows<ResponseStatusException> {
+            controller.create(
+                worldId = worldId.value,
+                nodeId = foreignNodeId.value,
+                req = CreateBuildingRequest(type = BuildingType.WOODEN_WALL),
+                admin = admin,
+            )
+        }
+        assertEquals(404, error.statusCode.value())
+    }
+
+    @Test
+    fun `create rejects unknown nodes`() {
+        val error = assertThrows<ResponseStatusException> {
+            controller.create(
+                worldId = worldId.value,
+                nodeId = unknownNodeId.value,
+                req = CreateBuildingRequest(type = BuildingType.WOODEN_WALL),
+                admin = admin,
+            )
+        }
+        assertEquals(404, error.statusCode.value())
+    }
+
+    @Test
+    fun `create emits BuildingAdminEdited and writes one audit row`() {
+        val response = controller.create(
+            worldId = worldId.value,
+            nodeId = nodeId.value,
+            req = CreateBuildingRequest(
+                type = BuildingType.WOODEN_WALL,
+                status = BuildingStatus.ACTIVE,
+                hpCurrent = 50,
+            ),
+            admin = admin,
+        )
+
+        val emitted = publisher.events.single() as EnvironmentEvent.BuildingAdminEdited
+        assertEquals(response.body!!.instanceId, emitted.instanceId)
+        assertEquals(false, emitted.removed)
+        assertEquals(admin.id.id, emitted.byAdminId)
+        assertTrue("status" in emitted.changedFields)
+        assertTrue("hpCurrent" in emitted.changedFields)
+        assertTrue("hpMax" !in emitted.changedFields)
+
+        val auditRow = audit.recorded.single()
+        assertEquals(admin.id, auditRow.adminId)
+        assertEquals("building.create", auditRow.action)
+        assertEquals("building", auditRow.target)
+        assertEquals(response.body!!.instanceId.toString(), auditRow.targetId)
+    }
+
+    @Test
+    fun `patch overwrites only Set fields and keeps Skip fields untouched`() {
+        val created = controller.create(
+            worldId = worldId.value,
+            nodeId = nodeId.value,
+            req = CreateBuildingRequest(type = BuildingType.WOODEN_WALL),
+            admin = admin,
+        ).body!!
+
+        val patched = controller.patch(
+            worldId = worldId.value,
+            instanceId = created.instanceId,
+            req = PatchBuildingRequest(hpCurrent = MaybeSet.Set(25)),
+            admin = admin,
+        )
+
+        assertEquals(25, patched.hpCurrent)
+        assertEquals(100, patched.hpMax)
+        assertEquals(BuildingStatus.ACTIVE, patched.status)
+        assertEquals(3, patched.progressSteps)
+        assertEquals(3, patched.totalSteps)
+    }
+
+    @Test
+    fun `patch can flip an ACTIVE building to UNDER_CONSTRUCTION when progress goes below total`() {
+        val created = controller.create(
+            worldId = worldId.value,
+            nodeId = nodeId.value,
+            req = CreateBuildingRequest(type = BuildingType.WOODEN_WALL),
+            admin = admin,
+        ).body!!
+
+        val patched = controller.patch(
+            worldId = worldId.value,
+            instanceId = created.instanceId,
+            req = PatchBuildingRequest(
+                status = MaybeSet.Set(BuildingStatus.UNDER_CONSTRUCTION),
+                progressSteps = MaybeSet.Set(1),
+            ),
+            admin = admin,
+        )
+
+        assertEquals(BuildingStatus.UNDER_CONSTRUCTION, patched.status)
+        assertEquals(1, patched.progressSteps)
+    }
+
+    @Test
+    fun `patch rejects status without matching progress`() {
+        val created = controller.create(
+            worldId = worldId.value,
+            nodeId = nodeId.value,
+            req = CreateBuildingRequest(type = BuildingType.WOODEN_WALL),
+            admin = admin,
+        ).body!!
+
+        val error = assertThrows<ResponseStatusException> {
+            controller.patch(
+                worldId = worldId.value,
+                instanceId = created.instanceId,
+                req = PatchBuildingRequest(status = MaybeSet.Set(BuildingStatus.UNDER_CONSTRUCTION)),
+                admin = admin,
+            )
+        }
+        assertEquals(400, error.statusCode.value())
+    }
+
+    @Test
+    fun `patch returns 404 for an unknown instance id`() {
+        val error = assertThrows<ResponseStatusException> {
+            controller.patch(
+                worldId = worldId.value,
+                instanceId = UUID.randomUUID(),
+                req = PatchBuildingRequest(hpCurrent = MaybeSet.Set(25)),
+                admin = admin,
+            )
+        }
+        assertEquals(404, error.statusCode.value())
+    }
+
+    @Test
+    fun `patch rejects when the building belongs to a different world than the path id`() {
+        store.rows += Building(
+            instanceId = UUID.randomUUID(),
+            nodeId = foreignNodeId,
+            type = BuildingType.WOODEN_WALL,
+            status = BuildingStatus.ACTIVE,
+            builtByAgentId = AdminSentinel.agentId,
+            builtAtTick = 0L,
+            lastProgressTick = 0L,
+            progressSteps = 3,
+            totalSteps = 3,
+            hpCurrent = 100,
+            hpMax = 100,
+        )
+        val foreign = store.rows.last()
+
+        val error = assertThrows<ResponseStatusException> {
+            controller.patch(
+                worldId = worldId.value,
+                instanceId = foreign.instanceId,
+                req = PatchBuildingRequest(hpCurrent = MaybeSet.Set(50)),
+                admin = admin,
+            )
+        }
+        assertEquals(404, error.statusCode.value())
+    }
+
+    @Test
+    fun `patch emits BuildingAdminEdited with the changed fields and writes one audit row`() {
+        val created = controller.create(
+            worldId = worldId.value,
+            nodeId = nodeId.value,
+            req = CreateBuildingRequest(type = BuildingType.WOODEN_WALL),
+            admin = admin,
+        ).body!!
+        publisher.events.clear()
+        audit.recorded.clear()
+
+        controller.patch(
+            worldId = worldId.value,
+            instanceId = created.instanceId,
+            req = PatchBuildingRequest(hpCurrent = MaybeSet.Set(25)),
+            admin = admin,
+        )
+
+        val emitted = publisher.events.single() as EnvironmentEvent.BuildingAdminEdited
+        assertEquals(false, emitted.removed)
+        assertEquals(setOf("hpCurrent"), emitted.changedFields)
+
+        val auditRow = audit.recorded.single()
+        assertEquals("building.patch", auditRow.action)
+    }
+
+    @Test
+    fun `delete removes the row and emits BuildingAdminEdited with removed=true`() {
+        val created = controller.create(
+            worldId = worldId.value,
+            nodeId = nodeId.value,
+            req = CreateBuildingRequest(type = BuildingType.WOODEN_WALL),
+            admin = admin,
+        ).body!!
+        publisher.events.clear()
+        audit.recorded.clear()
+
+        val response = controller.delete(
+            worldId = worldId.value,
+            instanceId = created.instanceId,
+            admin = admin,
+        )
+
+        assertEquals(204, response.statusCode.value())
+        assertNull(store.findById(created.instanceId))
+
+        val emitted = publisher.events.single() as EnvironmentEvent.BuildingAdminEdited
+        assertEquals(true, emitted.removed)
+        assertEquals(created.instanceId, emitted.instanceId)
+
+        val auditRow = audit.recorded.single()
+        assertEquals("building.delete", auditRow.action)
+    }
+
+    @Test
+    fun `delete returns 404 for an unknown instance id`() {
+        val error = assertThrows<ResponseStatusException> {
+            controller.delete(worldId.value, UUID.randomUUID(), admin)
+        }
+        assertEquals(404, error.statusCode.value())
+    }
+
+    private fun defView(type: BuildingType, hp: Int, steps: Int) = BuildingDefView(
+        type = type,
+        skillBars = listOf(BuildingBarView(skill = dev.gvart.genesara.player.SkillId("WOODWORKING"), level = 0, steps = steps, materialsPerStep = emptyMap())),
+        staminaPerStep = 5,
+        hp = hp,
+        categoryHint = BuildingCategoryHint.DEFENSIVE,
+    )
+
+    private class InMemoryBuildingsStore : BuildingsStore {
+        val rows: MutableList<Building> = mutableListOf()
+        override fun insert(building: Building) { rows += building }
+        override fun findById(id: UUID): Building? = rows.firstOrNull { it.instanceId == id }
+        override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? =
+            rows.firstOrNull {
+                it.nodeId == node && it.builtByAgentId == agent && it.type == type &&
+                    it.status == BuildingStatus.UNDER_CONSTRUCTION
+            }
+        override fun findAnyAtNodeOfType(node: NodeId, type: BuildingType): Building? =
+            rows.firstOrNull { it.nodeId == node && it.type == type }
+        override fun listAtNode(node: NodeId): List<Building> = rows.filter { it.nodeId == node }
+        override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
+            rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }
+        override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = null
+        override fun complete(id: UUID, asOfTick: Long): Building? = null
+        override fun update(updated: Building): Building? {
+            val idx = rows.indexOfFirst { it.instanceId == updated.instanceId }
+            if (idx < 0) return null
+            rows[idx] = updated
+            return updated
+        }
+        override fun delete(id: UUID): Boolean = rows.removeAll { it.instanceId == id }
+    }
+
+    private class StubWorld(
+        private val nodes: Map<NodeId, Node>,
+        private val regions: Map<RegionId, Region>,
+    ) : WorldQueryGateway {
+        override fun locationOf(agent: AgentId): NodeId? = null
+        override fun activePositionOf(agent: AgentId): NodeId? = null
+        override fun node(id: NodeId): Node? = nodes[id]
+        override fun region(id: RegionId): Region? = regions[id]
+        override fun nodesWithin(origin: NodeId, radius: Int): Set<NodeId> = emptySet()
+        override fun randomSpawnableNode(): NodeId? = null
+        override fun starterNodeFor(race: dev.gvart.genesara.player.RaceId): NodeId? = null
+        override fun bodyOf(agent: AgentId) = null
+        override fun inventoryOf(agent: AgentId) = dev.gvart.genesara.world.InventoryView(entries = emptyList())
+        override fun resourcesAt(nodeId: NodeId, tick: Long) = dev.gvart.genesara.world.NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId) = emptyList<dev.gvart.genesara.world.GroundItemView>()
+        override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>) = emptyMap<NodeId, List<AgentId>>()
+    }
+
+    private class StubCatalog(private val byType: Map<BuildingType, BuildingDefView>) : BuildingDefLookup {
+        override fun byType(type: BuildingType): BuildingDefView? = byType[type]
+        override fun all(): List<BuildingDefView> = byType.values.toList()
+    }
+
+    private class FixedTickClock(private val tick: Long) : TickClock {
+        override fun currentTick(): Long = tick
+    }
+
+    private class RecordingAuditLog : AdminAuditLog {
+        data class Recorded(
+            val adminId: AdminId,
+            val action: String,
+            val target: String,
+            val targetId: String?,
+            val payload: Map<String, Any?>,
+            val tick: Long,
+        )
+
+        val recorded: MutableList<Recorded> = mutableListOf()
+        override fun record(
+            adminId: AdminId,
+            action: String,
+            target: String,
+            targetId: String?,
+            payload: Map<String, Any?>,
+            tick: Long,
+        ): Long {
+            recorded += Recorded(adminId, action, target, targetId, payload, tick)
+            return recorded.size.toLong()
+        }
+
+        override fun readAfter(after: Long, limit: Int): List<AdminAuditEntry> = recorded
+            .drop(after.toInt())
+            .take(limit)
+            .mapIndexed { idx, r ->
+                AdminAuditEntry(
+                    seq = (after + idx + 1L),
+                    adminId = r.adminId,
+                    action = r.action,
+                    target = r.target,
+                    targetId = r.targetId,
+                    payload = r.payload,
+                    tick = r.tick,
+                    occurredAt = Instant.EPOCH,
+                )
+            }
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events: MutableList<WorldEvent> = mutableListOf()
+        override fun publishEvent(event: Any) {
+            (event as? WorldEvent)?.let { events += it }
+        }
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/BuildingAdminLookAroundIntegrationTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/BuildingAdminLookAroundIntegrationTest.kt
@@ -1,0 +1,218 @@
+package dev.gvart.genesara.api.internal.rest.admin.worlds
+
+import dev.gvart.genesara.admin.Admin
+import dev.gvart.genesara.admin.AdminAuditEntry
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.admin.AdminId
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AdminSentinel
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingBarView
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingDefLookup
+import dev.gvart.genesara.world.BuildingDefView
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsLookup
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.InventoryView
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NodeResources
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldQueryGateway
+import dev.gvart.genesara.world.events.WorldEvent
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class BuildingAdminLookAroundIntegrationTest {
+
+    private val worldId = WorldId(1L)
+    private val regionId = RegionId(7L)
+    private val currentNodeId = NodeId(42L)
+    private val adjacentNodeId = NodeId(43L)
+
+    private val region = Region(
+        id = regionId,
+        worldId = worldId,
+        sphereIndex = 0,
+        biome = Biome.FOREST,
+        climate = Climate.CONTINENTAL,
+        centroid = Vec3(0.0, 0.0, 0.0),
+        faceVertices = emptyList(),
+        neighbors = emptySet(),
+    )
+    private val currentNode = Node(
+        id = currentNodeId,
+        regionId = regionId,
+        q = 0, r = 0,
+        terrain = Terrain.PLAINS,
+        adjacency = setOf(adjacentNodeId),
+    )
+    private val adjacentNode = Node(
+        id = adjacentNodeId,
+        regionId = regionId,
+        q = 1, r = 0,
+        terrain = Terrain.PLAINS,
+        adjacency = setOf(currentNodeId),
+    )
+
+    private val admin = Admin(id = AdminId(UUID.randomUUID()), username = "ops")
+
+    @Test
+    fun `admin-placed half-HP ACTIVE WOODEN_WALL surfaces via BuildingsLookup on same node`() {
+        val store = InMemoryBuildingsStore()
+        val world = StubWorld(
+            nodes = mapOf(currentNodeId to currentNode, adjacentNodeId to adjacentNode),
+            regions = mapOf(regionId to region),
+        )
+        val catalog = StubCatalog(
+            mapOf(BuildingType.WOODEN_WALL to defView(BuildingType.WOODEN_WALL, hp = 100, steps = 3))
+        )
+        val controller = BuildingAdminController(
+            store = store,
+            world = world,
+            catalog = catalog,
+            tick = FixedTickClock(500L),
+            auditLog = RecordingAuditLog(),
+            publisher = RecordingPublisher(),
+        )
+        val lookup = StoreBackedBuildingsLookup(store)
+
+        val placed = controller.create(
+            worldId = worldId.value,
+            nodeId = currentNodeId.value,
+            req = CreateBuildingRequest(
+                type = BuildingType.WOODEN_WALL,
+                status = BuildingStatus.ACTIVE,
+                hpCurrent = 50,
+                hpMax = 100,
+            ),
+            admin = admin,
+        ).body!!
+
+        val onSame = lookup.byNode(currentNodeId)
+        assertEquals(1, onSame.size)
+        val seen = onSame.single()
+        assertEquals(placed.instanceId, seen.instanceId)
+        assertEquals(BuildingType.WOODEN_WALL, seen.type)
+        assertEquals(BuildingStatus.ACTIVE, seen.status)
+        assertEquals(50, seen.hpCurrent)
+        assertEquals(100, seen.hpMax)
+        assertEquals(AdminSentinel.agentId, seen.builtByAgentId)
+
+        val batched = lookup.byNodes(setOf(currentNodeId, adjacentNodeId))
+        assertNotNull(batched[currentNodeId])
+        assertTrue(batched[adjacentNodeId].isNullOrEmpty())
+        assertEquals(placed.instanceId, batched[currentNodeId]!!.single().instanceId)
+    }
+
+    private fun defView(type: BuildingType, hp: Int, steps: Int) = BuildingDefView(
+        type = type,
+        skillBars = listOf(
+            BuildingBarView(
+                skill = dev.gvart.genesara.player.SkillId("WOODWORKING"),
+                level = 0,
+                steps = steps,
+                materialsPerStep = emptyMap(),
+            )
+        ),
+        staminaPerStep = 5,
+        hp = hp,
+        categoryHint = BuildingCategoryHint.DEFENSIVE,
+    )
+
+    private class StoreBackedBuildingsLookup(private val store: BuildingsStore) : BuildingsLookup {
+        override fun byId(id: UUID): Building? = store.findById(id)
+        override fun byNode(node: NodeId): List<Building> = store.listAtNode(node)
+        override fun byNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = store.listByNodes(nodes)
+        override fun activeStationsAt(node: NodeId, hint: BuildingCategoryHint): List<Building> =
+            store.listAtNode(node).filter { it.status == BuildingStatus.ACTIVE }
+    }
+
+    private class InMemoryBuildingsStore : BuildingsStore {
+        val rows: MutableList<Building> = mutableListOf()
+        override fun insert(building: Building) { rows += building }
+        override fun findById(id: UUID): Building? = rows.firstOrNull { it.instanceId == id }
+        override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? =
+            rows.firstOrNull {
+                it.nodeId == node && it.builtByAgentId == agent && it.type == type &&
+                    it.status == BuildingStatus.UNDER_CONSTRUCTION
+            }
+        override fun findAnyAtNodeOfType(node: NodeId, type: BuildingType): Building? =
+            rows.firstOrNull { it.nodeId == node && it.type == type }
+        override fun listAtNode(node: NodeId): List<Building> = rows.filter { it.nodeId == node }
+        override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
+            rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }
+        override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = null
+        override fun complete(id: UUID, asOfTick: Long): Building? = null
+        override fun update(updated: Building): Building? {
+            val idx = rows.indexOfFirst { it.instanceId == updated.instanceId }
+            if (idx < 0) return null
+            rows[idx] = updated
+            return updated
+        }
+        override fun delete(id: UUID): Boolean = rows.removeAll { it.instanceId == id }
+    }
+
+    private class StubWorld(
+        private val nodes: Map<NodeId, Node>,
+        private val regions: Map<RegionId, Region>,
+    ) : WorldQueryGateway {
+        override fun locationOf(agent: AgentId): NodeId? = null
+        override fun activePositionOf(agent: AgentId): NodeId? = null
+        override fun node(id: NodeId): Node? = nodes[id]
+        override fun region(id: RegionId): Region? = regions[id]
+        override fun nodesWithin(origin: NodeId, radius: Int): Set<NodeId> = emptySet()
+        override fun randomSpawnableNode(): NodeId? = null
+        override fun starterNodeFor(race: RaceId): NodeId? = null
+        override fun bodyOf(agent: AgentId) = null
+        override fun inventoryOf(agent: AgentId) = InventoryView(entries = emptyList())
+        override fun resourcesAt(nodeId: NodeId, tick: Long) = NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId) = emptyList<GroundItemView>()
+        override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>) = emptyMap<NodeId, List<AgentId>>()
+    }
+
+    private class StubCatalog(private val byType: Map<BuildingType, BuildingDefView>) : BuildingDefLookup {
+        override fun byType(type: BuildingType): BuildingDefView? = byType[type]
+        override fun all(): List<BuildingDefView> = byType.values.toList()
+    }
+
+    private class FixedTickClock(private val tick: Long) : TickClock {
+        override fun currentTick(): Long = tick
+    }
+
+    private class RecordingAuditLog : AdminAuditLog {
+        override fun record(
+            adminId: AdminId,
+            action: String,
+            target: String,
+            targetId: String?,
+            payload: Map<String, Any?>,
+            tick: Long,
+        ): Long = 0L
+
+        override fun readAfter(after: Long, limit: Int): List<AdminAuditEntry> = emptyList()
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        override fun publishEvent(event: Any) {
+            event as? WorldEvent
+        }
+    }
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AdminSentinel.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AdminSentinel.kt
@@ -1,0 +1,14 @@
+package dev.gvart.genesara.player
+
+import java.util.UUID
+
+/**
+ * Deterministic owner agent used by admin tooling to author entities (buildings,
+ * NPCs, chests) that need an `AgentId` foreign key but no real player behind
+ * them. Bootstrapped by the player module's Flyway migration `V211`.
+ *
+ * See ADR-0004 §1.
+ */
+object AdminSentinel {
+    val agentId: AgentId = AgentId(UUID.fromString("00000000-0000-0000-0000-000000000abc"))
+}

--- a/player/src/main/resources/db/migration/player/V211__admin_sentinel_agent.sql
+++ b/player/src/main/resources/db/migration/player/V211__admin_sentinel_agent.sql
@@ -1,0 +1,16 @@
+-- ADR-0004 §1: bootstrap a deterministic owner agent for admin-placed entities.
+-- Idempotent via WHERE NOT EXISTS so a re-run (or multi-instance boot) is safe.
+-- The owner_id is the zero UUID — a soft cross-module convention for
+-- system-owned agents with no real account.player row behind them.
+--
+-- The NOT EXISTS form (rather than `ON CONFLICT (id) DO NOTHING`) keeps this
+-- migration parseable by the jOOQ + H2 DDL interpreter we use at codegen
+-- time; H2 mis-translates the conflict-target clause as an ambiguous MERGE.
+INSERT INTO agents (id, owner_id, name)
+SELECT
+    '00000000-0000-0000-0000-000000000abc',
+    '00000000-0000-0000-0000-000000000000',
+    'admin-sentinel'
+WHERE NOT EXISTS (
+    SELECT 1 FROM agents WHERE id = '00000000-0000-0000-0000-000000000abc'
+);

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/AdminSentinelMigrationIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/AdminSentinelMigrationIntegrationTest.kt
@@ -1,0 +1,73 @@
+package dev.gvart.genesara.player.internal.store
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.player.AdminSentinel
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENTS
+import dev.gvart.genesara.player.internal.testsupport.PlayerFlyway
+import org.flywaydb.core.Flyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+@Testcontainers
+class AdminSentinelMigrationIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("admin_sentinel_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = PlayerFlyway.pooledDataSource(postgres)
+            PlayerFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    @Test
+    fun `V211 inserts the sentinel agent at the constant UUID with deterministic defaults`() {
+        val row = assertNotNull(
+            dsl.selectFrom(AGENTS).where(AGENTS.ID.eq(AdminSentinel.agentId.id)).fetchOne()
+        )
+
+        assertEquals(AdminSentinel.agentId.id, row[AGENTS.ID])
+        assertEquals("admin-sentinel", row[AGENTS.NAME])
+    }
+
+    @Test
+    fun `re-running V211 does not duplicate the sentinel row`() {
+        Flyway.configure()
+            .dataSource(dataSource)
+            .locations("classpath:db/migration/player")
+            .load()
+            .migrate()
+
+        val count = dsl.selectCount()
+            .from(AGENTS)
+            .where(AGENTS.ID.eq(AdminSentinel.agentId.id))
+            .fetchOne(0, Long::class.java)
+        assertEquals(1L, count)
+    }
+}

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/BuildingsStore.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/BuildingsStore.kt
@@ -85,4 +85,18 @@ interface BuildingsStore {
      * updated row, or `null` when no row matches [id].
      */
     fun complete(id: UUID, asOfTick: Long): Building?
+
+    /**
+     * Overwrite an existing instance's mutable fields with [updated]. Admin-only
+     * write path — game reducers move state via [advanceProgress] / [complete]
+     * and pinned-FK guards. The row's `instance_id` and `node_id` must match
+     * an existing row; the schema CHECKs (status ↔ completion, hp_current ≤
+     * hp_max) still apply server-side and surface as integrity violations.
+     * Returns the persisted row on success, or `null` when no row matches
+     * [Building.instanceId].
+     */
+    fun update(updated: Building): Building?
+
+    /** Hard-delete the row. Returns true when a row was removed. */
+    fun delete(id: UUID): Boolean
 }

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/events/EnvironmentEvent.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/events/EnvironmentEvent.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.world.events
 
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.BuildingStatus
 import dev.gvart.genesara.world.BuildingType
 import dev.gvart.genesara.world.DroppedItemView
 import dev.gvart.genesara.world.ItemId
@@ -206,6 +207,29 @@ sealed interface EnvironmentEvent : WorldEvent {
         val killedBy: AgentId? = null,
         override val tick: Long,
         val causedBy: UUID? = null,
+    ) : EnvironmentEvent
+
+    /**
+     * Admin write landed on a building row — create, edit, or delete.
+     * Agent-facing dispatchers MUST NOT subscribe; this event is for the
+     * admin dashboard live feed only. [removed] is true for DELETE, false
+     * for POST and PATCH. [changedFields] enumerates the fields the admin
+     * actually wrote (post-defaults); empty for POST when every field
+     * defaulted from the catalog.
+     */
+    data class BuildingAdminEdited(
+        val instanceId: UUID,
+        val type: BuildingType,
+        val at: NodeId,
+        val status: BuildingStatus?,
+        val hpCurrent: Int?,
+        val hpMax: Int?,
+        val progressSteps: Int?,
+        val totalSteps: Int?,
+        val removed: Boolean,
+        val changedFields: Set<String>,
+        val byAdminId: UUID,
+        override val tick: Long,
     ) : EnvironmentEvent
 
     /**

--- a/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/buildings/JooqBuildingsStore.kt
+++ b/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/buildings/JooqBuildingsStore.kt
@@ -106,6 +106,28 @@ class JooqBuildingsStore(
             ?.into(NODE_BUILDINGS)
             ?.let(::toDomain)
 
+    @Transactional
+    override fun update(updated: Building): Building? =
+        dsl.update(NODE_BUILDINGS)
+            .set(NODE_BUILDINGS.STATUS, updated.status.name)
+            .set(NODE_BUILDINGS.BUILT_BY_AGENT_ID, updated.builtByAgentId.id)
+            .set(NODE_BUILDINGS.LAST_PROGRESS_TICK, updated.lastProgressTick)
+            .set(NODE_BUILDINGS.PROGRESS_STEPS, updated.progressSteps)
+            .set(NODE_BUILDINGS.TOTAL_STEPS, updated.totalSteps)
+            .set(NODE_BUILDINGS.HP_CURRENT, updated.hpCurrent)
+            .set(NODE_BUILDINGS.HP_MAX, updated.hpMax)
+            .where(NODE_BUILDINGS.INSTANCE_ID.eq(updated.instanceId))
+            .returningResult(NODE_BUILDINGS.asterisk())
+            .fetchOne()
+            ?.into(NODE_BUILDINGS)
+            ?.let(::toDomain)
+
+    @Transactional
+    override fun delete(id: UUID): Boolean =
+        dsl.deleteFrom(NODE_BUILDINGS)
+            .where(NODE_BUILDINGS.INSTANCE_ID.eq(id))
+            .execute() > 0
+
     private fun toDomain(
         record: dev.gvart.genesara.world.internal.jooq.tables.records.NodeBuildingsRecord,
     ): Building = Building(

--- a/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/buildings/BuildReducerTest.kt
+++ b/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/buildings/BuildReducerTest.kt
@@ -1028,6 +1028,9 @@ class BuildReducerTest {
             rows[idx] = updated
             return updated
         }
+
+        override fun update(updated: Building): Building? = error("not used")
+        override fun delete(id: UUID): Boolean = error("not used")
     }
 
     private inner class StubBuildingBarsStore : BuildingBarsStore {

--- a/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/buildings/BuildingsLookupImplTest.kt
+++ b/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/buildings/BuildingsLookupImplTest.kt
@@ -90,5 +90,7 @@ class BuildingsLookupImplTest {
             rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }
         override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = error("unused")
         override fun complete(id: UUID, asOfTick: Long): Building? = error("unused")
+        override fun update(updated: Building): Building? = error("unused")
+        override fun delete(id: UUID): Boolean = error("unused")
     }
 }

--- a/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/buildings/ChestReducersTest.kt
+++ b/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/buildings/ChestReducersTest.kt
@@ -422,6 +422,8 @@ class ChestReducersTest {
             rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }
         override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = error("not used")
         override fun complete(id: UUID, asOfTick: Long): Building? = error("not used")
+        override fun update(updated: Building): Building? = error("not used")
+        override fun delete(id: UUID): Boolean = error("not used")
     }
 
     private class StubChestContents : ChestContentsStore {

--- a/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/buildings/ToggleGateReducerTest.kt
+++ b/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/buildings/ToggleGateReducerTest.kt
@@ -119,6 +119,8 @@ class ToggleGateReducerTest {
         override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = emptyMap()
         override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = null
         override fun complete(id: UUID, asOfTick: Long): Building? = null
+        override fun update(updated: Building): Building? = error("not used")
+        override fun delete(id: UUID): Boolean = error("not used")
     }
 
     private class StubGateStates(initiallyOpen: Boolean) : BuildingGateStateStore {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/DefensiveExtractionFlowTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/buildings/DefensiveExtractionFlowTest.kt
@@ -488,6 +488,8 @@ class DefensiveExtractionFlowTest {
             rows[idx] = updated
             return updated
         }
+        override fun update(updated: Building): Building? = error("not used")
+        override fun delete(id: UUID): Boolean = error("not used")
     }
 
     private class FlowBuildingBarsStore(

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
@@ -524,6 +524,8 @@ class WorldTickHandlerHarvestXpEventIntegrationTest {
         override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = emptyMap()
         override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = null
         override fun complete(id: UUID, asOfTick: Long): Building? = null
+        override fun update(updated: Building): Building? = error("not used")
+        override fun delete(id: UUID): Boolean = error("not used")
     }
 
     private object NoopBuildingBarsStore : dev.gvart.genesara.world.BuildingBarsStore {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerSpawnResumeIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerSpawnResumeIntegrationTest.kt
@@ -392,6 +392,8 @@ class WorldTickHandlerSpawnResumeIntegrationTest {
         override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> = emptyMap()
         override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = null
         override fun complete(id: UUID, asOfTick: Long): Building? = null
+        override fun update(updated: Building): Building? = error("not used")
+        override fun delete(id: UUID): Boolean = error("not used")
     }
 
     private object NoopBuildingBarsStore : dev.gvart.genesara.world.BuildingBarsStore {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -443,6 +443,8 @@ class WorldTickHandlerTest {
         ): Map<NodeId, List<dev.gvart.genesara.world.Building>> = emptyMap()
         override fun advanceProgress(id: java.util.UUID, newProgress: Int, asOfTick: Long): dev.gvart.genesara.world.Building? = null
         override fun complete(id: java.util.UUID, asOfTick: Long): dev.gvart.genesara.world.Building? = null
+        override fun update(updated: dev.gvart.genesara.world.Building): dev.gvart.genesara.world.Building? = error("not used")
+        override fun delete(id: java.util.UUID): Boolean = error("not used")
     }
 
     private object NoopBuildingBarsStore : dev.gvart.genesara.world.BuildingBarsStore {


### PR DESCRIPTION
Closes #200.

## Summary

Phase 2 admin-tool surface for authoring buildings at any state — `ACTIVE` with arbitrary HP for "ruined town" scenarios, or `UNDER_CONSTRUCTION` at any progress step. Adds the deterministic `ADMIN_SENTINEL` owner agent from ADR-0004 §1 so admin-placed entities have a valid `built_by_agent_id` without a real account behind them.

- **`player/V211`** — Flyway migration inserts the sentinel agent at a fixed UUID using `WHERE NOT EXISTS` for idempotency (the conflict-target form trips the jOOQ + H2 codegen interpreter). Public `AdminSentinel.agentId` constant exposes the id cross-module.
- **`world:core`** — `BuildingsStore` gains `update(Building)` + `delete(UUID)`. New `EnvironmentEvent.BuildingAdminEdited(removed, changedFields, byAdminId, …)`; the `AgentEventDispatcher` deliberately does **not** subscribe — admin actions stay out of per-agent feeds.
- **`world:environment`** — `JooqBuildingsStore` wires the two new writes using the same `UPDATE … RETURNING` / `DELETE` patterns as `advanceProgress`/`complete`.
- **`api`** — `BuildingAdminController` under `/admin/worlds/{worldId}`:
  - `GET /nodes/{nodeId}/buildings`
  - `POST /nodes/{nodeId}/buildings` — accepts every `BuildingType`; null fields default from the catalog and the sentinel.
  - `PATCH /buildings/{instanceId}` — tri-state `MaybeSet` fields (status, hpCurrent, hpMax, progressSteps, totalSteps, builtByAgentId).
  - `DELETE /buildings/{instanceId}` — emits `BuildingAdminEdited(removed=true)`.

  Every mutating verb validates the `Building.kt` `init` invariants (status ↔ completion, `hp_current ≤ hp_max`, positive step/HP bounds) and writes one `AdminAuditLog` row. Invariant violations surface as **RFC 7807 ProblemDetail** via the existing `GlobalExceptionAdvice`.

## Test plan

- [x] `BuildingAdminControllerTest` — defaults from catalog, half-HP `ACTIVE WOODEN_WALL`, `UNDER_CONSTRUCTION` at partial progress, every invariant rejection (status↔completion, HP bounds, progress bounds, non-positive `hpMax`), world-scope guard (404 for foreign / unknown nodes), `BuildingAdminEdited` event payload + audit row on POST/PATCH/DELETE, PATCH partial overwrite semantics, ACTIVE→UNDER_CONSTRUCTION flip when progress drops, 404 on unknown instance id.
- [x] `BuildingAdminLookAroundIntegrationTest` — places a 50%-HP `ACTIVE WOODEN_WALL` via the controller and asserts it surfaces through `BuildingsLookup.byNode` + `byNodes` (the read path `look_around` uses).
- [x] `AdminSentinelMigrationIntegrationTest` — V211 lands the sentinel row at the deterministic UUID, and a Flyway re-run does **not** duplicate it.
- [x] `./gradlew :api:test :world:core:test :world:environment:test :world:test :player:test` — all green.

## Notes

- The integration test exercises the `BuildingsStore → BuildingsLookup` projection rather than booting the full `LookAroundTool` graph (which has 10+ dependencies). The placed row going through the same lookup the tool calls is the smallest test that proves the issue's acceptance criterion.
- `AdminSentinel` lives in `:player` (where the `agents` table is owned). The `owner_id` is the zero UUID — a soft cross-module convention for system-owned agents; there is no FK on `agents.owner_id` to enforce against.