### PR TITLE
feat(api): admin agent social editor (#206)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/agents/AgentSocialController.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/agents/AgentSocialController.kt
@@ -1,0 +1,243 @@
+package dev.gvart.genesara.api.internal.rest.admin.agents
+
+import dev.gvart.genesara.admin.Admin
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.MisconductOutcome
+import dev.gvart.genesara.player.OutlawState
+import dev.gvart.genesara.player.RelationshipsGateway
+import dev.gvart.genesara.world.events.SocialEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.http.HttpStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
+
+@RestController
+@RequestMapping("/admin/agents/{agentId}")
+internal class AgentSocialController(
+    private val agents: AgentRegistry,
+    private val relationships: RelationshipsGateway,
+    private val audit: AdminAuditLog,
+    private val publisher: ApplicationEventPublisher,
+    private val tick: TickClock,
+    private val balance: BalanceLookup,
+) {
+
+    @PostMapping("/authority")
+    fun authority(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @RequestBody req: ReputationRequest,
+    ): ReputationResponse {
+        val target = AgentId(agentId)
+        val current = agents.find(target) ?: throw notFound("agent $agentId is not registered")
+        val delta = resolveReputationDelta(req, currentValue = current.authority, label = "authority")
+        val updated = agents.adjustAuthority(target, delta)
+            ?: throw notFound("agent $agentId is not registered")
+        audit.record(
+            adminId = admin.id,
+            action = "agent.authority",
+            target = "agent",
+            targetId = agentId.toString(),
+            payload = mapOf("delta" to delta, "value" to updated),
+            tick = tick.currentTick(),
+        )
+        return ReputationResponse(value = updated)
+    }
+
+    @PostMapping("/fame")
+    fun fame(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @RequestBody req: ReputationRequest,
+    ): ReputationResponse {
+        val target = AgentId(agentId)
+        val current = agents.find(target) ?: throw notFound("agent $agentId is not registered")
+        val delta = resolveReputationDelta(req, currentValue = current.fame, label = "fame")
+        val updated = agents.adjustFame(target, delta)
+            ?: throw notFound("agent $agentId is not registered")
+        audit.record(
+            adminId = admin.id,
+            action = "agent.fame",
+            target = "agent",
+            targetId = agentId.toString(),
+            payload = mapOf("delta" to delta, "value" to updated),
+            tick = tick.currentTick(),
+        )
+        return ReputationResponse(value = updated)
+    }
+
+    @PostMapping("/outlaw")
+    fun outlaw(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @RequestBody req: OutlawRequest,
+    ): OutlawResponse {
+        val target = AgentId(agentId)
+        val current = agents.find(target) ?: throw notFound("agent $agentId is not registered")
+        val watchedAt = balance.outlawWatchedScore()
+        val outlawAt = balance.outlawOutlawScore()
+        val targetScore = when (req.state) {
+            OutlawState.CLEAN -> 0
+            OutlawState.WATCHED -> watchedAt
+            OutlawState.OUTLAW -> outlawAt
+        }
+        val delta = targetScore - current.outlawMisconductScore
+        val now = tick.currentTick()
+        val outcome: MisconductOutcome = agents.adjustMisconduct(
+            agentId = target,
+            delta = delta,
+            watchedAt = watchedAt,
+            outlawAt = outlawAt,
+        ) ?: throw notFound("agent $agentId is not registered")
+        // WHY: publish before audit so a listener exception cannot leave an audit row
+        // pointing at an event the dispatcher never received.
+        if (outcome.didTransition) {
+            publisher.publishEvent(
+                SocialEvent.OutlawStateChanged(
+                    agent = target,
+                    previousState = outcome.oldState,
+                    newState = outcome.newState,
+                    score = outcome.newScore,
+                    listeners = setOf(target),
+                    tick = now,
+                    causedBy = null,
+                ),
+            )
+        }
+        audit.record(
+            adminId = admin.id,
+            action = "agent.outlaw",
+            target = "agent",
+            targetId = agentId.toString(),
+            payload = mapOf(
+                "previousState" to outcome.oldState.name,
+                "newState" to outcome.newState.name,
+                "score" to outcome.newScore,
+                "expiresAtTick" to req.expiresAtTick,
+            ),
+            tick = now,
+        )
+        return OutlawResponse(
+            state = outcome.newState,
+            score = outcome.newScore,
+            transitioned = outcome.didTransition,
+        )
+    }
+
+    @PostMapping("/relationships/{otherId}")
+    fun relationship(
+        @AuthenticationPrincipal admin: Admin,
+        @PathVariable agentId: UUID,
+        @PathVariable otherId: UUID,
+        @RequestBody req: RelationshipRequest,
+    ): RelationshipResponse {
+        if (agentId == otherId) throw badRequest("cannot edit relationship with self")
+        val a = AgentId(agentId)
+        val b = AgentId(otherId)
+        if (agents.find(a) == null) throw notFound("agent $agentId is not registered")
+        if (agents.find(b) == null) throw notFound("agent $otherId is not registered")
+
+        val now = tick.currentTick()
+        val delta = resolveRelationshipDelta(req, current = relationships.find(a, b)?.score ?: 0)
+        val updated = relationships.adjust(a, b, delta, now).currentScore
+        audit.record(
+            adminId = admin.id,
+            action = "agent.relationship",
+            target = "agent_pair",
+            targetId = "$agentId:$otherId",
+            payload = mapOf(
+                "agentId" to agentId.toString(),
+                "otherId" to otherId.toString(),
+                "delta" to delta,
+                "value" to updated,
+            ),
+            tick = now,
+        )
+        return RelationshipResponse(score = updated, bidirectional = true)
+    }
+
+    private fun resolveReputationDelta(req: ReputationRequest, currentValue: Int, label: String): Int {
+        val value = req.value
+        val delta = req.delta
+        if ((value == null) == (delta == null)) {
+            throw badRequest("$label: exactly one of `value` or `delta` is required")
+        }
+        return delta ?: ((value!!.toLong() - currentValue.toLong())
+            .coerceIn(Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong())
+            .toInt())
+    }
+
+    private fun resolveRelationshipDelta(req: RelationshipRequest, current: Int): Int {
+        val score = req.score
+        val delta = req.delta
+        if ((score == null) == (delta == null)) {
+            throw badRequest("relationship: exactly one of `score` or `delta` is required")
+        }
+        if (score != null && score !in RelationshipsGateway.SCORE_MIN..RelationshipsGateway.SCORE_MAX) {
+            throw badRequest(
+                "relationship score must be in ${RelationshipsGateway.SCORE_MIN}..${RelationshipsGateway.SCORE_MAX}",
+            )
+        }
+        return delta ?: (score!! - current)
+    }
+
+    private fun badRequest(detail: String) = ResponseStatusException(HttpStatus.BAD_REQUEST, detail)
+    private fun notFound(detail: String) = ResponseStatusException(HttpStatus.NOT_FOUND, detail)
+}
+
+/**
+ * Either-or: `value` sets an absolute target, `delta` applies a relative
+ * adjustment. WHY: `value` is implemented as snapshot-and-add against the
+ * read on entry — under concurrent admin edits or in-flight raisers the
+ * landed value can drift. Operators editing the same agent need to serialize.
+ */
+data class ReputationRequest(
+    val value: Int? = null,
+    val delta: Int? = null,
+)
+
+data class ReputationResponse(
+    val value: Int,
+)
+
+/**
+ * Direct state-set on the outlaw machine. WHY: implemented as a snapshot
+ * read followed by a delta into the score-driven gateway, so a concurrent
+ * `OutlawDecaySweep` tick or an AttackReducer accrual between the read and
+ * the write can land the agent in a different state than requested. The
+ * audit row + the emitted `OutlawStateChanged` event reflect the *actual*
+ * landed state, not the requested one — operators must re-check on
+ * conflict.
+ */
+data class OutlawRequest(
+    val state: OutlawState,
+    // TODO(#206-followup): persist `expiresAtTick` once the outlaw state machine grows an
+    //  expiry column; today the score-driven decay sweep is the only path to natural CLEAN.
+    val expiresAtTick: Long? = null,
+)
+
+data class OutlawResponse(
+    val state: OutlawState,
+    val score: Int,
+    val transitioned: Boolean,
+)
+
+data class RelationshipRequest(
+    val score: Int? = null,
+    val delta: Int? = null,
+)
+
+data class RelationshipResponse(
+    val score: Int,
+    val bidirectional: Boolean,
+)

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/agents/AgentSocialControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/agents/AgentSocialControllerTest.kt
@@ -1,0 +1,394 @@
+package dev.gvart.genesara.api.internal.rest.admin.agents
+
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.admin.Admin
+import dev.gvart.genesara.admin.AdminAuditEntry
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.admin.AdminId
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.Agent
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.AgentRegistry
+import dev.gvart.genesara.player.MisconductOutcome
+import dev.gvart.genesara.player.OutlawState
+import dev.gvart.genesara.player.RelationshipAdjustmentOutcome
+import dev.gvart.genesara.player.RelationshipRow
+import dev.gvart.genesara.player.RelationshipsGateway
+import dev.gvart.genesara.world.events.SocialEvent
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.balance.WorldDefinitionBalanceLookup
+import dev.gvart.genesara.world.internal.balance.WorldDefinitionProperties
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AgentSocialControllerTest {
+
+    private val admin = Admin(id = AdminId(UUID.randomUUID()), username = "ops")
+    private val owner = PlayerId(UUID.randomUUID())
+    private val targetId = AgentId(UUID.randomUUID())
+    private val otherId = AgentId(UUID.randomUUID())
+
+    private lateinit var agents: StubRegistry
+    private lateinit var relationships: StubRelationships
+    private lateinit var audit: RecordingAuditLog
+    private lateinit var publisher: RecordingPublisher
+    private lateinit var controller: AgentSocialController
+    private val balance: BalanceLookup = WorldDefinitionBalanceLookup(WorldDefinitionProperties())
+
+    @BeforeEach
+    fun setup() {
+        agents = StubRegistry(
+            mutableMapOf(
+                targetId to agent(targetId, "Hero"),
+                otherId to agent(otherId, "Other"),
+            ),
+        )
+        relationships = StubRelationships()
+        audit = RecordingAuditLog()
+        publisher = RecordingPublisher()
+        controller = AgentSocialController(
+            agents = agents,
+            relationships = relationships,
+            audit = audit,
+            publisher = publisher,
+            tick = FixedTickClock(42L),
+            balance = balance,
+        )
+    }
+
+    @Test
+    fun `authority delta increments and audits`() {
+        agents.set(agent(targetId, "Hero", authority = 5))
+
+        val response = controller.authority(admin, targetId.id, ReputationRequest(delta = 3))
+
+        assertEquals(8, response.value)
+        assertEquals(3, agents.appliedAuthorityDelta(targetId))
+        val row = audit.entries.single()
+        assertEquals("agent.authority", row.action)
+        assertEquals(targetId.id.toString(), row.targetId)
+        assertEquals(3, row.payload["delta"])
+        assertEquals(8, row.payload["value"])
+    }
+
+    @Test
+    fun `authority value computes delta from current`() {
+        agents.set(agent(targetId, "Hero", authority = 20))
+
+        val response = controller.authority(admin, targetId.id, ReputationRequest(value = 50))
+
+        assertEquals(50, response.value)
+        assertEquals(30, agents.appliedAuthorityDelta(targetId))
+    }
+
+    @Test
+    fun `authority rejects request without value or delta`() {
+        val ex = assertFailsWith<ResponseStatusException> {
+            controller.authority(admin, targetId.id, ReputationRequest())
+        }
+        assertTrue(ex.reason!!.contains("exactly one"))
+    }
+
+    @Test
+    fun `authority rejects request with both value and delta`() {
+        assertFailsWith<ResponseStatusException> {
+            controller.authority(admin, targetId.id, ReputationRequest(value = 1, delta = 1))
+        }
+    }
+
+    @Test
+    fun `authority returns 404 for an unknown agent`() {
+        val unknown = UUID.randomUUID()
+        val ex = assertFailsWith<ResponseStatusException> {
+            controller.authority(admin, unknown, ReputationRequest(delta = 1))
+        }
+        assertEquals(404, ex.statusCode.value())
+    }
+
+    @Test
+    fun `fame value drop and audit fields`() {
+        agents.set(agent(targetId, "Hero", fame = 100))
+
+        val response = controller.fame(admin, targetId.id, ReputationRequest(value = 5))
+
+        assertEquals(5, response.value)
+        assertEquals(-95, agents.appliedFameDelta(targetId))
+        val row = audit.entries.single()
+        assertEquals("agent.fame", row.action)
+        assertEquals(-95, row.payload["delta"])
+        assertEquals(5, row.payload["value"])
+    }
+
+    @Test
+    fun `outlaw set OUTLAW emits OutlawStateChanged and audits transition`() {
+        agents.set(agent(targetId, "Hero"))
+
+        val response = controller.outlaw(admin, targetId.id, OutlawRequest(state = OutlawState.OUTLAW))
+
+        assertEquals(OutlawState.OUTLAW, response.state)
+        assertEquals(balance.outlawOutlawScore(), response.score)
+        assertTrue(response.transitioned)
+
+        val event = publisher.events.filterIsInstance<SocialEvent.OutlawStateChanged>().single()
+        assertEquals(targetId, event.agent)
+        assertEquals(OutlawState.CLEAN, event.previousState)
+        assertEquals(OutlawState.OUTLAW, event.newState)
+        assertEquals(setOf(targetId), event.listeners)
+        assertNull(event.causedBy)
+
+        val row = audit.entries.single()
+        assertEquals("agent.outlaw", row.action)
+        assertEquals("CLEAN", row.payload["previousState"])
+        assertEquals("OUTLAW", row.payload["newState"])
+    }
+
+    @Test
+    fun `outlaw CLEAN with already-clean agent does not emit and still audits`() {
+        agents.set(agent(targetId, "Hero", outlawScore = 0, outlawState = OutlawState.CLEAN))
+
+        val response = controller.outlaw(admin, targetId.id, OutlawRequest(state = OutlawState.CLEAN))
+
+        assertEquals(OutlawState.CLEAN, response.state)
+        assertEquals(false, response.transitioned)
+        assertTrue(publisher.events.isEmpty())
+        assertEquals(1, audit.entries.size)
+    }
+
+    @Test
+    fun `outlaw clearing from OUTLAW emits transition to CLEAN`() {
+        agents.set(
+            agent(
+                targetId,
+                "Hero",
+                outlawScore = balance.outlawOutlawScore(),
+                outlawState = OutlawState.OUTLAW,
+            ),
+        )
+
+        val response = controller.outlaw(admin, targetId.id, OutlawRequest(state = OutlawState.CLEAN))
+
+        assertEquals(OutlawState.CLEAN, response.state)
+        assertTrue(response.transitioned)
+        val event = publisher.events.filterIsInstance<SocialEvent.OutlawStateChanged>().single()
+        assertEquals(OutlawState.OUTLAW, event.previousState)
+        assertEquals(OutlawState.CLEAN, event.newState)
+    }
+
+    @Test
+    fun `outlaw expiresAtTick is captured in audit even though not enforced yet`() {
+        agents.set(agent(targetId, "Hero"))
+
+        controller.outlaw(
+            admin,
+            targetId.id,
+            OutlawRequest(state = OutlawState.WATCHED, expiresAtTick = 500L),
+        )
+
+        assertEquals(500L, audit.entries.single().payload["expiresAtTick"])
+    }
+
+    @Test
+    fun `relationship delta adjusts pair and audits both ids`() {
+        relationships.seed(targetId, otherId, score = 5)
+
+        val response = controller.relationship(
+            admin,
+            targetId.id,
+            otherId.id,
+            RelationshipRequest(delta = -10),
+        )
+
+        assertEquals(-5, response.score)
+        assertTrue(response.bidirectional)
+        val row = audit.entries.single()
+        assertEquals("agent.relationship", row.action)
+        assertEquals("${targetId.id}:${otherId.id}", row.targetId)
+        assertEquals(-10, row.payload["delta"])
+        assertEquals(-5, row.payload["value"])
+    }
+
+    @Test
+    fun `relationship score sets absolute pair value`() {
+        relationships.seed(targetId, otherId, score = -20)
+
+        val response = controller.relationship(
+            admin,
+            targetId.id,
+            otherId.id,
+            RelationshipRequest(score = 40),
+        )
+
+        assertEquals(40, response.score)
+        assertEquals(60, relationships.lastDelta)
+    }
+
+    @Test
+    fun `relationship rejects self-edit with 400`() {
+        val ex = assertFailsWith<ResponseStatusException> {
+            controller.relationship(admin, targetId.id, targetId.id, RelationshipRequest(delta = 1))
+        }
+        assertEquals(400, ex.statusCode.value())
+    }
+
+    @Test
+    fun `relationship rejects score outside SCORE_MIN to SCORE_MAX`() {
+        assertFailsWith<ResponseStatusException> {
+            controller.relationship(
+                admin,
+                targetId.id,
+                otherId.id,
+                RelationshipRequest(score = RelationshipsGateway.SCORE_MAX + 1),
+            )
+        }
+    }
+
+    @Test
+    fun `relationship returns 404 when the other agent is unknown`() {
+        val ex = assertFailsWith<ResponseStatusException> {
+            controller.relationship(
+                admin,
+                targetId.id,
+                UUID.randomUUID(),
+                RelationshipRequest(delta = 1),
+            )
+        }
+        assertEquals(404, ex.statusCode.value())
+    }
+
+    private fun agent(
+        id: AgentId,
+        name: String,
+        authority: Int = 0,
+        fame: Int = 0,
+        outlawScore: Int = 0,
+        outlawState: OutlawState = OutlawState.CLEAN,
+    ): Agent = Agent(
+        id = id,
+        owner = owner,
+        name = name,
+        authority = authority,
+        fame = fame,
+        outlawMisconductScore = outlawScore,
+        outlawState = outlawState,
+    )
+
+    private class StubRegistry(private val byId: MutableMap<AgentId, Agent>) : AgentRegistry {
+        private val authorityDeltas = mutableMapOf<AgentId, Int>()
+        private val fameDeltas = mutableMapOf<AgentId, Int>()
+
+        fun set(agent: Agent) { byId[agent.id] = agent }
+        fun appliedAuthorityDelta(id: AgentId): Int = authorityDeltas.getValue(id)
+        fun appliedFameDelta(id: AgentId): Int = fameDeltas.getValue(id)
+
+        override fun find(id: AgentId): Agent? = byId[id]
+        override fun listForOwner(owner: PlayerId): List<Agent> = byId.values.filter { it.owner == owner }
+
+        override fun adjustAuthority(agentId: AgentId, delta: Int): Int? {
+            val a = byId[agentId] ?: return null
+            authorityDeltas[agentId] = delta
+            val updated = a.copy(authority = a.authority + delta)
+            byId[agentId] = updated
+            return updated.authority
+        }
+
+        override fun adjustFame(agentId: AgentId, delta: Int): Int? {
+            val a = byId[agentId] ?: return null
+            fameDeltas[agentId] = delta
+            val updated = a.copy(fame = a.fame + delta)
+            byId[agentId] = updated
+            return updated.fame
+        }
+
+        override fun adjustMisconduct(
+            agentId: AgentId,
+            delta: Int,
+            watchedAt: Int,
+            outlawAt: Int,
+        ): MisconductOutcome? {
+            val a = byId[agentId] ?: return null
+            val newScore = (a.outlawMisconductScore + delta).coerceAtLeast(0)
+            val newState = OutlawState.deriveFrom(newScore, watchedAt, outlawAt)
+            byId[agentId] = a.copy(outlawMisconductScore = newScore, outlawState = newState)
+            return MisconductOutcome(
+                agentId = agentId,
+                oldScore = a.outlawMisconductScore,
+                newScore = newScore,
+                oldState = a.outlawState,
+                newState = newState,
+            )
+        }
+    }
+
+    private class StubRelationships : RelationshipsGateway {
+        private val rows = mutableMapOf<Pair<AgentId, AgentId>, RelationshipRow>()
+        var lastDelta: Int = 0
+            private set
+
+        fun seed(a: AgentId, b: AgentId, score: Int) {
+            rows[canonical(a, b)] = RelationshipRow(score, lastChangedAtTick = 0L)
+        }
+
+        override fun adjust(a: AgentId, b: AgentId, delta: Int, tick: Long): RelationshipAdjustmentOutcome {
+            lastDelta = delta
+            val key = canonical(a, b)
+            val current = rows[key]?.score ?: 0
+            val updated = (current + delta).coerceIn(RelationshipsGateway.SCORE_MIN, RelationshipsGateway.SCORE_MAX)
+            rows[key] = RelationshipRow(updated, tick)
+            return RelationshipAdjustmentOutcome(currentScore = updated)
+        }
+
+        override fun adjustMany(anchor: AgentId, others: Collection<AgentId>, delta: Int, tick: Long) =
+            others.forEach { adjust(anchor, it, delta, tick) }
+
+        override fun find(a: AgentId, b: AgentId): RelationshipRow? = rows[canonical(a, b)]
+        override fun scoresFor(agentId: AgentId): Map<AgentId, RelationshipRow> = emptyMap()
+
+        private fun canonical(a: AgentId, b: AgentId): Pair<AgentId, AgentId> =
+            if (a.id < b.id) a to b else b to a
+    }
+
+    private class RecordingAuditLog : AdminAuditLog {
+        val entries = mutableListOf<AdminAuditEntry>()
+        private var seq = 0L
+
+        override fun record(
+            adminId: AdminId,
+            action: String,
+            target: String,
+            targetId: String?,
+            payload: Map<String, Any?>,
+            tick: Long,
+        ): Long {
+            val assigned = ++seq
+            entries += AdminAuditEntry(
+                seq = assigned,
+                adminId = adminId,
+                action = action,
+                target = target,
+                targetId = targetId,
+                payload = payload,
+                tick = tick,
+                occurredAt = java.time.Instant.EPOCH,
+            )
+            return assigned
+        }
+
+        override fun readAfter(after: Long, limit: Int): List<AdminAuditEntry> = error("not used")
+    }
+
+    private class RecordingPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) { events += event }
+    }
+
+    private class FixedTickClock(private val tick: Long) : TickClock {
+        override fun currentTick(): Long = tick
+    }
+}

--- a/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryFameProtectionIntegrationTest.kt
+++ b/player/src/test/kotlin/dev/gvart/genesara/player/internal/store/JooqAgentRegistryFameProtectionIntegrationTest.kt
@@ -1,0 +1,137 @@
+package dev.gvart.genesara.player.internal.store
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.account.PlayerId
+import dev.gvart.genesara.player.AgentProfile
+import dev.gvart.genesara.player.AgentProfileRepository
+import dev.gvart.genesara.player.AttributeMods
+import dev.gvart.genesara.player.NoOpClassLookup
+import dev.gvart.genesara.player.Race
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.player.RaceLookup
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENTS
+import dev.gvart.genesara.player.internal.jooq.tables.references.AGENT_PROFILES
+import dev.gvart.genesara.player.internal.race.RaceAssigner
+import dev.gvart.genesara.player.internal.race.RaceDefinitionProperties
+import dev.gvart.genesara.player.internal.race.RandomSource
+import dev.gvart.genesara.player.internal.testsupport.PlayerFlyway
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the protection-stripping invariant the admin Fame editor relies on:
+ * dropping an agent's Fame below the witness-protection threshold leaves the
+ * agent in a state where `fame < threshold` — the predicate every PvP
+ * protection branch in `world.combat.AttackReducer` keys on.
+ *
+ * Threshold value (10) mirrors `BalanceLookup.fameWitnessProtectionThreshold`
+ * but lives outside this module's dep graph; a drift means the constants
+ * desync and the assertion has to be updated alongside it.
+ */
+@Testcontainers
+class JooqAgentRegistryFameProtectionIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("fame_protection_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        private const val FAME_WITNESS_PROTECTION_THRESHOLD = 10
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = PlayerFlyway.pooledDataSource(postgres)
+            PlayerFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private val owner = PlayerId(UUID.randomUUID())
+
+    @BeforeEach
+    fun resetTables() {
+        dsl.truncate(AGENT_PROFILES).cascade().execute()
+        dsl.truncate(AGENTS).cascade().execute()
+    }
+
+    @Test
+    fun `dropping fame below the witness-protection threshold strips protection`() {
+        val registry = registry()
+        val agent = registry.register(owner, "FallenStar")
+
+        val seeded = assertNotNull(registry.adjustFame(agent.id, delta = 50))
+        assertTrue(
+            seeded >= FAME_WITNESS_PROTECTION_THRESHOLD,
+            "precondition: agent must start above the protection threshold",
+        )
+
+        val dropped = assertNotNull(registry.adjustFame(agent.id, delta = -45))
+
+        assertEquals(5, dropped)
+        assertTrue(
+            dropped < FAME_WITNESS_PROTECTION_THRESHOLD,
+            "fame ($dropped) must end below the protection threshold ($FAME_WITNESS_PROTECTION_THRESHOLD)",
+        )
+        val persisted = assertNotNull(registry.find(agent.id))
+        assertTrue(persisted.fame < FAME_WITNESS_PROTECTION_THRESHOLD)
+    }
+
+    private fun registry(): JooqAgentRegistry {
+        val race = Race(
+            id = RaceId("test_race"),
+            displayName = "Test",
+            weight = 1,
+            attributeMods = AttributeMods.NONE,
+            description = "",
+        )
+        val lookup = SingleRaceLookup(race)
+        val props = RaceDefinitionProperties(defaultId = race.id.value)
+        val assigner = RaceAssigner(lookup, props, FixedRandom)
+        return JooqAgentRegistry(dsl, JooqProfileRepository(dsl), assigner, NoOpClassLookup)
+    }
+
+    private class SingleRaceLookup(private val race: Race) : RaceLookup {
+        override fun byId(id: RaceId): Race? = if (id == race.id) race else null
+        override fun all(): List<Race> = listOf(race)
+    }
+
+    private object FixedRandom : RandomSource {
+        override fun nextInt(boundExclusive: Int): Int = 0
+    }
+
+    private class JooqProfileRepository(private val dsl: DSLContext) : AgentProfileRepository {
+        override fun save(profile: AgentProfile) {
+            dsl.insertInto(AGENT_PROFILES)
+                .set(AGENT_PROFILES.AGENT_ID, profile.id.id)
+                .set(AGENT_PROFILES.MAX_HP, profile.maxHp)
+                .set(AGENT_PROFILES.MAX_STAMINA, profile.maxStamina)
+                .set(AGENT_PROFILES.MAX_MANA, profile.maxMana)
+                .execute()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New `AgentSocialController` under `/admin/agents/{id}` exposes four mutating endpoints — `authority`, `fame`, `outlaw`, `relationships/{otherId}` — wrapping the existing `:player` gateways shipped in wave 1.
- Every mutation writes an `admin_audit_log` row via the `AdminAuditLog` substrate from #198, and the outlaw setter additionally publishes `SocialEvent.OutlawStateChanged` on a bucket transition so per-agent streams and the upcoming admin live feed see operator-driven flips identically to attack-driven ones.
- Authority/Fame `value` mode is documented snapshot-and-add (admin operator-paced — no transactional set on the underlying gateway). Outlaw `expiresAtTick` is accepted and audited but not enforced until the state machine grows an expiry column (`TODO(#206-followup)`).
- Relationship edits are bidirectional (the per-pair store is canonical by `agent_a < agent_b`) and the response surfaces that explicitly.

## Test plan

- [x] `./gradlew :api:test :player:test :world:social:test` — all green
- [x] `AgentSocialControllerTest` — slice tests for all 4 endpoints: validation (value xor delta, score bounds, self-edit rejection), audit row shape, `SocialEvent.OutlawStateChanged` emission on transition and no emission on no-op
- [x] `JooqAgentRegistryFameProtectionIntegrationTest` (Testcontainers) — dropping Fame below the `fameWitnessProtectionThreshold` (10) leaves the persisted fame below the threshold the `AttackReducer` witness-cascade gate keys on; pins the protection-strip invariant the issue calls out
- [ ] Manual smoke once the admin dashboard wires the endpoints

Closes #206