### PR TITLE
fix(api): return 401 (not 403) for unauthenticated bearer/MCP requests

### DIFF
--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/security/BearerAuthenticationEntryPoint.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/security/BearerAuthenticationEntryPoint.kt
@@ -1,0 +1,23 @@
+package dev.gvart.genesara.api.internal.security
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+
+/**
+ * WHY: a bearer chain with no auth mechanism (no httpBasic/formLogin) defaults to Spring's
+ * `Http403ForbiddenEntryPoint`, returning 403 for a missing/invalid token instead of 401. The
+ * challenge is a bare RFC 6750 `Bearer` with NO `resource_metadata`, so MCP clients don't treat
+ * the endpoint as an OAuth-protected resource and start an OAuth flow the server doesn't implement.
+ */
+internal class BearerAuthenticationEntryPoint : AuthenticationEntryPoint {
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException,
+    ) {
+        response.setHeader("WWW-Authenticate", "Bearer error=\"invalid_token\"")
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED)
+    }
+}

--- a/api/src/main/kotlin/dev/gvart/genesara/api/internal/security/SecurityConfig.kt
+++ b/api/src/main/kotlin/dev/gvart/genesara/api/internal/security/SecurityConfig.kt
@@ -29,6 +29,8 @@ internal class SecurityConfig(
     private val properties: SecurityProperties,
 ) {
 
+    private val bearerAuthenticationEntryPoint = BearerAuthenticationEntryPoint()
+
     @Bean
     fun adminAuthenticationProvider(authenticator: AdminAuthenticator): AdminAuthenticationProvider =
         AdminAuthenticationProvider(authenticator)
@@ -74,6 +76,7 @@ internal class SecurityConfig(
             .cors(Customizer.withDefaults())
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .exceptionHandling { it.authenticationEntryPoint(bearerAuthenticationEntryPoint) }
             .authorizeHttpRequests {
                 it.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 it.anyRequest().hasRole("ADMIN")
@@ -94,6 +97,7 @@ internal class SecurityConfig(
             .cors(Customizer.withDefaults())
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .exceptionHandling { it.authenticationEntryPoint(bearerAuthenticationEntryPoint) }
             .authorizeHttpRequests {
                 it.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 it.anyRequest().authenticated()
@@ -117,6 +121,7 @@ internal class SecurityConfig(
             .cors(Customizer.withDefaults())
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .exceptionHandling { it.authenticationEntryPoint(bearerAuthenticationEntryPoint) }
             .authorizeHttpRequests {
                 it.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 it.anyRequest().hasRole("PLAYER")

--- a/api/src/test/kotlin/dev/gvart/genesara/api/internal/security/BearerAuthenticationEntryPointTest.kt
+++ b/api/src/test/kotlin/dev/gvart/genesara/api/internal/security/BearerAuthenticationEntryPointTest.kt
@@ -1,0 +1,56 @@
+package dev.gvart.genesara.api.internal.security
+
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.authentication.InsufficientAuthenticationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BearerAuthenticationEntryPointTest {
+
+    private val entryPoint = BearerAuthenticationEntryPoint()
+
+    @Test
+    fun `commence responds 401 unauthorized, not 403 forbidden`() {
+        val response = MockHttpServletResponse()
+
+        entryPoint.commence(
+            MockHttpServletRequest("POST", "/mcp"),
+            response,
+            InsufficientAuthenticationException("missing bearer"),
+        )
+
+        assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.status)
+    }
+
+    @Test
+    fun `commence emits a bare Bearer challenge`() {
+        val response = MockHttpServletResponse()
+
+        entryPoint.commence(
+            MockHttpServletRequest("POST", "/mcp"),
+            response,
+            InsufficientAuthenticationException("missing bearer"),
+        )
+
+        assertEquals("Bearer error=\"invalid_token\"", response.getHeader("WWW-Authenticate"))
+    }
+
+    @Test
+    fun `challenge advertises no OAuth resource metadata so clients do not start an OAuth flow`() {
+        val response = MockHttpServletResponse()
+
+        entryPoint.commence(
+            MockHttpServletRequest("GET", "/mcp"),
+            response,
+            InsufficientAuthenticationException("missing bearer"),
+        )
+
+        val challenge = response.getHeader("WWW-Authenticate").orEmpty()
+        assertTrue(challenge.startsWith("Bearer"))
+        assertFalse(challenge.contains("resource_metadata"))
+    }
+}


### PR DESCRIPTION
## Problem

The bearer-token Spring Security chains (`mcpSecurityChain`, `adminBearerChain`, `playerJwtChain`) configure no `authenticationEntryPoint`. The token filters are deliberately non-rejecting (they leave the `SecurityContext` empty and let the chain decide), so with no auth mechanism on the chain Spring falls back to `Http403ForbiddenEntryPoint` → **403** for missing/invalid credentials.

That is semantically wrong (the request is *unauthenticated*, not *forbidden*), and the 403-with-no-challenge is what misled the Claude Code MCP client into attempting an OAuth discovery/registration flow (`POST /register` → 404) instead of using the static `Authorization`/`X-Agent-Id` headers. Surfaced during the PR #222 clan/faction playtest.

## Fix

- Add `BearerAuthenticationEntryPoint` → `401` with a bare RFC 6750 `WWW-Authenticate: Bearer error="invalid_token"` challenge. It deliberately omits `resource_metadata`, so MCP clients don't treat the endpoint as an OAuth-protected resource.
- Wire it via `.exceptionHandling { authenticationEntryPoint(...) }` into the three bearer chains.

## Behavior change

Unauthenticated/bad-token requests to `/mcp/**`, `/sse`, `/message`, `/api/agent/**`, `/api/worlds/**`, `/admin/**`, `/api/agents/**`, `/api/me/**` now return **401** instead of 403. Valid requests are unaffected (200). The response body is unchanged (Spring's default error body — same as the prior 403); no ProblemDetail was introduced since the pre-existing chain-level denials already used the default body.

## Tests

`BearerAuthenticationEntryPointTest` asserts the entry point yields 401, the exact bare `Bearer` challenge, and the absence of `resource_metadata`. No existing test asserted 403 on these chains, so nothing regresses.

**Test-scope note:** a full on-the-wire integration test (unauthenticated request through the real filter chain) was *not* added — the `:api` module has no web-context test harness (`@SpringBootTest`/`spring-security-test`), and booting the full app (DB + Redis + MCP) for a declarative one-liner-per-chain change is disproportionate. The entry-point contract is unit-tested; the chain wiring is a one-line `exceptionHandling` per chain. Happy to add a full `@SpringBootTest` harness as a follow-up if on-the-wire coverage is wanted.

## Caveat (honest scope)

This is the correct HTTP semantics and removes the misleading signal, but it is not a guaranteed OAuth-stopper: an MCP client may still *probe* OAuth on a 401, which then fails harmlessly at the server's existing `/.well-known/oauth-*` and `/register` 404s. The durable prevention for the original incident (a stale token after a DB reset) is operational, not server-side.