### PR TITLE
feat(api,player): admin agent edit — meta (XP/level/attributes/skills/perks/class)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/agents/AgentAdminController.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/agents/AgentAdminController.kt
@@ -1,0 +1,502 @@
+package dev.gvart.genesara.api.internal.rest.admin.agents
+
+import dev.gvart.genesara.admin.Admin
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AdminAttributeOverrides
+import dev.gvart.genesara.player.AddCharacterXpOutcome
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentPerksRegistry
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.CharacterXpSource
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.PerkLookup
+import dev.gvart.genesara.player.RecordPerkResult
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillLookup
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.BodyView
+import dev.gvart.genesara.world.WorldQueryGateway
+import dev.gvart.genesara.world.internal.classes.Level10ChoiceEmitter
+import dev.gvart.genesara.world.internal.classes.Level50EvolutionEmitter
+import jakarta.validation.Valid
+import jakarta.validation.constraints.PositiveOrZero
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
+
+@RestController
+@RequestMapping("/admin/agents/{agentId}")
+internal class AgentAdminController(
+    private val agents: AgentRegistry,
+    private val skills: AgentSkillsRegistry,
+    private val skillLookup: SkillLookup,
+    private val perks: AgentPerksRegistry,
+    private val perkLookup: PerkLookup,
+    private val world: WorldQueryGateway,
+    private val safeNodes: AgentSafeNodeGateway,
+    private val auditLog: AdminAuditLog,
+    private val tickClock: TickClock,
+    private val publisher: ApplicationEventPublisher,
+    private val level10: Level10ChoiceEmitter,
+    private val level50: Level50EvolutionEmitter,
+) {
+
+    @GetMapping
+    fun detail(@PathVariable agentId: UUID): AgentDetailDto =
+        requireAgent(AgentId(agentId)).toDetailDto()
+
+    @PostMapping("/xp")
+    fun grantXp(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @Valid @RequestBody req: GrantXpRequest,
+    ): AgentDetailDto {
+        val target = AgentId(agentId)
+        val tick = tickClock.currentTick()
+        val outcome = agents.addCharacterXp(target, req.amount)
+            ?: throw notFound("agent $agentId is not registered")
+        if (outcome is AddCharacterXpOutcome.Granted) {
+            val commandId = UUID.randomUUID()
+            publisher.publishEvent(
+                AgentEvent.CharacterXpGained(
+                    agent = target,
+                    source = CharacterXpSource.ADMIN_GRANT,
+                    amount = outcome.accruedDelta,
+                    total = outcome.xpCurrent,
+                    toNext = outcome.xpToNext,
+                    level = outcome.currentLevel,
+                    unspentAttributePoints = outcome.unspentAttributePoints,
+                    tick = tick,
+                    causedBy = commandId,
+                ),
+            )
+            if (outcome.currentLevel > outcome.previousLevel) {
+                publisher.publishEvent(
+                    AgentEvent.AgentLeveled(
+                        agent = target,
+                        fromLevel = outcome.previousLevel,
+                        toLevel = outcome.currentLevel,
+                        unspentAttributePoints = outcome.unspentAttributePoints,
+                        tick = tick,
+                        causedBy = commandId,
+                    ),
+                )
+            }
+        }
+        audit(admin, "agent.xp_granted", target, mapOf("amount" to req.amount), tick)
+        return detail(agentId)
+    }
+
+    @PostMapping("/level")
+    fun setLevel(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @Valid @RequestBody req: SetLevelRequest,
+    ): AgentDetailDto {
+        if (req.level < 1) throw badRequest("level must be >= 1")
+        val target = AgentId(agentId)
+        val updated = agents.adminSetLevel(target, req.level)
+            ?: throw notFound("agent $agentId is not registered")
+        audit(
+            admin,
+            "agent.level_set",
+            target,
+            mapOf("level" to req.level, "force" to true),
+            tickClock.currentTick(),
+        )
+        return updated.toDetailDto()
+    }
+
+    @PostMapping("/attributes")
+    fun setAttributes(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @Valid @RequestBody req: SetAttributesRequest,
+    ): AgentDetailDto {
+        validateAttributeBounds(req)
+        val target = AgentId(agentId)
+        val updated = agents.adminSetAttributes(
+            target,
+            AdminAttributeOverrides(
+                strength = req.str,
+                dexterity = req.dex,
+                constitution = req.con,
+                perception = req.per,
+                intelligence = req.int,
+                luck = req.luck,
+                unspent = req.unspent,
+            ),
+        ) ?: throw notFound("agent $agentId is not registered")
+        audit(
+            admin,
+            "agent.attributes_set",
+            target,
+            buildMap {
+                req.str?.let { put("str", it) }
+                req.dex?.let { put("dex", it) }
+                req.con?.let { put("con", it) }
+                req.per?.let { put("per", it) }
+                req.int?.let { put("int", it) }
+                req.luck?.let { put("luck", it) }
+                req.unspent?.let { put("unspent", it) }
+            },
+            tickClock.currentTick(),
+        )
+        return updated.toDetailDto()
+    }
+
+    @PostMapping("/skills/{skillId}")
+    fun setSkill(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @PathVariable skillId: String,
+        @Valid @RequestBody req: SetSkillRequest,
+    ): SkillUpdateDto {
+        val target = AgentId(agentId)
+        requireAgent(target)
+        val skill = skillLookup.byId(SkillId(skillId))
+            ?: throw notFound("skill '$skillId' is not in the catalog")
+        val xp = req.toAbsoluteXp() ?: throw badRequest("must supply either `xp` or `level`")
+        if (xp < 0) throw badRequest("resulting xp must be >= 0")
+        val result = skills.adminSetSkillXp(target, skill.id, xp)
+        audit(
+            admin,
+            "agent.skill_set",
+            target,
+            buildMap {
+                put("skillId", skill.id.value)
+                req.xp?.let { put("xp", it) }
+                req.level?.let { put("level", it) }
+                put("previousXp", result.previousXp)
+                put("newXp", result.newXp)
+            },
+            tickClock.currentTick(),
+        )
+        return SkillUpdateDto(
+            skillId = skill.id.value,
+            previousXp = result.previousXp,
+            newXp = result.newXp,
+            crossedMilestones = result.crossedMilestones,
+        )
+    }
+
+    @DeleteMapping("/skills/{skillId}")
+    fun forceUnequip(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @PathVariable skillId: String,
+    ): ForceUnequipResponse {
+        val target = AgentId(agentId)
+        requireAgent(target)
+        val skill = skillLookup.byId(SkillId(skillId))
+            ?: throw notFound("skill '$skillId' is not in the catalog")
+        val removed = skills.adminForceUnequip(target, skill.id)
+        audit(
+            admin,
+            "agent.skill_force_unequipped",
+            target,
+            mapOf("skillId" to skill.id.value, "removed" to removed, "force" to true),
+            tickClock.currentTick(),
+        )
+        return ForceUnequipResponse(
+            skillId = skill.id.value,
+            removed = removed,
+            warning = "Slots are normally permanent; this is a force-unequip and bypasses the project's no-respec rule.",
+        )
+    }
+
+    @PostMapping("/perks/{perkId}")
+    fun grantPerk(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @PathVariable perkId: String,
+    ): PerkUpdateDto {
+        val target = AgentId(agentId)
+        requireAgent(target)
+        val perk = perkLookup.byId(PerkId(perkId))
+            ?: throw notFound("perk '$perkId' is not in the catalog")
+        val tick = tickClock.currentTick()
+        return when (val outcome = perks.recordChoice(target, perk.id, tick)) {
+            RecordPerkResult.Recorded -> {
+                publisher.publishEvent(
+                    AgentEvent.PerkChosen(
+                        agent = target,
+                        skill = perk.skill,
+                        milestone = perk.milestoneLevel,
+                        perk = perk.id,
+                        tick = tick,
+                    ),
+                )
+                audit(
+                    admin,
+                    "agent.perk_granted",
+                    target,
+                    mapOf("perkId" to perk.id.value, "skillId" to perk.skill.value, "milestone" to perk.milestoneLevel),
+                    tick,
+                )
+                PerkUpdateDto(perkId = perk.id.value, skillId = perk.skill.value, milestone = perk.milestoneLevel)
+            }
+            is RecordPerkResult.MilestoneAlreadyChosen ->
+                throw badRequest(
+                    "milestone ${outcome.skill.value}@${outcome.milestoneLevel} already has perk ${outcome.existing.value}",
+                )
+            is RecordPerkResult.UnknownPerk -> throw notFound("perk '${outcome.perk.value}' is not in the catalog")
+        }
+    }
+
+    @DeleteMapping("/perks/{perkId}")
+    fun revokePerk(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @PathVariable perkId: String,
+    ): PerkUpdateDto {
+        val target = AgentId(agentId)
+        requireAgent(target)
+        val perk = perkLookup.byId(PerkId(perkId))
+            ?: throw notFound("perk '$perkId' is not in the catalog")
+        val removed = perks.adminRevoke(target, perk.id)
+        if (!removed) throw notFound("agent does not hold perk '$perkId'")
+        audit(
+            admin,
+            "agent.perk_revoked",
+            target,
+            mapOf("perkId" to perk.id.value, "skillId" to perk.skill.value, "milestone" to perk.milestoneLevel, "force" to true),
+            tickClock.currentTick(),
+        )
+        return PerkUpdateDto(perkId = perk.id.value, skillId = perk.skill.value, milestone = perk.milestoneLevel)
+    }
+
+    @PostMapping("/class")
+    fun setClass(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @Valid @RequestBody req: SetClassRequest,
+    ): AgentDetailDto {
+        val target = AgentId(agentId)
+        val tick = tickClock.currentTick()
+        val updated = agents.adminAssignClass(target, req.classId)
+            ?: throw notFound("agent $agentId is not registered")
+        publisher.publishEvent(AgentEvent.ClassChosen(agent = target, classId = req.classId, tick = tick))
+        audit(
+            admin,
+            "agent.class_set",
+            target,
+            mapOf("classId" to req.classId.name, "force" to true),
+            tick,
+        )
+        return updated.toDetailDto()
+    }
+
+    @PostMapping("/class/offers")
+    fun reopenOffers(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+    ): AgentDetailDto {
+        val target = AgentId(agentId)
+        val before = requireAgent(target)
+        val tick = tickClock.currentTick()
+        agents.adminClearPendingOffers(target)
+        if (before.classId == null) {
+            level10.tryEmitFor(target, tick)
+        } else if (before.level >= LEVEL_FIFTY_THRESHOLD) {
+            level50.tryEmitFor(target, tick)
+        }
+        audit(
+            admin,
+            "agent.class_offers_reopened",
+            target,
+            mapOf("force" to true, "level" to before.level, "hadClass" to (before.classId != null)),
+            tick,
+        )
+        return detail(agentId)
+    }
+
+    private fun requireAgent(agentId: AgentId): Agent =
+        agents.find(agentId)
+            ?: throw notFound("agent ${agentId.id} is not registered")
+
+    private fun audit(admin: Admin, action: String, target: AgentId, payload: Map<String, Any?>, tick: Long) {
+        auditLog.record(
+            adminId = admin.id,
+            action = action,
+            target = "agent",
+            targetId = target.id.toString(),
+            payload = payload,
+            tick = tick,
+        )
+    }
+
+    private fun validateAttributeBounds(req: SetAttributesRequest) {
+        val minAttribute = 1
+        listOf("str" to req.str, "dex" to req.dex, "con" to req.con, "per" to req.per, "int" to req.int, "luck" to req.luck)
+            .forEach { (name, value) ->
+                if (value != null && value < minAttribute) {
+                    throw badRequest("$name must be >= $minAttribute, got $value")
+                }
+            }
+        if (req.unspent != null && req.unspent < 0) {
+            throw badRequest("unspent must be >= 0, got ${req.unspent}")
+        }
+        val noOp = listOfNotNull(req.str, req.dex, req.con, req.per, req.int, req.luck, req.unspent).isEmpty()
+        if (noOp) throw badRequest("at least one field must be supplied")
+    }
+
+    private fun badRequest(detail: String) = ResponseStatusException(HttpStatus.BAD_REQUEST, detail)
+    private fun notFound(detail: String) = ResponseStatusException(HttpStatus.NOT_FOUND, detail)
+
+    private fun Agent.toDetailDto(): AgentDetailDto {
+        val body = world.bodyOf(id)
+        val location = world.activePositionOf(id) ?: world.locationOf(id)
+        return AgentDetailDto(
+            agentId = id.id,
+            owner = owner.id,
+            name = name,
+            race = race.value,
+            classId = classId,
+            level = level,
+            xp = XpDto(current = xpCurrent, toNext = xpToNext),
+            attributes = toAttributesDto(),
+            unspentAttributePoints = unspentAttributePoints,
+            gauges = body?.toGaugesDto(),
+            location = location?.value,
+            safeNode = safeNodes.find(id)?.value,
+            tick = world.currentTickFor(id),
+            authority = authority,
+            fame = fame,
+            outlawState = outlawState.name,
+            outlawMisconductScore = outlawMisconductScore,
+            pendingClassChoice = offeredClasses?.toList() ?: emptyList(),
+            pendingEvolutionChoice = offeredEvolutions?.toList() ?: emptyList(),
+        )
+    }
+
+    private fun Agent.toAttributesDto() = AttributesDto(
+        strength = attributes.strength,
+        dexterity = attributes.dexterity,
+        constitution = attributes.constitution,
+        perception = attributes.perception,
+        intelligence = attributes.intelligence,
+        luck = attributes.luck,
+    )
+
+    private fun BodyView.toGaugesDto() = GaugesDto(
+        hp = PoolDto(hp, maxHp),
+        stamina = PoolDto(stamina, maxStamina),
+        mana = PoolDto(mana, maxMana),
+        hunger = PoolDto(hunger, maxHunger),
+        thirst = PoolDto(thirst, maxThirst),
+        sleep = PoolDto(sleep, maxSleep),
+    )
+
+    private companion object {
+        const val LEVEL_FIFTY_THRESHOLD = 50
+    }
+}
+
+data class AgentDetailDto(
+    val agentId: UUID,
+    val owner: UUID,
+    val name: String,
+    val race: String,
+    val classId: AgentClass?,
+    val level: Int,
+    val xp: XpDto,
+    val attributes: AttributesDto,
+    val unspentAttributePoints: Int,
+    val gauges: GaugesDto?,
+    val location: Long?,
+    val safeNode: Long?,
+    val tick: Long,
+    val authority: Int,
+    val fame: Int,
+    val outlawState: String,
+    val outlawMisconductScore: Int,
+    val pendingClassChoice: List<AgentClass>,
+    val pendingEvolutionChoice: List<AgentClass>,
+)
+
+data class XpDto(val current: Int, val toNext: Int)
+
+data class AttributesDto(
+    val strength: Int,
+    val dexterity: Int,
+    val constitution: Int,
+    val perception: Int,
+    val intelligence: Int,
+    val luck: Int,
+)
+
+data class GaugesDto(
+    val hp: PoolDto,
+    val stamina: PoolDto,
+    val mana: PoolDto,
+    val hunger: PoolDto,
+    val thirst: PoolDto,
+    val sleep: PoolDto,
+)
+
+data class PoolDto(val current: Int, val max: Int)
+
+data class GrantXpRequest(@field:PositiveOrZero val amount: Int)
+
+data class SetLevelRequest(val level: Int)
+
+data class SetAttributesRequest(
+    val str: Int? = null,
+    val dex: Int? = null,
+    val con: Int? = null,
+    val per: Int? = null,
+    val int: Int? = null,
+    val luck: Int? = null,
+    val unspent: Int? = null,
+)
+
+data class SetSkillRequest(
+    @field:PositiveOrZero val xp: Int? = null,
+    @field:PositiveOrZero val level: Int? = null,
+) {
+    fun toAbsoluteXp(): Int? = when {
+        xp != null -> xp
+        level != null -> level * SKILL_XP_PER_LEVEL
+        else -> null
+    }
+
+    private companion object {
+        const val SKILL_XP_PER_LEVEL = 10
+    }
+}
+
+data class SkillUpdateDto(
+    val skillId: String,
+    val previousXp: Int,
+    val newXp: Int,
+    val crossedMilestones: List<Int>,
+)
+
+data class ForceUnequipResponse(
+    val skillId: String,
+    val removed: Boolean,
+    val warning: String,
+)
+
+data class PerkUpdateDto(
+    val perkId: String,
+    val skillId: String,
+    val milestone: Int,
+)
+
+data class SetClassRequest(val classId: AgentClass)

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/agents/AgentAdminControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/agents/AgentAdminControllerTest.kt
@@ -1,0 +1,687 @@
+package dev.gvart.genesara.api.internal.rest.admin.agents
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.admin.Admin
+import dev.gvart.genesara.admin.AdminAuditEntry
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.admin.AdminId
+import dev.gvart.genesara.api.internal.rest.GlobalExceptionAdvice
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AddCharacterXpOutcome
+import dev.gvart.genesara.player.AdminAttributeOverrides
+import dev.gvart.genesara.player.AdminSkillXpResult
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentAttributes
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentPerk
+import dev.gvart.genesara.player.AgentPerksRegistry
+import dev.gvart.genesara.player.AgentPerksSnapshot
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.AgentSkillsRegistry
+import dev.gvart.genesara.player.AgentSkillState
+import dev.gvart.genesara.player.AgentSkillsSnapshot
+import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.CharacterXpSource
+import dev.gvart.genesara.player.ClassOffer
+import dev.gvart.genesara.player.Perk
+import dev.gvart.genesara.player.PerkEffect
+import dev.gvart.genesara.player.PerkId
+import dev.gvart.genesara.player.PerkLookup
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.player.RecordPerkResult
+import dev.gvart.genesara.player.Skill
+import dev.gvart.genesara.player.SkillCategory
+import dev.gvart.genesara.player.SkillId
+import dev.gvart.genesara.player.SkillLookup
+import dev.gvart.genesara.player.SkillSlotError
+import dev.gvart.genesara.player.events.AgentEvent
+import dev.gvart.genesara.player.ClassDefinition
+import dev.gvart.genesara.player.ClassLookup
+import dev.gvart.genesara.player.NoOpClassLookup
+import dev.gvart.genesara.player.RecordClassOfferOutcome
+import dev.gvart.genesara.world.AgentSafeNodeGateway
+import dev.gvart.genesara.world.BodyView
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.InventoryView
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NodeResources
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.WorldQueryGateway
+import dev.gvart.genesara.world.internal.behavior.ActionCategory
+import dev.gvart.genesara.world.internal.behavior.BehaviorTracker
+import dev.gvart.genesara.world.internal.classes.Level10ChoiceEmitter
+import dev.gvart.genesara.world.internal.classes.Level50EvolutionEmitter
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class AgentAdminControllerTest {
+
+    private val admin = Admin(id = AdminId(UUID.randomUUID()), username = "ops")
+    private val owner = PlayerId(UUID.randomUUID())
+    private val agent = Agent(
+        id = AgentId(UUID.randomUUID()),
+        owner = owner,
+        name = "Ada",
+        classId = null,
+        race = RaceId("human_commoner"),
+        level = 4,
+        xpCurrent = 30,
+        xpToNext = 400,
+        unspentAttributePoints = 2,
+        attributes = AgentAttributes.DEFAULT,
+        authority = 7,
+        fame = 12,
+    )
+    private val swordSkill = Skill(
+        id = SkillId("SWORD"),
+        displayName = "Sword",
+        description = "",
+        category = SkillCategory.COMBAT,
+    )
+    private val swordPerk = Perk(
+        id = PerkId("SWORD_BLEEDER"),
+        skill = swordSkill.id,
+        milestoneLevel = 50,
+        displayName = "Bleeder",
+        description = "",
+        effect = PerkEffect.PassiveAura(target = dev.gvart.genesara.player.ScalingEffect.SLASH_DAMAGE_BONUS, magnitude = 1),
+    )
+
+    private lateinit var agents: StubAgentRegistry
+    private lateinit var skills: StubSkillsRegistry
+    private lateinit var perks: StubPerksRegistry
+    private lateinit var audit: RecordingAuditLog
+    private lateinit var publisher: RecordingPublisher
+    private lateinit var emitterAgents: StubAgentRegistry
+    private lateinit var behavior: InMemoryBehaviorTracker
+    private lateinit var emitter10: Level10ChoiceEmitter
+    private lateinit var emitter50: Level50EvolutionEmitter
+    private lateinit var mvc: MockMvc
+
+    @BeforeEach
+    fun setup() {
+        agents = StubAgentRegistry(mutableMapOf(agent.id to agent))
+        skills = StubSkillsRegistry()
+        perks = StubPerksRegistry()
+        audit = RecordingAuditLog()
+        publisher = RecordingPublisher()
+        behavior = InMemoryBehaviorTracker()
+        val classes = StubClassLookup(
+            classFor(AgentClass.SOLDIER, mapOf("COMBAT" to 1.0)),
+            classFor(AgentClass.HUNTER, mapOf("COMBAT" to 0.6, "GATHER" to 0.4)),
+        )
+        emitter10 = Level10ChoiceEmitter(agents, classes, behavior, publisher)
+        emitter50 = Level50EvolutionEmitter(agents, classes, behavior, publisher)
+        val controller = AgentAdminController(
+            agents = agents,
+            skills = skills,
+            skillLookup = SingleSkillLookup(swordSkill),
+            perks = perks,
+            perkLookup = SinglePerkLookup(swordPerk),
+            world = StubWorld(),
+            safeNodes = NoopSafeNodeGateway,
+            auditLog = audit,
+            tickClock = FixedTickClock(99L),
+            publisher = publisher,
+            level10 = emitter10,
+            level50 = emitter50,
+        )
+        mvc = MockMvcBuilders.standaloneSetup(controller)
+            .setControllerAdvice(GlobalExceptionAdvice())
+            .setCustomArgumentResolvers(AuthenticationPrincipalArgumentResolver())
+            .build()
+        authenticate()
+    }
+
+    private fun authenticate() {
+        val authn = UsernamePasswordAuthenticationToken(
+            admin,
+            null,
+            listOf(SimpleGrantedAuthority("ROLE_ADMIN")),
+        )
+        SecurityContextHolder.getContext().authentication = authn
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun teardown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `GET detail returns the combined agent view`() {
+        mvc.get("/admin/agents/${agent.id.id}").andExpect {
+            status { isOk() }
+            jsonPath("$.agentId") { value(agent.id.id.toString()) }
+            jsonPath("$.name") { value("Ada") }
+            jsonPath("$.level") { value(4) }
+            jsonPath("$.xp.current") { value(30) }
+            jsonPath("$.xp.toNext") { value(400) }
+            jsonPath("$.authority") { value(7) }
+            jsonPath("$.fame") { value(12) }
+        }
+    }
+
+    @Test
+    fun `GET detail 404 when agent missing`() {
+        val other = UUID.randomUUID()
+        mvc.get("/admin/agents/$other").andExpect {
+            status { isNotFound() }
+            jsonPath("$.detail") { value("agent $other is not registered") }
+        }
+    }
+
+    @Test
+    fun `POST xp adds character XP, publishes the gained event, and records audit`() {
+        mvc.post("/admin/agents/${agent.id.id}/xp") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"amount":50}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.xp.current") { value(80) }
+        }
+
+        val gained = publisher.events.filterIsInstance<AgentEvent.CharacterXpGained>().single()
+        assertEquals(CharacterXpSource.ADMIN_GRANT, gained.source)
+        assertEquals(50, gained.amount)
+
+        val entry = audit.records.single()
+        assertEquals("agent.xp_granted", entry.action)
+        assertEquals("agent", entry.target)
+        assertEquals(agent.id.id.toString(), entry.targetId)
+        assertEquals(50, entry.payload["amount"])
+    }
+
+    @Test
+    fun `POST xp rejects negative amounts with 400`() {
+        mvc.post("/admin/agents/${agent.id.id}/xp") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"amount":-1}"""
+        }.andExpect { status { isBadRequest() } }
+    }
+
+    @Test
+    fun `POST level sets the level, audits with force=true`() {
+        mvc.post("/admin/agents/${agent.id.id}/level") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"level":17}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.level") { value(17) }
+            jsonPath("$.xp.toNext") { value(17 * 100) }
+        }
+
+        val entry = audit.records.single()
+        assertEquals("agent.level_set", entry.action)
+        assertEquals(17, entry.payload["level"])
+        assertEquals(true, entry.payload["force"])
+    }
+
+    @Test
+    fun `POST level rejects zero with 400`() {
+        mvc.post("/admin/agents/${agent.id.id}/level") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"level":0}"""
+        }.andExpect { status { isBadRequest() } }
+    }
+
+    @Test
+    fun `POST attributes sets absolute values and audits`() {
+        mvc.post("/admin/agents/${agent.id.id}/attributes") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"str":12,"con":8,"unspent":3}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.attributes.strength") { value(12) }
+            jsonPath("$.attributes.constitution") { value(8) }
+            jsonPath("$.unspentAttributePoints") { value(3) }
+        }
+
+        val entry = audit.records.single()
+        assertEquals("agent.attributes_set", entry.action)
+        assertEquals(12, entry.payload["str"])
+        assertEquals(8, entry.payload["con"])
+        assertEquals(3, entry.payload["unspent"])
+    }
+
+    @Test
+    fun `POST attributes rejects empty body with 400`() {
+        mvc.post("/admin/agents/${agent.id.id}/attributes") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{}"""
+        }.andExpect { status { isBadRequest() } }
+    }
+
+    @Test
+    fun `POST skill xp upserts ledger, audits with previous and new values`() {
+        mvc.post("/admin/agents/${agent.id.id}/skills/SWORD") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"xp":75}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.skillId") { value("SWORD") }
+            jsonPath("$.newXp") { value(75) }
+            jsonPath("$.crossedMilestones[0]") { value(50) }
+        }
+
+        val entry = audit.records.single()
+        assertEquals("agent.skill_set", entry.action)
+        assertEquals("SWORD", entry.payload["skillId"])
+        assertEquals(75, entry.payload["xp"])
+        assertEquals(75, entry.payload["newXp"])
+    }
+
+    @Test
+    fun `POST skill 404 for unknown skill`() {
+        mvc.post("/admin/agents/${agent.id.id}/skills/PHANTOM") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"xp":10}"""
+        }.andExpect {
+            status { isNotFound() }
+            jsonPath("$.detail") { value("skill 'PHANTOM' is not in the catalog") }
+        }
+    }
+
+    @Test
+    fun `POST skill rejects missing xp and level`() {
+        mvc.post("/admin/agents/${agent.id.id}/skills/SWORD") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{}"""
+        }.andExpect { status { isBadRequest() } }
+    }
+
+    @Test
+    fun `DELETE skill force-unequips with a warning and audit force=true`() {
+        skills.equip(agent.id, swordSkill.id, slotIndex = 0)
+
+        mvc.delete("/admin/agents/${agent.id.id}/skills/SWORD").andExpect {
+            status { isOk() }
+            jsonPath("$.removed") { value(true) }
+            jsonPath("$.warning") { exists() }
+        }
+
+        val entry = audit.records.single()
+        assertEquals("agent.skill_force_unequipped", entry.action)
+        assertEquals(true, entry.payload["force"])
+        assertEquals(true, entry.payload["removed"])
+    }
+
+    @Test
+    fun `POST perk grants the perk, publishes PerkChosen, audits`() {
+        mvc.post("/admin/agents/${agent.id.id}/perks/SWORD_BLEEDER").andExpect {
+            status { isOk() }
+            jsonPath("$.perkId") { value("SWORD_BLEEDER") }
+            jsonPath("$.skillId") { value("SWORD") }
+            jsonPath("$.milestone") { value(50) }
+        }
+
+        val chosen = publisher.events.filterIsInstance<AgentEvent.PerkChosen>().single()
+        assertEquals(swordPerk.id, chosen.perk)
+
+        val entry = audit.records.single()
+        assertEquals("agent.perk_granted", entry.action)
+        assertEquals("SWORD_BLEEDER", entry.payload["perkId"])
+    }
+
+    @Test
+    fun `POST perk rejects an unknown perk with 404`() {
+        mvc.post("/admin/agents/${agent.id.id}/perks/PHANTOM").andExpect {
+            status { isNotFound() }
+        }
+    }
+
+    @Test
+    fun `POST perk rejects when milestone already taken with 400`() {
+        perks.recordChoice(agent.id, swordPerk.id, tick = 0L)
+
+        mvc.post("/admin/agents/${agent.id.id}/perks/SWORD_BLEEDER").andExpect {
+            status { isBadRequest() }
+        }
+    }
+
+    @Test
+    fun `DELETE perk revokes and audits force=true`() {
+        perks.recordChoice(agent.id, swordPerk.id, tick = 0L)
+
+        mvc.delete("/admin/agents/${agent.id.id}/perks/SWORD_BLEEDER").andExpect {
+            status { isOk() }
+            jsonPath("$.perkId") { value("SWORD_BLEEDER") }
+        }
+
+        val entry = audit.records.single()
+        assertEquals("agent.perk_revoked", entry.action)
+        assertEquals(true, entry.payload["force"])
+    }
+
+    @Test
+    fun `DELETE perk 404 when the agent does not hold it`() {
+        mvc.delete("/admin/agents/${agent.id.id}/perks/SWORD_BLEEDER").andExpect {
+            status { isNotFound() }
+        }
+    }
+
+    @Test
+    fun `POST class assigns regardless of the offer gate and audits force=true`() {
+        mvc.post("/admin/agents/${agent.id.id}/class") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"classId":"SCOUT"}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.classId") { value("SCOUT") }
+        }
+
+        val chosen = publisher.events.filterIsInstance<AgentEvent.ClassChosen>().single()
+        assertEquals(AgentClass.SCOUT, chosen.classId)
+
+        val entry = audit.records.single()
+        assertEquals("agent.class_set", entry.action)
+        assertEquals("SCOUT", entry.payload["classId"])
+        assertEquals(true, entry.payload["force"])
+    }
+
+    @Test
+    fun `POST class rejects an unknown class with 400`() {
+        mvc.post("/admin/agents/${agent.id.id}/class") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"classId":"WIZARD"}"""
+        }.andExpect { status { isBadRequest() } }
+    }
+
+    @Test
+    fun `POST class offers re-opens the L10 gate when unclassed and at threshold`() {
+        agents.replace(
+            agent.copy(
+                level = 10,
+                classId = null,
+                offeredClasses = ClassOffer(AgentClass.SOLDIER, AgentClass.HUNTER),
+            ),
+        )
+        repeat(20) { _ -> behavior.record(agent.id, ActionCategory.COMBAT, 0L) }
+
+        mvc.post("/admin/agents/${agent.id.id}/class/offers").andExpect {
+            status { isOk() }
+        }
+
+        val emitted = publisher.events.filterIsInstance<AgentEvent.ClassChoiceOffered>().single()
+        assertEquals(setOf(AgentClass.SOLDIER, AgentClass.HUNTER), emitted.candidates.toSet())
+
+        val entry = audit.records.single()
+        assertEquals("agent.class_offers_reopened", entry.action)
+        assertEquals(true, entry.payload["force"])
+        assertEquals(false, entry.payload["hadClass"])
+    }
+
+    private class StubAgentRegistry(
+        private val byId: MutableMap<AgentId, Agent>,
+    ) : AgentRegistry {
+        override fun find(id: AgentId): Agent? = byId[id]
+        override fun listForOwner(owner: PlayerId): List<Agent> =
+            byId.values.filter { it.owner == owner }
+
+        fun replace(agent: Agent) {
+            byId[agent.id] = agent
+        }
+
+        override fun addCharacterXp(agentId: AgentId, delta: Int): AddCharacterXpOutcome? {
+            if (delta < 0) return AddCharacterXpOutcome.NegativeDelta
+            val current = byId[agentId] ?: return null
+            val newXp = current.xpCurrent + delta
+            byId[agentId] = current.copy(xpCurrent = newXp)
+            return AddCharacterXpOutcome.Granted(
+                previousLevel = current.level,
+                currentLevel = current.level,
+                xpCurrent = newXp,
+                xpToNext = current.xpToNext,
+                unspentAttributePoints = current.unspentAttributePoints,
+                accruedDelta = delta,
+                cappedAtPendingClassChoice = false,
+                cappedAtPendingEvolutionChoice = false,
+            )
+        }
+
+        override fun adminSetLevel(agentId: AgentId, level: Int): Agent? {
+            val current = byId[agentId] ?: return null
+            val newXpToNext = level * 100
+            val updated = current.copy(
+                level = level,
+                xpToNext = newXpToNext,
+                xpCurrent = current.xpCurrent.coerceAtMost(newXpToNext),
+            )
+            byId[agentId] = updated
+            return updated
+        }
+
+        override fun adminSetAttributes(agentId: AgentId, set: AdminAttributeOverrides): Agent? {
+            val current = byId[agentId] ?: return null
+            val attrs = AgentAttributes(
+                strength = set.strength ?: current.attributes.strength,
+                dexterity = set.dexterity ?: current.attributes.dexterity,
+                constitution = set.constitution ?: current.attributes.constitution,
+                perception = set.perception ?: current.attributes.perception,
+                intelligence = set.intelligence ?: current.attributes.intelligence,
+                luck = set.luck ?: current.attributes.luck,
+            )
+            val updated = current.copy(
+                attributes = attrs,
+                unspentAttributePoints = set.unspent ?: current.unspentAttributePoints,
+            )
+            byId[agentId] = updated
+            return updated
+        }
+
+        override fun adminAssignClass(agentId: AgentId, classId: AgentClass): Agent? {
+            val current = byId[agentId] ?: return null
+            val updated = current.copy(classId = classId, offeredClasses = null)
+            byId[agentId] = updated
+            return updated
+        }
+
+        override fun adminClearClassAndOffers(agentId: AgentId): Agent? {
+            val current = byId[agentId] ?: return null
+            val updated = current.copy(classId = null, offeredClasses = null, offeredEvolutions = null)
+            byId[agentId] = updated
+            return updated
+        }
+
+        override fun adminClearPendingOffers(agentId: AgentId): Agent? {
+            val current = byId[agentId] ?: return null
+            val updated = current.copy(offeredClasses = null, offeredEvolutions = null)
+            byId[agentId] = updated
+            return updated
+        }
+
+        override fun recordPendingClassChoice(agentId: AgentId, offer: ClassOffer): RecordClassOfferOutcome {
+            val current = byId[agentId] ?: return RecordClassOfferOutcome.UnknownAgent
+            if (current.classId != null) return RecordClassOfferOutcome.AlreadyClassed
+            if (current.offeredClasses != null) return RecordClassOfferOutcome.AlreadyOffered(current.offeredClasses!!)
+            byId[agentId] = current.copy(offeredClasses = offer)
+            return RecordClassOfferOutcome.Recorded
+        }
+    }
+
+    private class StubSkillsRegistry : AgentSkillsRegistry {
+        private val xp = mutableMapOf<Pair<AgentId, SkillId>, Int>()
+        private val slots = mutableMapOf<Pair<AgentId, SkillId>, Int>()
+
+        fun equip(agent: AgentId, skill: SkillId, slotIndex: Int) {
+            slots[agent to skill] = slotIndex
+        }
+
+        override fun snapshot(agent: AgentId): AgentSkillsSnapshot {
+            val perSkill = xp.filterKeys { it.first == agent }.mapKeys { it.key.second }
+                .map { (skill, x) ->
+                    skill to AgentSkillState(
+                        skill = skill,
+                        xp = x,
+                        level = x / 10,
+                        slotIndex = slots[agent to skill],
+                        recommendCount = 0,
+                    )
+                }.toMap()
+            return AgentSkillsSnapshot(perSkill = perSkill, slotCount = 8, slotsFilled = slots.size)
+        }
+
+        override fun addXpIfSlotted(agent: AgentId, skill: SkillId, delta: Int): AddXpResult =
+            AddXpResult.Unslotted
+
+        override fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int? = null
+
+        override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? = null
+
+        override fun adminSetSkillXp(agent: AgentId, skill: SkillId, xp: Int): AdminSkillXpResult {
+            val key = agent to skill
+            val old = this.xp[key] ?: 0
+            this.xp[key] = xp
+            val crossed = if (xp > old) listOf(50, 100, 150).filter { it in (old + 1)..xp } else emptyList()
+            return AdminSkillXpResult(previousXp = old, newXp = xp, crossedMilestones = crossed)
+        }
+
+        override fun adminForceUnequip(agent: AgentId, skill: SkillId): Boolean =
+            slots.remove(agent to skill) != null
+    }
+
+    private class StubPerksRegistry : AgentPerksRegistry {
+        private val held = mutableMapOf<Pair<AgentId, PerkId>, Long>()
+
+        override fun snapshot(agent: AgentId): AgentPerksSnapshot {
+            val perks = held.filterKeys { it.first == agent }.map { (key, tick) ->
+                AgentPerk(skill = SkillId("SWORD"), milestoneLevel = 50, perkId = key.second, chosenAtTick = tick)
+            }
+            return AgentPerksSnapshot(perks)
+        }
+
+        override fun recordChoice(agent: AgentId, perk: PerkId, tick: Long): RecordPerkResult {
+            val key = agent to perk
+            if (held.containsKey(key)) {
+                return RecordPerkResult.MilestoneAlreadyChosen(SkillId("SWORD"), 50, perk)
+            }
+            held[key] = tick
+            return RecordPerkResult.Recorded
+        }
+
+        override fun adminRevoke(agent: AgentId, perk: PerkId): Boolean =
+            held.remove(agent to perk) != null
+    }
+
+    private class RecordingAuditLog : AdminAuditLog {
+        val records = mutableListOf<AdminAuditEntry>()
+
+        override fun record(
+            adminId: AdminId,
+            action: String,
+            target: String,
+            targetId: String?,
+            payload: Map<String, Any?>,
+            tick: Long,
+        ): Long {
+            records += AdminAuditEntry(
+                seq = records.size.toLong() + 1,
+                adminId = adminId,
+                action = action,
+                target = target,
+                targetId = targetId,
+                payload = payload,
+                tick = tick,
+                occurredAt = Instant.EPOCH,
+            )
+            return records.size.toLong()
+        }
+
+        override fun readAfter(after: Long, limit: Int): List<AdminAuditEntry> =
+            records.filter { it.seq > after }.take(limit)
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events += event
+        }
+        override fun publishEvent(event: ApplicationEvent) {
+            events += event
+        }
+    }
+
+    private class FixedTickClock(private val tick: Long) : TickClock {
+        override fun currentTick(): Long = tick
+    }
+
+    private class SingleSkillLookup(private val only: Skill) : SkillLookup {
+        override fun byId(id: SkillId): Skill? = if (id == only.id) only else null
+        override fun all(): List<Skill> = listOf(only)
+    }
+
+    private class SinglePerkLookup(private val only: Perk) : PerkLookup {
+        override fun byId(id: PerkId): Perk? = if (id == only.id) only else null
+        override fun choicesAt(skill: SkillId, milestoneLevel: Int) = null
+        override fun choicesFor(skill: SkillId) = emptyList<dev.gvart.genesara.player.PerkChoice>()
+        override fun all(): List<Perk> = listOf(only)
+    }
+
+    private object NoopSafeNodeGateway : AgentSafeNodeGateway {
+        override fun set(agentId: AgentId, nodeId: NodeId, tick: Long) {}
+        override fun find(agentId: AgentId): NodeId? = null
+        override fun clear(agentId: AgentId) {}
+    }
+
+    private class StubWorld : WorldQueryGateway {
+        override fun locationOf(agent: AgentId): NodeId? = null
+        override fun activePositionOf(agent: AgentId): NodeId? = null
+        override fun bodyOf(agent: AgentId): BodyView? = null
+        override fun node(id: NodeId): Node? = null
+        override fun region(id: RegionId): Region? = null
+        override fun nodesWithin(origin: NodeId, radius: Int): Set<NodeId> = emptySet()
+        override fun randomSpawnableNode(): NodeId? = null
+        override fun starterNodeFor(race: RaceId): NodeId? = null
+        override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
+        override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId): List<GroundItemView> = emptyList()
+        override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> = emptyMap()
+    }
+
+    private class InMemoryBehaviorTracker : BehaviorTracker {
+        private val counts = mutableMapOf<AgentId, MutableMap<ActionCategory, Int>>()
+        override fun record(agent: AgentId, category: ActionCategory, tick: Long) {
+            counts.getOrPut(agent) { mutableMapOf() }.merge(category, 1, Int::plus)
+        }
+        override fun snapshotFor(agent: AgentId): Map<ActionCategory, Int> = counts[agent] ?: emptyMap()
+        override fun markBaseline(agent: AgentId) {}
+        override fun snapshotForWindow(agent: AgentId): Map<ActionCategory, Int> = counts[agent] ?: emptyMap()
+    }
+
+    private class StubClassLookup(private val byId: Map<AgentClass, ClassDefinition>) : ClassLookup by NoOpClassLookup {
+        constructor(vararg defs: ClassDefinition) : this(defs.associateBy { it.id })
+        override fun byId(classId: AgentClass): ClassDefinition? = byId[classId]
+        override fun baseClasses(): List<ClassDefinition> = byId.values.toList()
+    }
+
+    private fun classFor(id: AgentClass, multipliers: Map<String, Double>): ClassDefinition =
+        ClassDefinition(
+            id = id,
+            displayName = id.name,
+            description = "",
+            sightRange = 3,
+            primarySkills = emptySet(),
+            neutralSkills = emptySet(),
+            forbiddenCombatSkills = emptySet(),
+            damageMultipliers = emptyMap(),
+            behaviorFingerprint = multipliers,
+        )
+}

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentPerksRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentPerksRegistry.kt
@@ -12,6 +12,13 @@ interface AgentPerksRegistry {
 
     /** Skill + milestone are derived from the catalog entry, so callers cannot mismatch them. */
     fun recordChoice(agent: AgentId, perk: PerkId, tick: Long): RecordPerkResult
+
+    /**
+     * Admin override: remove the (agent, perk) row regardless of the "perks are
+     * forever" rule. Returns true when a row was deleted.
+     */
+    fun adminRevoke(agent: AgentId, perk: PerkId): Boolean =
+        throw NotImplementedError("adminRevoke not implemented for this AgentPerksRegistry")
 }
 
 data class AgentPerksSnapshot(val perks: List<AgentPerk>)

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentRegistry.kt
@@ -139,6 +139,52 @@ interface AgentRegistry {
     fun assignEvolution(agentId: AgentId, evolutionId: AgentClass): AssignEvolutionOutcome =
         throw NotImplementedError("assignEvolution not implemented for this AgentRegistry")
 
+    /**
+     * Admin override: set [agentId]'s level directly to [level], recomputing `xp_to_next`
+     * via the linear `level * XP_PER_LEVEL` rule and clamping `xp_current` to the new
+     * `xp_to_next`. Bypasses the L10/L50 progression caps — use [reopenClassOffers] /
+     * [reopenEvolutionOffers] separately to re-trigger choice gates.
+     *
+     * Returns the resulting [Agent] snapshot, or null when the row is missing.
+     */
+    fun adminSetLevel(agentId: AgentId, level: Int): Agent? =
+        throw NotImplementedError("adminSetLevel not implemented for this AgentRegistry")
+
+    /**
+     * Admin override: set [agentId]'s attribute columns to the supplied absolute values.
+     * Any null entry leaves the matching column untouched. Recomputes derived pools and
+     * refreshes the agent profile. Returns the resulting [Agent] snapshot, or null when
+     * the row is missing.
+     */
+    fun adminSetAttributes(agentId: AgentId, set: AdminAttributeOverrides): Agent? =
+        throw NotImplementedError("adminSetAttributes not implemented for this AgentRegistry")
+
+    /**
+     * Admin override: write [classId] to `agents.class_id` regardless of the pending
+     * offer or current class state. Clears any pending L10 offer columns. Used when the
+     * operator overrides the agent's choice gate. Returns the resulting [Agent]
+     * snapshot, or null when the row is missing.
+     */
+    fun adminAssignClass(agentId: AgentId, classId: AgentClass): Agent? =
+        throw NotImplementedError("adminAssignClass not implemented for this AgentRegistry")
+
+    /**
+     * Admin override: clear `class_id` + all pending offer columns so the L10/L50
+     * emitter can be re-invoked. Returns the resulting [Agent] snapshot, or null
+     * when the row is missing.
+     */
+    fun adminClearClassAndOffers(agentId: AgentId): Agent? =
+        throw NotImplementedError("adminClearClassAndOffers not implemented for this AgentRegistry")
+
+    /**
+     * Admin override: clear the pending L10 + L50 offer columns only, leaving
+     * `class_id` untouched. Lets the emitters re-score on the next call without
+     * un-classing the agent. Returns the resulting [Agent] snapshot, or null when
+     * the row is missing.
+     */
+    fun adminClearPendingOffers(agentId: AgentId): Agent? =
+        throw NotImplementedError("adminClearPendingOffers not implemented for this AgentRegistry")
+
     /** Atomic clamp-add on `agents.authority` under a `forUpdate` row lock. Returns null for an unknown agent. */
     fun adjustAuthority(agentId: AgentId, delta: Int): Int? =
         throw NotImplementedError("adjustAuthority not implemented for this AgentRegistry")
@@ -252,6 +298,21 @@ sealed interface AllocateAttributesOutcome {
 
 /** A single (attribute, milestone) pair crossed by an allocation. */
 data class AttributeMilestoneCrossing(val attribute: Attribute, val milestone: Int)
+
+/**
+ * Absolute overrides for [AgentRegistry.adminSetAttributes]. Null fields leave the
+ * corresponding column untouched. All non-null values must be >= [AgentAttributes.MIN_ATTRIBUTE]
+ * for the six attribute fields and >= 0 for [unspent].
+ */
+data class AdminAttributeOverrides(
+    val strength: Int? = null,
+    val dexterity: Int? = null,
+    val constitution: Int? = null,
+    val perception: Int? = null,
+    val intelligence: Int? = null,
+    val luck: Int? = null,
+    val unspent: Int? = null,
+)
 
 /** Result of [AgentRegistry.addCharacterXp]. */
 sealed interface AddCharacterXpOutcome {

--- a/player/src/main/kotlin/dev/gvart/genesara/player/AgentSkillsRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/AgentSkillsRegistry.kt
@@ -68,6 +68,21 @@ interface AgentSkillsRegistry {
     fun maybeRecommend(agent: AgentId, skill: SkillId, tick: Long): Int?
 
     /**
+     * Admin override: upsert (agent, skill) to the given absolute [xp], bypassing the
+     * slot gate that normally guards XP accrual. Reports milestone thresholds (50/100/150)
+     * strictly crossed by an upward change; downward sets report no crossings.
+     */
+    fun adminSetSkillXp(agent: AgentId, skill: SkillId, xp: Int): AdminSkillXpResult =
+        throw NotImplementedError("adminSetSkillXp not implemented for this AgentSkillsRegistry")
+
+    /**
+     * Admin override: remove [skill] from its slot for [agent] regardless of the
+     * "slots are forever" rule. Returns true when a row was deleted.
+     */
+    fun adminForceUnequip(agent: AgentId, skill: SkillId): Boolean =
+        throw NotImplementedError("adminForceUnequip not implemented for this AgentSkillsRegistry")
+
+    /**
      * Place [skill] permanently into [slotIndex]. Validates:
      *  - [slotIndex] is within the agent's computed slot count.
      *  - [skill] exists in the catalog (caller's responsibility — registry trusts).
@@ -119,6 +134,13 @@ sealed interface AddXpResult {
      */
     data class Accrued(val crossedMilestones: List<Int>) : AddXpResult
 }
+
+/** Result of [AgentSkillsRegistry.adminSetSkillXp] — carries final xp + crossed milestones. */
+data class AdminSkillXpResult(
+    val previousXp: Int,
+    val newXp: Int,
+    val crossedMilestones: List<Int>,
+)
 
 /** Why a [AgentSkillsRegistry.setSlot] call was rejected. */
 sealed interface SkillSlotError {

--- a/player/src/main/kotlin/dev/gvart/genesara/player/CharacterXpSource.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/CharacterXpSource.kt
@@ -9,4 +9,5 @@ package dev.gvart.genesara.player
 enum class CharacterXpSource {
     HARVEST,
     CONSUME,
+    ADMIN_GRANT,
 }

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentPerksRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentPerksRegistry.kt
@@ -77,6 +77,13 @@ internal class JooqAgentPerksRegistry(
         RecordPerkResult.MilestoneAlreadyChosen(skill, milestoneLevel, existing)
     }
 
+    @Transactional
+    override fun adminRevoke(agent: AgentId, perk: PerkId): Boolean =
+        dsl.deleteFrom(AGENT_PERKS)
+            .where(AGENT_PERKS.AGENT_ID.eq(agent.id))
+            .and(AGENT_PERKS.PERK_ID.eq(perk.value))
+            .execute() > 0
+
     private fun readExistingPick(agent: AgentId, skill: SkillId, milestoneLevel: Int): PerkId? =
         dsl.select(AGENT_PERKS.PERK_ID)
             .from(AGENT_PERKS)

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistry.kt
@@ -7,6 +7,7 @@ import dev.gvart.genesara.player.AgentClass
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentLastActiveStore
 import dev.gvart.genesara.player.AddCharacterXpOutcome
+import dev.gvart.genesara.player.AdminAttributeOverrides
 import dev.gvart.genesara.player.AgentProfile
 import dev.gvart.genesara.player.AgentProfileRepository
 import dev.gvart.genesara.player.AgentRegistrar
@@ -524,6 +525,114 @@ internal class JooqAgentRegistry(
         Attribute.PERCEPTION -> AGENTS.PERCEPTION
         Attribute.INTELLIGENCE -> AGENTS.INTELLIGENCE
         Attribute.LUCK -> AGENTS.LUCK
+    }
+
+    @Transactional
+    override fun adminSetLevel(agentId: AgentId, level: Int): Agent? {
+        require(level >= INITIAL_LEVEL) { "level must be >= $INITIAL_LEVEL, got $level" }
+        val record = lockAgentRow(agentId) ?: return null
+        val newXpToNext = level * XP_PER_LEVEL
+        val newXpCurrent = record[AGENTS.XP_CURRENT]!!.coerceAtMost(newXpToNext)
+        dsl.update(AGENTS)
+            .set(AGENTS.LEVEL, level)
+            .set(AGENTS.XP_TO_NEXT, newXpToNext)
+            .set(AGENTS.XP_CURRENT, newXpCurrent)
+            .where(AGENTS.ID.eq(agentId.id))
+            .execute()
+        return find(agentId)
+    }
+
+    @Transactional
+    override fun adminSetAttributes(agentId: AgentId, set: AdminAttributeOverrides): Agent? {
+        validateOverrides(set)
+        val record = lockAgentRow(agentId) ?: return null
+        val finalAttrs = AgentAttributes(
+            strength = set.strength ?: record[AGENTS.STRENGTH]!!,
+            dexterity = set.dexterity ?: record[AGENTS.DEXTERITY]!!,
+            constitution = set.constitution ?: record[AGENTS.CONSTITUTION]!!,
+            perception = set.perception ?: record[AGENTS.PERCEPTION]!!,
+            intelligence = set.intelligence ?: record[AGENTS.INTELLIGENCE]!!,
+            luck = set.luck ?: record[AGENTS.LUCK]!!,
+        )
+        val finalUnspent = set.unspent ?: record[AGENTS.UNSPENT_ATTRIBUTE_POINTS]!!
+        dsl.update(AGENTS)
+            .set(AGENTS.STRENGTH, finalAttrs.strength)
+            .set(AGENTS.DEXTERITY, finalAttrs.dexterity)
+            .set(AGENTS.CONSTITUTION, finalAttrs.constitution)
+            .set(AGENTS.PERCEPTION, finalAttrs.perception)
+            .set(AGENTS.INTELLIGENCE, finalAttrs.intelligence)
+            .set(AGENTS.LUCK, finalAttrs.luck)
+            .set(AGENTS.UNSPENT_ATTRIBUTE_POINTS, finalUnspent)
+            .where(AGENTS.ID.eq(agentId.id))
+            .execute()
+
+        val pools = AttributeDerivation.deriveMaxPools(finalAttrs)
+        profiles.save(
+            AgentProfile(
+                id = agentId,
+                maxHp = pools.maxHp,
+                maxStamina = pools.maxStamina,
+                maxMana = pools.maxMana,
+            ),
+        )
+        return find(agentId)
+    }
+
+    private fun validateOverrides(set: AdminAttributeOverrides) {
+        listOf(
+            "strength" to set.strength,
+            "dexterity" to set.dexterity,
+            "constitution" to set.constitution,
+            "perception" to set.perception,
+            "intelligence" to set.intelligence,
+            "luck" to set.luck,
+        ).forEach { (name, value) ->
+            if (value != null) {
+                require(value >= AgentAttributes.MIN_ATTRIBUTE) {
+                    "$name must be >= ${AgentAttributes.MIN_ATTRIBUTE}, got $value"
+                }
+            }
+        }
+        set.unspent?.let { require(it >= 0) { "unspent must be >= 0, got $it" } }
+    }
+
+    @Transactional
+    override fun adminAssignClass(agentId: AgentId, classId: AgentClass): Agent? {
+        lockAgentRow(agentId) ?: return null
+        dsl.update(AGENTS)
+            .set(AGENTS.CLASS_ID, classId.name)
+            .setNull(AGENTS.OFFERED_CLASS_A)
+            .setNull(AGENTS.OFFERED_CLASS_B)
+            .where(AGENTS.ID.eq(agentId.id))
+            .execute()
+        return find(agentId)
+    }
+
+    @Transactional
+    override fun adminClearClassAndOffers(agentId: AgentId): Agent? {
+        lockAgentRow(agentId) ?: return null
+        dsl.update(AGENTS)
+            .setNull(AGENTS.CLASS_ID)
+            .setNull(AGENTS.OFFERED_CLASS_A)
+            .setNull(AGENTS.OFFERED_CLASS_B)
+            .setNull(AGENTS.OFFERED_EVOLUTION_A)
+            .setNull(AGENTS.OFFERED_EVOLUTION_B)
+            .where(AGENTS.ID.eq(agentId.id))
+            .execute()
+        return find(agentId)
+    }
+
+    @Transactional
+    override fun adminClearPendingOffers(agentId: AgentId): Agent? {
+        lockAgentRow(agentId) ?: return null
+        dsl.update(AGENTS)
+            .setNull(AGENTS.OFFERED_CLASS_A)
+            .setNull(AGENTS.OFFERED_CLASS_B)
+            .setNull(AGENTS.OFFERED_EVOLUTION_A)
+            .setNull(AGENTS.OFFERED_EVOLUTION_B)
+            .where(AGENTS.ID.eq(agentId.id))
+            .execute()
+        return find(agentId)
     }
 
     @Transactional

--- a/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentSkillsRegistry.kt
+++ b/player/src/main/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentSkillsRegistry.kt
@@ -1,6 +1,7 @@
 package dev.gvart.genesara.player.internal.store
 
 import dev.gvart.genesara.player.AddXpResult
+import dev.gvart.genesara.player.AdminSkillXpResult
 import dev.gvart.genesara.player.AgentId
 import dev.gvart.genesara.player.AgentSkillsRegistry
 import dev.gvart.genesara.player.AgentSkillState
@@ -185,6 +186,22 @@ internal class JooqAgentSkillsRegistry(
             .set(AGENT_SKILL_RECOMMENDATIONS.LAST_RECOMMENDED_AT_TICK, tick)
             .execute()
     }
+
+    @Transactional
+    override fun adminSetSkillXp(agent: AgentId, skill: SkillId, xp: Int): AdminSkillXpResult {
+        require(xp >= 0) { "xp must be non-negative; got $xp" }
+        val oldXp = readSkillXp(agent, skill)
+        upsertSkillXp(agent, skill, xp)
+        val crossed = if (xp > oldXp) MILESTONE_THRESHOLDS.filter { it in (oldXp + 1)..xp } else emptyList()
+        return AdminSkillXpResult(previousXp = oldXp, newXp = xp, crossedMilestones = crossed)
+    }
+
+    @Transactional
+    override fun adminForceUnequip(agent: AgentId, skill: SkillId): Boolean =
+        dsl.deleteFrom(AGENT_SKILL_SLOTS)
+            .where(AGENT_SKILL_SLOTS.AGENT_ID.eq(agent.id))
+            .and(AGENT_SKILL_SLOTS.SKILL_ID.eq(skill.value))
+            .execute() > 0
 
     @Transactional
     override fun setSlot(agent: AgentId, skill: SkillId, slotIndex: Int): SkillSlotError? {

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentPerksRegistryIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentPerksRegistryIntegrationTest.kt
@@ -133,6 +133,21 @@ class JooqAgentPerksRegistryIntegrationTest {
     }
 
     @Test
+    fun `adminRevoke removes the perk row and returns true`() {
+        assertEquals(RecordPerkResult.Recorded, registry.recordChoice(agent, bleeder.id, tick = 0L))
+
+        val removed = registry.adminRevoke(agent, bleeder.id)
+
+        assertEquals(true, removed)
+        assertEquals(emptyList(), registry.snapshot(agent).perks)
+    }
+
+    @Test
+    fun `adminRevoke returns false when the perk row does not exist`() {
+        assertEquals(false, registry.adminRevoke(agent, bleeder.id))
+    }
+
+    @Test
     fun `snapshot orders rows by skill ascending then milestone ascending`() {
         val bowQuickDraw = stubPerk(
             id = "BOW_QUICK_DRAW",

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryAdminIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryAdminIntegrationTest.kt
@@ -1,0 +1,231 @@
+package dev.gvart.genesara.player.internal.store
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AdminAttributeOverrides
+import dev.gvart.genesara.player.AgentClass
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentProfile
+import dev.gvart.genesara.player.AgentProfileRepository
+import dev.gvart.genesara.player.AttributeMods
+import dev.gvart.genesara.player.ClassOffer
+import dev.gvart.genesara.player.NoOpClassLookup
+import dev.gvart.genesara.player.Race
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.player.RaceLookup
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENTS
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENT_PROFILES
+import dev.gvart.genesara.player.internal.race.RaceAssigner
+import dev.gvart.genesara.player.internal.race.RaceDefinitionProperties
+import dev.gvart.genesara.player.internal.race.RandomSource
+import dev.gvart.genesara.player.internal.testsupport.PlayerFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@Testcontainers
+class JooqAgentRegistryAdminIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("admin_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = PlayerFlyway.pooledDataSource(postgres)
+            PlayerFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private val owner = PlayerId(UUID.randomUUID())
+
+    @BeforeEach
+    fun resetTables() {
+        dsl.truncate(AGENT_PROFILES).cascade().execute()
+        dsl.truncate(AGENTS).cascade().execute()
+    }
+
+    @Test
+    fun `adminSetLevel writes level, recomputes xpToNext, clamps xpCurrent`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Levelable")
+        dsl.update(AGENTS)
+            .set(AGENTS.XP_CURRENT, 9_999)
+            .where(AGENTS.ID.eq(agent.id.id))
+            .execute()
+
+        val updated = assertNotNull(registry.adminSetLevel(agent.id, 7))
+
+        assertEquals(7, updated.level)
+        assertEquals(700, updated.xpToNext)
+        assertEquals(700, updated.xpCurrent)
+    }
+
+    @Test
+    fun `adminSetLevel returns null for an unknown agent`() {
+        val registry = registry()
+        assertNull(registry.adminSetLevel(AgentId(UUID.randomUUID()), 5))
+    }
+
+    @Test
+    fun `adminSetAttributes writes overrides and recomputes derived pools`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Statter")
+
+        val updated = assertNotNull(
+            registry.adminSetAttributes(
+                agent.id,
+                AdminAttributeOverrides(strength = 12, constitution = 8, unspent = 4),
+            ),
+        )
+
+        assertEquals(12, updated.attributes.strength)
+        assertEquals(8, updated.attributes.constitution)
+        assertEquals(4, updated.unspentAttributePoints)
+        val profile = readProfile(agent.id)
+        assertTrue(profile[AGENT_PROFILES.MAX_HP]!! > 0)
+    }
+
+    @Test
+    fun `adminSetAttributes leaves untouched columns alone`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Partial")
+        val beforeDex = agent.attributes.dexterity
+
+        val updated = assertNotNull(registry.adminSetAttributes(agent.id, AdminAttributeOverrides(strength = 20)))
+
+        assertEquals(20, updated.attributes.strength)
+        assertEquals(beforeDex, updated.attributes.dexterity)
+    }
+
+    @Test
+    fun `adminAssignClass writes class and clears the pending class offer`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Pickable")
+        registry.recordPendingClassChoice(agent.id, ClassOffer(AgentClass.SOLDIER, AgentClass.SCOUT))
+
+        val updated = assertNotNull(registry.adminAssignClass(agent.id, AgentClass.RESEARCHER))
+
+        assertEquals(AgentClass.RESEARCHER, updated.classId)
+        assertNull(updated.offeredClasses)
+    }
+
+    @Test
+    fun `adminAssignClass overrides an already-classed agent`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Reclassable")
+        dsl.update(AGENTS)
+            .set(AGENTS.CLASS_ID, AgentClass.SOLDIER.name)
+            .where(AGENTS.ID.eq(agent.id.id))
+            .execute()
+
+        val updated = assertNotNull(registry.adminAssignClass(agent.id, AgentClass.HUNTER))
+
+        assertEquals(AgentClass.HUNTER, updated.classId)
+    }
+
+    @Test
+    fun `adminClearPendingOffers clears offer columns but keeps class_id`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Stuck")
+        dsl.update(AGENTS)
+            .set(AGENTS.CLASS_ID, AgentClass.SOLDIER.name)
+            .set(AGENTS.OFFERED_EVOLUTION_A, AgentClass.HEAVY_SOLDIER.name)
+            .set(AGENTS.OFFERED_EVOLUTION_B, AgentClass.STEALTH_SOLDIER.name)
+            .where(AGENTS.ID.eq(agent.id.id))
+            .execute()
+
+        val updated = assertNotNull(registry.adminClearPendingOffers(agent.id))
+
+        assertEquals(AgentClass.SOLDIER, updated.classId)
+        assertNull(updated.offeredClasses)
+        assertNull(updated.offeredEvolutions)
+    }
+
+    @Test
+    fun `adminClearClassAndOffers clears class and both offer pairs`() {
+        val registry = registry()
+        val agent = registry.register(owner, "Reset")
+        dsl.update(AGENTS)
+            .set(AGENTS.CLASS_ID, AgentClass.SOLDIER.name)
+            .set(AGENTS.OFFERED_EVOLUTION_A, AgentClass.HEAVY_SOLDIER.name)
+            .set(AGENTS.OFFERED_EVOLUTION_B, AgentClass.STEALTH_SOLDIER.name)
+            .where(AGENTS.ID.eq(agent.id.id))
+            .execute()
+
+        val updated = assertNotNull(registry.adminClearClassAndOffers(agent.id))
+
+        assertNull(updated.classId)
+        assertNull(updated.offeredClasses)
+        assertNull(updated.offeredEvolutions)
+    }
+
+    private fun registry(): JooqAgentRegistry {
+        val race = Race(
+            id = RaceId("test_race"),
+            displayName = "Test",
+            weight = 1,
+            attributeMods = AttributeMods.NONE,
+            description = "",
+        )
+        val lookup = SingleRaceLookup(race)
+        val props = RaceDefinitionProperties(defaultId = race.id.value)
+        val assigner = RaceAssigner(lookup, props, FixedRandom)
+        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner, NoOpClassLookup)
+    }
+
+    private fun readProfile(id: AgentId) =
+        assertNotNull(dsl.selectFrom(AGENT_PROFILES).where(AGENT_PROFILES.AGENT_ID.eq(id.id)).fetchOne())
+
+    private class SingleRaceLookup(private val race: Race) : RaceLookup {
+        override fun byId(id: RaceId): Race? = if (id == race.id) race else null
+        override fun all(): List<Race> = listOf(race)
+    }
+
+    private object FixedRandom : RandomSource {
+        override fun nextInt(boundExclusive: Int): Int = 0
+    }
+
+    private class JooqProfileRepository(private val dsl: DSLContext) : AgentProfileRepository {
+        override fun save(profile: AgentProfile) {
+            dsl.insertInto(AGENT_PROFILES)
+                .set(AGENT_PROFILES.AGENT_ID, profile.id.id)
+                .set(AGENT_PROFILES.MAX_HP, profile.maxHp)
+                .set(AGENT_PROFILES.MAX_STAMINA, profile.maxStamina)
+                .set(AGENT_PROFILES.MAX_MANA, profile.maxMana)
+                .onConflict(AGENT_PROFILES.AGENT_ID)
+                .doUpdate()
+                .set(AGENT_PROFILES.MAX_HP, profile.maxHp)
+                .set(AGENT_PROFILES.MAX_STAMINA, profile.maxStamina)
+                .set(AGENT_PROFILES.MAX_MANA, profile.maxMana)
+                .execute()
+        }
+    }
+}

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentSkillsRegistryIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentSkillsRegistryIntegrationTest.kt
@@ -349,6 +349,49 @@ class JooqAgentSkillsRegistryIntegrationTest {
         assertEquals(7, registry.slottedSkillLevel(agent, foraging))
     }
 
+    @Test
+    fun `adminSetSkillXp upserts XP regardless of slot state and reports crossed milestones`() {
+        val result = registry.adminSetSkillXp(agent, foraging, xp = 110)
+
+        assertEquals(0, result.previousXp)
+        assertEquals(110, result.newXp)
+        assertEquals(listOf(50, 100), result.crossedMilestones)
+        val xp = dsl.select(AGENT_SKILLS.XP)
+            .from(AGENT_SKILLS)
+            .where(AGENT_SKILLS.AGENT_ID.eq(agent.id))
+            .and(AGENT_SKILLS.SKILL_ID.eq(foraging.value))
+            .fetchOne(AGENT_SKILLS.XP)
+        assertEquals(110, xp)
+    }
+
+    @Test
+    fun `adminSetSkillXp overwrites an existing XP row downward without reporting milestones`() {
+        registry.adminSetSkillXp(agent, foraging, xp = 200)
+
+        val result = registry.adminSetSkillXp(agent, foraging, xp = 30)
+
+        assertEquals(200, result.previousXp)
+        assertEquals(30, result.newXp)
+        assertEquals(emptyList(), result.crossedMilestones)
+    }
+
+    @Test
+    fun `adminForceUnequip removes the slot row and returns true`() {
+        recommend(foraging)
+        assertNull(registry.setSlot(agent, foraging, slotIndex = 0))
+
+        val removed = registry.adminForceUnequip(agent, foraging)
+
+        assertTrue(removed)
+        val rows = dsl.fetchCount(AGENT_SKILL_SLOTS, AGENT_SKILL_SLOTS.AGENT_ID.eq(agent.id))
+        assertEquals(0, rows)
+    }
+
+    @Test
+    fun `adminForceUnequip returns false when there is nothing to remove`() {
+        assertEquals(false, registry.adminForceUnequip(agent, foraging))
+    }
+
     private fun createAgent(level: Int): AgentId {
         val id = AgentId(UUID.randomUUID())
         dsl.insertInto(AGENTS)


### PR DESCRIPTION
## Summary
- Adds `AgentAdminController` under `/admin/agents/{id}` mirroring `AgentDetailController`, plus the ten endpoints from the spec (GET detail; POST xp/level/attributes; POST/DELETE skills/{skillId}; POST/DELETE perks/{perkId}; POST class; POST class/offers).
- Adds the necessary public `:player` gateway surfaces (`AgentRegistry.adminSetLevel`/`adminSetAttributes`/`adminAssignClass`/`adminClearClassAndOffers`/`adminClearPendingOffers`; `AgentSkillsRegistry.adminSetSkillXp`/`adminForceUnequip`; `AgentPerksRegistry.adminRevoke`) — no `internal/*` imports from `:player`.
- Force overrides (`/level`, `/attributes`, DELETE skill, DELETE perk, set class, reopen offers) stamp `force=true` in the audit payload; DELETE skill response carries a `warning` field. Every mutation writes an `admin_audit_log` row.
- RFC 7807 ProblemDetail via `ResponseStatusException`.
- Adds `CharacterXpSource.ADMIN_GRANT` to tag operator-issued XP grants on the `CharacterXpGained` event.

## Endpoint → audit action map
| Endpoint | Action | force flag |
| --- | --- | --- |
| POST `/xp` | `agent.xp_granted` | — |
| POST `/level` | `agent.level_set` | yes |
| POST `/attributes` | `agent.attributes_set` | — |
| POST `/skills/{id}` | `agent.skill_set` | — |
| DELETE `/skills/{id}` | `agent.skill_force_unequipped` | yes |
| POST `/perks/{id}` | `agent.perk_granted` | — |
| DELETE `/perks/{id}` | `agent.perk_revoked` | yes |
| POST `/class` | `agent.class_set` | yes |
| POST `/class/offers` | `agent.class_offers_reopened` | yes |

## Test plan
- [x] `./gradlew :api:test` — 20 MockMvc round-trips through `AgentAdminControllerTest` cover every verb, capture published `AgentEvent.*` and `admin_audit_log` writes
- [x] `./gradlew :player:test` — Testcontainers integration tests for the new `JooqAgentRegistry` / `JooqAgentSkillsRegistry` / `JooqAgentPerksRegistry` admin methods

## Deviations
- `CharacterXpSource` gained an `ADMIN_GRANT` variant because the issue spec said "via `CharacterXpSource`" and neither HARVEST nor CONSUME fits operator grants.
- `force=true` is also stamped on `/level` and `/class/offers` payloads (spec required it only on skill DELETE and class set); kept for audit consistency on every override-style mutation.
- `/class/offers` re-opens by clearing the pending offer columns and re-invoking `Level10ChoiceEmitter` (when unclassed) or `Level50EvolutionEmitter` (when on a base class at L50+). Keeps `class_id` intact for the L50 path.

Closes #203