### PR TITLE
feat(world,api): admin NPC zones — per-region/per-node spawn overrides (#207)

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/NpcZoneAdminIo.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/NpcZoneAdminIo.kt
@@ -1,0 +1,42 @@
+package dev.gvart.genesara.api.internal.rest.admin.worlds
+
+import dev.gvart.genesara.api.internal.rest.worlds.MaybeSetDeserializer
+import dev.gvart.genesara.world.MaybeSet
+import dev.gvart.genesara.world.NpcZoneScope
+import tools.jackson.databind.annotation.JsonDeserialize
+import java.util.UUID
+
+data class CreateNpcZoneRequest(
+    val scope: NpcZoneScope,
+    val regionId: Long? = null,
+    val nodeId: Long? = null,
+    val weights: Map<String, Int>,
+    val maxConcurrent: Int,
+    val respawnTicks: Int? = null,
+    val active: Boolean = true,
+)
+
+data class PatchNpcZoneRequest(
+    @JsonDeserialize(using = MaybeSetDeserializer::class)
+    val weights: MaybeSet<Map<String, Int>> = MaybeSet.Skip,
+    @JsonDeserialize(using = MaybeSetDeserializer::class)
+    val maxConcurrent: MaybeSet<Int> = MaybeSet.Skip,
+    @JsonDeserialize(using = MaybeSetDeserializer::class)
+    val respawnTicks: MaybeSet<Int?> = MaybeSet.Skip,
+    @JsonDeserialize(using = MaybeSetDeserializer::class)
+    val active: MaybeSet<Boolean> = MaybeSet.Skip,
+)
+
+data class NpcZoneDto(
+    val zoneId: UUID,
+    val worldId: Long,
+    val scope: NpcZoneScope,
+    val regionId: Long?,
+    val nodeId: Long?,
+    val weights: Map<String, Int>,
+    val maxConcurrent: Int,
+    val respawnTicks: Int?,
+    val active: Boolean,
+    val createdBy: UUID,
+    val createdAtTick: Long,
+)

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/NpcZoneController.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/NpcZoneController.kt
@@ -1,0 +1,203 @@
+package dev.gvart.genesara.api.internal.rest.admin.worlds
+
+import dev.gvart.genesara.admin.Admin
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.world.MaybeSet
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NpcType
+import dev.gvart.genesara.world.NpcZone
+import dev.gvart.genesara.world.NpcZoneAdminError
+import dev.gvart.genesara.world.NpcZoneAdminGateway
+import dev.gvart.genesara.world.NpcZoneCreateSpec
+import dev.gvart.genesara.world.NpcZonePatch
+import dev.gvart.genesara.world.NpcZoneScope
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.WorldId
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.util.UUID
+
+@RestController
+@RequestMapping("/admin/worlds/{worldId}/npc-zones")
+internal class NpcZoneController(
+    private val gateway: NpcZoneAdminGateway,
+    private val auditLog: AdminAuditLog,
+    private val tickClock: TickClock,
+) {
+
+    @GetMapping
+    fun list(@PathVariable worldId: Long): List<NpcZoneDto> =
+        gateway.list(WorldId(worldId)).map(NpcZone::toDto)
+
+    @PostMapping
+    fun create(
+        @PathVariable worldId: Long,
+        @RequestBody req: CreateNpcZoneRequest,
+        @AuthenticationPrincipal admin: Admin,
+    ): ResponseEntity<NpcZoneDto> {
+        val tick = tickClock.currentTick()
+        val spec = NpcZoneCreateSpec(
+            worldId = WorldId(worldId),
+            scope = req.scope,
+            regionId = req.regionId?.let(::RegionId),
+            nodeId = req.nodeId?.let(::NodeId),
+            weights = req.weights.mapKeys { NpcType(it.key) },
+            maxConcurrent = req.maxConcurrent,
+            respawnTicks = req.respawnTicks,
+            active = req.active,
+            createdBy = admin.id.id,
+            createdAtTick = tick,
+        )
+        val zone = create(spec)
+        auditLog.record(
+            adminId = admin.id,
+            action = "npc-zone.create",
+            target = "npc-zone",
+            targetId = zone.zoneId.toString(),
+            payload = zone.toAuditPayload(),
+            tick = tick,
+        )
+        return ResponseEntity.status(HttpStatus.CREATED).body(zone.toDto())
+    }
+
+    @PatchMapping("/{zoneId}")
+    fun patch(
+        @PathVariable worldId: Long,
+        @PathVariable zoneId: UUID,
+        @RequestBody req: PatchNpcZoneRequest,
+        @AuthenticationPrincipal admin: Admin,
+    ): NpcZoneDto {
+        val patch = NpcZonePatch(
+            weights = req.weights.map { it.mapKeys { e -> NpcType(e.key) } },
+            maxConcurrent = req.maxConcurrent,
+            respawnTicks = req.respawnTicks,
+            active = req.active,
+        )
+        val updated = applyPatch(zoneId, patch)
+        requireZoneInWorld(WorldId(worldId), updated)
+        val tick = tickClock.currentTick()
+        val changedFields = mutableSetOf<String>().apply {
+            if (req.weights is MaybeSet.Set) add("weights")
+            if (req.maxConcurrent is MaybeSet.Set) add("maxConcurrent")
+            if (req.respawnTicks is MaybeSet.Set) add("respawnTicks")
+            if (req.active is MaybeSet.Set) add("active")
+        }
+        auditLog.record(
+            adminId = admin.id,
+            action = "npc-zone.patch",
+            target = "npc-zone",
+            targetId = zoneId.toString(),
+            payload = updated.toAuditPayload() + ("changedFields" to changedFields.toList()),
+            tick = tick,
+        )
+        return updated.toDto()
+    }
+
+    @DeleteMapping("/{zoneId}")
+    fun delete(
+        @PathVariable worldId: Long,
+        @PathVariable zoneId: UUID,
+        @AuthenticationPrincipal admin: Admin,
+    ): ResponseEntity<Void> {
+        val existing = gateway.list(WorldId(worldId)).firstOrNull { it.zoneId == zoneId }
+            ?: throw notFound("npc zone $zoneId not found in world $worldId")
+        val removed = gateway.delete(zoneId)
+        if (!removed) throw notFound("npc zone $zoneId not found")
+        auditLog.record(
+            adminId = admin.id,
+            action = "npc-zone.delete",
+            target = "npc-zone",
+            targetId = zoneId.toString(),
+            payload = existing.toAuditPayload(),
+            tick = tickClock.currentTick(),
+        )
+        return ResponseEntity.noContent().build()
+    }
+
+    private fun create(spec: NpcZoneCreateSpec): NpcZone =
+        try {
+            gateway.create(spec)
+        } catch (e: NpcZoneAdminError.UnknownNpcTypes) {
+            throw badRequest("unknown NPC types: ${e.types.joinToString { it.value }}")
+        } catch (e: NpcZoneAdminError.WorldMismatch) {
+            throw notFound(e.message ?: "target not found")
+        } catch (e: NpcZoneAdminError.ScopeMismatch) {
+            throw badRequest(e.message ?: "scope mismatch")
+        } catch (e: NpcZoneAdminError.EmptyWeights) {
+            throw badRequest("weights must contain at least one entry")
+        } catch (e: NpcZoneAdminError.NonPositiveWeight) {
+            throw badRequest("weight for ${e.type.value} must be positive (was ${e.weight})")
+        } catch (e: NpcZoneAdminError.NegativeMaxConcurrent) {
+            throw badRequest("maxConcurrent must be >= 0 (was ${e.value})")
+        } catch (e: NpcZoneAdminError.NegativeRespawnTicks) {
+            throw badRequest("respawnTicks must be >= 0 (was ${e.value})")
+        }
+
+    private fun applyPatch(zoneId: UUID, patch: NpcZonePatch): NpcZone =
+        try {
+            gateway.patch(zoneId, patch)
+        } catch (e: NpcZoneAdminError.NotFound) {
+            throw notFound("npc zone $zoneId not found")
+        } catch (e: NpcZoneAdminError.UnknownNpcTypes) {
+            throw badRequest("unknown NPC types: ${e.types.joinToString { it.value }}")
+        } catch (e: NpcZoneAdminError.EmptyWeights) {
+            throw badRequest("weights must contain at least one entry")
+        } catch (e: NpcZoneAdminError.NonPositiveWeight) {
+            throw badRequest("weight for ${e.type.value} must be positive (was ${e.weight})")
+        } catch (e: NpcZoneAdminError.NegativeMaxConcurrent) {
+            throw badRequest("maxConcurrent must be >= 0 (was ${e.value})")
+        } catch (e: NpcZoneAdminError.NegativeRespawnTicks) {
+            throw badRequest("respawnTicks must be >= 0 (was ${e.value})")
+        }
+
+    private fun requireZoneInWorld(worldId: WorldId, zone: NpcZone) {
+        if (zone.worldId != worldId) {
+            throw notFound("npc zone ${zone.zoneId} not found in world ${worldId.value}")
+        }
+    }
+
+    private fun badRequest(detail: String) = ResponseStatusException(HttpStatus.BAD_REQUEST, detail)
+    private fun notFound(detail: String) = ResponseStatusException(HttpStatus.NOT_FOUND, detail)
+}
+
+private fun NpcZone.toDto() = NpcZoneDto(
+    zoneId = zoneId,
+    worldId = worldId.value,
+    scope = scope,
+    regionId = regionId?.value,
+    nodeId = nodeId?.value,
+    weights = weights.mapKeys { it.key.value },
+    maxConcurrent = maxConcurrent,
+    respawnTicks = respawnTicks,
+    active = active,
+    createdBy = createdBy,
+    createdAtTick = createdAtTick,
+)
+
+private fun NpcZone.toAuditPayload(): Map<String, Any?> = mapOf(
+    "zoneId" to zoneId.toString(),
+    "worldId" to worldId.value,
+    "scope" to scope.name,
+    "regionId" to regionId?.value,
+    "nodeId" to nodeId?.value,
+    "weights" to weights.mapKeys { it.key.value },
+    "maxConcurrent" to maxConcurrent,
+    "respawnTicks" to respawnTicks,
+    "active" to active,
+)
+
+private inline fun <T, R> MaybeSet<T>.map(transform: (T) -> R): MaybeSet<R> = when (this) {
+    is MaybeSet.Skip -> MaybeSet.Skip
+    is MaybeSet.Set -> MaybeSet.Set(transform(value))
+}

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/NpcZoneControllerTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/rest/admin/worlds/NpcZoneControllerTest.kt
@@ -1,0 +1,275 @@
+package dev.gvart.genesara.api.internal.rest.admin.worlds
+
+import dev.gvart.genesara.admin.Admin
+import dev.gvart.genesara.admin.AdminAuditEntry
+import dev.gvart.genesara.admin.AdminAuditLog
+import dev.gvart.genesara.admin.AdminId
+import dev.gvart.genesara.api.internal.rest.GlobalExceptionAdvice
+import dev.gvart.genesara.engine.TickClock
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NpcType
+import dev.gvart.genesara.world.NpcZone
+import dev.gvart.genesara.world.NpcZoneAdminError
+import dev.gvart.genesara.world.NpcZoneAdminGateway
+import dev.gvart.genesara.world.NpcZoneCreateSpec
+import dev.gvart.genesara.world.NpcZonePatch
+import dev.gvart.genesara.world.NpcZoneScope
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.WorldId
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.patch
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NpcZoneControllerTest {
+
+    private val worldId = WorldId(7L)
+    private val admin = Admin(id = AdminId(UUID.randomUUID()), username = "ops")
+    private val tick = 42L
+
+    private lateinit var gateway: RecordingGateway
+    private lateinit var audit: RecordingAuditLog
+    private lateinit var mvc: MockMvc
+
+    @BeforeEach
+    fun setup() {
+        gateway = RecordingGateway()
+        audit = RecordingAuditLog()
+        mvc = MockMvcBuilders.standaloneSetup(
+            NpcZoneController(gateway, audit, FixedTickClock(tick)),
+        )
+            .setControllerAdvice(GlobalExceptionAdvice())
+            .setCustomArgumentResolvers(AuthenticationPrincipalArgumentResolver())
+            .build()
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken(admin, null, emptyList())
+    }
+
+    @AfterEach
+    fun clear() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `create node-scoped zone returns 201 and writes audit row`() {
+        val expected = sampleZone()
+        gateway.createResult = expected
+
+        mvc.post("/admin/worlds/${worldId.value}/npc-zones") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """
+                {
+                  "scope": "NODE",
+                  "nodeId": 11,
+                  "weights": {"GRAY_WOLF": 1},
+                  "maxConcurrent": 3,
+                  "respawnTicks": 100,
+                  "active": true
+                }
+            """.trimIndent()
+        }.andExpect {
+            status { isCreated() }
+            jsonPath("$.scope") { value("NODE") }
+            jsonPath("$.nodeId") { value(11) }
+            jsonPath("$.weights.GRAY_WOLF") { value(1) }
+        }
+
+        assertEquals(NpcZoneScope.NODE, gateway.lastCreateSpec?.scope)
+        assertEquals(NodeId(11L), gateway.lastCreateSpec?.nodeId)
+        assertEquals(mapOf(NpcType("GRAY_WOLF") to 1), gateway.lastCreateSpec?.weights)
+        val entry = audit.entries.single()
+        assertEquals("npc-zone.create", entry.action)
+        assertEquals(expected.zoneId.toString(), entry.targetId)
+    }
+
+    @Test
+    fun `create rejects unknown NPC type with 400`() {
+        gateway.createError = NpcZoneAdminError.UnknownNpcTypes(setOf(NpcType("PHANTOM")))
+
+        mvc.post("/admin/worlds/${worldId.value}/npc-zones") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"scope":"NODE","nodeId":11,"weights":{"PHANTOM":1},"maxConcurrent":1}"""
+        }.andExpect {
+            status { isBadRequest() }
+            jsonPath("$.detail") { value("unknown NPC types: PHANTOM") }
+        }
+
+        assertTrue(audit.entries.isEmpty())
+    }
+
+    @Test
+    fun `create rejects node outside world with 404`() {
+        gateway.createError = NpcZoneAdminError.WorldMismatch(WorldId(worldId.value), WorldId(99L))
+
+        mvc.post("/admin/worlds/${worldId.value}/npc-zones") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"scope":"NODE","nodeId":11,"weights":{"GRAY_WOLF":1},"maxConcurrent":1}"""
+        }.andExpect { status { isNotFound() } }
+
+        assertTrue(audit.entries.isEmpty())
+    }
+
+    @Test
+    fun `list returns zones for world`() {
+        gateway.listResult = listOf(sampleZone())
+
+        mvc.get("/admin/worlds/${worldId.value}/npc-zones").andExpect {
+            status { isOk() }
+            jsonPath("$.length()") { value(1) }
+        }
+    }
+
+    @Test
+    fun `patch updates weights and writes audit row`() {
+        val zoneId = UUID.randomUUID()
+        gateway.patchResult = sampleZone().copy(zoneId = zoneId, weights = mapOf(NpcType("WILD_BOAR") to 2))
+
+        mvc.patch("/admin/worlds/${worldId.value}/npc-zones/$zoneId") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"weights":{"WILD_BOAR":2}}"""
+        }.andExpect {
+            status { isOk() }
+            jsonPath("$.weights.WILD_BOAR") { value(2) }
+        }
+
+        assertEquals(mapOf(NpcType("WILD_BOAR") to 2), (gateway.lastPatch?.weights as? dev.gvart.genesara.world.MaybeSet.Set)?.value)
+        val entry = audit.entries.single()
+        assertEquals("npc-zone.patch", entry.action)
+        assertEquals(listOf("weights"), entry.payload["changedFields"])
+    }
+
+    @Test
+    fun `patch rejects when zone belongs to another world`() {
+        val zoneId = UUID.randomUUID()
+        gateway.patchResult = sampleZone().copy(zoneId = zoneId, worldId = WorldId(99L))
+
+        mvc.patch("/admin/worlds/${worldId.value}/npc-zones/$zoneId") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"maxConcurrent":5}"""
+        }.andExpect { status { isNotFound() } }
+    }
+
+    @Test
+    fun `patch returns 404 when gateway reports not found`() {
+        val zoneId = UUID.randomUUID()
+        gateway.patchError = NpcZoneAdminError.NotFound(zoneId)
+
+        mvc.patch("/admin/worlds/${worldId.value}/npc-zones/$zoneId") {
+            contentType = MediaType.APPLICATION_JSON
+            content = """{"active":false}"""
+        }.andExpect { status { isNotFound() } }
+    }
+
+    @Test
+    fun `delete removes zone and writes audit row`() {
+        val zoneId = UUID.randomUUID()
+        val existing = sampleZone().copy(zoneId = zoneId)
+        gateway.listResult = listOf(existing)
+        gateway.deleteResult = true
+
+        mvc.delete("/admin/worlds/${worldId.value}/npc-zones/$zoneId")
+            .andExpect { status { isNoContent() } }
+
+        assertEquals(zoneId, gateway.lastDeleteId)
+        assertEquals("npc-zone.delete", audit.entries.single().action)
+    }
+
+    @Test
+    fun `delete returns 404 when zone not in world`() {
+        val zoneId = UUID.randomUUID()
+        gateway.listResult = emptyList()
+
+        mvc.delete("/admin/worlds/${worldId.value}/npc-zones/$zoneId")
+            .andExpect { status { isNotFound() } }
+
+        assertTrue(audit.entries.isEmpty())
+    }
+
+    private fun sampleZone() = NpcZone(
+        zoneId = UUID.randomUUID(),
+        worldId = worldId,
+        scope = NpcZoneScope.NODE,
+        regionId = null,
+        nodeId = NodeId(11L),
+        weights = mapOf(NpcType("GRAY_WOLF") to 1),
+        maxConcurrent = 3,
+        respawnTicks = 100,
+        active = true,
+        createdBy = admin.id.id,
+        createdAtTick = tick,
+    )
+
+    private class RecordingGateway : NpcZoneAdminGateway {
+        var createResult: NpcZone? = null
+        var createError: RuntimeException? = null
+        var lastCreateSpec: NpcZoneCreateSpec? = null
+        var listResult: List<NpcZone> = emptyList()
+        var patchResult: NpcZone? = null
+        var patchError: RuntimeException? = null
+        var lastPatch: NpcZonePatch? = null
+        var deleteResult = true
+        var lastDeleteId: UUID? = null
+
+        override fun list(worldId: WorldId): List<NpcZone> = listResult
+
+        override fun create(spec: NpcZoneCreateSpec): NpcZone {
+            lastCreateSpec = spec
+            createError?.let { throw it }
+            return createResult ?: error("createResult not set")
+        }
+
+        override fun patch(zoneId: UUID, patch: NpcZonePatch): NpcZone {
+            lastPatch = patch
+            patchError?.let { throw it }
+            return patchResult ?: error("patchResult not set")
+        }
+
+        override fun delete(zoneId: UUID): Boolean {
+            lastDeleteId = zoneId
+            return deleteResult
+        }
+    }
+
+    private class RecordingAuditLog : AdminAuditLog {
+        val entries = mutableListOf<AdminAuditEntry>()
+        override fun record(
+            adminId: AdminId,
+            action: String,
+            target: String,
+            targetId: String?,
+            payload: Map<String, Any?>,
+            tick: Long,
+        ): Long {
+            entries += AdminAuditEntry(
+                seq = entries.size + 1L,
+                adminId = adminId,
+                action = action,
+                target = target,
+                targetId = targetId,
+                payload = payload,
+                tick = tick,
+                occurredAt = Instant.EPOCH,
+            )
+            return entries.last().seq
+        }
+        override fun readAfter(after: Long, limit: Int): List<AdminAuditEntry> = error("unused")
+    }
+
+    private class FixedTickClock(private val tick: Long) : TickClock {
+        override fun currentTick(): Long = tick
+    }
+}

--- a/world/core/build.gradle.kts
+++ b/world/core/build.gradle.kts
@@ -32,5 +32,5 @@ dependencies {
 jooqModule {
     migrationsSubdir.set("world-core")
     generatedPackage.set("dev.gvart.genesara.world.internal.jooq")
-    tableIncludes.set("worlds|regions|region_neighbors|nodes|node_adjacency|agent_positions|agent_bodies|starter_nodes|agent_inventory|non_renewable_resources|agent_node_memory|agent_item_instances|agent_safe_nodes|node_buildings|node_building_bars|building_chest_inventory|building_gate_states|world_tick|agent_action_counters|agent_known_recipes|trade_offers|agent_plots|npcs|mounts|mount_inventory")
+    tableIncludes.set("worlds|regions|region_neighbors|nodes|node_adjacency|agent_positions|agent_bodies|starter_nodes|agent_inventory|non_renewable_resources|agent_node_memory|agent_item_instances|agent_safe_nodes|node_buildings|node_building_bars|building_chest_inventory|building_gate_states|world_tick|agent_action_counters|agent_known_recipes|trade_offers|agent_plots|npcs|mounts|mount_inventory|npc_zones")
 }

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/NpcZone.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/NpcZone.kt
@@ -1,0 +1,23 @@
+package dev.gvart.genesara.world
+
+import java.util.UUID
+
+/**
+ * Operator overlay over biome-driven spawn rules; exactly one of [regionId] / [nodeId]
+ * is non-null per [scope], and the catalog's `spawnBiomes` filter is still enforced.
+ */
+data class NpcZone(
+    val zoneId: UUID,
+    val worldId: WorldId,
+    val scope: NpcZoneScope,
+    val regionId: RegionId?,
+    val nodeId: NodeId?,
+    val weights: Map<NpcType, Int>,
+    val maxConcurrent: Int,
+    val respawnTicks: Int?,
+    val active: Boolean,
+    val createdBy: UUID,
+    val createdAtTick: Long,
+)
+
+enum class NpcZoneScope { REGION, NODE }

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/NpcZoneAdminGateway.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/NpcZoneAdminGateway.kt
@@ -1,0 +1,53 @@
+package dev.gvart.genesara.world
+
+import java.util.UUID
+
+/** Admin-side CRUD for [NpcZone]; validates weights against the NPC catalog and target ownership. */
+interface NpcZoneAdminGateway {
+    fun list(worldId: WorldId): List<NpcZone>
+
+    fun create(spec: NpcZoneCreateSpec): NpcZone
+
+    fun patch(zoneId: UUID, patch: NpcZonePatch): NpcZone
+
+    fun delete(zoneId: UUID): Boolean
+}
+
+data class NpcZoneCreateSpec(
+    val worldId: WorldId,
+    val scope: NpcZoneScope,
+    val regionId: RegionId?,
+    val nodeId: NodeId?,
+    val weights: Map<NpcType, Int>,
+    val maxConcurrent: Int,
+    val respawnTicks: Int?,
+    val active: Boolean,
+    val createdBy: UUID,
+    val createdAtTick: Long,
+)
+
+data class NpcZonePatch(
+    val weights: MaybeSet<Map<NpcType, Int>> = MaybeSet.Skip,
+    val maxConcurrent: MaybeSet<Int> = MaybeSet.Skip,
+    val respawnTicks: MaybeSet<Int?> = MaybeSet.Skip,
+    val active: MaybeSet<Boolean> = MaybeSet.Skip,
+)
+
+sealed class NpcZoneAdminError(message: String) : RuntimeException(message) {
+    class NotFound(val zoneId: UUID) : NpcZoneAdminError("Zone not found: $zoneId")
+    class UnknownNpcTypes(val types: Set<NpcType>) :
+        NpcZoneAdminError("Unknown NPC types: ${types.joinToString { it.value }}")
+    class WorldMismatch(val expected: WorldId, val actual: WorldId?) :
+        NpcZoneAdminError(
+            "Target does not belong to world ${expected.value}" +
+                (actual?.let { " (found in ${it.value})" } ?: " (not found)")
+        )
+    class ScopeMismatch(val detail: String) : NpcZoneAdminError("Scope mismatch: $detail")
+    class EmptyWeights : NpcZoneAdminError("weights must contain at least one entry")
+    class NonPositiveWeight(val type: NpcType, val weight: Int) :
+        NpcZoneAdminError("weight for ${type.value} must be positive (was $weight)")
+    class NegativeMaxConcurrent(val value: Int) :
+        NpcZoneAdminError("max_concurrent must be >= 0 (was $value)")
+    class NegativeRespawnTicks(val value: Int) :
+        NpcZoneAdminError("respawn_ticks must be >= 0 (was $value)")
+}

--- a/world/core/src/main/kotlin/dev/gvart/genesara/world/NpcZoneLookup.kt
+++ b/world/core/src/main/kotlin/dev/gvart/genesara/world/NpcZoneLookup.kt
@@ -1,0 +1,6 @@
+package dev.gvart.genesara.world
+
+/** Node match beats region match; only [NpcZone.active] rows participate. */
+interface NpcZoneLookup {
+    fun resolveFor(nodeId: NodeId, regionId: RegionId): NpcZone?
+}

--- a/world/core/src/main/resources/db/migration/world-core/V31__npc_zones.sql
+++ b/world/core/src/main/resources/db/migration/world-core/V31__npc_zones.sql
@@ -1,0 +1,31 @@
+-- Phase 2 admin overlay: operator-defined per-region / per-node spawn rules
+-- that override the catalog's biome-driven density without editing the
+-- catalog YAML. A zone never overrides the catalog's `spawnBiomes` filter
+-- (zones tune *how much* spawns, not *whether the biome allows it*); the
+-- LazyNpcSpawn reducer enforces that intersection at seed time.
+--
+-- Resolution at seed time is node first, then region — a NODE zone defined
+-- inside a REGION-zoned region wins. When no zone resolves, the seeder falls
+-- back to the biome-driven nodeNpcCapacity behaviour verbatim.
+CREATE TABLE npc_zones
+(
+    zone_id           UUID         NOT NULL,
+    world_id          BIGINT       NOT NULL REFERENCES worlds (id),
+    scope             VARCHAR(16)  NOT NULL,
+    region_id         BIGINT       NULL REFERENCES regions (id),
+    node_id           BIGINT       NULL REFERENCES nodes (id),
+    weights           JSONB        NOT NULL,
+    max_concurrent    INT          NOT NULL CHECK (max_concurrent >= 0),
+    respawn_ticks     INT          NULL CHECK (respawn_ticks IS NULL OR respawn_ticks >= 0),
+    active            BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_by        UUID         NOT NULL,
+    created_at_tick   BIGINT       NOT NULL,
+    PRIMARY KEY (zone_id),
+    CHECK (scope IN ('REGION', 'NODE')),
+    CHECK ((scope = 'REGION' AND region_id IS NOT NULL AND node_id IS NULL)
+        OR (scope = 'NODE'   AND node_id   IS NOT NULL AND region_id IS NULL))
+);
+
+CREATE INDEX idx_npc_zones_world  ON npc_zones (world_id);
+CREATE INDEX idx_npc_zones_region ON npc_zones (region_id) WHERE region_id IS NOT NULL;
+CREATE INDEX idx_npc_zones_node   ON npc_zones (node_id)   WHERE node_id   IS NOT NULL;

--- a/world/core/src/testFixtures/kotlin/dev/gvart/genesara/world/internal/testsupport/NoOpNpcsStore.kt
+++ b/world/core/src/testFixtures/kotlin/dev/gvart/genesara/world/internal/testsupport/NoOpNpcsStore.kt
@@ -7,8 +7,11 @@ import dev.gvart.genesara.world.NpcCatalog
 import dev.gvart.genesara.world.NpcDef
 import dev.gvart.genesara.world.NpcId
 import dev.gvart.genesara.world.NpcType
+import dev.gvart.genesara.world.NpcZone
+import dev.gvart.genesara.world.NpcZoneLookup
 import dev.gvart.genesara.world.NpcsStore
 import dev.gvart.genesara.world.NodeClearedTimestampStore
+import dev.gvart.genesara.world.RegionId
 
 /** Empty [NpcsStore] for tests that don't exercise NPC behavior. */
 object NoOpNpcsStore : NpcsStore {
@@ -31,4 +34,9 @@ object NoOpNpcCatalog : NpcCatalog {
 object NoOpNodeClearedTimestampStore : NodeClearedTimestampStore {
     override fun lastClearedTick(nodeId: NodeId): Long = 0L
     override fun setLastClearedTick(nodeId: NodeId, tick: Long) = Unit
+}
+
+/** Never resolves a zone — seeder falls through to biome-driven behaviour. */
+object NoOpNpcZoneLookup : NpcZoneLookup {
+    override fun resolveFor(nodeId: NodeId, regionId: RegionId): NpcZone? = null
 }

--- a/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/npc/LazyNpcSpawn.kt
+++ b/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/npc/LazyNpcSpawn.kt
@@ -1,12 +1,15 @@
 package dev.gvart.genesara.world.environment.internal.npc
 
 import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.Biome
 import dev.gvart.genesara.world.NodeClearedTimestampStore
 import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.Npc
 import dev.gvart.genesara.world.NpcCatalog
 import dev.gvart.genesara.world.NpcDef
 import dev.gvart.genesara.world.NpcId
+import dev.gvart.genesara.world.NpcZone
+import dev.gvart.genesara.world.NpcZoneLookup
 import dev.gvart.genesara.world.events.EnvironmentEvent
 import dev.gvart.genesara.world.events.WorldEvent
 import dev.gvart.genesara.world.internal.balance.BalanceLookup
@@ -58,6 +61,7 @@ class LazyNpcSpawn(
     private val balance: BalanceLookup,
     private val worldDef: WorldDefinitionProperties,
     private val clearedStore: NodeClearedTimestampStore,
+    private val zoneLookup: NpcZoneLookup,
 ) : LazyNpcSpawnHook {
     /**
      * Hook from [dev.gvart.genesara.world.internal.movement.MovementReducer] —
@@ -75,36 +79,38 @@ class LazyNpcSpawn(
         val region = state.regions[node.regionId] ?: return state to emptyList()
         val biome = region.biome ?: return state to emptyList()
         val biomeProps = worldDef.biomes[biome] ?: return state to emptyList()
-        val capacity = biomeProps.nodeNpcCapacity
+
+        val zone = zoneLookup.resolveFor(destination, region.id)
+        val capacity = zone?.maxConcurrent ?: biomeProps.nodeNpcCapacity
         if (capacity <= 0) return state to emptyList()
 
-        if (!nodeSelectedForSpawn(destination, biomeProps.nodeSpawnProbability)) {
+        if (zone == null && !nodeSelectedForSpawn(destination, biomeProps.nodeSpawnProbability)) {
             return state to emptyList()
         }
 
-        val pool = catalog.byBiome(biome)
+        val pool = resolvePool(zone, biome)
         if (pool.isEmpty()) return state to emptyList()
 
         val existing = state.npcs.values.count { it.nodeId == destination }
         if (existing > 0) return state to emptyList()
 
+        val respawnThreshold = zone?.respawnTicks?.toLong() ?: balance.npcRespawnTicks()
         val lastCleared = state.nodesClearedThisTick[destination]
             ?: clearedStore.lastClearedTick(destination)
-        if (tick - lastCleared < balance.npcRespawnTicks()) return state to emptyList()
+        if (tick - lastCleared < respawnThreshold) return state to emptyList()
 
-        val totalWeight = pool.sumOf { it.spawnWeight }
+        val totalWeight = pool.sumOf { it.weight }
         if (totalWeight <= 0) return state to emptyList()
-        val toSpawn = capacity
         val spawned = mutableListOf<Npc>()
-        repeat(toSpawn) {
+        repeat(capacity) {
             val pick = weightedPick(pool, totalWeight, rng)
             val npc = Npc(
                 id = NpcId(UUID.randomUUID()),
-                type = pick.type,
+                type = pick.def.type,
                 nodeId = destination,
                 spawnNodeId = destination,
-                hpCurrent = pick.hpMax,
-                hpMax = pick.hpMax,
+                hpCurrent = pick.def.hpMax,
+                hpMax = pick.def.hpMax,
                 spawnedAtTick = tick,
                 lastAttackTick = tick,
             )
@@ -126,6 +132,19 @@ class LazyNpcSpawn(
         }
         return nextState to events
     }
+
+    // Zone weights override the catalog's spawn-weight, but `spawnBiomes` still applies:
+    // a zone can't conjure wolves into a desert biome that doesn't list them.
+    private fun resolvePool(zone: NpcZone?, biome: Biome): List<WeightedDef> {
+        if (zone == null) {
+            return catalog.byBiome(biome).map { WeightedDef(it, it.spawnWeight) }
+        }
+        return zone.weights.mapNotNull { (type, weight) ->
+            val def = catalog.byType(type) ?: return@mapNotNull null
+            if (biome !in def.spawnBiomes) return@mapNotNull null
+            WeightedDef(def, weight)
+        }
+    }
 }
 
 internal fun nodeSelectedForSpawn(nodeId: NodeId, probability: Double): Boolean {
@@ -144,11 +163,13 @@ private fun nodeSpawnFraction(nodeId: NodeId): Double {
     return unsigned.toDouble() / (1L shl 53).toDouble()
 }
 
-private fun weightedPick(pool: List<NpcDef>, totalWeight: Int, rng: Random): NpcDef {
+internal data class WeightedDef(val def: NpcDef, val weight: Int)
+
+private fun weightedPick(pool: List<WeightedDef>, totalWeight: Int, rng: Random): WeightedDef {
     val pick = rng.nextInt(totalWeight.coerceAtLeast(1))
     var acc = 0
     for (entry in pool) {
-        acc += entry.spawnWeight
+        acc += entry.weight
         if (pick < acc) return entry
     }
     return pool.last()

--- a/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/zones/JooqNpcZonesStore.kt
+++ b/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/zones/JooqNpcZonesStore.kt
@@ -1,0 +1,112 @@
+package dev.gvart.genesara.world.environment.internal.zones
+
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NpcType
+import dev.gvart.genesara.world.NpcZone
+import dev.gvart.genesara.world.NpcZoneScope
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.internal.jooq.tables.records.NpcZonesRecord
+import dev.gvart.genesara.world.internal.jooq.tables.references.NPC_ZONES
+import org.jooq.DSLContext
+import org.jooq.JSON
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import tools.jackson.core.type.TypeReference
+import tools.jackson.databind.ObjectMapper
+import java.util.UUID
+
+@Component
+internal class JooqNpcZonesStore(
+    private val dsl: DSLContext,
+    private val mapper: ObjectMapper,
+) : NpcZonesStore {
+
+    @Transactional(readOnly = true)
+    override fun listByWorld(worldId: WorldId): List<NpcZone> =
+        dsl.selectFrom(NPC_ZONES)
+            .where(NPC_ZONES.WORLD_ID.eq(worldId.value))
+            .orderBy(NPC_ZONES.CREATED_AT_TICK.asc())
+            .fetch(::toDomain)
+
+    @Transactional(readOnly = true)
+    override fun findById(zoneId: UUID): NpcZone? =
+        dsl.selectFrom(NPC_ZONES)
+            .where(NPC_ZONES.ZONE_ID.eq(zoneId))
+            .fetchOne(::toDomain)
+
+    @Transactional(readOnly = true)
+    override fun findActiveByNode(nodeId: NodeId): NpcZone? =
+        dsl.selectFrom(NPC_ZONES)
+            .where(NPC_ZONES.NODE_ID.eq(nodeId.value))
+            .and(NPC_ZONES.ACTIVE.eq(true))
+            .orderBy(NPC_ZONES.CREATED_AT_TICK.desc())
+            .limit(1)
+            .fetchOne(::toDomain)
+
+    @Transactional(readOnly = true)
+    override fun findActiveByRegion(regionId: RegionId): NpcZone? =
+        dsl.selectFrom(NPC_ZONES)
+            .where(NPC_ZONES.REGION_ID.eq(regionId.value))
+            .and(NPC_ZONES.ACTIVE.eq(true))
+            .orderBy(NPC_ZONES.CREATED_AT_TICK.desc())
+            .limit(1)
+            .fetchOne(::toDomain)
+
+    @Transactional
+    override fun insert(zone: NpcZone) {
+        dsl.insertInto(NPC_ZONES)
+            .set(NPC_ZONES.ZONE_ID, zone.zoneId)
+            .set(NPC_ZONES.WORLD_ID, zone.worldId.value)
+            .set(NPC_ZONES.SCOPE, zone.scope.name)
+            .set(NPC_ZONES.REGION_ID, zone.regionId?.value)
+            .set(NPC_ZONES.NODE_ID, zone.nodeId?.value)
+            .set(NPC_ZONES.WEIGHTS, encodeWeights(zone.weights))
+            .set(NPC_ZONES.MAX_CONCURRENT, zone.maxConcurrent)
+            .set(NPC_ZONES.RESPAWN_TICKS, zone.respawnTicks)
+            .set(NPC_ZONES.ACTIVE, zone.active)
+            .set(NPC_ZONES.CREATED_BY, zone.createdBy)
+            .set(NPC_ZONES.CREATED_AT_TICK, zone.createdAtTick)
+            .execute()
+    }
+
+    @Transactional
+    override fun update(zone: NpcZone): NpcZone? {
+        val updated = dsl.update(NPC_ZONES)
+            .set(NPC_ZONES.WEIGHTS, encodeWeights(zone.weights))
+            .set(NPC_ZONES.MAX_CONCURRENT, zone.maxConcurrent)
+            .set(NPC_ZONES.RESPAWN_TICKS, zone.respawnTicks)
+            .set(NPC_ZONES.ACTIVE, zone.active)
+            .where(NPC_ZONES.ZONE_ID.eq(zone.zoneId))
+            .execute()
+        return if (updated > 0) zone else null
+    }
+
+    @Transactional
+    override fun delete(zoneId: UUID): Boolean =
+        dsl.deleteFrom(NPC_ZONES).where(NPC_ZONES.ZONE_ID.eq(zoneId)).execute() > 0
+
+    private fun encodeWeights(weights: Map<NpcType, Int>): JSON =
+        JSON.valueOf(mapper.writeValueAsString(weights.mapKeys { it.key.value }))
+
+    private fun decodeWeights(json: JSON): Map<NpcType, Int> =
+        mapper.readValue(json.data(), WEIGHT_MAP_TYPE).mapKeys { NpcType(it.key) }
+
+    private fun toDomain(record: NpcZonesRecord): NpcZone = NpcZone(
+        zoneId = record.zoneId,
+        worldId = WorldId(record.worldId),
+        scope = NpcZoneScope.valueOf(record.scope),
+        regionId = record.regionId?.let(::RegionId),
+        nodeId = record.nodeId?.let(::NodeId),
+        weights = decodeWeights(record.weights),
+        maxConcurrent = record.maxConcurrent,
+        respawnTicks = record.respawnTicks,
+        active = record.active!!,
+        createdBy = record.createdBy,
+        createdAtTick = record.createdAtTick,
+    )
+
+    private companion object {
+        private val WEIGHT_MAP_TYPE = object : TypeReference<Map<String, Int>>() {}
+    }
+}

--- a/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/zones/NpcZoneAdminGatewayImpl.kt
+++ b/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/zones/NpcZoneAdminGatewayImpl.kt
@@ -1,0 +1,134 @@
+package dev.gvart.genesara.world.environment.internal.zones
+
+import dev.gvart.genesara.world.MaybeSet
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NpcCatalog
+import dev.gvart.genesara.world.NpcType
+import dev.gvart.genesara.world.NpcZone
+import dev.gvart.genesara.world.NpcZoneAdminError
+import dev.gvart.genesara.world.NpcZoneAdminGateway
+import dev.gvart.genesara.world.NpcZoneCreateSpec
+import dev.gvart.genesara.world.NpcZonePatch
+import dev.gvart.genesara.world.NpcZoneScope
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldQueryGateway
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+internal class NpcZoneAdminGatewayImpl(
+    private val store: NpcZonesStore,
+    private val catalog: NpcCatalog,
+    private val world: WorldQueryGateway,
+) : NpcZoneAdminGateway {
+
+    override fun list(worldId: WorldId): List<NpcZone> = store.listByWorld(worldId)
+
+    override fun create(spec: NpcZoneCreateSpec): NpcZone {
+        validateScope(spec.scope, spec.regionId, spec.nodeId)
+        validateWeights(spec.weights)
+        if (spec.maxConcurrent < 0) throw NpcZoneAdminError.NegativeMaxConcurrent(spec.maxConcurrent)
+        spec.respawnTicks?.let { if (it < 0) throw NpcZoneAdminError.NegativeRespawnTicks(it) }
+        when (spec.scope) {
+            NpcZoneScope.REGION -> requireRegionInWorld(spec.worldId, spec.regionId!!)
+            NpcZoneScope.NODE -> requireNodeInWorld(spec.worldId, spec.nodeId!!)
+        }
+        val zone = NpcZone(
+            zoneId = UUID.randomUUID(),
+            worldId = spec.worldId,
+            scope = spec.scope,
+            regionId = spec.regionId,
+            nodeId = spec.nodeId,
+            weights = spec.weights,
+            maxConcurrent = spec.maxConcurrent,
+            respawnTicks = spec.respawnTicks,
+            active = spec.active,
+            createdBy = spec.createdBy,
+            createdAtTick = spec.createdAtTick,
+        )
+        store.insert(zone)
+        return zone
+    }
+
+    override fun patch(zoneId: UUID, patch: NpcZonePatch): NpcZone {
+        val existing = store.findById(zoneId) ?: throw NpcZoneAdminError.NotFound(zoneId)
+        val weightsPatch = patch.weights
+        val newWeights = when (weightsPatch) {
+            is MaybeSet.Skip -> existing.weights
+            is MaybeSet.Set -> weightsPatch.value.also(::validateWeights)
+        }
+        val maxConcurrentPatch = patch.maxConcurrent
+        val newMaxConcurrent = when (maxConcurrentPatch) {
+            is MaybeSet.Skip -> existing.maxConcurrent
+            is MaybeSet.Set -> maxConcurrentPatch.value.also {
+                if (it < 0) throw NpcZoneAdminError.NegativeMaxConcurrent(it)
+            }
+        }
+        val respawnTicksPatch = patch.respawnTicks
+        val newRespawnTicks = when (respawnTicksPatch) {
+            is MaybeSet.Skip -> existing.respawnTicks
+            is MaybeSet.Set -> respawnTicksPatch.value?.also {
+                if (it < 0) throw NpcZoneAdminError.NegativeRespawnTicks(it)
+            }
+        }
+        val activePatch = patch.active
+        val newActive = when (activePatch) {
+            is MaybeSet.Skip -> existing.active
+            is MaybeSet.Set -> activePatch.value
+        }
+        val updated = existing.copy(
+            weights = newWeights,
+            maxConcurrent = newMaxConcurrent,
+            respawnTicks = newRespawnTicks,
+            active = newActive,
+        )
+        return store.update(updated) ?: throw NpcZoneAdminError.NotFound(zoneId)
+    }
+
+    override fun delete(zoneId: UUID): Boolean = store.delete(zoneId)
+
+    private fun validateScope(scope: NpcZoneScope, regionId: RegionId?, nodeId: NodeId?) {
+        when (scope) {
+            NpcZoneScope.REGION ->
+                if (regionId == null || nodeId != null) {
+                    throw NpcZoneAdminError.ScopeMismatch(
+                        "REGION scope requires regionId set and nodeId null"
+                    )
+                }
+            NpcZoneScope.NODE ->
+                if (nodeId == null || regionId != null) {
+                    throw NpcZoneAdminError.ScopeMismatch(
+                        "NODE scope requires nodeId set and regionId null"
+                    )
+                }
+        }
+    }
+
+    private fun validateWeights(weights: Map<NpcType, Int>) {
+        if (weights.isEmpty()) throw NpcZoneAdminError.EmptyWeights()
+        val unknown = weights.keys.filter { catalog.byType(it) == null }.toSet()
+        if (unknown.isNotEmpty()) throw NpcZoneAdminError.UnknownNpcTypes(unknown)
+        for ((type, weight) in weights) {
+            if (weight <= 0) throw NpcZoneAdminError.NonPositiveWeight(type, weight)
+        }
+    }
+
+    private fun requireNodeInWorld(worldId: WorldId, nodeId: NodeId) {
+        val node = world.node(nodeId)
+            ?: throw NpcZoneAdminError.WorldMismatch(expected = worldId, actual = null)
+        val region = world.region(node.regionId)
+            ?: throw NpcZoneAdminError.WorldMismatch(expected = worldId, actual = null)
+        if (region.worldId != worldId) {
+            throw NpcZoneAdminError.WorldMismatch(expected = worldId, actual = region.worldId)
+        }
+    }
+
+    private fun requireRegionInWorld(worldId: WorldId, regionId: RegionId) {
+        val region = world.region(regionId)
+            ?: throw NpcZoneAdminError.WorldMismatch(expected = worldId, actual = null)
+        if (region.worldId != worldId) {
+            throw NpcZoneAdminError.WorldMismatch(expected = worldId, actual = region.worldId)
+        }
+    }
+}

--- a/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/zones/NpcZoneLookupImpl.kt
+++ b/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/zones/NpcZoneLookupImpl.kt
@@ -1,0 +1,15 @@
+package dev.gvart.genesara.world.environment.internal.zones
+
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NpcZone
+import dev.gvart.genesara.world.NpcZoneLookup
+import dev.gvart.genesara.world.RegionId
+import org.springframework.stereotype.Component
+
+@Component
+internal class NpcZoneLookupImpl(
+    private val store: NpcZonesStore,
+) : NpcZoneLookup {
+    override fun resolveFor(nodeId: NodeId, regionId: RegionId): NpcZone? =
+        store.findActiveByNode(nodeId) ?: store.findActiveByRegion(regionId)
+}

--- a/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/zones/NpcZonesStore.kt
+++ b/world/environment/src/main/kotlin/dev/gvart/genesara/world/environment/internal/zones/NpcZonesStore.kt
@@ -1,0 +1,17 @@
+package dev.gvart.genesara.world.environment.internal.zones
+
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NpcZone
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.WorldId
+import java.util.UUID
+
+internal interface NpcZonesStore {
+    fun listByWorld(worldId: WorldId): List<NpcZone>
+    fun findById(zoneId: UUID): NpcZone?
+    fun findActiveByNode(nodeId: NodeId): NpcZone?
+    fun findActiveByRegion(regionId: RegionId): NpcZone?
+    fun insert(zone: NpcZone)
+    fun update(zone: NpcZone): NpcZone?
+    fun delete(zoneId: UUID): Boolean
+}

--- a/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/npc/LazyNpcSpawnTest.kt
+++ b/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/npc/LazyNpcSpawnTest.kt
@@ -13,6 +13,9 @@ import dev.gvart.genesara.world.NodeId
 import dev.gvart.genesara.world.NpcCatalog
 import dev.gvart.genesara.world.NpcDef
 import dev.gvart.genesara.world.NpcType
+import dev.gvart.genesara.world.NpcZone
+import dev.gvart.genesara.world.NpcZoneLookup
+import dev.gvart.genesara.world.NpcZoneScope
 import dev.gvart.genesara.world.Region
 import dev.gvart.genesara.world.RegionId
 import dev.gvart.genesara.world.ResourceSpawnRule
@@ -57,6 +60,21 @@ class LazyNpcSpawnTest {
         spawnBiomes = setOf(Biome.FOREST),
         spawnWeight = 1,
     )
+    private val boarDef = NpcDef(
+        type = NpcType("WILD_BOAR"),
+        displayName = "Wild Boar",
+        hpMax = 40,
+        damage = 5,
+        damageType = DamageType.BLUNT,
+        range = 1,
+        attackIntervalTicks = 4,
+        defense = 1,
+        dodgeChancePercent = 0,
+        aggressionProfile = AggressionProfile.HOSTILE,
+        territoryRadius = 0,
+        spawnBiomes = setOf(Biome.FOREST),
+        spawnWeight = 1,
+    )
 
     private val baseState = WorldState(
         regions = mapOf(regionId to region),
@@ -73,6 +91,7 @@ class LazyNpcSpawnTest {
             balance = balance(respawnTicks = 100),
             worldDef = worldDefWithCapacity(forest = 2),
             clearedStore = StubClearedStore(default = 0L),
+            zoneLookup = StubZoneLookup(),
         )
 
         val (after, events) = spawn.maybeSeed(baseState, nodeId, agent, tick = 1000L, rng = Random(0L))
@@ -90,6 +109,7 @@ class LazyNpcSpawnTest {
             balance = balance(respawnTicks = 500),
             worldDef = worldDefWithCapacity(forest = 2),
             clearedStore = StubClearedStore(default = 900L),
+            zoneLookup = StubZoneLookup(),
         )
 
         val (after, events) = spawn.maybeSeed(baseState, nodeId, agent, tick = 1000L, rng = Random(0L))
@@ -105,6 +125,7 @@ class LazyNpcSpawnTest {
             balance = balance(respawnTicks = 0),
             worldDef = worldDefWithCapacity(forest = 0),
             clearedStore = StubClearedStore(default = 0L),
+            zoneLookup = StubZoneLookup(),
         )
 
         val (after, events) = spawn.maybeSeed(baseState, nodeId, agent, tick = 100L, rng = Random(0L))
@@ -151,6 +172,7 @@ class LazyNpcSpawnTest {
             balance = balance(respawnTicks = 0),
             worldDef = worldDefWithCapacity(forest = 2, nodeSpawnProbability = 0.10),
             clearedStore = StubClearedStore(default = 0L),
+            zoneLookup = StubZoneLookup(),
         )
 
         for (i in 0 until 50) {
@@ -188,6 +210,7 @@ class LazyNpcSpawnTest {
             balance = balance(respawnTicks = 0),
             worldDef = worldDefWithCapacity(forest = 2, nodeSpawnProbability = 0.0),
             clearedStore = StubClearedStore(default = 0L),
+            zoneLookup = StubZoneLookup(),
         )
 
         val (after, events) = spawn.maybeSeed(pre, nodeId, agent, tick = 1000L, rng = Random(0L))
@@ -218,6 +241,7 @@ class LazyNpcSpawnTest {
             balance = balance(respawnTicks = 0),
             worldDef = worldDefWithCapacity(forest = 4),
             clearedStore = StubClearedStore(default = 0L),
+            zoneLookup = StubZoneLookup(),
         )
 
         val (after, events) = spawn.maybeSeed(existing, nodeId, agent, tick = 100L, rng = Random(0L))
@@ -225,6 +249,133 @@ class LazyNpcSpawnTest {
         assertEquals(1, after.npcs.size)
         assertEquals(0, events.size)
     }
+
+    @Test
+    fun `node zone weights override biome catalog selection`() {
+        val zone = nodeZone(nodeId, weights = mapOf(wolfDef.type to 1), maxConcurrent = 3)
+        val spawn = LazyNpcSpawn(
+            catalog = catalogWith(wolfDef, boarDef),
+            balance = balance(respawnTicks = 0),
+            worldDef = worldDefWithCapacity(forest = 5),
+            clearedStore = StubClearedStore(default = 0L),
+            zoneLookup = StubZoneLookup(byNode = mapOf(nodeId to zone)),
+        )
+
+        val (after, _) = spawn.maybeSeed(baseState, nodeId, agent, tick = 1000L, rng = Random(0L))
+
+        assertEquals(3, after.npcs.size)
+        assertTrue(after.npcs.values.all { it.type == wolfDef.type })
+    }
+
+    @Test
+    fun `node zone resolution beats region zone`() {
+        val nodeZone = nodeZone(nodeId, weights = mapOf(wolfDef.type to 1), maxConcurrent = 1)
+        val regionZone = regionZone(regionId, weights = mapOf(boarDef.type to 1), maxConcurrent = 5)
+        val spawn = LazyNpcSpawn(
+            catalog = catalogWith(wolfDef, boarDef),
+            balance = balance(respawnTicks = 0),
+            worldDef = worldDefWithCapacity(forest = 4),
+            clearedStore = StubClearedStore(default = 0L),
+            zoneLookup = StubZoneLookup(
+                byNode = mapOf(this.nodeId to nodeZone),
+                byRegion = mapOf(this.regionId to regionZone),
+            ),
+        )
+
+        val (after, _) = spawn.maybeSeed(baseState, this.nodeId, agent, tick = 1000L, rng = Random(0L))
+
+        assertEquals(1, after.npcs.size)
+        assertEquals(wolfDef.type, after.npcs.values.single().type)
+    }
+
+    @Test
+    fun `zone with respawn_ticks shorter than balance opens reseed window`() {
+        val zone = nodeZone(
+            nodeId = nodeId,
+            weights = mapOf(wolfDef.type to 1),
+            maxConcurrent = 1,
+            respawnTicks = 50,
+        )
+        val spawn = LazyNpcSpawn(
+            catalog = catalogWith(wolfDef),
+            balance = balance(respawnTicks = 500L),
+            worldDef = worldDefWithCapacity(forest = 1),
+            clearedStore = StubClearedStore(default = 900L),
+            zoneLookup = StubZoneLookup(byNode = mapOf(nodeId to zone)),
+        )
+
+        val (after, _) = spawn.maybeSeed(baseState, nodeId, agent, tick = 1000L, rng = Random(0L))
+
+        assertEquals(1, after.npcs.size)
+    }
+
+    @Test
+    fun `zone respects catalog spawnBiomes — wolves cannot spawn in a non-forest biome`() {
+        val desertNode = Node(NodeId(999L), regionId, 0, 0, Terrain.DESERT, emptySet())
+        val desertRegion = region.copy(biome = Biome.DESERT)
+        val desertState = baseState.copy(
+            regions = mapOf(regionId to desertRegion),
+            nodes = mapOf(desertNode.id to desertNode),
+        )
+        val zone = nodeZone(desertNode.id, weights = mapOf(wolfDef.type to 1), maxConcurrent = 3)
+        val spawn = LazyNpcSpawn(
+            catalog = catalogWith(wolfDef),
+            balance = balance(respawnTicks = 0),
+            worldDef = WorldDefinitionProperties(
+                biomes = mapOf(
+                    Biome.DESERT to BiomeProperties(
+                        displayName = "Desert",
+                        nodeNpcCapacity = 0,
+                        nodeSpawnProbability = 1.0,
+                    ),
+                ),
+            ),
+            clearedStore = StubClearedStore(default = 0L),
+            zoneLookup = StubZoneLookup(byNode = mapOf(desertNode.id to zone)),
+        )
+
+        val (after, _) = spawn.maybeSeed(desertState, desertNode.id, agent, tick = 1000L, rng = Random(0L))
+
+        assertEquals(0, after.npcs.size)
+    }
+
+    private fun nodeZone(
+        nodeId: NodeId,
+        weights: Map<NpcType, Int>,
+        maxConcurrent: Int,
+        respawnTicks: Int? = null,
+    ) = NpcZone(
+        zoneId = UUID.randomUUID(),
+        worldId = WorldId(1L),
+        scope = NpcZoneScope.NODE,
+        regionId = null,
+        nodeId = nodeId,
+        weights = weights,
+        maxConcurrent = maxConcurrent,
+        respawnTicks = respawnTicks,
+        active = true,
+        createdBy = UUID.randomUUID(),
+        createdAtTick = 0L,
+    )
+
+    private fun regionZone(
+        regionId: RegionId,
+        weights: Map<NpcType, Int>,
+        maxConcurrent: Int,
+        respawnTicks: Int? = null,
+    ) = NpcZone(
+        zoneId = UUID.randomUUID(),
+        worldId = WorldId(1L),
+        scope = NpcZoneScope.REGION,
+        regionId = regionId,
+        nodeId = null,
+        weights = weights,
+        maxConcurrent = maxConcurrent,
+        respawnTicks = respawnTicks,
+        active = true,
+        createdBy = UUID.randomUUID(),
+        createdAtTick = 0L,
+    )
 
     private fun catalogWith(vararg defs: NpcDef): NpcCatalog = object : NpcCatalog {
         private val byType = defs.associateBy { it.type }
@@ -250,6 +401,14 @@ class LazyNpcSpawnTest {
     private class StubClearedStore(val default: Long) : NodeClearedTimestampStore {
         override fun lastClearedTick(nodeId: NodeId): Long = default
         override fun setLastClearedTick(nodeId: NodeId, tick: Long) = Unit
+    }
+
+    private class StubZoneLookup(
+        private val byNode: Map<NodeId, NpcZone> = emptyMap(),
+        private val byRegion: Map<RegionId, NpcZone> = emptyMap(),
+    ) : NpcZoneLookup {
+        override fun resolveFor(nodeId: NodeId, regionId: RegionId): NpcZone? =
+            byNode[nodeId] ?: byRegion[regionId]
     }
 
     private fun balance(respawnTicks: Long): BalanceLookup = object : BalanceLookup {

--- a/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/zones/NpcZoneAdminGatewayImplIntegrationTest.kt
+++ b/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/zones/NpcZoneAdminGatewayImplIntegrationTest.kt
@@ -1,0 +1,339 @@
+package dev.gvart.genesara.world.environment.internal.zones
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.player.RaceId
+import dev.gvart.genesara.world.AggressionProfile
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.BodyView
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.GroundItemView
+import dev.gvart.genesara.world.InventoryView
+import dev.gvart.genesara.world.MaybeSet
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NodeResources
+import dev.gvart.genesara.world.Npc
+import dev.gvart.genesara.world.NpcCatalog
+import dev.gvart.genesara.world.NpcDef
+import dev.gvart.genesara.world.NpcType
+import dev.gvart.genesara.world.NpcZoneAdminError
+import dev.gvart.genesara.world.NpcZoneCreateSpec
+import dev.gvart.genesara.world.NpcZonePatch
+import dev.gvart.genesara.world.NpcZoneScope
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.WorldQueryGateway
+import dev.gvart.genesara.world.internal.jooq.tables.references.NODES
+import dev.gvart.genesara.world.internal.jooq.tables.references.NPC_ZONES
+import dev.gvart.genesara.world.internal.jooq.tables.references.REGIONS
+import dev.gvart.genesara.world.internal.jooq.tables.references.WORLDS
+import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import org.jooq.DSLContext
+import org.jooq.JSON
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+
+@Testcontainers
+class NpcZoneAdminGatewayImplIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("npc_zones_admin_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = WorldFlyway.pooledDataSource(postgres)
+            WorldFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+    private val wolfType = NpcType("GRAY_WOLF")
+    private val wolfDef = NpcDef(
+        type = wolfType,
+        displayName = "Gray Wolf",
+        hpMax = 30,
+        damage = 1,
+        damageType = DamageType.PIERCE,
+        range = 1,
+        attackIntervalTicks = 4,
+        defense = 0,
+        dodgeChancePercent = 0,
+        aggressionProfile = AggressionProfile.HOSTILE,
+        territoryRadius = 0,
+        spawnBiomes = setOf(Biome.FOREST),
+        spawnWeight = 1,
+    )
+    private val admin = UUID.randomUUID()
+
+    private lateinit var store: JooqNpcZonesStore
+    private lateinit var gateway: NpcZoneAdminGatewayImpl
+    private var worldOneId: Long = 0L
+    private var worldTwoId: Long = 0L
+    private var regionOneId: Long = 0L
+    private var regionTwoId: Long = 0L
+    private var nodeInWorldOneId: Long = 0L
+    private var nodeInWorldTwoId: Long = 0L
+
+    @BeforeEach
+    fun reset() {
+        dsl.deleteFrom(NPC_ZONES).execute()
+        dsl.deleteFrom(NODES).execute()
+        dsl.deleteFrom(REGIONS).execute()
+        dsl.deleteFrom(WORLDS).execute()
+        worldOneId = insertWorld("w1")
+        worldTwoId = insertWorld("w2")
+        regionOneId = insertRegion(worldOneId)
+        regionTwoId = insertRegion(worldTwoId)
+        nodeInWorldOneId = insertNode(regionOneId)
+        nodeInWorldTwoId = insertNode(regionTwoId)
+
+        store = JooqNpcZonesStore(dsl, mapper)
+        gateway = NpcZoneAdminGatewayImpl(
+            store = store,
+            catalog = catalogFor(wolfDef),
+            world = StubWorldQuery(),
+        )
+    }
+
+    @Test
+    fun `create node-scoped zone persists and returns row`() {
+        val created = gateway.create(
+            NpcZoneCreateSpec(
+                worldId = WorldId(worldOneId),
+                scope = NpcZoneScope.NODE,
+                regionId = null,
+                nodeId = NodeId(nodeInWorldOneId),
+                weights = mapOf(wolfType to 3),
+                maxConcurrent = 5,
+                respawnTicks = 200,
+                active = true,
+                createdBy = admin,
+                createdAtTick = 100L,
+            )
+        )
+
+        val loaded = store.findById(created.zoneId)
+        assertNotNull(loaded)
+        assertEquals(NpcZoneScope.NODE, loaded.scope)
+        assertEquals(NodeId(nodeInWorldOneId), loaded.nodeId)
+        assertEquals(mapOf(wolfType to 3), loaded.weights)
+        assertEquals(5, loaded.maxConcurrent)
+    }
+
+    @Test
+    fun `create rejects unknown NPC types`() {
+        assertThrows<NpcZoneAdminError.UnknownNpcTypes> {
+            gateway.create(
+                spec(
+                    scope = NpcZoneScope.NODE,
+                    nodeId = NodeId(nodeInWorldOneId),
+                    weights = mapOf(NpcType("PHANTOM") to 1),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `create rejects node belonging to a different world`() {
+        assertThrows<NpcZoneAdminError.WorldMismatch> {
+            gateway.create(
+                spec(
+                    scope = NpcZoneScope.NODE,
+                    nodeId = NodeId(nodeInWorldTwoId),
+                    weights = mapOf(wolfType to 1),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `create rejects empty weights`() {
+        assertThrows<NpcZoneAdminError.EmptyWeights> {
+            gateway.create(
+                spec(scope = NpcZoneScope.NODE, nodeId = NodeId(nodeInWorldOneId), weights = emptyMap())
+            )
+        }
+    }
+
+    @Test
+    fun `patch applies weights and max_concurrent updates`() {
+        val created = gateway.create(
+            spec(
+                scope = NpcZoneScope.NODE,
+                nodeId = NodeId(nodeInWorldOneId),
+                weights = mapOf(wolfType to 1),
+                maxConcurrent = 1,
+            )
+        )
+
+        val patched = gateway.patch(
+            created.zoneId,
+            NpcZonePatch(
+                weights = MaybeSet.Set(mapOf(wolfType to 5)),
+                maxConcurrent = MaybeSet.Set(7),
+                respawnTicks = MaybeSet.Set(null),
+                active = MaybeSet.Set(false),
+            ),
+        )
+
+        assertEquals(mapOf(wolfType to 5), patched.weights)
+        assertEquals(7, patched.maxConcurrent)
+        assertNull(patched.respawnTicks)
+        assertFalse(patched.active)
+    }
+
+    @Test
+    fun `delete removes the row`() {
+        val created = gateway.create(
+            spec(scope = NpcZoneScope.NODE, nodeId = NodeId(nodeInWorldOneId), weights = mapOf(wolfType to 1))
+        )
+
+        val removed = gateway.delete(created.zoneId)
+
+        assertEquals(true, removed)
+        assertNull(store.findById(created.zoneId))
+    }
+
+    @Test
+    fun `list returns only zones for that world`() {
+        gateway.create(spec(scope = NpcZoneScope.NODE, nodeId = NodeId(nodeInWorldOneId), weights = mapOf(wolfType to 1)))
+        gateway.create(
+            spec(
+                worldId = WorldId(worldTwoId),
+                scope = NpcZoneScope.NODE,
+                nodeId = NodeId(nodeInWorldTwoId),
+                weights = mapOf(wolfType to 1),
+            )
+        )
+
+        val worldOneZones = gateway.list(WorldId(worldOneId))
+
+        assertEquals(1, worldOneZones.size)
+        assertEquals(NodeId(nodeInWorldOneId), worldOneZones.single().nodeId)
+    }
+
+    private fun spec(
+        worldId: WorldId = WorldId(worldOneId),
+        scope: NpcZoneScope,
+        nodeId: NodeId? = null,
+        regionId: RegionId? = null,
+        weights: Map<NpcType, Int>,
+        maxConcurrent: Int = 1,
+    ) = NpcZoneCreateSpec(
+        worldId = worldId,
+        scope = scope,
+        regionId = regionId,
+        nodeId = nodeId,
+        weights = weights,
+        maxConcurrent = maxConcurrent,
+        respawnTicks = null,
+        active = true,
+        createdBy = admin,
+        createdAtTick = 100L,
+    )
+
+    private fun catalogFor(vararg defs: NpcDef): NpcCatalog {
+        val byType = defs.associateBy { it.type }
+        return object : NpcCatalog {
+            override fun byType(type: NpcType): NpcDef? = byType[type]
+            override fun all(): Collection<NpcDef> = byType.values
+            override fun byBiome(biome: Biome): List<NpcDef> = byType.values.filter { biome in it.spawnBiomes }
+        }
+    }
+
+    private inner class StubWorldQuery : WorldQueryGateway {
+        override fun locationOf(agent: AgentId): NodeId? = null
+        override fun activePositionOf(agent: AgentId): NodeId? = null
+        override fun node(id: NodeId): Node? = when (id.value) {
+            nodeInWorldOneId -> Node(id, RegionId(regionOneId), 0, 0, Terrain.PLAINS, emptySet())
+            nodeInWorldTwoId -> Node(id, RegionId(regionTwoId), 0, 0, Terrain.PLAINS, emptySet())
+            else -> null
+        }
+        override fun region(id: RegionId): Region? = when (id.value) {
+            regionOneId -> region(id, WorldId(worldOneId))
+            regionTwoId -> region(id, WorldId(worldTwoId))
+            else -> null
+        }
+        override fun nodesWithin(origin: NodeId, radius: Int): Set<NodeId> = emptySet()
+        override fun randomSpawnableNode(): NodeId? = null
+        override fun starterNodeFor(race: RaceId): NodeId? = null
+        override fun bodyOf(agent: AgentId): BodyView? = null
+        override fun inventoryOf(agent: AgentId): InventoryView = InventoryView(emptyList())
+        override fun resourcesAt(nodeId: NodeId, tick: Long): NodeResources = NodeResources.EMPTY
+        override fun groundItemsAt(nodeId: NodeId): List<GroundItemView> = emptyList()
+        override fun currentTickFor(agent: AgentId): Long = 0L
+        override fun activeAgentsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<AgentId>> = emptyMap()
+        override fun npcsAtNodes(nodeIds: Set<NodeId>): Map<NodeId, List<Npc>> = emptyMap()
+    }
+
+    private fun region(id: RegionId, worldId: WorldId) = Region(
+        id = id, worldId = worldId, sphereIndex = 0,
+        biome = Biome.FOREST, climate = Climate.OCEANIC,
+        centroid = Vec3(0.0, 0.0, 1.0), faceVertices = emptyList(), neighbors = emptySet(),
+    )
+
+    private fun insertWorld(name: String): Long =
+        dsl.insertInto(WORLDS)
+            .set(WORLDS.NAME, "$name-${System.nanoTime()}")
+            .set(WORLDS.NODE_COUNT, 1)
+            .set(WORLDS.NODE_SIZE, 1)
+            .set(WORLDS.FREQUENCY, 1)
+            .returningResult(WORLDS.ID)
+            .fetchOne()!!.value1()!!
+
+    private fun insertRegion(worldId: Long): Long =
+        dsl.insertInto(REGIONS)
+            .set(REGIONS.WORLD_ID, worldId)
+            .set(REGIONS.SPHERE_INDEX, (System.nanoTime() % Int.MAX_VALUE).toInt())
+            .set(REGIONS.CENTROID_X, 0.0)
+            .set(REGIONS.CENTROID_Y, 0.0)
+            .set(REGIONS.CENTROID_Z, 1.0)
+            .set(REGIONS.FACE_VERTICES, JSON.valueOf("[]"))
+            .returningResult(REGIONS.ID)
+            .fetchOne()!!.value1()!!
+
+    private fun insertNode(regionId: Long): Long =
+        dsl.insertInto(NODES)
+            .set(NODES.REGION_ID, regionId)
+            .set(NODES.Q, (System.nanoTime() % Int.MAX_VALUE).toInt())
+            .set(NODES.R, 0)
+            .set(NODES.TERRAIN, "FOREST")
+            .returningResult(NODES.ID)
+            .fetchOne()!!.value1()!!
+}

--- a/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/zones/NpcZoneLazySpawnIntegrationTest.kt
+++ b/world/environment/src/test/kotlin/dev/gvart/genesara/world/environment/internal/zones/NpcZoneLazySpawnIntegrationTest.kt
@@ -1,0 +1,293 @@
+package dev.gvart.genesara.world.environment.internal.zones
+
+import com.zaxxer.hikari.HikariDataSource
+import dev.gvart.genesara.player.AgentId
+import dev.gvart.genesara.world.AggressionProfile
+import dev.gvart.genesara.world.Biome
+import dev.gvart.genesara.world.Climate
+import dev.gvart.genesara.world.DamageType
+import dev.gvart.genesara.world.Gauge
+import dev.gvart.genesara.world.ItemId
+import dev.gvart.genesara.world.Node
+import dev.gvart.genesara.world.NodeClearedTimestampStore
+import dev.gvart.genesara.world.NodeId
+import dev.gvart.genesara.world.NpcCatalog
+import dev.gvart.genesara.world.NpcDef
+import dev.gvart.genesara.world.NpcType
+import dev.gvart.genesara.world.NpcZone
+import dev.gvart.genesara.world.NpcZoneScope
+import dev.gvart.genesara.world.Region
+import dev.gvart.genesara.world.RegionId
+import dev.gvart.genesara.world.ResourceSpawnRule
+import dev.gvart.genesara.world.Terrain
+import dev.gvart.genesara.world.Vec3
+import dev.gvart.genesara.world.WorldId
+import dev.gvart.genesara.world.environment.internal.npc.LazyNpcSpawn
+import dev.gvart.genesara.world.internal.balance.BalanceLookup
+import dev.gvart.genesara.world.internal.balance.BiomeProperties
+import dev.gvart.genesara.world.internal.balance.WorldDefinitionProperties
+import dev.gvart.genesara.world.internal.jooq.tables.references.NODES
+import dev.gvart.genesara.world.internal.jooq.tables.references.NPC_ZONES
+import dev.gvart.genesara.world.internal.jooq.tables.references.REGIONS
+import dev.gvart.genesara.world.internal.jooq.tables.references.WORLDS
+import dev.gvart.genesara.world.internal.testsupport.WorldFlyway
+import dev.gvart.genesara.world.internal.worldstate.WorldState
+import java.util.UUID
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.jooq.DSLContext
+import org.jooq.JSON
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.kotlinModule
+
+@Testcontainers
+class NpcZoneLazySpawnIntegrationTest {
+
+    companion object {
+        @Container
+        @JvmStatic
+        val postgres: PostgreSQLContainer<*> = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("npc_zones_lazy_it")
+            .withUsername("test")
+            .withPassword("test")
+
+        private lateinit var dataSource: HikariDataSource
+        private lateinit var dsl: DSLContext
+
+        @BeforeAll
+        @JvmStatic
+        fun migrateOnce() {
+            dataSource = WorldFlyway.pooledDataSource(postgres)
+            WorldFlyway.migrate(dataSource)
+            dsl = DSL.using(dataSource, SQLDialect.POSTGRES)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun closePool() {
+            dataSource.close()
+        }
+    }
+
+    private val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+    private val agent = AgentId(UUID.randomUUID())
+
+    private val wolfDef = npcDef("GRAY_WOLF", weight = 1)
+    private val boarDef = npcDef("WILD_BOAR", weight = 1)
+
+    private lateinit var store: JooqNpcZonesStore
+    private lateinit var lookup: NpcZoneLookupImpl
+    private lateinit var spawn: LazyNpcSpawn
+    private var worldId: Long = 0L
+    private var regionId: Long = 0L
+    private var nodeId: Long = 0L
+
+    @BeforeEach
+    fun reset() {
+        dsl.deleteFrom(NPC_ZONES).execute()
+        dsl.deleteFrom(NODES).execute()
+        dsl.deleteFrom(REGIONS).execute()
+        dsl.deleteFrom(WORLDS).execute()
+        worldId = insertWorld()
+        regionId = insertRegion(worldId)
+        nodeId = insertNode(regionId)
+
+        store = JooqNpcZonesStore(dsl, mapper)
+        lookup = NpcZoneLookupImpl(store)
+        spawn = LazyNpcSpawn(
+            catalog = catalogFor(wolfDef, boarDef),
+            balance = balance(respawnTicks = 500L),
+            worldDef = forestCapacity(2),
+            clearedStore = stubClearedStore(),
+            zoneLookup = lookup,
+        )
+    }
+
+    @Test
+    fun `wolves-only node zone seeds only wolves even when biome catalog allows boar`() {
+        store.insert(
+            zone(
+                scope = NpcZoneScope.NODE,
+                nodeId = NodeId(nodeId),
+                weights = mapOf("GRAY_WOLF" to 1),
+                max = 3,
+            )
+        )
+
+        val (after, _) = spawn.maybeSeed(baseState(), NodeId(nodeId), agent, tick = 1000L, rng = Random(0L))
+
+        assertEquals(3, after.npcs.size)
+        assertTrue(after.npcs.values.all { it.type == wolfDef.type })
+    }
+
+    @Test
+    fun `no zone falls through to biome behaviour and seeds biome catalog mix`() {
+        val (after, _) = spawn.maybeSeed(baseState(), NodeId(nodeId), agent, tick = 1000L, rng = Random(0L))
+
+        assertEquals(2, after.npcs.size)
+        assertTrue(after.npcs.values.all { it.type == wolfDef.type || it.type == boarDef.type })
+    }
+
+    @Test
+    fun `inactive zone is ignored and falls through to biome behaviour`() {
+        store.insert(
+            zone(scope = NpcZoneScope.NODE, nodeId = NodeId(nodeId), weights = mapOf("GRAY_WOLF" to 1), max = 3)
+                .copy(active = false)
+        )
+
+        val (after, _) = spawn.maybeSeed(baseState(), NodeId(nodeId), agent, tick = 1000L, rng = Random(0L))
+
+        assertEquals(2, after.npcs.size)
+    }
+
+    @Test
+    fun `node zone resolution beats region zone`() {
+        store.insert(
+            zone(
+                scope = NpcZoneScope.REGION,
+                regionId = RegionId(regionId),
+                weights = mapOf("WILD_BOAR" to 1),
+                max = 5,
+            )
+        )
+        store.insert(
+            zone(scope = NpcZoneScope.NODE, nodeId = NodeId(nodeId), weights = mapOf("GRAY_WOLF" to 1), max = 1)
+        )
+
+        val (after, _) = spawn.maybeSeed(baseState(), NodeId(nodeId), agent, tick = 1000L, rng = Random(0L))
+
+        assertEquals(1, after.npcs.size)
+        assertEquals(wolfDef.type, after.npcs.values.single().type)
+    }
+
+    private fun baseState() = WorldState(
+        regions = mapOf(
+            RegionId(regionId) to Region(
+                id = RegionId(regionId), worldId = WorldId(worldId), sphereIndex = 0,
+                biome = Biome.FOREST, climate = Climate.OCEANIC,
+                centroid = Vec3(0.0, 0.0, 1.0), faceVertices = emptyList(), neighbors = emptySet(),
+            )
+        ),
+        nodes = mapOf(NodeId(nodeId) to Node(NodeId(nodeId), RegionId(regionId), 0, 0, Terrain.FOREST, emptySet())),
+        positions = emptyMap(),
+        bodies = emptyMap(),
+        inventories = emptyMap(),
+    )
+
+    private fun zone(
+        scope: NpcZoneScope,
+        nodeId: NodeId? = null,
+        regionId: RegionId? = null,
+        weights: Map<String, Int>,
+        max: Int,
+        respawnTicks: Int? = null,
+    ) = NpcZone(
+        zoneId = UUID.randomUUID(),
+        worldId = WorldId(worldId),
+        scope = scope,
+        regionId = regionId,
+        nodeId = nodeId,
+        weights = weights.mapKeys { NpcType(it.key) },
+        maxConcurrent = max,
+        respawnTicks = respawnTicks,
+        active = true,
+        createdBy = UUID.randomUUID(),
+        createdAtTick = 0L,
+    )
+
+    private fun npcDef(type: String, weight: Int) = NpcDef(
+        type = NpcType(type),
+        displayName = type,
+        hpMax = 30,
+        damage = 1,
+        damageType = DamageType.BLUNT,
+        range = 1,
+        attackIntervalTicks = 4,
+        defense = 0,
+        dodgeChancePercent = 0,
+        aggressionProfile = AggressionProfile.HOSTILE,
+        territoryRadius = 0,
+        spawnBiomes = setOf(Biome.FOREST),
+        spawnWeight = weight,
+    )
+
+    private fun catalogFor(vararg defs: NpcDef): NpcCatalog {
+        val byType = defs.associateBy { it.type }
+        return object : NpcCatalog {
+            override fun byType(type: NpcType): NpcDef? = byType[type]
+            override fun all(): Collection<NpcDef> = byType.values
+            override fun byBiome(biome: Biome): List<NpcDef> = byType.values.filter { biome in it.spawnBiomes }
+        }
+    }
+
+    private fun forestCapacity(capacity: Int) = WorldDefinitionProperties(
+        biomes = mapOf(
+            Biome.FOREST to BiomeProperties(
+                displayName = "Forest",
+                nodeNpcCapacity = capacity,
+                nodeSpawnProbability = 1.0,
+            ),
+        ),
+    )
+
+    private fun stubClearedStore() = object : NodeClearedTimestampStore {
+        override fun lastClearedTick(nodeId: NodeId): Long = 0L
+        override fun setLastClearedTick(nodeId: NodeId, tick: Long) = Unit
+    }
+
+    private fun balance(respawnTicks: Long) = object : BalanceLookup {
+        override fun moveStaminaCost(biome: Biome, climate: Climate, terrain: Terrain) = 1
+        override fun staminaRegenPerTick(climate: Climate) = 0
+        override fun resourceSpawnsFor(terrain: Terrain): List<ResourceSpawnRule> = emptyList()
+        override fun harvestStaminaCost(item: ItemId): Int = 1
+        override fun harvestYield(item: ItemId): Int = 1
+        override fun gaugeDrainPerTick(gauge: Gauge): Int = 0
+        override fun gaugeLowThreshold(gauge: Gauge): Int = 0
+        override fun starvationDamagePerTick(): Int = 0
+        override fun isWaterSource(terrain: Terrain): Boolean = false
+        override fun drinkStaminaCost(): Int = 0
+        override fun drinkThirstRefill(): Int = 0
+        override fun sleepRegenPerOfflineTick(): Int = 0
+        override fun isTraversable(terrain: Terrain): Boolean = true
+        override fun npcRespawnTicks(): Long = respawnTicks
+    }
+
+    private fun insertWorld(): Long =
+        dsl.insertInto(WORLDS)
+            .set(WORLDS.NAME, "lazy-zone-it-${System.nanoTime()}")
+            .set(WORLDS.NODE_COUNT, 1)
+            .set(WORLDS.NODE_SIZE, 1)
+            .set(WORLDS.FREQUENCY, 1)
+            .returningResult(WORLDS.ID)
+            .fetchOne()!!.value1()!!
+
+    private fun insertRegion(worldId: Long): Long =
+        dsl.insertInto(REGIONS)
+            .set(REGIONS.WORLD_ID, worldId)
+            .set(REGIONS.SPHERE_INDEX, 0)
+            .set(REGIONS.CENTROID_X, 0.0)
+            .set(REGIONS.CENTROID_Y, 0.0)
+            .set(REGIONS.CENTROID_Z, 1.0)
+            .set(REGIONS.FACE_VERTICES, JSON.valueOf("[]"))
+            .returningResult(REGIONS.ID)
+            .fetchOne()!!.value1()!!
+
+    private fun insertNode(regionId: Long): Long =
+        dsl.insertInto(NODES)
+            .set(NODES.REGION_ID, regionId)
+            .set(NODES.Q, 0)
+            .set(NODES.R, 0)
+            .set(NODES.TERRAIN, "FOREST")
+            .returningResult(NODES.ID)
+            .fetchOne()!!.value1()!!
+}

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerHarvestXpEventIntegrationTest.kt
@@ -325,6 +325,7 @@ class WorldTickHandlerHarvestXpEventIntegrationTest {
                 balance = balance,
                 worldDef = dev.gvart.genesara.world.internal.balance.WorldDefinitionProperties(),
                 clearedStore = dev.gvart.genesara.world.internal.testsupport.NoOpNodeClearedTimestampStore,
+                zoneLookup = dev.gvart.genesara.world.internal.testsupport.NoOpNpcZoneLookup,
             ),
             npcAiSweep = dev.gvart.genesara.world.environment.internal.npc.NpcAiSweep(
                 catalog = dev.gvart.genesara.world.internal.testsupport.NoOpNpcCatalog,

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerSpawnResumeIntegrationTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerSpawnResumeIntegrationTest.kt
@@ -263,6 +263,7 @@ class WorldTickHandlerSpawnResumeIntegrationTest {
                 balance = balance,
                 worldDef = dev.gvart.genesara.world.internal.balance.WorldDefinitionProperties(),
                 clearedStore = dev.gvart.genesara.world.internal.testsupport.NoOpNodeClearedTimestampStore,
+                zoneLookup = dev.gvart.genesara.world.internal.testsupport.NoOpNpcZoneLookup,
             ),
             npcAiSweep = dev.gvart.genesara.world.environment.internal.npc.NpcAiSweep(
                 catalog = dev.gvart.genesara.world.internal.testsupport.NoOpNpcCatalog,

--- a/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
+++ b/world/src/test/kotlin/dev/gvart/genesara/world/internal/tick/WorldTickHandlerTest.kt
@@ -261,6 +261,7 @@ class WorldTickHandlerTest {
             balance = balance,
             worldDef = dev.gvart.genesara.world.internal.balance.WorldDefinitionProperties(),
             clearedStore = dev.gvart.genesara.world.internal.testsupport.NoOpNodeClearedTimestampStore,
+            zoneLookup = dev.gvart.genesara.world.internal.testsupport.NoOpNpcZoneLookup,
         )
         val aiSweep = dev.gvart.genesara.world.environment.internal.npc.NpcAiSweep(
             catalog = dev.gvart.genesara.world.internal.testsupport.NoOpNpcCatalog,


### PR DESCRIPTION
Closes #207.

## Summary
- Operator overlay over the biome-driven NPC density: a zone targets a region or a node, lists which catalog NPC types may spawn (weighted), and pins `max_concurrent` + `respawn_ticks`.
- The lazy-on-entry seeder prefers a NODE zone, then a REGION zone, then falls through to the biome's `nodeNpcCapacity` behaviour verbatim. The catalog's `spawnBiomes` filter still intersects — a wolves-only zone in a desert biome that doesn't list wolves still spawns nothing.
- All mutating endpoints write to `admin_audit_log`; errors surface via RFC 7807 ProblemDetail through `ResponseStatusException`.

## Architectural notes
- Public surfaces (`NpcZone`, `NpcZoneScope`, `NpcZoneLookup`, `NpcZoneAdminGateway`, `NpcZoneCreateSpec`, `NpcZonePatch`, `NpcZoneAdminError`) live in `:world.core` so `:api` can call them through the umbrella `:world` module without importing `:world:environment` internals. Impls (`NpcZoneLookupImpl`, `NpcZoneAdminGatewayImpl`, `JooqNpcZonesStore`) are `internal` in `:world:environment`.
- `LazyNpcSpawn` gained a `zoneLookup: NpcZoneLookup` constructor arg; the only behavioural change when no zone resolves is that `zoneLookup.resolveFor(...)` is consulted once per call — the biome-driven path is unchanged.

## Schema
- `V31__npc_zones.sql` adds `npc_zones` with the scope/region/node CHECK invariant from the issue, FK references to `worlds`/`regions`/`nodes`, a `weights` JSONB column, and partial indexes on `region_id` / `node_id`.

## Surface
- `GET    /admin/worlds/{worldId}/npc-zones`
- `POST   /admin/worlds/{worldId}/npc-zones`
- `PATCH  /admin/worlds/{worldId}/npc-zones/{zoneId}` (MaybeSet)
- `DELETE /admin/worlds/{worldId}/npc-zones/{zoneId}`

## Test plan
- [x] `:world:environment:test` — unit `LazyNpcSpawnTest` covers: node beats region, zone weights override biome catalog, zone respawn_ticks short-circuits balance, zone respects `spawnBiomes` (no spawn in a non-matching biome).
- [x] `:world:environment:test` — integration `NpcZoneLazySpawnIntegrationTest` (real Postgres) seeds a wolves-only NODE zone on top of a forest biome that allows boar; only wolves spawn. Also covers inactive zones falling through, and a NODE zone beating a REGION zone.
- [x] `:world:environment:test` — integration `NpcZoneAdminGatewayImplIntegrationTest` (real Postgres) covers create/patch/delete, world-mismatch rejection, unknown-type rejection, empty-weights rejection.
- [x] `:api:test` — `NpcZoneControllerTest` covers 201/400/404 paths and audit row payloads for create/patch/delete.
- [x] `:app:test --tests dev.gvart.genesara.ModularityTests` passes (`:api` only imports public surfaces from `:world`).