### PR TITLE
feat(world,api): admin chest CRUD over chest-shaped buildings

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/ChestAdminController.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/ChestAdminController.kt
@@ -1,0 +1,151 @@
+package dev.gvart.genesara.api.internal.rest.admin.worlds
+
+import dev.gvart.genesara.admin.Admin
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.ChestContentsStore
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldQueryGateway
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
+
+@RestController
+@RequestMapping("/admin/worlds/{worldId}/buildings/{instanceId}/chest")
+internal class ChestAdminController(
+    private val buildings: BuildingsStore,
+    private val chestContents: ChestContentsStore,
+    private val world: WorldQueryGateway,
+    private val auditLog: AdminAuditLog,
+    private val tick: TickClock,
+) {
+
+    @GetMapping
+    fun get(
+        @PathVariable worldId: Long,
+        @PathVariable instanceId: UUID,
+    ): ChestContentsDto {
+        val chest = resolveChest(WorldId(worldId), instanceId)
+        return chest.toDto(chestContents.contentsOf(instanceId))
+    }
+
+    @PutMapping
+    fun replace(
+        @PathVariable worldId: Long,
+        @PathVariable instanceId: UUID,
+        @RequestBody req: ReplaceChestContentsRequest,
+        @AuthenticationPrincipal admin: Admin,
+    ): ChestContentsDto {
+        val chest = resolveChest(WorldId(worldId), instanceId)
+        req.contents.forEach { (itemId, qty) ->
+            if (qty <= 0) throw badRequest("quantity for $itemId ($qty) must be positive")
+        }
+        val typed = req.contents.mapKeys { (id, _) -> ItemId(id) }
+        chestContents.replace(instanceId, typed)
+        audit(admin, "chest.replace", instanceId, mapOf(
+            "worldId" to worldId,
+            "nodeId" to chest.nodeId.value,
+            "contents" to req.contents,
+        ))
+        return chest.toDto(chestContents.contentsOf(instanceId))
+    }
+
+    @PatchMapping
+    fun patch(
+        @PathVariable worldId: Long,
+        @PathVariable instanceId: UUID,
+        @RequestBody req: PatchChestContentsRequest,
+        @AuthenticationPrincipal admin: Admin,
+    ): ChestContentsDto {
+        val chest = resolveChest(WorldId(worldId), instanceId)
+        if (req.delta == 0) throw badRequest("delta must be non-zero")
+        val item = ItemId(req.itemId)
+        if (req.delta > 0) {
+            chestContents.add(instanceId, item, req.delta)
+        } else {
+            val removed = chestContents.remove(instanceId, item, -req.delta)
+            if (!removed) {
+                val have = chestContents.quantityOf(instanceId, item)
+                throw badRequest("cannot remove ${-req.delta} of ${req.itemId}: chest holds $have")
+            }
+        }
+        audit(admin, "chest.patch", instanceId, mapOf(
+            "worldId" to worldId,
+            "nodeId" to chest.nodeId.value,
+            "itemId" to req.itemId,
+            "delta" to req.delta,
+        ))
+        return chest.toDto(chestContents.contentsOf(instanceId))
+    }
+
+    @DeleteMapping("/{itemId}")
+    fun delete(
+        @PathVariable worldId: Long,
+        @PathVariable instanceId: UUID,
+        @PathVariable itemId: String,
+        @AuthenticationPrincipal admin: Admin,
+    ): ResponseEntity<Void> {
+        val chest = resolveChest(WorldId(worldId), instanceId)
+        chestContents.removeAll(instanceId, ItemId(itemId))
+        audit(admin, "chest.delete", instanceId, mapOf(
+            "worldId" to worldId,
+            "nodeId" to chest.nodeId.value,
+            "itemId" to itemId,
+        ))
+        return ResponseEntity.noContent().build()
+    }
+
+    private fun resolveChest(worldId: WorldId, instanceId: UUID): Building {
+        val building = buildings.findById(instanceId)
+            ?: throw notFound("building $instanceId not found")
+        requireNodeInWorld(worldId, building.nodeId)
+        if (!building.type.holdsChest()) {
+            throw badRequest("building ${building.type} does not hold a chest")
+        }
+        return building
+    }
+
+    private fun requireNodeInWorld(worldId: WorldId, nodeId: NodeId) {
+        val node = world.node(nodeId)
+            ?: throw notFound("node ${nodeId.value} not found in world ${worldId.value}")
+        val region = world.region(node.regionId)
+            ?: throw notFound("node ${nodeId.value} not found in world ${worldId.value}")
+        if (region.worldId != worldId) {
+            throw notFound("node ${nodeId.value} not found in world ${worldId.value}")
+        }
+    }
+
+    private fun audit(admin: Admin, action: String, instanceId: UUID, payload: Map<String, Any?>) {
+        auditLog.record(
+            adminId = admin.id,
+            action = action,
+            target = "chest",
+            targetId = instanceId.toString(),
+            payload = payload,
+            tick = tick.currentTick(),
+        )
+    }
+
+    private fun Building.toDto(contents: Map<ItemId, Int>) = ChestContentsDto(
+        instanceId = instanceId,
+        nodeId = nodeId.value,
+        contents = contents.mapKeys { (id, _) -> id.value },
+    )
+
+    private fun notFound(detail: String) = ResponseStatusException(HttpStatus.NOT_FOUND, detail)
+    private fun badRequest(detail: String) = ResponseStatusException(HttpStatus.BAD_REQUEST, detail)
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/ChestAdminIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/ChestAdminIo.kt
@@ -1,0 +1,18 @@
+package dev.gvart.genesara.api.internal.rest.admin.worlds
+
+import java.util.UUID
+
+data class ChestContentsDto(
+    val instanceId: UUID,
+    val nodeId: Long,
+    val contents: Map<String, Int>,
+)
+
+data class ReplaceChestContentsRequest(
+    val contents: Map<String, Int>,
+)
+
+data class PatchChestContentsRequest(
+    val itemId: String,
+    val delta: Int,
+)

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectBuildingTest.kt
@@ -434,6 +434,8 @@ class InspectBuildingTest {
             map.merge(buildingId to item, quantity, Int::plus)
         }
         override fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean = error("not used")
+        override fun replace(buildingId: UUID, contents: Map<ItemId, Int>): Unit = error("not used")
+        override fun removeAll(buildingId: UUID, item: ItemId): Boolean = error("not used")
     }
 
     private class MutableTestClock(private var now: Instant) : Clock() {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectLookAroundParityTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectLookAroundParityTest.kt
@@ -307,6 +307,8 @@ class InspectLookAroundParityTest {
         override fun contentsOf(buildingId: UUID): Map<ItemId, Int> = emptyMap()
         override fun add(buildingId: UUID, item: ItemId, quantity: Int) = error("not used")
         override fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean = error("not used")
+        override fun replace(buildingId: UUID, contents: Map<ItemId, Int>): Unit = error("not used")
+        override fun removeAll(buildingId: UUID, item: ItemId): Boolean = error("not used")
     }
 
     private object NoEquipmentInstances : dev.gvart.genesara.api.testsupport.InMemoryAgentItemInstancesStore() {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/mcp/tools/inspect/InspectToolTest.kt
@@ -802,6 +802,8 @@ class InspectToolTest {
         override fun contentsOf(buildingId: java.util.UUID): Map<ItemId, Int> = emptyMap()
         override fun add(buildingId: java.util.UUID, item: ItemId, quantity: Int) = error("not used")
         override fun remove(buildingId: java.util.UUID, item: ItemId, quantity: Int): Boolean = error("not used")
+        override fun replace(buildingId: java.util.UUID, contents: Map<ItemId, Int>): Unit = error("not used")
+        override fun removeAll(buildingId: java.util.UUID, item: ItemId): Boolean = error("not used")
     }
 
     internal object NoGates : dev.gvart.genesara.world.BuildingGateStateStore {

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/ChestAdminControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/ChestAdminControllerTest.kt
@@ -1,0 +1,368 @@
+package dev.gvart.genesara.api.internal.rest.admin.worlds
+
+import dev.gvart.genesara.admin.Admin
+import dev.gvart.genesara.admin.AdminAuditEntry
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.admin.AdminId
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AdminSentinel
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.ChestContentsStore
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.InventoryView
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NodeResources
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldQueryGateway
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.web.server.ResponseStatusException
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ChestAdminControllerTest {
+
+    private val worldId = WorldId(1L)
+    private val regionId = RegionId(7L)
+    private val nodeId = NodeId(42L)
+    private val foreignNodeId = NodeId(43L)
+
+    private val region = Region(
+        id = regionId,
+        worldId = worldId,
+        sphereIndex = 0,
+        biome = Biome.FOREST,
+        climate = Climate.CONTINENTAL,
+        centroid = Vec3(0.0, 0.0, 0.0),
+        faceVertices = emptyList(),
+        neighbors = emptySet(),
+    )
+    private val foreignRegion = Region(
+        id = RegionId(8L),
+        worldId = WorldId(2L),
+        sphereIndex = 0,
+        biome = Biome.FOREST,
+        climate = Climate.CONTINENTAL,
+        centroid = Vec3(0.0, 0.0, 0.0),
+        faceVertices = emptyList(),
+        neighbors = emptySet(),
+    )
+    private val node = Node(nodeId, regionId, q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())
+    private val foreignNode = Node(foreignNodeId, foreignRegion.id, q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())
+
+    private val admin = Admin(id = AdminId(UUID.randomUUID()), username = "ops")
+
+    private lateinit var buildings: InMemoryBuildingsStore
+    private lateinit var chest: InMemoryChestContentsStore
+    private lateinit var world: StubWorld
+    private lateinit var audit: RecordingAuditLog
+    private lateinit var controller: ChestAdminController
+
+    private lateinit var chestId: UUID
+
+    @BeforeEach
+    fun setup() {
+        buildings = InMemoryBuildingsStore()
+        chest = InMemoryChestContentsStore()
+        world = StubWorld(
+            nodes = mapOf(nodeId to node, foreignNodeId to foreignNode),
+            regions = mapOf(regionId to region, foreignRegion.id to foreignRegion),
+        )
+        audit = RecordingAuditLog()
+        controller = ChestAdminController(
+            buildings = buildings,
+            chestContents = chest,
+            world = world,
+            auditLog = audit,
+            tick = FixedTickClock(500L),
+        )
+        chestId = placeChest(BuildingType.STORAGE_CHEST, nodeId)
+    }
+
+    @Test
+    fun `GET returns empty contents for a freshly placed chest`() {
+        val dto = controller.get(worldId.value, chestId)
+
+        assertEquals(chestId, dto.instanceId)
+        assertEquals(nodeId.value, dto.nodeId)
+        assertTrue(dto.contents.isEmpty())
+    }
+
+    @Test
+    fun `PUT replaces contents atomically — entries not in body are removed`() {
+        chest.add(chestId, ItemId("WOOD"), 3)
+        chest.add(chestId, ItemId("STONE"), 5)
+
+        val dto = controller.replace(
+            worldId.value,
+            chestId,
+            ReplaceChestContentsRequest(contents = mapOf("WOOD" to 7, "BERRY" to 2)),
+            admin,
+        )
+
+        assertEquals(mapOf("WOOD" to 7, "BERRY" to 2), dto.contents)
+        assertEquals(0, chest.quantityOf(chestId, ItemId("STONE")))
+        assertEquals(7, chest.quantityOf(chestId, ItemId("WOOD")))
+    }
+
+    @Test
+    fun `PUT rejects non-positive quantities`() {
+        val error = assertThrows<ResponseStatusException> {
+            controller.replace(
+                worldId.value,
+                chestId,
+                ReplaceChestContentsRequest(contents = mapOf("WOOD" to 0)),
+                admin,
+            )
+        }
+        assertEquals(400, error.statusCode.value())
+    }
+
+    @Test
+    fun `PUT writes one audit row`() {
+        controller.replace(
+            worldId.value,
+            chestId,
+            ReplaceChestContentsRequest(contents = mapOf("WOOD" to 1)),
+            admin,
+        )
+
+        val row = audit.recorded.single()
+        assertEquals("chest.replace", row.action)
+        assertEquals("chest", row.target)
+        assertEquals(chestId.toString(), row.targetId)
+    }
+
+    @Test
+    fun `PATCH positive delta adds quantity`() {
+        chest.add(chestId, ItemId("WOOD"), 2)
+
+        val dto = controller.patch(
+            worldId.value,
+            chestId,
+            PatchChestContentsRequest(itemId = "WOOD", delta = 3),
+            admin,
+        )
+
+        assertEquals(5, dto.contents["WOOD"])
+    }
+
+    @Test
+    fun `PATCH negative delta removes quantity`() {
+        chest.add(chestId, ItemId("WOOD"), 5)
+
+        val dto = controller.patch(
+            worldId.value,
+            chestId,
+            PatchChestContentsRequest(itemId = "WOOD", delta = -2),
+            admin,
+        )
+
+        assertEquals(3, dto.contents["WOOD"])
+    }
+
+    @Test
+    fun `PATCH over-remove rejects with 400 and does not mutate`() {
+        chest.add(chestId, ItemId("WOOD"), 2)
+
+        val error = assertThrows<ResponseStatusException> {
+            controller.patch(
+                worldId.value,
+                chestId,
+                PatchChestContentsRequest(itemId = "WOOD", delta = -5),
+                admin,
+            )
+        }
+
+        assertEquals(400, error.statusCode.value())
+        assertEquals(2, chest.quantityOf(chestId, ItemId("WOOD")))
+        assertTrue(audit.recorded.isEmpty())
+    }
+
+    @Test
+    fun `PATCH zero delta rejects`() {
+        val error = assertThrows<ResponseStatusException> {
+            controller.patch(
+                worldId.value,
+                chestId,
+                PatchChestContentsRequest(itemId = "WOOD", delta = 0),
+                admin,
+            )
+        }
+        assertEquals(400, error.statusCode.value())
+    }
+
+    @Test
+    fun `DELETE removes all of one item but keeps others`() {
+        chest.add(chestId, ItemId("WOOD"), 3)
+        chest.add(chestId, ItemId("STONE"), 5)
+
+        val response = controller.delete(worldId.value, chestId, "WOOD", admin)
+
+        assertEquals(204, response.statusCode.value())
+        assertEquals(0, chest.quantityOf(chestId, ItemId("WOOD")))
+        assertEquals(5, chest.quantityOf(chestId, ItemId("STONE")))
+    }
+
+    @Test
+    fun `non-chest building rejects with 400`() {
+        val campfireId = placeChest(BuildingType.CAMPFIRE, nodeId)
+
+        val error = assertThrows<ResponseStatusException> {
+            controller.get(worldId.value, campfireId)
+        }
+        assertEquals(400, error.statusCode.value())
+        assertTrue(error.reason!!.contains("CAMPFIRE"))
+    }
+
+    @Test
+    fun `unknown building returns 404`() {
+        val error = assertThrows<ResponseStatusException> {
+            controller.get(worldId.value, UUID.randomUUID())
+        }
+        assertEquals(404, error.statusCode.value())
+    }
+
+    @Test
+    fun `building in different world returns 404`() {
+        val foreignChestId = placeChest(BuildingType.STORAGE_CHEST, foreignNodeId)
+
+        val error = assertThrows<ResponseStatusException> {
+            controller.get(worldId.value, foreignChestId)
+        }
+        assertEquals(404, error.statusCode.value())
+    }
+
+    @Test
+    fun `holdsChest predicate`() {
+        assertTrue(BuildingType.STORAGE_CHEST.holdsChest())
+        assertFalse(BuildingType.CAMPFIRE.holdsChest())
+        assertFalse(BuildingType.WOODEN_WALL.holdsChest())
+    }
+
+    private fun placeChest(type: BuildingType, at: NodeId): UUID {
+        val id = UUID.randomUUID()
+        buildings.rows += Building(
+            instanceId = id,
+            nodeId = at,
+            type = type,
+            status = BuildingStatus.ACTIVE,
+            builtByAgentId = AdminSentinel.agentId,
+            builtAtTick = 0L,
+            lastProgressTick = 0L,
+            progressSteps = 1,
+            totalSteps = 1,
+            hpCurrent = 100,
+            hpMax = 100,
+        )
+        return id
+    }
+
+    private class InMemoryBuildingsStore : BuildingsStore {
+        val rows: MutableList<Building> = mutableListOf()
+        override fun insert(building: Building) { rows += building }
+        override fun findById(id: UUID): Building? = rows.firstOrNull { it.instanceId == id }
+        override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? = null
+        override fun findAnyAtNodeOfType(node: NodeId, type: BuildingType): Building? = null
+        override fun listAtNode(node: NodeId): List<Building> = rows.filter { it.nodeId == node }
+        override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
+            rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }
+        override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = null
+        override fun complete(id: UUID, asOfTick: Long): Building? = null
+        override fun update(updated: Building): Building? = null
+        override fun delete(id: UUID): Boolean = rows.removeAll { it.instanceId == id }
+    }
+
+    private class InMemoryChestContentsStore : ChestContentsStore {
+        private val rows: MutableMap<Pair<UUID, ItemId>, Int> = mutableMapOf()
+        override fun quantityOf(buildingId: UUID, item: ItemId): Int = rows[buildingId to item] ?: 0
+        override fun contentsOf(buildingId: UUID): Map<ItemId, Int> =
+            rows.filterKeys { it.first == buildingId }.mapKeys { it.key.second }
+        override fun add(buildingId: UUID, item: ItemId, quantity: Int) {
+            require(quantity > 0)
+            rows.merge(buildingId to item, quantity, Int::plus)
+        }
+        override fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean {
+            require(quantity > 0)
+            val key = buildingId to item
+            val have = rows[key] ?: 0
+            if (have < quantity) return false
+            val next = have - quantity
+            if (next == 0) rows.remove(key) else rows[key] = next
+            return true
+        }
+        override fun replace(buildingId: UUID, contents: Map<ItemId, Int>) {
+            contents.values.forEach { require(it > 0) }
+            rows.keys.removeAll { it.first == buildingId }
+            contents.forEach { (item, qty) -> rows[buildingId to item] = qty }
+        }
+        override fun removeAll(buildingId: UUID, item: ItemId): Boolean =
+            rows.remove(buildingId to item) != null
+    }
+
+    private class StubWorld(
+        private val nodes: Map<NodeId, Node>,
+        private val regions: Map<RegionId, Region>,
+    ) : WorldQueryGateway {
+        override fun locationOf(agent: AgentId): NodeId? = null
+        override fun activePositionOf(agent: AgentId): NodeId? = null
+        override fun node(id: NodeId): Node? = nodes[id]
+        override fun region(id: RegionId): Region? = regions[id]
+        override fun nodesWithin(origin: NodeId, radius: Int): Set<NodeId> = emptySet()
+        override fun randomSpawnableNode(): NodeId? = null
+        override fun starterNodeFor(race: RaceId): NodeId? = null
+        override fun bodyOf(agent: AgentId) = null
+        override fun inventoryOf(agent: AgentId) = InventoryView(entries = emptyList())
+        override fun resourcesAt(nodeId: NodeId, tick: Long) = NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId) = emptyList<GroundItemView>()
+        override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>) = emptyMap<NodeId, List<AgentId>>()
+    }
+
+    private class FixedTickClock(private val tick: Long) : TickClock {
+        override fun currentTick(): Long = tick
+    }
+
+    private class RecordingAuditLog : AdminAuditLog {
+        data class Recorded(
+            val adminId: AdminId,
+            val action: String,
+            val target: String,
+            val targetId: String?,
+            val payload: Map<String, Any?>,
+            val tick: Long,
+        )
+
+        val recorded: MutableList<Recorded> = mutableListOf()
+        override fun record(
+            adminId: AdminId,
+            action: String,
+            target: String,
+            targetId: String?,
+            payload: Map<String, Any?>,
+            tick: Long,
+        ): Long {
+            recorded += Recorded(adminId, action, target, targetId, payload, tick)
+            return recorded.size.toLong()
+        }
+
+        override fun readAfter(after: Long, limit: Int): List<AdminAuditEntry> = emptyList()
+    }
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/ChestAdminLoopIntegrationTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/ChestAdminLoopIntegrationTest.kt
@@ -1,0 +1,231 @@
+package dev.gvart.genesara.api.internal.rest.admin.worlds
+
+import dev.gvart.genesara.admin.Admin
+import dev.gvart.genesara.admin.AdminAuditEntry
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.admin.AdminId
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Building
+import dev.gvart.genesara.world.BuildingBarView
+import dev.gvart.genesara.world.BuildingCategoryHint
+import dev.gvart.genesara.world.BuildingDefLookup
+import dev.gvart.genesara.world.BuildingDefView
+import dev.gvart.genesara.world.BuildingStatus
+import dev.gvart.genesara.world.BuildingType
+import dev.gvart.genesara.world.BuildingsStore
+import dev.gvart.genesara.world.ChestContentsStore
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.InventoryView
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NodeResources
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldQueryGateway
+import dev.gvart.genesara.world.events.WorldEvent
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ChestAdminLoopIntegrationTest {
+
+    private val worldId = WorldId(1L)
+    private val regionId = RegionId(7L)
+    private val nodeId = NodeId(42L)
+    private val region = Region(
+        id = regionId, worldId = worldId, sphereIndex = 0,
+        biome = Biome.FOREST, climate = Climate.CONTINENTAL,
+        centroid = Vec3(0.0, 0.0, 0.0), faceVertices = emptyList(), neighbors = emptySet(),
+    )
+    private val node = Node(nodeId, regionId, q = 0, r = 0, terrain = Terrain.PLAINS, adjacency = emptySet())
+    private val admin = Admin(id = AdminId(UUID.randomUUID()), username = "ops")
+
+    @Test
+    fun `place chest, seed via PUT, agent reads same contents through ChestContentsStore`() {
+        val buildings = InMemoryBuildingsStore()
+        val chest = InMemoryChestContentsStore()
+        val world = StubWorld(mapOf(nodeId to node), mapOf(regionId to region))
+        val tick = FixedTickClock(500L)
+        val audit = NullAuditLog()
+        val publisher = NullPublisher()
+        val catalog = StubCatalog(
+            mapOf(BuildingType.STORAGE_CHEST to defView(BuildingType.STORAGE_CHEST, hp = 40, steps = 8)),
+        )
+
+        val buildingAdmin = BuildingAdminController(
+            store = buildings, world = world, catalog = catalog,
+            tick = tick, auditLog = audit, publisher = publisher,
+        )
+        val chestAdmin = ChestAdminController(
+            buildings = buildings, chestContents = chest,
+            world = world, auditLog = audit, tick = tick,
+        )
+
+        val placed = buildingAdmin.create(
+            worldId = worldId.value,
+            nodeId = nodeId.value,
+            req = CreateBuildingRequest(type = BuildingType.STORAGE_CHEST),
+            admin = admin,
+        ).body!!
+
+        chestAdmin.replace(
+            worldId = worldId.value,
+            instanceId = placed.instanceId,
+            req = ReplaceChestContentsRequest(contents = mapOf("WOOD" to 5, "STONE" to 3)),
+            admin = admin,
+        )
+
+        val visible = chest.contentsOf(placed.instanceId)
+        assertEquals(5, visible[ItemId("WOOD")])
+        assertEquals(3, visible[ItemId("STONE")])
+
+        val withdrew = chest.remove(placed.instanceId, ItemId("WOOD"), 2)
+        assertTrue(withdrew)
+        assertEquals(3, chest.quantityOf(placed.instanceId, ItemId("WOOD")))
+        assertEquals(3, chest.quantityOf(placed.instanceId, ItemId("STONE")))
+    }
+
+    @Test
+    fun `PATCH increments contents already visible to the withdraw path`() {
+        val buildings = InMemoryBuildingsStore()
+        val chest = InMemoryChestContentsStore()
+        val world = StubWorld(mapOf(nodeId to node), mapOf(regionId to region))
+        val tick = FixedTickClock(500L)
+        val catalog = StubCatalog(
+            mapOf(BuildingType.STORAGE_CHEST to defView(BuildingType.STORAGE_CHEST, hp = 40, steps = 8)),
+        )
+        val buildingAdmin = BuildingAdminController(
+            store = buildings, world = world, catalog = catalog,
+            tick = tick, auditLog = NullAuditLog(), publisher = NullPublisher(),
+        )
+        val chestAdmin = ChestAdminController(
+            buildings = buildings, chestContents = chest,
+            world = world, auditLog = NullAuditLog(), tick = tick,
+        )
+
+        val placed = buildingAdmin.create(
+            worldId = worldId.value,
+            nodeId = nodeId.value,
+            req = CreateBuildingRequest(type = BuildingType.STORAGE_CHEST),
+            admin = admin,
+        ).body!!
+
+        chestAdmin.patch(
+            worldId.value, placed.instanceId,
+            PatchChestContentsRequest(itemId = "BERRY", delta = 4), admin,
+        )
+        chestAdmin.patch(
+            worldId.value, placed.instanceId,
+            PatchChestContentsRequest(itemId = "BERRY", delta = 2), admin,
+        )
+
+        assertEquals(6, chest.quantityOf(placed.instanceId, ItemId("BERRY")))
+    }
+
+    private fun defView(type: BuildingType, hp: Int, steps: Int) = BuildingDefView(
+        type = type,
+        skillBars = listOf(
+            BuildingBarView(
+                skill = dev.gvart.genesara.player.SkillId("CARPENTRY"),
+                level = 0, steps = steps, materialsPerStep = emptyMap(),
+            ),
+        ),
+        staminaPerStep = 5,
+        hp = hp,
+        categoryHint = BuildingCategoryHint.STORAGE,
+    )
+
+    private class InMemoryBuildingsStore : BuildingsStore {
+        val rows: MutableList<Building> = mutableListOf()
+        override fun insert(building: Building) { rows += building }
+        override fun findById(id: UUID): Building? = rows.firstOrNull { it.instanceId == id }
+        override fun findInProgress(node: NodeId, agent: AgentId, type: BuildingType): Building? = null
+        override fun findAnyAtNodeOfType(node: NodeId, type: BuildingType): Building? = null
+        override fun listAtNode(node: NodeId): List<Building> = rows.filter { it.nodeId == node }
+        override fun listByNodes(nodes: Set<NodeId>): Map<NodeId, List<Building>> =
+            rows.filter { it.nodeId in nodes }.groupBy { it.nodeId }
+        override fun advanceProgress(id: UUID, newProgress: Int, asOfTick: Long): Building? = null
+        override fun complete(id: UUID, asOfTick: Long): Building? = null
+        override fun update(updated: Building): Building? = null
+        override fun delete(id: UUID): Boolean = rows.removeAll { it.instanceId == id }
+    }
+
+    private class InMemoryChestContentsStore : ChestContentsStore {
+        private val rows: MutableMap<Pair<UUID, ItemId>, Int> = mutableMapOf()
+        override fun quantityOf(buildingId: UUID, item: ItemId): Int = rows[buildingId to item] ?: 0
+        override fun contentsOf(buildingId: UUID): Map<ItemId, Int> =
+            rows.filterKeys { it.first == buildingId }.mapKeys { it.key.second }
+        override fun add(buildingId: UUID, item: ItemId, quantity: Int) {
+            require(quantity > 0)
+            rows.merge(buildingId to item, quantity, Int::plus)
+        }
+        override fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean {
+            require(quantity > 0)
+            val key = buildingId to item
+            val have = rows[key] ?: 0
+            if (have < quantity) return false
+            val next = have - quantity
+            if (next == 0) rows.remove(key) else rows[key] = next
+            return true
+        }
+        override fun replace(buildingId: UUID, contents: Map<ItemId, Int>) {
+            contents.values.forEach { require(it > 0) }
+            rows.keys.removeAll { it.first == buildingId }
+            contents.forEach { (item, qty) -> rows[buildingId to item] = qty }
+        }
+        override fun removeAll(buildingId: UUID, item: ItemId): Boolean =
+            rows.remove(buildingId to item) != null
+    }
+
+    private class StubWorld(
+        private val nodes: Map<NodeId, Node>,
+        private val regions: Map<RegionId, Region>,
+    ) : WorldQueryGateway {
+        override fun locationOf(agent: AgentId): NodeId? = null
+        override fun activePositionOf(agent: AgentId): NodeId? = null
+        override fun node(id: NodeId): Node? = nodes[id]
+        override fun region(id: RegionId): Region? = regions[id]
+        override fun nodesWithin(origin: NodeId, radius: Int): Set<NodeId> = emptySet()
+        override fun randomSpawnableNode(): NodeId? = null
+        override fun starterNodeFor(race: RaceId): NodeId? = null
+        override fun bodyOf(agent: AgentId) = null
+        override fun inventoryOf(agent: AgentId) = InventoryView(entries = emptyList())
+        override fun resourcesAt(nodeId: NodeId, tick: Long) = NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId) = emptyList<GroundItemView>()
+        override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>) = emptyMap<NodeId, List<AgentId>>()
+    }
+
+    private class StubCatalog(private val byType: Map<BuildingType, BuildingDefView>) : BuildingDefLookup {
+        override fun byType(type: BuildingType): BuildingDefView? = byType[type]
+        override fun all(): List<BuildingDefView> = byType.values.toList()
+    }
+
+    private class FixedTickClock(private val tick: Long) : TickClock {
+        override fun currentTick(): Long = tick
+    }
+
+    private class NullAuditLog : AdminAuditLog {
+        override fun record(
+            adminId: AdminId, action: String, target: String, targetId: String?,
+            payload: Map<String, Any?>, tick: Long,
+        ): Long = 0L
+        override fun readAfter(after: Long, limit: Int): List<AdminAuditEntry> = emptyList()
+    }
+
+    private class NullPublisher : ApplicationEventPublisher {
+        override fun publishEvent(event: Any) {
+            event as? WorldEvent
+        }
+    }
+}

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/BuildingType.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/BuildingType.kt
@@ -70,5 +70,8 @@ enum class BuildingType {
     SMOKEHOUSE,
 
     /** Brewing station — gates `craft` recipes whose `requiredStation` is CRAFTING_STATION_BREW (ales, wines, meads, tonics). */
-    BREWERY,
+    BREWERY;
+
+    /** True when this type stores agent-deposited items via `ChestContentsStore`. */
+    fun holdsChest(): Boolean = this == STORAGE_CHEST
 }

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/ChestContentsStore.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/ChestContentsStore.kt
@@ -37,4 +37,24 @@ interface ChestContentsStore {
      * deletes the row so an empty chest has zero rows in the table.
      */
     fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean
+
+    /**
+     * Atomically replace the chest's contents with [contents]: rows not in
+     * [contents] are deleted, rows in both have their quantity overwritten,
+     * rows only in [contents] are inserted. Empty [contents] empties the
+     * chest. All quantities in [contents] must be positive — non-positive
+     * entries are a programmer error and throw.
+     *
+     * Admin-only write path: the verb reducers go through [add] / [remove]
+     * to preserve their per-call invariants. This bypasses them for operator
+     * authoring.
+     */
+    fun replace(buildingId: UUID, contents: Map<ItemId, Int>)
+
+    /**
+     * Remove every row of [item] from the chest. Returns `true` when at least
+     * one row was deleted, `false` when the chest held none. Used by the
+     * admin DELETE endpoint to clear a single stack.
+     */
+    fun removeAll(buildingId: UUID, item: ItemId): Boolean
 }

--- a/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/buildings/JooqChestContentsStore.kt
+++ b/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/buildings/JooqChestContentsStore.kt
@@ -48,6 +48,34 @@ internal class JooqChestContentsStore(
     }
 
     @Transactional
+    override fun replace(buildingId: UUID, contents: Map<ItemId, Int>) {
+        contents.forEach { (item, qty) ->
+            require(qty > 0) { "quantity for ${item.value} must be positive, got $qty" }
+        }
+        dsl.deleteFrom(BUILDING_CHEST_INVENTORY)
+            .where(BUILDING_CHEST_INVENTORY.BUILDING_ID.eq(buildingId))
+            .execute()
+        if (contents.isEmpty()) return
+        var insert = dsl.insertInto(
+            BUILDING_CHEST_INVENTORY,
+            BUILDING_CHEST_INVENTORY.BUILDING_ID,
+            BUILDING_CHEST_INVENTORY.ITEM_ID,
+            BUILDING_CHEST_INVENTORY.QUANTITY,
+        )
+        contents.forEach { (item, qty) ->
+            insert = insert.values(buildingId, item.value, qty)
+        }
+        insert.execute()
+    }
+
+    @Transactional
+    override fun removeAll(buildingId: UUID, item: ItemId): Boolean =
+        dsl.deleteFrom(BUILDING_CHEST_INVENTORY)
+            .where(BUILDING_CHEST_INVENTORY.BUILDING_ID.eq(buildingId))
+            .and(BUILDING_CHEST_INVENTORY.ITEM_ID.eq(item.value))
+            .execute() > 0
+
+    @Transactional
     override fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean {
         require(quantity > 0) { "quantity to remove must be positive, got $quantity" }
         // Two-pass under @Transactional. Delete-on-exact-match first to avoid

--- a/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/buildings/ChestReducersTest.kt
+++ b/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/buildings/ChestReducersTest.kt
@@ -441,6 +441,12 @@ class ChestReducersTest {
             if (next == 0) map.remove(buildingId to item) else map[buildingId to item] = next
             return true
         }
+        override fun replace(buildingId: UUID, contents: Map<ItemId, Int>) {
+            map.keys.removeAll { it.first == buildingId }
+            contents.forEach { (item, qty) -> map[buildingId to item] = qty }
+        }
+        override fun removeAll(buildingId: UUID, item: ItemId): Boolean =
+            map.remove(buildingId to item) != null
     }
 }
 

--- a/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/buildings/JooqChestContentsStoreIntegrationTest.kt
+++ b/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/buildings/JooqChestContentsStoreIntegrationTest.kt
@@ -154,4 +154,56 @@ class JooqChestContentsStoreIntegrationTest {
     fun `contentsOf returns an empty map for a never-touched chest`() {
         assertEquals(emptyMap(), store.contentsOf(chest))
     }
+
+    @Test
+    fun `replace deletes rows not in the new map and overwrites overlapping ones`() {
+        store.add(chest, wood, 3)
+        store.add(chest, stone, 5)
+
+        store.replace(chest, mapOf(wood to 10, ItemId("BERRY") to 2))
+
+        assertEquals(mapOf(wood to 10, ItemId("BERRY") to 2), store.contentsOf(chest))
+    }
+
+    @Test
+    fun `replace with an empty map empties the chest`() {
+        store.add(chest, wood, 3)
+
+        store.replace(chest, emptyMap())
+
+        assertEquals(emptyMap(), store.contentsOf(chest))
+    }
+
+    @Test
+    fun `replace is scoped per chest — other chest contents are untouched`() {
+        store.add(otherChest, wood, 99)
+        store.add(chest, wood, 1)
+
+        store.replace(chest, mapOf(stone to 4))
+
+        assertEquals(mapOf(stone to 4), store.contentsOf(chest))
+        assertEquals(99, store.quantityOf(otherChest, wood))
+    }
+
+    @Test
+    fun `replace rejects non-positive quantities`() {
+        assertFailsWith<IllegalArgumentException> { store.replace(chest, mapOf(wood to 0)) }
+        assertFailsWith<IllegalArgumentException> { store.replace(chest, mapOf(wood to -1)) }
+    }
+
+    @Test
+    fun `removeAll deletes every row of one item and returns true`() {
+        store.add(chest, wood, 5)
+        store.add(chest, stone, 2)
+
+        assertTrue(store.removeAll(chest, wood))
+
+        assertEquals(0, store.quantityOf(chest, wood))
+        assertEquals(2, store.quantityOf(chest, stone))
+    }
+
+    @Test
+    fun `removeAll returns false when the chest has no row for that item`() {
+        assertFalse(store.removeAll(chest, wood))
+    }
 }

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
@@ -547,6 +547,8 @@ class WorldTickHandlerHarvestXpEventIntegrationTest {
         override fun contentsOf(buildingId: UUID): Map<ItemId, Int> = emptyMap()
         override fun add(buildingId: UUID, item: ItemId, quantity: Int) = error("not used")
         override fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean = error("not used")
+        override fun replace(buildingId: UUID, contents: Map<ItemId, Int>): Unit = error("not used")
+        override fun removeAll(buildingId: UUID, item: ItemId): Boolean = error("not used")
     }
 
     private object NoopAgentPlotsStore : dev.gvart.genesara.world.AgentPlotsStore {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerSpawnResumeIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerSpawnResumeIntegrationTest.kt
@@ -415,6 +415,8 @@ class WorldTickHandlerSpawnResumeIntegrationTest {
         override fun contentsOf(buildingId: UUID): Map<ItemId, Int> = emptyMap()
         override fun add(buildingId: UUID, item: ItemId, quantity: Int) = error("not used")
         override fun remove(buildingId: UUID, item: ItemId, quantity: Int): Boolean = error("not used")
+        override fun replace(buildingId: UUID, contents: Map<ItemId, Int>): Unit = error("not used")
+        override fun removeAll(buildingId: UUID, item: ItemId): Boolean = error("not used")
     }
 
     private object NoopAgentPlotsStore : dev.gvart.genesara.world.AgentPlotsStore {

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -478,6 +478,10 @@ class WorldTickHandlerTest {
             error("not used")
         override fun remove(buildingId: java.util.UUID, item: dev.gvart.genesara.world.ItemId, quantity: Int): Boolean =
             error("not used")
+        override fun replace(buildingId: java.util.UUID, contents: Map<dev.gvart.genesara.world.ItemId, Int>): Unit =
+            error("not used")
+        override fun removeAll(buildingId: java.util.UUID, item: dev.gvart.genesara.world.ItemId): Boolean =
+            error("not used")
     }
 
     private object NoopBuildingGateStateStore : dev.gvart.genesara.world.BuildingGateStateStore {


### PR DESCRIPTION
## Summary
- `BuildingType.holdsChest()` predicate (STORAGE_CHEST only today; future chest variants extend the same gate).
- `ChestAdminController` under `api/internal/rest/admin/worlds/` with GET/PUT/PATCH/DELETE on `/admin/worlds/{worldId}/buildings/{instanceId}/chest`.
- `ChestContentsStore.replace(buildingId, contents)` for atomic-replace in a single transaction; `removeAll(buildingId, item)` for the DELETE path. JOOQ impl rolls delete-all + bulk-insert under `@Transactional`.
- Non-chest targets return RFC 7807 400; unknown / cross-world buildings 404 (matching `BuildingAdminController`'s convention). PATCH over-remove rejects without mutating state.
- Every mutating endpoint writes one row to `admin_audit_log` (`chest.replace` / `chest.patch` / `chest.delete`).

## Loop-close
Integration test in `:api` exercises the round-trip: place STORAGE_CHEST via `BuildingAdminController.create` -> seed contents via `ChestAdminController.replace` -> read/`remove` through `ChestContentsStore` (which is exactly what the agent-facing `WithdrawFromChest` reducer calls after permission checks).

## Modulith
`:api` reaches only `ChestContentsStore` / `BuildingsStore` / `WorldQueryGateway` / `BuildingType` — all from `:world.core` via the `:world` umbrella. No `:world:environment` imports. `./gradlew :app:test --tests 'dev.gvart.genesara.ModularityTests'` passes.

## Deviations / open
- **No live-feed event emitted for chest mutations.** The existing `EnvironmentEvent.BuildingAdminEdited` is shaped around building-row writes (status/HP/progress) and doesn't carry chest contents; piggy-backing it would force null-everywhere payloads. A dedicated `ChestContentsAdminEdited` event for the admin live feed is deferred to a later slice once the feed surface is in heavier playtest use — admins still see the audit row, just not a live SSE push.

## Test plan
- [x] `./gradlew :api:test` green
- [x] `./gradlew :world:core:test :world:test :world:environment:test --tests '*Chest*'` green
- [x] `./gradlew :app:test --tests 'dev.gvart.genesara.ModularityTests'` green
- [x] Unit tests: PUT atomicity, PATCH over-remove rejection, non-chest target rejection, unknown / cross-world 404, audit row written
- [x] JOOQ integration test for `replace` (delete-rows-not-in-map, overwrite-overlap, empty=clear, non-positive reject) and `removeAll`
- [x] Loop integration test: place chest -> PUT seed -> read/remove via store

Closes #208