### PR TITLE
feat(world,api): admin agent body edit — gauges/teleport/safe-node/respawn (#204)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/agents/AgentBodyController.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/agents/AgentBodyController.kt
@@ -1,0 +1,178 @@
+package dev.gvart.genesara.api.internal.rest.admin.agents
+
+import dev.gvart.genesara.admin.Admin
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.AgentBodyAdminGateway
+import dev.gvart.genesara.world.AgentBodyAdminResult
+import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.NodeId
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
+
+@RestController
+@RequestMapping("/admin/agents/{agentId}")
+internal class AgentBodyController(
+    private val gateway: AgentBodyAdminGateway,
+    private val safeNodes: AgentSafeNodeGateway,
+    private val auditLog: AdminAuditLog,
+    private val tick: TickClock,
+) {
+
+    @PostMapping("/gauges")
+    fun setGauges(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @RequestBody req: GaugesRequest,
+    ): GaugesResponse {
+        if (req.isEmpty()) throw badRequest("at least one gauge field must be set")
+        val agent = AgentId(agentId)
+        val result = gateway.setGauges(
+            agent = agent,
+            hp = req.hp,
+            stamina = req.stamina,
+            mana = req.mana,
+            hunger = req.hunger,
+            thirst = req.thirst,
+            sleep = req.sleep,
+        )
+        val applied = when (result) {
+            is AgentBodyAdminResult.GaugesUpdated -> result.applied
+            is AgentBodyAdminResult.AgentNotFound -> throw notFound("agent $agentId has no body row")
+            else -> throw unexpected(result)
+        }
+        auditLog.record(
+            adminId = admin.id,
+            action = "agent.gauges",
+            target = AUDIT_TARGET,
+            targetId = agentId.toString(),
+            payload = applied.mapValues { it.value as Any? },
+            tick = tick.currentTick(),
+        )
+        return GaugesResponse(applied)
+    }
+
+    @PostMapping("/position")
+    fun teleport(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @RequestBody req: PositionRequest,
+    ): PositionResponse {
+        val agent = AgentId(agentId)
+        val nodeId = NodeId(req.nodeId)
+        val result = gateway.teleport(agent, nodeId, tick.currentTick())
+        val teleported = when (result) {
+            is AgentBodyAdminResult.Teleported -> result
+            is AgentBodyAdminResult.AgentNotFound -> throw notFound("agent $agentId is not registered")
+            is AgentBodyAdminResult.NodeNotFound -> throw notFound("node ${req.nodeId} not found")
+            else -> throw unexpected(result)
+        }
+        auditLog.record(
+            adminId = admin.id,
+            action = "agent.teleport",
+            target = AUDIT_TARGET,
+            targetId = agentId.toString(),
+            payload = mapOf(
+                "cause" to "admin",
+                "to" to req.nodeId,
+                "from" to teleported.from?.value,
+                "crossedWorld" to teleported.crossedWorld,
+            ),
+            tick = tick.currentTick(),
+        )
+        return PositionResponse(
+            from = teleported.from?.value,
+            to = teleported.to.value,
+            crossedWorld = teleported.crossedWorld,
+        )
+    }
+
+    @PostMapping("/safe-node")
+    fun setSafeNode(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @RequestBody req: SafeNodeRequest,
+    ): SafeNodeResponse {
+        val agent = AgentId(agentId)
+        val currentTick = tick.currentTick()
+        safeNodes.set(agent, NodeId(req.nodeId), currentTick)
+        auditLog.record(
+            adminId = admin.id,
+            action = "agent.safe_node",
+            target = AUDIT_TARGET,
+            targetId = agentId.toString(),
+            payload = mapOf("nodeId" to req.nodeId),
+            tick = currentTick,
+        )
+        return SafeNodeResponse(req.nodeId)
+    }
+
+    @PostMapping("/respawn")
+    fun respawn(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+    ): RespawnResponse {
+        val agent = AgentId(agentId)
+        val result = gateway.forceRespawn(agent, tick.currentTick())
+        val respawned = when (result) {
+            is AgentBodyAdminResult.Respawned -> result
+            is AgentBodyAdminResult.AgentNotFound -> throw notFound("agent $agentId is not registered")
+            is AgentBodyAdminResult.NoSpawnableNode -> throw conflict("no safe node and no spawnable fallback for $agentId")
+            else -> throw unexpected(result)
+        }
+        auditLog.record(
+            adminId = admin.id,
+            action = "agent.force_respawn",
+            target = AUDIT_TARGET,
+            targetId = agentId.toString(),
+            payload = mapOf(
+                "at" to respawned.at.value,
+                "fromCheckpoint" to respawned.fromCheckpoint,
+            ),
+            tick = tick.currentTick(),
+        )
+        return RespawnResponse(at = respawned.at.value, fromCheckpoint = respawned.fromCheckpoint)
+    }
+
+    private fun badRequest(detail: String) = ResponseStatusException(HttpStatus.BAD_REQUEST, detail)
+    private fun notFound(detail: String) = ResponseStatusException(HttpStatus.NOT_FOUND, detail)
+    private fun conflict(detail: String) = ResponseStatusException(HttpStatus.CONFLICT, detail)
+    private fun unexpected(result: AgentBodyAdminResult) =
+        ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "unexpected gateway result: $result")
+
+    private companion object {
+        const val AUDIT_TARGET = "agent"
+    }
+}
+
+data class GaugesRequest(
+    val hp: Int? = null,
+    val stamina: Int? = null,
+    val mana: Int? = null,
+    val hunger: Int? = null,
+    val thirst: Int? = null,
+    val sleep: Int? = null,
+) {
+    fun isEmpty(): Boolean =
+        hp == null && stamina == null && mana == null && hunger == null && thirst == null && sleep == null
+}
+
+data class GaugesResponse(val applied: Map<String, Int>)
+
+data class PositionRequest(val nodeId: Long)
+
+data class PositionResponse(val from: Long?, val to: Long, val crossedWorld: Boolean)
+
+data class SafeNodeRequest(val nodeId: Long)
+
+data class SafeNodeResponse(val nodeId: Long)
+
+data class RespawnResponse(val at: Long, val fromCheckpoint: Boolean)

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/agents/AgentBodyControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/agents/AgentBodyControllerTest.kt
@@ -1,0 +1,275 @@
+package dev.gvart.genesara.api.internal.rest.admin.agents
+
+import dev.gvart.genesara.admin.Admin
+import dev.gvart.genesara.admin.AdminAuditEntry
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.admin.AdminId
+import dev.gvart.genesara.api.internal.rest.GlobalExceptionAdvice
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.AgentBodyAdminGateway
+import dev.gvart.genesara.world.AgentBodyAdminResult
+import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.NodeId
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class AgentBodyControllerTest {
+
+    private val adminId = AdminId(UUID.randomUUID())
+    private val admin = Admin(adminId, "ops")
+    private val agentId = UUID.randomUUID()
+
+    private lateinit var gateway: StubGateway
+    private lateinit var safeNodes: StubSafeNodes
+    private lateinit var audit: StubAudit
+    private lateinit var mvc: MockMvc
+
+    @BeforeEach
+    fun setup() {
+        gateway = StubGateway()
+        safeNodes = StubSafeNodes()
+        audit = StubAudit()
+        mvc = MockMvcBuilders.standaloneSetup(
+            AgentBodyController(gateway, safeNodes, audit, FixedTickClock(42L)),
+        )
+            .setCustomArgumentResolvers(AuthenticationPrincipalArgumentResolver())
+            .setControllerAdvice(GlobalExceptionAdvice())
+            .build()
+        SecurityContextHolder.getContext().authentication = UsernamePasswordAuthenticationToken(
+            admin, null, listOf(SimpleGrantedAuthority("ROLE_ADMIN")),
+        )
+    }
+
+    @AfterEach
+    fun clear() { SecurityContextHolder.clearContext() }
+
+    @Test
+    fun `gauges applies the gateway result and writes audit`() {
+        gateway.gaugesResult = AgentBodyAdminResult.GaugesUpdated(
+            mapOf("hp" to 50, "thirst" to 80),
+        )
+
+        mvc.post("/admin/agents/$agentId/gauges") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"hp":50,"thirst":80}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.applied.hp") { value(50) }
+            jsonPath("$.applied.thirst") { value(80) }
+        }
+
+        val entry = audit.entries.single()
+        assertEquals("agent.gauges", entry.action)
+        assertEquals("agent", entry.target)
+        assertEquals(agentId.toString(), entry.targetId)
+        assertEquals(mapOf("hp" to 50 as Any?, "thirst" to 80 as Any?), entry.payload)
+        assertEquals(42L, entry.tick)
+    }
+
+    @Test
+    fun `gauges rejects an empty body with 400`() {
+        mvc.post("/admin/agents/$agentId/gauges") {
+            contentType = MediaType.APPLICATION_JSON
+            content = "{}"
+        }.andExpect {
+            status { isBadRequest() }
+            jsonPath("$.detail") { value("at least one gauge field must be set") }
+        }
+        assertEquals(0, audit.entries.size)
+    }
+
+    @Test
+    fun `gauges returns 404 when the agent body is missing`() {
+        gateway.gaugesResult = AgentBodyAdminResult.AgentNotFound(AgentId(agentId))
+
+        mvc.post("/admin/agents/$agentId/gauges") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"hp":10}"""
+        }.andExpect {
+            status { isNotFound() }
+            jsonPath("$.detail") { value("agent $agentId has no body row") }
+        }
+        assertEquals(0, audit.entries.size)
+    }
+
+    @Test
+    fun `gauges forwards negative values to the gateway for clamping`() {
+        gateway.gaugesResult = AgentBodyAdminResult.GaugesUpdated(mapOf("hp" to 0))
+
+        mvc.post("/admin/agents/$agentId/gauges") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"hp":-1}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.applied.hp") { value(0) }
+        }
+
+        assertEquals(-1, gateway.lastGaugeInputs["hp"])
+    }
+
+    @Test
+    fun `position teleports and writes audit with admin cause`() {
+        gateway.teleportResult = AgentBodyAdminResult.Teleported(
+            from = NodeId(100),
+            to = NodeId(200),
+            crossedWorld = true,
+        )
+
+        mvc.post("/admin/agents/$agentId/position") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"nodeId":200}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.from") { value(100) }
+            jsonPath("$.to") { value(200) }
+            jsonPath("$.crossedWorld") { value(true) }
+        }
+
+        val entry = audit.entries.single()
+        assertEquals("agent.teleport", entry.action)
+        assertEquals("admin", entry.payload["cause"])
+        assertEquals(200L, (entry.payload["to"] as Number).toLong())
+        assertEquals(100L, (entry.payload["from"] as Number).toLong())
+        assertEquals(true, entry.payload["crossedWorld"])
+    }
+
+    @Test
+    fun `position returns 404 when the target node is missing`() {
+        gateway.teleportResult = AgentBodyAdminResult.NodeNotFound(NodeId(99))
+
+        mvc.post("/admin/agents/$agentId/position") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"nodeId":99}"""
+        }.andExpect {
+            status { isNotFound() }
+            jsonPath("$.detail") { value("node 99 not found") }
+        }
+    }
+
+    @Test
+    fun `safe-node delegates to the gateway and writes audit`() {
+        mvc.post("/admin/agents/$agentId/safe-node") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"nodeId":777}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.nodeId") { value(777) }
+        }
+
+        assertEquals(1, safeNodes.sets.size)
+        val (storedAgent, storedNode, storedTick) = safeNodes.sets.single()
+        assertEquals(AgentId(agentId), storedAgent)
+        assertEquals(NodeId(777), storedNode)
+        assertEquals(42L, storedTick)
+
+        val entry = audit.entries.single()
+        assertEquals("agent.safe_node", entry.action)
+        assertEquals(777L, (entry.payload["nodeId"] as Number).toLong())
+    }
+
+    @Test
+    fun `respawn calls force-respawn and writes audit`() {
+        gateway.respawnResult = AgentBodyAdminResult.Respawned(
+            at = NodeId(555),
+            fromCheckpoint = false,
+        )
+
+        mvc.post("/admin/agents/$agentId/respawn") {
+            contentType = MediaType.APPLICATION_JSON
+            content = "{}"
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.at") { value(555) }
+            jsonPath("$.fromCheckpoint") { value(false) }
+        }
+
+        val entry = audit.entries.single()
+        assertEquals("agent.force_respawn", entry.action)
+        assertEquals(555L, (entry.payload["at"] as Number).toLong())
+        assertEquals(false, entry.payload["fromCheckpoint"])
+    }
+
+    @Test
+    fun `respawn returns 409 when no spawnable node exists`() {
+        gateway.respawnResult = AgentBodyAdminResult.NoSpawnableNode(AgentId(agentId))
+
+        mvc.post("/admin/agents/$agentId/respawn") {
+            contentType = MediaType.APPLICATION_JSON
+            content = "{}"
+        }.andExpect {
+            status { isConflict() }
+            jsonPath("$.detail") { value("no safe node and no spawnable fallback for $agentId") }
+        }
+    }
+
+    private class StubGateway : AgentBodyAdminGateway {
+        var gaugesResult: AgentBodyAdminResult = AgentBodyAdminResult.GaugesUpdated(emptyMap())
+        var teleportResult: AgentBodyAdminResult = AgentBodyAdminResult.Teleported(null, NodeId(0), false)
+        var respawnResult: AgentBodyAdminResult = AgentBodyAdminResult.Respawned(NodeId(0), false)
+        var lastGaugeInputs: Map<String, Int?> = emptyMap()
+
+        override fun setGauges(
+            agent: AgentId,
+            hp: Int?, stamina: Int?, mana: Int?, hunger: Int?, thirst: Int?, sleep: Int?,
+        ): AgentBodyAdminResult {
+            lastGaugeInputs = mapOf(
+                "hp" to hp, "stamina" to stamina, "mana" to mana,
+                "hunger" to hunger, "thirst" to thirst, "sleep" to sleep,
+            )
+            return gaugesResult
+        }
+
+        override fun teleport(agent: AgentId, nodeId: NodeId, tick: Long): AgentBodyAdminResult = teleportResult
+        override fun forceRespawn(agent: AgentId, tick: Long): AgentBodyAdminResult = respawnResult
+    }
+
+    private class StubSafeNodes : AgentSafeNodeGateway {
+        val sets = mutableListOf<Triple<AgentId, NodeId, Long>>()
+        override fun set(agentId: AgentId, nodeId: NodeId, tick: Long) {
+            sets += Triple(agentId, nodeId, tick)
+        }
+        override fun find(agentId: AgentId): NodeId? = null
+        override fun clear(agentId: AgentId) {}
+    }
+
+    private class StubAudit : AdminAuditLog {
+        data class Recorded(
+            val seq: Long,
+            val adminId: AdminId,
+            val action: String,
+            val target: String,
+            val targetId: String?,
+            val payload: Map<String, Any?>,
+            val tick: Long,
+        )
+        val entries = mutableListOf<Recorded>()
+        override fun record(
+            adminId: AdminId,
+            action: String,
+            target: String,
+            targetId: String?,
+            payload: Map<String, Any?>,
+            tick: Long,
+        ): Long {
+            entries += Recorded(entries.size + 1L, adminId, action, target, targetId, payload, tick)
+            return entries.size.toLong()
+        }
+        override fun readAfter(after: Long, limit: Int): List<AdminAuditEntry> = emptyList()
+    }
+
+    private class FixedTickClock(private val tick: Long) : TickClock {
+        override fun currentTick(): Long = tick
+    }
+}

--- a/world/body/src/main/kotlin/dev/gvart/genesara/world/body/internal/admin/JooqAgentBodyAdminGateway.kt
+++ b/world/body/src/main/kotlin/dev/gvart/genesara/world/body/internal/admin/JooqAgentBodyAdminGateway.kt
@@ -1,0 +1,212 @@
+package dev.gvart.genesara.world.body.internal.admin
+
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentProfileLookup
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.world.AgentBodyAdminGateway
+import dev.gvart.genesara.world.AgentBodyAdminResult
+import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.WorldQueryGateway
+import dev.gvart.genesara.world.events.BodyEvent
+import dev.gvart.genesara.world.events.CoreEvent
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_BODIES
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_POSITIONS
+import dev.gvart.genesara.world.internal.jooq.tables.references.NODES
+import dev.gvart.genesara.world.internal.jooq.tables.references.REGIONS
+import org.jooq.DSLContext
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Component
+internal class JooqAgentBodyAdminGateway(
+    private val dsl: DSLContext,
+    private val publisher: ApplicationEventPublisher,
+    private val safeNodes: AgentSafeNodeGateway,
+    private val profiles: AgentProfileLookup,
+    private val agents: AgentRegistry,
+    private val world: WorldQueryGateway,
+) : AgentBodyAdminGateway {
+
+    @Transactional
+    override fun setGauges(
+        agent: AgentId,
+        hp: Int?,
+        stamina: Int?,
+        mana: Int?,
+        hunger: Int?,
+        thirst: Int?,
+        sleep: Int?,
+    ): AgentBodyAdminResult {
+        val row = dsl.select(
+            AGENT_BODIES.HP, AGENT_BODIES.MAX_HP,
+            AGENT_BODIES.STAMINA, AGENT_BODIES.MAX_STAMINA,
+            AGENT_BODIES.MANA, AGENT_BODIES.MAX_MANA,
+            AGENT_BODIES.HUNGER, AGENT_BODIES.MAX_HUNGER,
+            AGENT_BODIES.THIRST, AGENT_BODIES.MAX_THIRST,
+            AGENT_BODIES.SLEEP, AGENT_BODIES.MAX_SLEEP,
+        )
+            .from(AGENT_BODIES)
+            .where(AGENT_BODIES.AGENT_ID.eq(agent.id))
+            .fetchOne() ?: return AgentBodyAdminResult.AgentNotFound(agent)
+
+        val applied = mutableMapOf<String, Int>()
+        val update = dsl.update(AGENT_BODIES).set(AGENT_BODIES.AGENT_ID, agent.id)
+
+        hp?.let { value ->
+            val clamped = value.coerceIn(0, row[AGENT_BODIES.MAX_HP]!!)
+            update.set(AGENT_BODIES.HP, clamped)
+            applied["hp"] = clamped
+        }
+        stamina?.let { value ->
+            val clamped = value.coerceIn(0, row[AGENT_BODIES.MAX_STAMINA]!!)
+            update.set(AGENT_BODIES.STAMINA, clamped)
+            applied["stamina"] = clamped
+        }
+        mana?.let { value ->
+            val clamped = value.coerceIn(0, row[AGENT_BODIES.MAX_MANA]!!)
+            update.set(AGENT_BODIES.MANA, clamped)
+            applied["mana"] = clamped
+        }
+        hunger?.let { value ->
+            val clamped = value.coerceIn(0, row[AGENT_BODIES.MAX_HUNGER]!!)
+            update.set(AGENT_BODIES.HUNGER, clamped)
+            applied["hunger"] = clamped
+        }
+        thirst?.let { value ->
+            val clamped = value.coerceIn(0, row[AGENT_BODIES.MAX_THIRST]!!)
+            update.set(AGENT_BODIES.THIRST, clamped)
+            applied["thirst"] = clamped
+        }
+        sleep?.let { value ->
+            val clamped = value.coerceIn(0, row[AGENT_BODIES.MAX_SLEEP]!!)
+            update.set(AGENT_BODIES.SLEEP, clamped)
+            applied["sleep"] = clamped
+        }
+
+        if (applied.isNotEmpty()) {
+            update.where(AGENT_BODIES.AGENT_ID.eq(agent.id)).execute()
+        }
+        return AgentBodyAdminResult.GaugesUpdated(applied)
+    }
+
+    @Transactional
+    override fun teleport(agent: AgentId, nodeId: NodeId, tick: Long): AgentBodyAdminResult {
+        val targetWorldId = dsl.select(REGIONS.WORLD_ID)
+            .from(NODES).join(REGIONS).on(REGIONS.ID.eq(NODES.REGION_ID))
+            .where(NODES.ID.eq(nodeId.value))
+            .fetchOne(REGIONS.WORLD_ID) ?: return AgentBodyAdminResult.NodeNotFound(nodeId)
+
+        val priorRow = dsl.select(AGENT_POSITIONS.NODE_ID, AGENT_POSITIONS.WORLD_ID, AGENT_POSITIONS.ACTIVE)
+            .from(AGENT_POSITIONS)
+            .where(AGENT_POSITIONS.AGENT_ID.eq(agent.id))
+            .fetchOne()
+
+        if (agents.find(agent) == null && priorRow == null) {
+            return AgentBodyAdminResult.AgentNotFound(agent)
+        }
+
+        val priorNode = priorRow?.get(AGENT_POSITIONS.NODE_ID)?.let(::NodeId)
+        val priorWorld = priorRow?.get(AGENT_POSITIONS.WORLD_ID)
+        val priorActive = priorRow?.get(AGENT_POSITIONS.ACTIVE) ?: false
+        val crossedWorld = priorWorld != null && priorWorld != targetWorldId
+
+        dsl.insertInto(AGENT_POSITIONS)
+            .set(AGENT_POSITIONS.AGENT_ID, agent.id)
+            .set(AGENT_POSITIONS.NODE_ID, nodeId.value)
+            .set(AGENT_POSITIONS.WORLD_ID, targetWorldId)
+            .set(AGENT_POSITIONS.ACTIVE, priorActive)
+            .onConflict(AGENT_POSITIONS.AGENT_ID)
+            .doUpdate()
+            .set(AGENT_POSITIONS.NODE_ID, nodeId.value)
+            .set(AGENT_POSITIONS.WORLD_ID, targetWorldId)
+            .execute()
+
+        publisher.publishEvent(
+            CoreEvent.AgentMoved(
+                agent = agent,
+                from = priorNode ?: nodeId,
+                to = nodeId,
+                staminaSpent = 0,
+                tick = tick,
+                causedBy = UUID.randomUUID(),
+            ),
+        )
+
+        return AgentBodyAdminResult.Teleported(from = priorNode, to = nodeId, crossedWorld = crossedWorld)
+    }
+
+    @Transactional
+    override fun forceRespawn(agent: AgentId, tick: Long): AgentBodyAdminResult {
+        val profile = profiles.find(agent) ?: return AgentBodyAdminResult.AgentNotFound(agent)
+        val landing = resolveLanding(agent) ?: return AgentBodyAdminResult.NoSpawnableNode(agent)
+
+        val targetWorldId = dsl.select(REGIONS.WORLD_ID)
+            .from(NODES).join(REGIONS).on(REGIONS.ID.eq(NODES.REGION_ID))
+            .where(NODES.ID.eq(landing.nodeId.value))
+            .fetchOne(REGIONS.WORLD_ID) ?: return AgentBodyAdminResult.NoSpawnableNode(agent)
+
+        dsl.insertInto(AGENT_BODIES)
+            .set(AGENT_BODIES.AGENT_ID, agent.id)
+            .set(AGENT_BODIES.HP, profile.maxHp)
+            .set(AGENT_BODIES.MAX_HP, profile.maxHp)
+            .set(AGENT_BODIES.STAMINA, profile.maxStamina)
+            .set(AGENT_BODIES.MAX_STAMINA, profile.maxStamina)
+            .set(AGENT_BODIES.MANA, profile.maxMana)
+            .set(AGENT_BODIES.MAX_MANA, profile.maxMana)
+            .set(AGENT_BODIES.HUNGER, FULL_GAUGE)
+            .set(AGENT_BODIES.MAX_HUNGER, FULL_GAUGE)
+            .set(AGENT_BODIES.THIRST, FULL_GAUGE)
+            .set(AGENT_BODIES.MAX_THIRST, FULL_GAUGE)
+            .set(AGENT_BODIES.SLEEP, FULL_GAUGE)
+            .set(AGENT_BODIES.MAX_SLEEP, FULL_GAUGE)
+            .onConflict(AGENT_BODIES.AGENT_ID)
+            .doUpdate()
+            .set(AGENT_BODIES.HP, profile.maxHp)
+            .set(AGENT_BODIES.STAMINA, profile.maxStamina)
+            .set(AGENT_BODIES.MANA, profile.maxMana)
+            .set(AGENT_BODIES.HUNGER, FULL_GAUGE)
+            .set(AGENT_BODIES.THIRST, FULL_GAUGE)
+            .set(AGENT_BODIES.SLEEP, FULL_GAUGE)
+            .execute()
+
+        dsl.insertInto(AGENT_POSITIONS)
+            .set(AGENT_POSITIONS.AGENT_ID, agent.id)
+            .set(AGENT_POSITIONS.NODE_ID, landing.nodeId.value)
+            .set(AGENT_POSITIONS.WORLD_ID, targetWorldId)
+            .set(AGENT_POSITIONS.ACTIVE, true)
+            .onConflict(AGENT_POSITIONS.AGENT_ID)
+            .doUpdate()
+            .set(AGENT_POSITIONS.NODE_ID, landing.nodeId.value)
+            .set(AGENT_POSITIONS.WORLD_ID, targetWorldId)
+            .set(AGENT_POSITIONS.ACTIVE, true)
+            .execute()
+
+        publisher.publishEvent(
+            BodyEvent.AgentRespawned(
+                agent = agent,
+                at = landing.nodeId,
+                fromCheckpoint = landing.fromCheckpoint,
+                tick = tick,
+                causedBy = UUID.randomUUID(),
+            ),
+        )
+
+        return AgentBodyAdminResult.Respawned(at = landing.nodeId, fromCheckpoint = landing.fromCheckpoint)
+    }
+
+    private fun resolveLanding(agent: AgentId): Landing? {
+        safeNodes.find(agent)?.let { return Landing(it, fromCheckpoint = true) }
+        val record = agents.find(agent)
+        record?.let { world.starterNodeFor(it.race)?.let { node -> return Landing(node, fromCheckpoint = false) } }
+        return world.randomSpawnableNode()?.let { Landing(it, fromCheckpoint = false) }
+    }
+
+    private data class Landing(val nodeId: NodeId, val fromCheckpoint: Boolean)
+
+    private companion object {
+        const val FULL_GAUGE = 100
+    }
+}

--- a/world/body/src/test/kotlin/dev/gvart/genesara/world/body/internal/admin/JooqAgentBodyAdminGatewayIntegrationTest.kt
+++ b/world/body/src/test/kotlin/dev/gvart/genesara/world/body/internal/admin/JooqAgentBodyAdminGatewayIntegrationTest.kt
@@ -1,0 +1,365 @@
+package dev.gvart.genesara.world.body.internal.admin
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentProfile
+import dev.gvart.genesara.player.AgentProfileLookup
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.DeathPenaltyOutcome
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.world.AgentBodyAdminResult
+import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.WorldQueryGateway
+import dev.gvart.genesara.world.body.internal.death.JooqAgentSafeNodeGateway
+import dev.gvart.genesara.world.events.BodyEvent
+import dev.gvart.genesara.world.events.CoreEvent
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_BODIES
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_POSITIONS
+import dev.gvart.genesara.world.internal.jooq.tables.references.AGENT_SAFE_NODES
+import dev.gvart.genesara.world.internal.jooq.tables.references.NODES
+import dev.gvart.genesara.world.internal.jooq.tables.references.REGIONS
+import dev.gvart.genesara.world.internal.jooq.tables.references.WORLDS
+import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
+import org.jooq.DSLContext
+import org.jooq.JSON
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@Testcontainers
+class JooqAgentBodyAdminGatewayIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("body_admin_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = WorldFlyway.pooledDataSource(postgres)
+            WorldFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private val agent = AgentId(UUID.randomUUID())
+    private val owner = PlayerId(UUID.randomUUID())
+    private var worldA: Long = 0L
+    private var worldB: Long = 0L
+    private var nodeA1: Long = 0L
+    private var nodeB1: Long = 0L
+    private var nodeB2: Long = 0L
+
+    private lateinit var publisher: RecordingPublisher
+    private lateinit var safeNodes: JooqAgentSafeNodeGateway
+    private lateinit var profiles: FixedProfileLookup
+    private lateinit var registry: TrackingRegistry
+    private lateinit var world: StubWorldQuery
+    private lateinit var gateway: JooqAgentBodyAdminGateway
+
+    @BeforeEach
+    fun reset() {
+        dsl.truncate(AGENT_BODIES).cascade().execute()
+        dsl.truncate(AGENT_POSITIONS).cascade().execute()
+        dsl.truncate(AGENT_SAFE_NODES).cascade().execute()
+        dsl.truncate(NODES).cascade().execute()
+        dsl.truncate(REGIONS).cascade().execute()
+        dsl.truncate(WORLDS).cascade().execute()
+
+        worldA = insertWorld("worldA")
+        worldB = insertWorld("worldB")
+        val regionA = insertRegion(worldA, sphereIndex = 0)
+        val regionB = insertRegion(worldB, sphereIndex = 0)
+        nodeA1 = insertNode(regionA, q = 0, r = 0)
+        nodeB1 = insertNode(regionB, q = 0, r = 0)
+        nodeB2 = insertNode(regionB, q = 1, r = 0)
+
+        publisher = RecordingPublisher()
+        safeNodes = JooqAgentSafeNodeGateway(dsl)
+        profiles = FixedProfileLookup(AgentProfile(id = agent, maxHp = 80, maxStamina = 50, maxMana = 30))
+        registry = TrackingRegistry(
+            present = mapOf(
+                agent to Agent(id = agent, owner = owner, name = "victim", race = RaceId("human_commoner")),
+            ),
+        )
+        world = StubWorldQuery(starterByRace = emptyMap(), randomSpawnable = NodeId(nodeA1))
+        gateway = JooqAgentBodyAdminGateway(dsl, publisher, safeNodes, profiles, registry, world)
+    }
+
+    @Test
+    fun `setGauges clamps each pool to its max and underflow to zero`() {
+        seedBody(hp = 80, stamina = 50, mana = 30, hunger = 100, thirst = 100, sleep = 100)
+
+        val result = gateway.setGauges(
+            agent,
+            hp = 999,
+            stamina = -10,
+            mana = 0,
+            hunger = 250,
+            thirst = 17,
+            sleep = -1,
+        )
+
+        val applied = assertIs<AgentBodyAdminResult.GaugesUpdated>(result).applied
+        assertEquals(80, applied["hp"], "above-max clamped to max_hp")
+        assertEquals(0, applied["stamina"], "negative clamped to 0")
+        assertEquals(0, applied["mana"])
+        assertEquals(100, applied["hunger"], "above max_hunger clamped to 100")
+        assertEquals(17, applied["thirst"], "in-range kept verbatim")
+        assertEquals(0, applied["sleep"])
+
+        val row = readBody()
+        assertEquals(80, row[AGENT_BODIES.HP])
+        assertEquals(0, row[AGENT_BODIES.STAMINA])
+        assertEquals(0, row[AGENT_BODIES.MANA])
+        assertEquals(100, row[AGENT_BODIES.HUNGER])
+        assertEquals(17, row[AGENT_BODIES.THIRST])
+        assertEquals(0, row[AGENT_BODIES.SLEEP])
+    }
+
+    @Test
+    fun `setGauges only touches fields that were provided`() {
+        seedBody(hp = 80, stamina = 25, mana = 10, hunger = 70, thirst = 60, sleep = 50)
+
+        gateway.setGauges(agent, hp = 50)
+
+        val row = readBody()
+        assertEquals(50, row[AGENT_BODIES.HP])
+        assertEquals(25, row[AGENT_BODIES.STAMINA])
+        assertEquals(10, row[AGENT_BODIES.MANA])
+        assertEquals(70, row[AGENT_BODIES.HUNGER])
+        assertEquals(60, row[AGENT_BODIES.THIRST])
+        assertEquals(50, row[AGENT_BODIES.SLEEP])
+    }
+
+    @Test
+    fun `setGauges returns AgentNotFound when no body row exists`() {
+        val result = gateway.setGauges(agent, hp = 10)
+        assertIs<AgentBodyAdminResult.AgentNotFound>(result)
+    }
+
+    @Test
+    fun `teleport across worlds updates world_id and emits AgentMoved`() {
+        seedPosition(node = nodeA1, world = worldA, active = true)
+
+        val result = gateway.teleport(agent, NodeId(nodeB2), tick = 7L)
+
+        val tele = assertIs<AgentBodyAdminResult.Teleported>(result)
+        assertEquals(NodeId(nodeA1), tele.from)
+        assertEquals(NodeId(nodeB2), tele.to)
+        assertTrue(tele.crossedWorld)
+
+        val row = readPosition()
+        assertEquals(nodeB2, row[AGENT_POSITIONS.NODE_ID])
+        assertEquals(worldB, row[AGENT_POSITIONS.WORLD_ID])
+        assertTrue(row[AGENT_POSITIONS.ACTIVE]!!, "active flag preserved across teleport")
+
+        val moved = assertIs<CoreEvent.AgentMoved>(publisher.events.single())
+        assertEquals(agent, moved.agent)
+        assertEquals(NodeId(nodeA1), moved.from)
+        assertEquals(NodeId(nodeB2), moved.to)
+        assertEquals(0, moved.staminaSpent)
+        assertEquals(7L, moved.tick)
+    }
+
+    @Test
+    fun `teleport returns NodeNotFound for an unknown destination`() {
+        seedPosition(node = nodeA1, world = worldA, active = true)
+        val result = gateway.teleport(agent, NodeId(9_999_999L), tick = 1L)
+        assertIs<AgentBodyAdminResult.NodeNotFound>(result)
+        assertTrue(publisher.events.isEmpty())
+    }
+
+    @Test
+    fun `teleport creates the position row when the agent has none yet`() {
+        val result = gateway.teleport(agent, NodeId(nodeA1), tick = 3L)
+        val tele = assertIs<AgentBodyAdminResult.Teleported>(result)
+        assertEquals(null, tele.from)
+        assertFalse(tele.crossedWorld, "first-ever placement is not a world-cross")
+
+        val row = readPosition()
+        assertEquals(nodeA1, row[AGENT_POSITIONS.NODE_ID])
+        assertEquals(worldA, row[AGENT_POSITIONS.WORLD_ID])
+    }
+
+    @Test
+    fun `forceRespawn restores body to profile maxima and does not de-level even on empty XP bar`() {
+        safeNodes.set(agent, NodeId(nodeB1), tick = 1L)
+        seedBody(hp = 0, stamina = 0, mana = 0, hunger = 0, thirst = 0, sleep = 0)
+        seedPosition(node = nodeA1, world = worldA, active = false)
+
+        val result = gateway.forceRespawn(agent, tick = 9L)
+
+        val respawn = assertIs<AgentBodyAdminResult.Respawned>(result)
+        assertEquals(NodeId(nodeB1), respawn.at)
+        assertTrue(respawn.fromCheckpoint)
+
+        val body = readBody()
+        assertEquals(80, body[AGENT_BODIES.HP])
+        assertEquals(50, body[AGENT_BODIES.STAMINA])
+        assertEquals(30, body[AGENT_BODIES.MANA])
+        assertEquals(100, body[AGENT_BODIES.HUNGER])
+        assertEquals(100, body[AGENT_BODIES.THIRST])
+        assertEquals(100, body[AGENT_BODIES.SLEEP])
+
+        val position = readPosition()
+        assertEquals(nodeB1, position[AGENT_POSITIONS.NODE_ID])
+        assertEquals(worldB, position[AGENT_POSITIONS.WORLD_ID])
+        assertTrue(position[AGENT_POSITIONS.ACTIVE]!!)
+
+        assertEquals(0, registry.deathPenaltyCallCount, "force-respawn must skip the de-level path")
+
+        val event = assertIs<BodyEvent.AgentRespawned>(publisher.events.single())
+        assertEquals(agent, event.agent)
+        assertEquals(NodeId(nodeB1), event.at)
+        assertTrue(event.fromCheckpoint)
+        assertEquals(9L, event.tick)
+    }
+
+    @Test
+    fun `forceRespawn falls back to random spawnable when no checkpoint or starter exists`() {
+        seedBody(hp = 0, stamina = 0, mana = 0, hunger = 0, thirst = 0, sleep = 0)
+        seedPosition(node = nodeA1, world = worldA, active = false)
+
+        val result = gateway.forceRespawn(agent, tick = 4L)
+
+        val respawn = assertIs<AgentBodyAdminResult.Respawned>(result)
+        assertEquals(NodeId(nodeA1), respawn.at)
+        assertFalse(respawn.fromCheckpoint)
+    }
+
+    @Test
+    fun `forceRespawn returns AgentNotFound when no profile exists`() {
+        val unknown = AgentId(UUID.randomUUID())
+        val result = gateway.forceRespawn(unknown, tick = 1L)
+        assertIs<AgentBodyAdminResult.AgentNotFound>(result)
+        assertTrue(publisher.events.isEmpty())
+    }
+
+    private fun seedBody(hp: Int, stamina: Int, mana: Int, hunger: Int, thirst: Int, sleep: Int) {
+        dsl.insertInto(AGENT_BODIES)
+            .set(AGENT_BODIES.AGENT_ID, agent.id)
+            .set(AGENT_BODIES.HP, hp).set(AGENT_BODIES.MAX_HP, 80)
+            .set(AGENT_BODIES.STAMINA, stamina).set(AGENT_BODIES.MAX_STAMINA, 50)
+            .set(AGENT_BODIES.MANA, mana).set(AGENT_BODIES.MAX_MANA, 30)
+            .set(AGENT_BODIES.HUNGER, hunger).set(AGENT_BODIES.MAX_HUNGER, 100)
+            .set(AGENT_BODIES.THIRST, thirst).set(AGENT_BODIES.MAX_THIRST, 100)
+            .set(AGENT_BODIES.SLEEP, sleep).set(AGENT_BODIES.MAX_SLEEP, 100)
+            .execute()
+    }
+
+    private fun seedPosition(node: Long, world: Long, active: Boolean) {
+        dsl.insertInto(AGENT_POSITIONS)
+            .set(AGENT_POSITIONS.AGENT_ID, agent.id)
+            .set(AGENT_POSITIONS.NODE_ID, node)
+            .set(AGENT_POSITIONS.WORLD_ID, world)
+            .set(AGENT_POSITIONS.ACTIVE, active)
+            .execute()
+    }
+
+    private fun readBody() = dsl.selectFrom(AGENT_BODIES).where(AGENT_BODIES.AGENT_ID.eq(agent.id)).fetchSingle()
+    private fun readPosition() = dsl.selectFrom(AGENT_POSITIONS).where(AGENT_POSITIONS.AGENT_ID.eq(agent.id)).fetchSingle()
+
+    private fun insertWorld(name: String): Long =
+        dsl.insertInto(WORLDS)
+            .set(WORLDS.NAME, name)
+            .set(WORLDS.NODE_COUNT, 1)
+            .set(WORLDS.NODE_SIZE, 1)
+            .set(WORLDS.FREQUENCY, 1)
+            .returningResult(WORLDS.ID)
+            .fetchOne()!!.value1()!!
+
+    private fun insertRegion(worldId: Long, sphereIndex: Int): Long =
+        dsl.insertInto(REGIONS)
+            .set(REGIONS.WORLD_ID, worldId)
+            .set(REGIONS.SPHERE_INDEX, sphereIndex)
+            .set(REGIONS.BIOME, Biome.PLAINS.name)
+            .set(REGIONS.CLIMATE, Climate.CONTINENTAL.name)
+            .set(REGIONS.CENTROID_X, 0.0)
+            .set(REGIONS.CENTROID_Y, 0.0)
+            .set(REGIONS.CENTROID_Z, 1.0)
+            .set(REGIONS.FACE_VERTICES, JSON.valueOf("[]"))
+            .returningResult(REGIONS.ID)
+            .fetchOne()!!.value1()!!
+
+    private fun insertNode(regionId: Long, q: Int, r: Int): Long =
+        dsl.insertInto(NODES)
+            .set(NODES.REGION_ID, regionId)
+            .set(NODES.Q, q)
+            .set(NODES.R, r)
+            .set(NODES.TERRAIN, Terrain.PLAINS.name)
+            .returningResult(NODES.ID)
+            .fetchOne()!!.value1()!!
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: ApplicationEvent) { events += event }
+        override fun publishEvent(event: Any) { events += event }
+    }
+
+    private class FixedProfileLookup(private val profile: AgentProfile) : AgentProfileLookup {
+        override fun find(id: AgentId): AgentProfile? = if (id == profile.id) profile else null
+    }
+
+    private class TrackingRegistry(private val present: Map<AgentId, Agent>) : AgentRegistry {
+        var deathPenaltyCallCount: Int = 0
+        override fun find(id: AgentId): Agent? = present[id]
+        override fun listForOwner(owner: PlayerId): List<Agent> = present.values.filter { it.owner == owner }
+        override fun applyDeathPenalty(agentId: AgentId, xpLossOnDeath: Int): DeathPenaltyOutcome? {
+            deathPenaltyCallCount += 1
+            return DeathPenaltyOutcome(xpLost = 0, deleveled = false, attributePointLost = null)
+        }
+    }
+
+    private class StubWorldQuery(
+        private val starterByRace: Map<RaceId, NodeId>,
+        private val randomSpawnable: NodeId?,
+    ) : WorldQueryGateway {
+        override fun locationOf(agent: AgentId): NodeId? = null
+        override fun activePositionOf(agent: AgentId): NodeId? = null
+        override fun node(id: NodeId) = null
+        override fun region(id: dev.gvart.genesara.world.RegionId) = null
+        override fun nodesWithin(origin: NodeId, radius: Int): Set<NodeId> = emptySet()
+        override fun randomSpawnableNode(): NodeId? = randomSpawnable
+        override fun starterNodeFor(race: RaceId): NodeId? = starterByRace[race]
+        override fun bodyOf(agent: AgentId) = null
+        override fun inventoryOf(agent: AgentId) = dev.gvart.genesara.world.InventoryView(emptyList())
+        override fun resourcesAt(nodeId: NodeId, tick: Long) = dev.gvart.genesara.world.NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId) = emptyList<dev.gvart.genesara.world.GroundItemView>()
+        override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>) = emptyMap<NodeId, List<AgentId>>()
+    }
+}

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/AgentBodyAdminGateway.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/AgentBodyAdminGateway.kt
@@ -1,0 +1,61 @@
+package dev.gvart.genesara.world
+
+import dev.gvart.genesara.player.AgentId
+
+/**
+ * Operator-only mutations on an agent's body and position state. Bypasses the
+ * tick-reducer loop so admins can intervene out-of-band during incidents.
+ *
+ * Writes hit the persisted `agent_bodies` / `agent_positions` / `agent_safe_nodes`
+ * tables directly and emit matching [dev.gvart.genesara.world.events.WorldEvent]s so
+ * the agent's event stream reflects the change. Mid-tick races against the live
+ * world state are accepted — admin interventions are rare and operator-driven.
+ *
+ * All operations return a [AgentBodyAdminResult] describing what changed so the
+ * controller can write the matching audit row.
+ */
+interface AgentBodyAdminGateway {
+
+    /**
+     * Overwrite any subset of [hp]/[stamina]/[mana]/[hunger]/[thirst]/[sleep] for [agent].
+     * Each non-null value is clamped to `0..max{pool}` (max read from the body row).
+     * Null fields are left untouched. No-ops on a missing agent body — returns
+     * [AgentBodyAdminResult.AgentNotFound].
+     */
+    fun setGauges(
+        agent: AgentId,
+        hp: Int? = null,
+        stamina: Int? = null,
+        mana: Int? = null,
+        hunger: Int? = null,
+        thirst: Int? = null,
+        sleep: Int? = null,
+    ): AgentBodyAdminResult
+
+    /**
+     * Move [agent] to [nodeId], crossing worlds when the target lives in a different
+     * world from the agent's current position. Updates `agent_positions.world_id`
+     * atomically and emits [dev.gvart.genesara.world.events.CoreEvent.AgentMoved]
+     * with `staminaSpent = 0` (admin teleports never charge stamina).
+     */
+    fun teleport(agent: AgentId, nodeId: NodeId, tick: Long): AgentBodyAdminResult
+
+    /**
+     * Materialize [agent] at their resolved safe node with full HP/Stamina/Mana
+     * and full survival gauges. Skips the de-level + XP-loss penalty —
+     * [dev.gvart.genesara.player.AgentRegistry.applyDeathPenalty] is NOT invoked.
+     * Emits [dev.gvart.genesara.world.events.BodyEvent.AgentRespawned].
+     *
+     * Resolution order: explicit safe-node row → race-keyed starter → random spawnable.
+     */
+    fun forceRespawn(agent: AgentId, tick: Long): AgentBodyAdminResult
+}
+
+sealed interface AgentBodyAdminResult {
+    data class GaugesUpdated(val applied: Map<String, Int>) : AgentBodyAdminResult
+    data class Teleported(val from: NodeId?, val to: NodeId, val crossedWorld: Boolean) : AgentBodyAdminResult
+    data class Respawned(val at: NodeId, val fromCheckpoint: Boolean) : AgentBodyAdminResult
+    data class AgentNotFound(val agent: AgentId) : AgentBodyAdminResult
+    data class NodeNotFound(val node: NodeId) : AgentBodyAdminResult
+    data class NoSpawnableNode(val agent: AgentId) : AgentBodyAdminResult
+}


### PR DESCRIPTION
## Summary

Operator surface under `/admin/agents/{id}` for editing one agent's transient body and position state. Closes #204.

- **`POST /gauges`** `{ hp?, stamina?, mana?, hunger?, thirst?, sleep? }` — each gauge clamped to `0..max{pool}` per the body row; null fields are left untouched.
- **`POST /position`** `{ nodeId }` — teleport, supports cross-world (updates `agent_positions.world_id`); emits `CoreEvent.AgentMoved` with `staminaSpent = 0`; audit row carries `cause=admin`.
- **`POST /safe-node`** `{ nodeId }` — delegates to existing `AgentSafeNodeGateway`.
- **`POST /respawn`** — force-respawn at resolved safe node (checkpoint → race starter → random spawnable); restores body to profile maxima + full gauges; **skips** the de-level / XP-loss penalty (never calls `AgentRegistry.applyDeathPenalty`); emits `BodyEvent.AgentRespawned`.

Every mutating endpoint writes a row to `admin_audit_log` via the substrate from #198.

## Surfaces touched

- `:world:core` — new public interface `AgentBodyAdminGateway` (`+ AgentBodyAdminResult` sealed return type).
- `:world:body` — `JooqAgentBodyAdminGateway` impl using `DSLContext`, `ApplicationEventPublisher`, `AgentSafeNodeGateway`, `AgentProfileLookup`, `AgentRegistry`, `WorldQueryGateway`.
- `:api` — `AgentBodyController` under `internal/rest/admin/agents/`, gated by the existing admin bearer chain.

## Design note

The gateway bypasses the tick-reducer loop and writes directly to the persisted tables (`agent_bodies`, `agent_positions`, `agent_safe_nodes`). This is the simplest path that supports cross-world teleport — the per-world reducer / state-load path can't naturally handle world A → world B. Mid-tick races against live world state are accepted: admin interventions are rare and operator-driven, matching the doc's framing of these as incident-response tools.

## Test plan

- [x] Unit (slice MockMvc) — `AgentBodyControllerTest` covers happy paths + audit row shape + 400/404/409 error paths.
- [x] Integration (Testcontainers Postgres) — `JooqAgentBodyAdminGatewayIntegrationTest`:
  - gauge clamp above max → max, below 0 → 0, in-range preserved, only provided fields touched
  - cross-world teleport updates `world_id` and `node_id`, preserves `active` flag, emits `AgentMoved` with `staminaSpent=0`
  - force-respawn at empty XP bar (HP=0, all gauges=0) restores full body and does NOT call `applyDeathPenalty` (counter == 0)
  - resolution fallback chain: checkpoint → starter → random spawnable
- [x] `./gradlew :api:test :world:body:test :world:core:test` green.
- [x] `./gradlew :world:test :app:assemble` green (downstream wiring intact).